### PR TITLE
Сильно изменяем вес рулсетов в динамике

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -59,7 +59,7 @@
 	protected_roles = list("Shaft Miner", "NanoTrasen Representative", "Lawyer", "Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director") //BLUEMOON CHANGES
 	restricted_roles = list("AI", "Cyborg")
 	required_candidates = 1
-	weight = 3  //BLUEMOON CHANGES
+	weight = 6  //BLUEMOON CHANGES
 	cost = 6 //BLUEMOON CHANGES
 	requirements = list(101,40,25,20,15,10,10,10,10,10)
 	repeatable = TRUE
@@ -82,7 +82,7 @@
 	required_candidates = 1
 	weight = 2
 	delay = 1 MINUTES // Prevents rule start while head is offstation.
-	cost = 20
+	cost = 7 //BLUEMOON CHANGES - маленький шанс и низкая стоимость из-за сложности
 	requirements = list(101,101,101,101,50,20,20,20,20,20)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
@@ -155,7 +155,7 @@
 	protected_roles = list("Shaft Miner", "NanoTrasen Representative", "Lawyer", "Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Prisoner", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director")  //BLUEMOON CHANGES
 	restricted_roles = list("AI", "Cyborg", "Prisoner")  //BLUEMOON CHANGES
 	required_candidates = 1
-	weight = 3 //BLUEMOON CHANGES
+	weight = 4 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,50,40,20,20,15,10,10)
 	repeatable = TRUE
@@ -175,7 +175,7 @@
 	protected_roles = list("Prisoner", "Shaft Miner", "NanoTrasen Representative", "Lawyer", "Security Officer", "Blueshield", "Peacekeeper", "Brig Physician", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_roles = list("AI", "Cyborg")
 	required_candidates = 1
-	weight = 3
+	weight = 4
 	cost = 10
 	requirements = list(101,101,60,50,40,30,20,15,10,10)
 	antag_cap = list("denominator" = 24)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -256,8 +256,8 @@
 	antag_flag_override = ROLE_FAMILIES
 	restricted_roles = list("AI", "Cyborg", "Prisoner", "Shaft Miner", "NanoTrasen Representative", "Lawyer", "Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director")  //BLUEMOON CHANGES
 	required_candidates = 9
-	weight = 3
-	cost = 15
+	weight = 4 //BLUEMOON CHANGES
+	cost = 10 //BLUEMOON CHANGES - низкая цена, т.к. надо в соло поднять семью
 	requirements = list(101,101,101,50,30,20,10,10,10,10)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/families)
@@ -318,7 +318,7 @@
 	exclusive_roles = list("AI")
 	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 3
+	weight = 6 //BLUEMOON CHANGES
 	cost = 15 //BLUEMOON CHANGES - было 35, сейчас это обычный предатель
 	requirements = list(101,101,80,70,60,60,50,50,40,40)
 	required_type = /mob/living/silicon/ai
@@ -368,8 +368,8 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 2
-	cost = 20
+	weight = 5 //BLUEMOON CHANGES
+	cost = 15 //BLUEMOON CHANGES
 	requirements = list(101,101,100,60,40,20,20,20,10,10)
 	repeatable = TRUE
 	var/datum/mind/wizard
@@ -589,7 +589,7 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 2
+	weight = 3 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,101,50,40,30,20,10,10)
 	repeatable = TRUE
@@ -609,7 +609,7 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	required_enemies = list(0,0,0,0,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 2
+	weight = 3 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,101,50,40,30,20,10,10)
 	repeatable = TRUE
@@ -694,7 +694,7 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	required_enemies = list(0,0,0,4,4,3,3,2,0,0) //BLUEMOON CHANGES
 	required_candidates = 1
-	weight = 3 //BLUEMOON CHANGES
+	weight = 6 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,50,30,25,20,10,10,10) //BLUEMOON CHANGES
 	repeatable = TRUE
@@ -741,7 +741,7 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGE (should we include miners?)
 	required_enemies = list(0,0,0,0,5,5,4,4,3,0) //BLUEMOON CHANGES
 	required_candidates = 1
-	weight = 3
+	weight = 6 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,101,50,40,30,20,10,10)
 	repeatable = TRUE
@@ -860,7 +860,7 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	required_enemies = list(0,0,0,0,5,5,4,4,3,0) //BLUEMOON CHANGES
 	required_candidates = 1
-	weight = 3 //BLUEMOON CHANGES
+	weight = 6 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,101,60,50,30,20,10,10) //BLUEMOON CHANGES
 	repeatable = TRUE
@@ -947,7 +947,7 @@
 	antag_flag = "Sentient Disease"
 	antag_flag_override = ROLE_ALIEN
 	required_candidates = 1
-	weight = 3 //BLUEMOON CHANGES
+	weight = 6 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,50,30,25,20,10,10,10) //BLUEMOON CHANGES
 	repeatable = TRUE
@@ -969,7 +969,7 @@
 	enemy_roles = list("Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGE
 	required_enemies = list(0,0,0,0,0,5,4,3,3,3) //BLUEMOON CHANGES
 	required_candidates = 0
-	weight = 3 //BLUEMOON CHANGES
+	weight = 6 //BLUEMOON CHANGES
 	cost = 10
 	requirements = list(101,101,101,101,101,40,30,20,10,10) //BLUEMOON CHANGES
 	repeatable = TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -14,7 +14,7 @@
 	protected_roles = list("Prisoner", "Shaft Miner", "NanoTrasen Representative", "Lawyer", "Security Officer", "Blueshield", "Peacekeeper", "Brig Physician", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	restricted_roles = list("AI", "Cyborg") //BLUEMOON CHANGES
 	required_candidates = 1
-	weight = 3 //BLUEMOON CHANGES
+	weight = 13 //BLUEMOON CHANGES
 	cost = 8 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
 	scaling_cost = 9
 	requirements = list(101,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
@@ -56,7 +56,7 @@
 	protected_roles = list("Prisoner", "Shaft Miner", "NanoTrasen Representative", "Lawyer", "Security Officer", "Blueshield", "Peacekeeper", "Brig Physician", "Warden", "Detective", "Head of Security", "Captain") //BLUEMOON CHANGES
 	restricted_roles = list("Cyborg", "AI")
 	required_candidates = 2
-	weight = 3 //BLUEMOON CHANGES
+	weight = 6 //BLUEMOON CHANGES
 	cost = 15
 	scaling_cost = 15
 	requirements = list(101,101,101,101,60,50,40,30,20,10) //BLUEMOON CHANGES
@@ -104,7 +104,7 @@
 	protected_roles = list("Prisoner", "Shaft Miner", "NanoTrasen Representative", "Lawyer", "Security Officer", "Blueshield", "Peacekeeper", "Brig Physician", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director") //BLUEMOON CHANGES
 	restricted_roles = list("AI", "Cyborg")
 	required_candidates = 1
-	weight = 3
+	weight = 8 //BLUEMOON CHANGES
 	cost = 15 //BLUEMOON CHANGES
 	scaling_cost = 10
 	requirements = list(101,101,60,50,40,30,20,15,10,10) //BLUEMOON CHANGES
@@ -139,7 +139,7 @@
 	protected_roles = list("Prisoner", "Shaft Miner", "NanoTrasen Representative", "Lawyer", "Security Officer", "Blueshield", "Peacekeeper", "Brig Physician", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director") //BLUEMOON CHANGES
 	restricted_roles = list("AI", "Cyborg")
 	required_candidates = 1
-	weight = 3
+	weight = 8 //BLUEMOON CHANGES
 	cost = 15
 	scaling_cost = 9
 	requirements = list(101,101,101,50,40,20,20,15,10,10) //higher because of 'round end'
@@ -180,7 +180,7 @@
 	minimum_required_age = 14
 	restricted_roles = list("Head of Security", "Captain") // Just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	required_candidates = 1
-	weight = 3
+	weight = 6 //BLUEMOON CHANGES
 	cost = 20
 	requirements = list(101,101,101,60,40,20,20,20,10,10)  //BLUEMOON CHANGES
 	var/list/roundstart_wizards = list()
@@ -280,7 +280,7 @@
 	minimum_required_age = 14
 	restricted_roles = list("Head of Security", "Captain") // Just to be sure that a nukie getting picked won't ever imply a Captain or HoS not getting drafted
 	required_candidates = 5
-	weight = 3
+	weight = 3 //BLUEMOON CHANGES
 	cost = 20
 	requirements = list(101,101,101,101,101,101,60,40,30,10) //BLUEMOON CHANGES
 	flags = HIGH_IMPACT_RULESET
@@ -699,7 +699,7 @@ BLUEMOON REMOVAL END*/
 	antag_flag_override = ROLE_NINJA
 	flags = LONE_RULESET
 	required_candidates = 1
-	weight = 3
+	weight = 6 //BLUEMOON CHANGES
 	cost = 20
 	requirements = list(101,101,101,60,40,20,20,20,10,10)
 	var/list/spawn_locs = list()


### PR DESCRIPTION
# About The Pull Request

Изменён вес (читать как шанс спавна) рулсетов.
Я руководствовался импактом в раунд. Крупные командные режимы получили небольшой вес. Более традиционные одиночные высокий. Редкие одиночные средний. Раздражающие (ревенант, свармеры, абдакторы) - редкий.

Помимо этого, учитывался потенциальный ущерб течению раунда (повышению шанса на шаттл).

Раньше, у всех был шанс 2-3, что практически одинаково по итогу.

# Roundstart (с начала раунда)
- Предатели (с последующим доспавном автотрейтором) - 13
- Кровавые братья - 6
- Генокрад - 6
- Еретик - 8
- Маг - 6
- Ниндзя - 6

- Кровавый куль - 3
- Нюка - 3
- Рева - 3
- Клок культ - 3
- Семьи - 3
- Экста - -999
- Чужие - 3
- 

# Мидраунд (в процессе раунда)
- Семьи - 4
- Малф - 6
- Маг - 5
- Нюка - 3
- Клок культ - 3
- Культ - 3
- Блоб - 3
- Экипажник-блобист - 3
- Алиумы - 3
- КОШМАР - 6
- Дракон - 6
- Абдакторы - 3
- Свармеры - 2
- Ниндзя - 6
- Ревенант - 3
- Вирус - 6
- Пираты - 6

# Latejoin (после начала раунда с шаттла новому игроку)
- Предатель - 6
- Генокрад - 4
- Еретик -  4
- Революционер - 2 (также снижена стоимость очень сильно, т.к. нужно в соло на пустом месте поднять революцию, что бывает крайне сложно и куда чаще эту роль просто снимают, как я понял).

## Why It's Good For The Game

Меньше "у нас сегодня было 3 динамика и 3 культа, что за нахуй".
Надеюсь, градус РЕЗНИ снизится.

