### PR TITLE
Новый квирк: Бесконтрольный вой

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -226,6 +226,7 @@
 #define TRAIT_KARTAVII			"kartavii"
 #define TRAIT_ASIAT				"asiatish"
 #define TRAIT_UKRAINE			"ukraine"
+#define TRAIT_AWOO				"autoawoo"
 #define TRAIT_FRIENDLY			"friendly"
 #define TRAIT_SNOB				"snob"
 #define TRAIT_MULTILINGUAL		"multilingual"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -267,3 +267,8 @@
 	description = "<span class='nicegreen'>В коробочке на удивление приятно</span>\n"
 	mood_change = 3
 	timeout = 2 MINUTES
+
+/datum/mood_event/to_awoo
+	description = "<span class='nicegreen'>Обожаю выть!</span>\n"
+	mood_change = 2
+	timeout = 2 MINUTES

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -184,6 +184,13 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 
 		S.falloff = isnull(max_distance)? FALLOFF_SOUNDS : max_distance //use max_distance, else just use 1 as we are a direct sound so falloff isnt relevant.
 
+		if(iscarbon(src))
+			if(HAS_TRAIT(src, TRAIT_AWOO))
+				if((S.file == 'modular_citadel/sound/voice/awoo.ogg' || S.file == 'modular_splurt/sound/voice/wolfhowl.ogg') && distance > 0)
+					var/mob/living/carbon/M = src
+					var/datum/quirk/awoo/quirk_target = locate() in M.roundstart_quirks
+					quirk_target.do_awoo()
+
 		/*
 		/// Tg reverb removed
 		if(S.environment == SOUND_ENVIRONMENT_NONE)

--- a/modular_bluemoon/code/datums/traits/neutral.dm
+++ b/modular_bluemoon/code/datums/traits/neutral.dm
@@ -1,0 +1,56 @@
+/datum/quirk/awoo
+	name = "Неконтролируемый вой"
+	desc = "Вам иногда нравиться завывать, есть ли на то причиниа или нет. Также вы не можете удержаться перед воем других."
+	value = 0
+	gain_text = "<span class='notice'>Иногда так хочется повыть...</span>"
+	lose_text = "<span class='notice'>Я больше не хочу выть.</span>"
+	mob_trait = TRAIT_AWOO
+	//var/timer	//можно через таймеры, но я бы предпочел псевдорандом
+	//var/timer_trigger = 1 MINUTES
+	var/last_awoo
+	var/default_chance = 0.1 //десятая часть процента
+	var/chance = 0.01
+	processing_quirk = TRUE
+	mood_quirk = TRUE
+
+/datum/quirk/awoo/add()
+	// Set timer
+	//timer = addtimer(CALLBACK(src, .proc/do_awoo), timer_trigger, TIMER_STOPPABLE)
+	last_awoo = world.time
+	chance = default_chance
+
+//datum/quirk/awoo/remove()
+	// Remove timer
+	//deltimer(timer)
+
+/datum/quirk/awoo/on_process()
+	if(prob(chance))
+		if((last_awoo + 5 SECONDS) > world.time)
+			return
+		// Check if conscious
+		if(quirk_holder.stat == CONSCIOUS)
+			// Display emote
+			quirk_holder.nextsoundemote = world.time - 10
+			addtimer(CALLBACK(quirk_holder, TYPE_PROC_REF(/mob, emote), pick("awoo", "howl")), rand(10,30))
+			chance = default_chance
+	if(chance < 100)
+		chance += 0.001
+
+/datum/quirk/awoo/proc/do_awoo()
+	if(quirk_holder)
+		if((last_awoo + 5 SECONDS) > world.time)
+			return
+		// Check if conscious
+		if(quirk_holder.stat == CONSCIOUS)
+			// Display emote
+			quirk_holder.nextsoundemote = world.time - 10
+			addtimer(CALLBACK(quirk_holder, TYPE_PROC_REF(/mob, emote), pick("awoo", "howl")), rand(10,30))
+			chance = default_chance
+			//timer_trigger = 1 MINUTES
+		//else
+			//timer_trigger = 5 MINUTES
+	// Remove timer
+	//deltimer(timer)
+	//timer = null
+	// Add new timer
+	//timer = addtimer(CALLBACK(src, .proc/do_awoo), timer_trigger, TIMER_STOPPABLE)

--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -139,7 +139,13 @@
 	if(user.nextsoundemote >= world.time)
 		return
 	user.nextsoundemote = world.time + 7
-	playsound(user, 'modular_citadel/sound/voice/awoo.ogg', 50, 1, -1)
+	playsound(user, 'modular_citadel/sound/voice/awoo.ogg', 100, 1, -1)
+	if (HAS_TRAIT(user, TRAIT_AWOO))
+		var/datum/quirk/awoo/quirk_target = locate() in user.roundstart_quirks
+		quirk_target.last_awoo = world.time
+		quirk_target.chance = quirk_target.default_chance
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "to_awoo", /datum/mood_event/to_awoo)
+
 
 /datum/emote/living/hiss
 	key = "hiss"

--- a/modular_splurt/code/modules/mob/living/emotes.dm
+++ b/modular_splurt/code/modules/mob/living/emotes.dm
@@ -809,6 +809,16 @@
 	message_mime = "acts out a howl!"
 	emote_sound = 'modular_splurt/sound/voice/wolfhowl.ogg'
 	emote_cooldown = 12.04 SECONDS
+	emote_volume = 100
+
+/datum/emote/living/audio/howl/run_emote(mob/user, params)
+	if (HAS_TRAIT(user, TRAIT_AWOO))
+		var/mob/living/carbon/M = user
+		var/datum/quirk/awoo/quirk_target = locate() in M.roundstart_quirks
+		quirk_target.last_awoo = world.time
+		quirk_target.chance = quirk_target.default_chance
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "to_awoo", /datum/mood_event/to_awoo)
+	. = ..()
 
 /datum/emote/living/audio/coyhowl
 	key = "coyhowl"

--- a/modular_splurt/code/modules/mob/living/silicon/emotes.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/emotes.dm
@@ -773,6 +773,16 @@
 	message_mime = "acts out a howl!"
 	emote_sound = 'modular_splurt/sound/voice/wolfhowl.ogg'
 	emote_cooldown = 12.04 SECONDS
+	emote_volume = 100
+
+/datum/emote/living/audio/howl/run_emote(mob/user, params)
+	if (HAS_TRAIT(user, TRAIT_AWOO))
+		var/mob/living/carbon/M = user
+		var/datum/quirk/awoo/quirk_target = locate() in M.roundstart_quirks
+		quirk_target.last_awoo = world.time
+		quirk_target.chance = quirk_target.default_chance
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "to_awoo", /datum/mood_event/to_awoo)
+	. = ..()
 
 /datum/emote/living/audio/coyhowl
 	key = "coyhowl"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2041,6 +2041,7 @@
 #include "code\modules\atmospherics\machinery\components\unary_devices\unary_devices.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\vent_pump.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\vent_scrubber.dm"
+#include "modular_bluemoon\code\datums\traits\neutral.dm"
 #include "code\modules\atmospherics\machinery\other\meter.dm"
 #include "code\modules\atmospherics\machinery\other\miner.dm"
 #include "code\modules\atmospherics\machinery\pipes\bluespace.dm"


### PR DESCRIPTION
Нейтральный квирк, обладатели которого изредка непроизвольно воют. Также если обладатель квирка услышал чужой вой, то он сам начнет выть. Также вой слегка поднимает мораль обладателям квирка. 
(Квирк вдохновлен дефолтной механикой вульп с парадиза, которые воют по цепочке, если хотя бы одна из них завыла, так что чем больше народу возмет данный квирк, тем эффектнее он будет выглядеть)