### PR TITLE
Fix DS2 turbine console

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -2628,8 +2628,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "kd" = (
 /obj/machinery/computer/turbine_computer{
-	dir = 1;
-	id = "ds2_turbine"
+	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod,
 /obj/structure/window/reinforced/survival_pod{


### PR DESCRIPTION
Коноль не может подключиться без пересборки ибо у неё прописан `id`. А турбина по умолчанию не собрана, поэтому `id` только мешает, а не помогает подключиться.