### PR TITLE
Add ability to not dance at disco

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -518,5 +518,5 @@
 	if(active)
 		//for(var/mob/living/M in rangers)
 		for(var/mob/living/M in hearers(2, src))
-			if(prob(5+(allowed(M)*4)) && CHECK_MOBILITY(M, MOBILITY_MOVE))
+			if(prob(5+(allowed(M)*4)) && CHECK_MOBILITY(M, MOBILITY_MOVE) && (!M.client || M.client?.prefs.disco_dance))
 				dance(M)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -129,6 +129,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/extremeharm = "No" //If "extreme content" is enabled, this option serves as a toggle for the related interactions to cause damage or not
 	var/see_chat_emotes = TRUE
 	var/view_pixelshift = FALSE
+	var/disco_dance = TRUE
 	var/enable_personal_chat_color = FALSE
 	var/personal_chat_color = "#ffffff"
 	var/list/alt_titles_preferences = list()
@@ -1319,6 +1320,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<b>See Runechat for emotes:</b> <a href='?_src_=prefs;preference=see_chat_emotes'>[see_chat_emotes ? "Enabled" : "Disabled"]</a><br>"
 					//SKYRAT CHANGES END
 					dat += "<b>Shift view when pixelshifting:</b> <a href='?_src_=prefs;preference=view_pixelshift'>[view_pixelshift ? "Enabled" : "Disabled"]</a><br>" //SPLURT Edit
+					dat += "<b>Dance near disco ball:</b> <a href='?_src_=prefs;preference=disco_dance'>[disco_dance ? "Enabled" : "Disabled"]</a><br>"
 					dat += "<br>"
 					dat += "<b>Action Buttons:</b> <a href='?_src_=prefs;preference=action_buttons'>[(buttons_locked) ? "Locked In Place" : "Unlocked"]</a><br>"
 					dat += "<br>"
@@ -3689,6 +3691,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				//End of skyrat changes
 				if("view_pixelshift") //SPLURT Edit
 					view_pixelshift = !view_pixelshift
+				if ("disco_dance")
+					disco_dance = !disco_dance
 				if("action_buttons")
 					buttons_locked = !buttons_locked
 				if("tgui_fancy")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -498,6 +498,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["gfluid_blacklist"]		>> gfluid_blacklist
 	S["new_character_creator"]	>> new_character_creator
 	S["view_pixelshift"]		>> view_pixelshift
+	S["disco_dance"]			>> disco_dance
 
 	//favorite outfits
 	S["favorite_outfits"] >> favorite_outfits
@@ -706,6 +707,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["gfluid_blacklist"], gfluid_blacklist)
 	WRITE_FILE(S["new_character_creator"], new_character_creator)
 	WRITE_FILE(S["view_pixelshift"], view_pixelshift)
+	WRITE_FILE(S["disco_dance"], disco_dance)
 
 	var/mob/living/carbon/human/H = parent.mob
 	if(istype(H))


### PR DESCRIPTION
Добавляет в преференсы опцию танца около дискошара.

По умолчанию опция включена, но шарящие, а также особо жаждающие прекратить этот эппилептический припадок своего персонажа смогут наконец выключить это