### PR TITLE
Микропроверка

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -133,7 +133,7 @@
 
 /obj/machinery/computer/security/proc/update_active_camera_screen()
 	// Show static if can't use the camera
-	if(!active_camera?.can_use())
+	if(QDELETED(active_camera) || !active_camera?.can_use())
 		show_camera_static()
 		return
 

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -138,7 +138,7 @@
 
 /datum/computer_file/program/secureye/proc/update_active_camera_screen()
 	// Show static if can't use the camera
-	if(!active_camera?.can_use())
+	if(QDELETED(active_camera) || !active_camera?.can_use())
 		show_camera_static()
 		return
 


### PR DESCRIPTION
Незначительная проверка для камер. Она ничего не решает, но паранойя говорит "надо".