### PR TITLE
Решаем проблему манча хардсьютов рейдеров

### DIFF
--- a/modular_bluemoon/krashly/code/datums/components/uplink.dm
+++ b/modular_bluemoon/krashly/code/datums/components/uplink.dm
@@ -23,3 +23,5 @@
 		// and never is updated outside of user input.
 		ui.set_autoupdate(FALSE)
 		ui.open()
+
+#define IS_INTEQ(mob) (mob.mind?.has_antag_datum(/datum/antagonist/traitor) || mob.mind?.has_antag_datum(/datum/antagonist/raiders) || mob.mind?.has_antag_datum(/datum/antagonist/nukeop))

--- a/modular_bluemoon/krashly/code/modules/clothing/armor.dm
+++ b/modular_bluemoon/krashly/code/modules/clothing/armor.dm
@@ -175,6 +175,20 @@ obj/item/clothing/suit/donator/bm/cerberus_suit/armored/inkvd
 	mob_overlay_icon = 'modular_bluemoon/krashly/icons/mob/clothing/suits.dmi'
 	anthro_mob_worn_overlay = 'modular_bluemoon/krashly/icons/mob/clothing/suits_digidrated.dmi'
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite/inteq
+
+/obj/item/clothing/suit/space/hardsuit/syndi/elite/inteq/equipped(mob/user, slot)
+	..()
+	if(slot == ITEM_SLOT_OCLOTHING)
+		if(!IS_INTEQ(user))
+			to_chat(user, "<span class='danger'><B>СКАФАНДР МОДЕЛЬ ДВА</B>: Обнаружены неавторизованные сигнатуры. <B>Производится нейтрализация экипировки.</B></span>")
+			playsound(get_turf(src), 'sound/machines/nuke/confirm_beep.ogg', 65, 1, 1)
+			addtimer(CALLBACK(src, .proc/explode), 4 SECONDS)
+
+/obj/item/clothing/suit/space/hardsuit/syndi/elite/inteq/proc/explode()
+	do_sparks(3, 1, src)
+	explosion(src.loc,0,1,1,1)
+	qdel(src)
+
 //////////
 
 //Helmet_STANDART
@@ -251,6 +265,20 @@ obj/item/clothing/suit/donator/bm/cerberus_suit/armored/inkvd
 	anthro_mob_worn_overlay = 'modular_bluemoon/krashly/icons/mob/clothing/suits_digidrated.dmi'
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi/inteq
 	shield_state = "shield-yellow"
+
+/obj/item/clothing/suit/space/hardsuit/shielded/syndi/inteq/equipped(mob/user, slot)
+	..()
+	if(slot == ITEM_SLOT_OCLOTHING)
+		if(!IS_INTEQ(user))
+			to_chat(user, "<span class='danger'><B>СКАФАНДР МОДЕЛЬ ОДИН - ЩИТ</B>: Обнаружены неавторизованные сигнатуры. <B>Производится нейтрализация экипировки.</B></span>")
+			playsound(get_turf(src), 'sound/machines/nuke/confirm_beep.ogg', 65, 1, 1)
+			addtimer(CALLBACK(src, .proc/explode), 4 SECONDS)
+
+/obj/item/clothing/suit/space/hardsuit/shielded/syndi/inteq/proc/explode()
+	do_sparks(3, 1, src)
+	explosion(src.loc,0,1,1,1)
+	qdel(src)
+
 //////////
 
 ///Kovac added

--- a/modular_bluemoon/krashly/code/modules/clothing/armor.dm
+++ b/modular_bluemoon/krashly/code/modules/clothing/armor.dm
@@ -182,7 +182,7 @@ obj/item/clothing/suit/donator/bm/cerberus_suit/armored/inkvd
 		if(!IS_INTEQ(user))
 			to_chat(user, "<span class='danger'><B>СКАФАНДР МОДЕЛЬ ДВА</B>: Обнаружены неавторизованные сигнатуры. <B>Производится нейтрализация экипировки.</B></span>")
 			playsound(get_turf(src), 'sound/machines/nuke/confirm_beep.ogg', 65, 1, 1)
-			addtimer(CALLBACK(src, .proc/explode), 4 SECONDS)
+			addtimer(CALLBACK(src, .proc/explode), 3 SECONDS)
 
 /obj/item/clothing/suit/space/hardsuit/syndi/elite/inteq/proc/explode()
 	do_sparks(3, 1, src)
@@ -272,7 +272,7 @@ obj/item/clothing/suit/donator/bm/cerberus_suit/armored/inkvd
 		if(!IS_INTEQ(user))
 			to_chat(user, "<span class='danger'><B>СКАФАНДР МОДЕЛЬ ОДИН - ЩИТ</B>: Обнаружены неавторизованные сигнатуры. <B>Производится нейтрализация экипировки.</B></span>")
 			playsound(get_turf(src), 'sound/machines/nuke/confirm_beep.ogg', 65, 1, 1)
-			addtimer(CALLBACK(src, .proc/explode), 4 SECONDS)
+			addtimer(CALLBACK(src, .proc/explode), 3 SECONDS)
 
 /obj/item/clothing/suit/space/hardsuit/shielded/syndi/inteq/proc/explode()
 	do_sparks(3, 1, src)


### PR DESCRIPTION
- Элитный и щитовой хардсьюты проверяют носителя. В случае, если костюм наденет чужой - костюм этого не оценит.
- Обычный хардсьют первой модели (триторский) не затронут и остался как есть.