### PR TITLE
Убираем sizeray из кинкмата

### DIFF
--- a/code/modules/vending/kinkmate.dm
+++ b/code/modules/vending/kinkmate.dm
@@ -61,8 +61,7 @@
 	premium = list(
 				/obj/item/clothing/accessory/skullcodpiece/fake = 3,
 				/obj/item/reagent_containers/glass/bottle/hexacrocin = 10,
-				/obj/item/clothing/under/pants/chaps = 5,
-				/obj/item/gun/energy/laser/sizeray = 2
+				/obj/item/clothing/under/pants/chaps = 5
 				)
 	refill_canister = /obj/item/vending_refill/kink
 	default_price = PRICE_CHEAP


### PR DESCRIPTION
# About The Pull Request

Убираем sizeray из кинкмата.

1. Это дебаговый инструмент. Он не должен находиться в общем доступе.
2. Он используется для ЛРП целей. Персонажам повышают размер до 800% без их согласия (или наоборот, снижают). Защиты от этого нет.
3. По механу, это лазер капитана (сам себя заряжает). Можно так грифонить всю станцию/бар.

Я делаю отдельный тул, который не будет иметь этих недостатков. Он будет идти в отдельном ПРе.

## Why It's Good For The Game

Меньше LRP.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
