### PR TITLE
Фикс автовиляния хвостом

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -19,6 +19,7 @@
 	var/stat_allowed = CONSCIOUS
 	var/static/list/emote_list = list()
 	var/static/regex/stop_bad_mime = regex(@"says|exclaims|yells|asks")
+	var/ignore_cooldown = FALSE
 
 	var/chat_popup = TRUE //Skyrat edit
 	var/image_popup
@@ -41,7 +42,7 @@
 
 /datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)
 	. = TRUE
-	if(!can_run_emote(user, TRUE, intentional) || user.nextsoundemote >= world.time)
+	if(!can_run_emote(user, TRUE, intentional) || (user.nextsoundemote >= world.time && !ignore_cooldown))
 		return FALSE
 	var/msg = select_message_type(user)
 	if(params && message_param)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -88,6 +88,7 @@
 	key = "wag"
 	key_third_person = "wags"
 	message = "начинает вилять своим хвостом."
+	ignore_cooldown = TRUE
 
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params)
 	. = ..()
@@ -119,6 +120,7 @@
 	key = "wing"
 	key_third_person = "wings"
 	message = "хлопает своими крыльями."
+	ignore_cooldown = TRUE
 
 /datum/emote/living/carbon/human/wing/run_emote(mob/user, params)
 	. = ..()

--- a/modular_splurt/code/modules/mob/living/emotes.dm
+++ b/modular_splurt/code/modules/mob/living/emotes.dm
@@ -112,7 +112,7 @@
 		return FALSE
 
 	// Check cooldown
-	if(user?.nextsoundemote >= world.time)
+	if(user?.nextsoundemote >= world.time && !ignore_cooldown)
 		//to_chat(user, span_warning("Рано! Очень рано!!"))
 		//SEND_SOUND(user, 'sound/machines/buzz-sigh.ogg')
 		return FALSE

--- a/modular_splurt/code/modules/mob/living/silicon/emotes.dm
+++ b/modular_splurt/code/modules/mob/living/silicon/emotes.dm
@@ -112,7 +112,7 @@
 		return FALSE
 
 	// Check cooldown
-	if(user?.nextsoundemote >= world.time)
+	if(user?.nextsoundemote >= world.time && !ignore_cooldown)
 		//to_chat(user, span_warning("Рано! Очень рано!!"))
 		//SEND_SOUND(user, 'sound/machines/buzz-sigh.ogg')
 		return FALSE


### PR DESCRIPTION
Виляние хвостом это эмоут, и оно учитывало КД на эмоуты = ломало механику автовиляния. Теперь нет.

P.S.: Кодеры теперь точечно смогут ставить флаг игнора кд нужным им эмоутам.