### PR TITLE
Фикс командной частоты для персонажей с нестандартным размером

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -230,6 +230,12 @@
 		return
 
 	if(use_command)
+		// BLUEMOON ADD START - чтобы работал большой текст у больших и маленький персонажей
+		if(spans & SPAN_BIG)
+			spans &= ~SPAN_BIG
+		if(spans & SPAN_SMALL)
+			spans &= ~SPAN_SMALL
+		// BLUEMOON ADD END
 		spans |= commandspan
 
 	/*

--- a/modular_bluemoon/bigtalk/bigtalk.dm
+++ b/modular_bluemoon/bigtalk/bigtalk.dm
@@ -16,4 +16,4 @@
 /datum/element/bigtalk/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
 
-	speech_args[SPEECH_SPANS] |= SPAN_BIG
+	speech_args[SPEECH_SPANS] |= SPAN_BIG // todo: не придумал фикс, чтобы в мегафоны был большой текст (этот спан его оверрайдит)


### PR DESCRIPTION
# About The Pull Request

У больших персонажей (и маленьких) есть SPAN_BIG или SPAN_SMALL при общении. Он ломал большой текст в радио-канал при попытке писать от лица большого персонажа, оставляя его обычным.

## Why It's Good For The Game