### PR TITLE
Множество исправлений возможности писать на частях тела

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -357,6 +357,23 @@
 		if(BODY_ZONE_R_LEG)
 			return list(LEG_RIGHT, FOOT_RIGHT)
 
+// BLUEMOON ADD START - Применяется, когда нужна специфичная часть тела
+/proc/zone2body_parts_covered_complicated(def_zone)
+	switch(def_zone)
+		if(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)
+			return HEAD
+		if(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN)
+			return CHEST
+		if(BODY_ZONE_L_ARM)
+			return ARM_LEFT
+		if(BODY_ZONE_R_ARM)
+			return ARM_RIGHT
+		if(BODY_ZONE_L_LEG)
+			return LEG_LEFT
+		if(BODY_ZONE_R_LEG)
+			return LEG_RIGHT
+// BLUEMOON ADD END
+
 //Turns a Body_parts_covered bitfield into a list of organ/limb names.
 //(I challenge you to find a use for this) -I found a use for it!!
 /proc/body_parts_covered2organ_names(bpc)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -104,7 +104,7 @@
 		var/obj/item/bodypart/affected = H.get_bodypart(target_limb)
 
 		if(try_to_clean_genitals)
-			if(BODY_ZONE_PRECISE_GROIN) // механически, моется не таз, а грудь
+			if(user.zone_selected == BODY_ZONE_PRECISE_GROIN) // механически, моется не таз, а грудь
 				H.visible_message(span_lewd("[user] begins to wash [target]'s groin with [name], as well as taking in account their genitals there."), span_lewd("[user] is starting to wash your groin with [name]... And your genitals their."))
 			else
 				H.visible_message(span_lewd("[user] begins to wash [target]'s [affected] with [name], as well as taking in account their private parts."), span_lewd("[user] is starting to wash your [affected] with [name]... And your private parts."))

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -31,6 +31,12 @@
 	. = ..()
 	AddComponent(/datum/component/slippery, 80)
 
+// BLUEMOON ADD START - дополнительное описание
+/obj/item/soap/examine(user, distance)
+	. = ..()
+	. += span_info("Мылом можно в том числе убирать надписи с частей тела, оставленные ручкой.") // рассказываем о механиках через описания
+// BLUEMOON ADD END
+
 /obj/item/soap/nanotrasen
 	desc = "A Nanotrasen brand bar of soap. Smells of plasma."
 	icon_state = "soapnt"
@@ -61,7 +67,6 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target // BLUEMOON EDIT
 
-		// Проверка, не закрыта ли часть тела
 		var/target_limb
 
 		target_limb = zone2body_parts_covered_complicated(user.zone_selected)
@@ -79,6 +84,7 @@
 				to_chat(user, span_warning("The target body part is covered with their clothes."))
 				return
 
+		var/try_to_clean_genitals = FALSE
 		switch(user.zone_selected)
 			if(BODY_ZONE_PRECISE_MOUTH)
 				H.visible_message("<span class='warning'>\the [user] begins to wash out \the [target]'s mouth with [src.name]!</span>", "<span class='danger'>[user] is starting to wash out your mouth with [src.name]! IT'S AWFUL!</span>") //washes mouth out with soap sounds better than 'the soap' here
@@ -89,22 +95,36 @@
 					return
 			if(BODY_ZONE_PRECISE_EYES)
 				target_limb = BODY_ZONE_HEAD
-			if(BODY_ZONE_PRECISE_GROIN) // технически, у моба нет органа таза на момент написания
+			if(BODY_ZONE_PRECISE_GROIN, BODY_ZONE_CHEST) // технически, у моба нет органа таза на момент написания
 				target_limb = BODY_ZONE_CHEST
+				try_to_clean_genitals = TRUE
 			else
 				target_limb = user.zone_selected
 
 		var/obj/item/bodypart/affected = H.get_bodypart(target_limb)
 
-		H.visible_message(span_notice("[user] begins to wash [target]'s [affected] with [name]!"), span_notice("[user] is starting to wash your [affected] with [name]!"))
+		if(try_to_clean_genitals)
+			if(BODY_ZONE_PRECISE_GROIN) // механически, моется не таз, а грудь
+				H.visible_message(span_lewd("[user] begins to wash [target]'s groin with [name], as well as taking in account their genitals there."), span_lewd("[user] is starting to wash your groin with [name]... And your genitals their."))
+			else
+				H.visible_message(span_lewd("[user] begins to wash [target]'s [affected] with [name], as well as taking in account their private parts."), span_lewd("[user] is starting to wash your [affected] with [name]... And your private parts."))
+		else
+			H.visible_message(span_notice("[user] begins to wash [target]'s [affected] with [name]!"), span_notice("[user] is starting to wash your [affected] with [name]!"))
+
 		if(do_after(user, 4 SECONDS, target = H))
-			H.visible_message(span_notice("[user] washed up [target]'s [affected]!"), span_notice("[user] washed up your [affected]!"))
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			target.clean_blood()
 			SEND_SIGNAL(target, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 			target.wash_cream()
 			target.wash_cum()
 			affected.writtentext = ""
+			if(try_to_clean_genitals)
+				for(var/obj/item/organ/genital/G in H.internal_organs)
+					if(G.writtentext && G.is_exposed() && G.zone == user.zone_selected)
+						G.writtentext = ""
+				H.visible_message(span_lewd("[user] washed up [target]'s [affected]!... As well as personal belongings there."), span_lewd("[user] washed up your [affected], as well as your personal belongings there."))
+			else
+				H.visible_message(span_notice("[user] washed up [target]'s [affected]!"), span_notice("[user] washed up your [affected]!"))
 // BLUEMOON ADD END
 
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)

--- a/code/modules/arousal/organs/breasts.dm
+++ b/code/modules/arousal/organs/breasts.dm
@@ -3,6 +3,9 @@
 
 /obj/item/organ/genital/breasts
 	name = "Грудь"
+	ru_name = "грудь" // BLUEMOON ADD
+	ru_name_v = "груди" // BLUEMOON ADD
+	ru_name_capital = "Грудь" // BLUEMOON ADD
 	desc = "Female milk producing organs."
 	icon_state = "breasts"
 	icon = 'icons/obj/genitals/breasts.dmi'

--- a/code/modules/arousal/organs/butt.dm
+++ b/code/modules/arousal/organs/butt.dm
@@ -1,5 +1,8 @@
 /obj/item/organ/genital/butt
 	name 					= "Попа"
+	ru_name				 	= "попа" // BLUEMOON ADD
+	ru_name_v 				= "попе" // BLUEMOON ADD
+	ru_name_capital 		= "Попа" // BLUEMOON ADD
 	desc 					= "You see a pair of asscheeks."
 	icon_state 				= "butt"
 	icon 					= 'icons/obj/genitals/butt.dmi'

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -1,5 +1,8 @@
 /obj/item/organ/genital/penis
-	name = "Член"
+	name = "член"
+	ru_name = "член" // BLUEMOON ADD
+	ru_name_v = "члене" // BLUEMOON ADD
+	ru_name_capital = "Член" // BLUEMOON ADD
 	desc = "A male reproductive organ."
 	icon_state = "penis"
 	icon = 'icons/obj/genitals/penis.dmi'

--- a/code/modules/arousal/organs/testicles.dm
+++ b/code/modules/arousal/organs/testicles.dm
@@ -1,5 +1,8 @@
 /obj/item/organ/genital/testicles
 	name = "яйца"
+	ru_name = "яйца" // BLUEMOON ADD
+	ru_name_v = "яйцах" // BLUEMOON ADD
+	ru_name_capital = "Яйца" // BLUEMOON ADD
 	desc = "A male reproductive organ."
 	icon_state = "testicles"
 	icon = 'icons/obj/genitals/testicles.dmi'

--- a/code/modules/arousal/organs/vagina.dm
+++ b/code/modules/arousal/organs/vagina.dm
@@ -1,5 +1,8 @@
 /obj/item/organ/genital/vagina
 	name = "вагина"
+	ru_name = "вагина" // BLUEMOON ADD
+	ru_name_v = "вагине" // BLUEMOON ADD
+	ru_name_capital = "Вагина" // BLUEMOON ADD
 	desc = "A female reproductive organ."
 	icon = 'icons/obj/genitals/vagina.dmi'
 	icon_state = ORGAN_SLOT_VAGINA

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -227,19 +227,7 @@
 
 			// BLUEMOON ADD START - отображение написанного на части тела только в случае, если она видима
 			var/covered_area
-			switch(BP.body_zone)
-				if(BODY_ZONE_HEAD)
-					covered_area = HEAD
-				if(BODY_ZONE_CHEST)
-					covered_area = CHEST
-				if(BODY_ZONE_L_ARM)
-					covered_area = ARM_LEFT
-				if(BODY_ZONE_R_ARM)
-					covered_area = ARM_RIGHT
-				if(BODY_ZONE_L_LEG)
-					covered_area = LEG_LEFT
-				if(BODY_ZONE_R_LEG)
-					covered_area = LEG_RIGHT
+			covered_area = zone2body_parts_covered_complicated(BP.body_zone)
 
 			if(!covered_area) // если в будущем введутся новые органы, чтобы этот момент не забыли
 				to_chat(user, span_danger("DEV: При осмотре обнаружен неизвестный орган, сообщите разработчикам!"))
@@ -453,7 +441,7 @@
 		// BLUEMOON ADD START - отображение надписей на теле, если они видимы и есть
 		if(show_written_on_bodypart_text != "")
 			msg += show_written_on_bodypart_text
-		if(user.client?.cit_toggles & GENITAL_EXAMINE)
+		if(user.client?.prefs.cit_toggles & GENITAL_EXAMINE)
 		// BLUEMOON ADD END
 			for(var/obj/item/organ/genital/G in internal_organs)
 				if(length(G.writtentext) && istype(G) && G.is_exposed())

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -40,6 +40,12 @@
 		use_bold = FALSE,
 	)
 
+// BLUEMOON ADD START - дополнительное описание
+/obj/item/pen/examine(user, distance)
+	. = ..()
+	. += span_info("Ручкой можно оставлять надписи на частях тела.") // рассказываем о механиках через описания
+// BLUEMOON ADD END
+
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is scribbling numbers all over себя with [src]! It looks like [user.ru_who()] trying to commit sudoku...</span>")
 	return(BRUTELOSS)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -31,6 +31,7 @@
 	var/useable = TRUE
 	var/list/food_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	var/ru_name = ""
+	var/ru_name_v = ""
 	var/ru_name_capital = ""
 
 /obj/item/organ/Initialize(mapload)

--- a/modular_splurt/code/game/objects/structures/watercloset.dm
+++ b/modular_splurt/code/game/objects/structures/watercloset.dm
@@ -1,6 +1,7 @@
 /obj/machinery/shower/wash_mob(mob/living/L)
 	. = ..()
 	L.wash_cum()
+	/* BLUEMOON REMOVAL START - смывание текста с частей тела теперь производится с помощью мыла
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		for(var/obj/item/bodypart/BP in H.bodyparts)
@@ -8,6 +9,7 @@
 		for(var/obj/item/organ/genital/G in H.internal_organs)
 			if(istype(G) && G.is_exposed())
 				G.writtentext = ""
+	/ BLUEMOON REMOVAL END */
 
 /obj/machinery/shower/wash_obj(obj/O)
 	. = ..()

--- a/modular_splurt/code/modules/paperwork/pen.dm
+++ b/modular_splurt/code/modules/paperwork/pen.dm
@@ -11,16 +11,55 @@
 				var/mob/living/carbon/human/T = M
 				if(!iscarbon(T)) //not carbon.
 					return
+
+				var/try_to_write_on_genitals = FALSE
+				var/target_body_part
+
+				switch(user.zone_selected)
+					if(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)
+						target_body_part = HEAD
+
+					if(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN)
+						target_body_part = CHEST
+						try_to_write_on_genitals = TRUE
+
+					if(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
+						target_body_part = ARMS
+
+					if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+						target_body_part = LEGS
+
+				if(!target_body_part)
+					to_chat(user, span_warning("You must choose a bodypart on your doll to write on!"))
+					return
+
+				var/list/items_on_target = list()
+				items_on_target = T.get_equipped_items()
+
+				for(var/A in items_on_target)
+					var/obj/item/worn_clothes = A
+					if(worn_clothes.body_parts_covered & target_body_part)
+						to_chat(user, span_warning("The target body part is covered with their clothes."))
+						return
+
+				var/obj/item/G
+				if(try_to_write_on_genitals && T.exposed_genitals.len)
+					G = user:pick_receiving_organ(T, NONE, "Pick a genital to write on", "PRESS CANCEL to write on the targeted body part")
+
+				/* BLUEMOON REMOVAL START - сверху более умная реализация по отдельным частям тела
 				if(!T.is_chest_exposed())
 					to_chat(user, "<span class='warning'>You cannot write on someone with their clothes on.</span>")
 					return
+				/ BLUEMOON REMOVAL END */
 
-				var/obj/item/G = user:pick_receiving_organ(T, NONE, "Pick a genital to write on", "Cancel to write on the targeted body part")
+				var/obj/item/BP  = (G ? G : T.get_bodypart(user.zone_selected))
 
+				/* BLUEMOON ADD START - перемещаем код выше
 				var/obj/item/BP = (G ? G : T.get_bodypart(user.zone_selected))
 
 				if(!BP)
 					return
+				/ BLUEMOON ADD END */
 
 				var/writting = input(user, "Add writing, doesn't replace current text", "Writing on [T]")  as text|null
 				if(!writting)

--- a/modular_splurt/code/modules/paperwork/pen.dm
+++ b/modular_splurt/code/modules/paperwork/pen.dm
@@ -12,6 +12,7 @@
 				if(!iscarbon(T)) //not carbon.
 					return
 
+				// BLUEMOON EDIT START - возможность писать на отдельных частях тела
 				var/try_to_write_on_genitals = FALSE
 				var/target_body_part
 
@@ -45,6 +46,7 @@
 				var/obj/item/G
 				if(try_to_write_on_genitals && T.exposed_genitals.len)
 					G = user:pick_receiving_organ(T, NONE, "Pick a genital to write on", "PRESS CANCEL to write on the targeted body part")
+				// BLUEMOON ADD END
 
 				/* BLUEMOON REMOVAL START - сверху более умная реализация по отдельным частям тела
 				if(!T.is_chest_exposed())

--- a/modular_splurt/code/modules/paperwork/pen.dm
+++ b/modular_splurt/code/modules/paperwork/pen.dm
@@ -16,19 +16,7 @@
 				var/try_to_write_on_genitals = FALSE
 				var/target_body_part
 
-				switch(user.zone_selected)
-					if(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)
-						target_body_part = HEAD
-
-					if(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN)
-						target_body_part = CHEST
-						try_to_write_on_genitals = TRUE
-
-					if(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
-						target_body_part = ARMS
-
-					if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-						target_body_part = LEGS
+				target_body_part = zone2body_parts_covered_complicated(user.zone_selected)
 
 				if(!target_body_part)
 					to_chat(user, span_warning("You must choose a bodypart on your doll to write on!"))


### PR DESCRIPTION
# About The Pull Request

Исправлено множество косяков в коде.

1. Теперь, надписи на теле с отдельных конечностей отображаются только, если видны эти самые конечности, а не при условии, что на цели открыта грудь.

2. Нет больше "На его chest написано: [...]". Корректно переведено.

3. Можно писать на отдельных конечностях, а не только когда открыта грудь.

4. Надписи на теле можно убирать с помощью мыла.

5. В описание мыла и ручки добавлены нужные примечания, что можно делать этими предметами.