### PR TITLE
Если лампочка смотрит вниз - то она находится "под" персонажем.

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -311,6 +311,7 @@
 	. = ..()
 	if(start_with_cell && !no_emergency)
 		cell = new/obj/item/stock_parts/cell/emergency_light(src)
+	set_layer_by_dir() // BLUEMOON ADD START
 	spawn(2)
 		switch(fitting)
 			if("tube")
@@ -330,6 +331,12 @@
 		on = FALSE
 	QDEL_NULL(cell)
 	return ..()
+
+// BLUEMOON ADD START - если лампа смотрит вниз, то она находится "под" мобом, чтобы можно было корректно её загораживать своим спрайтом
+/obj/machinery/light/proc/set_layer_by_dir()
+	if(dir == NORTH)
+		layer = MOB_LOWER_LAYER
+// BLUEMOON ADD END
 
 /obj/machinery/light/update_icon_state()
 	switch(status)		// set icon_states
@@ -891,6 +898,11 @@
 	layer = 2.5
 	light_type = /obj/item/light/bulb
 	fitting = "floor" //making deconstruction give out the right type.
+
+// BLUEMOON ADD START - если лампа смотрит вниз, то она находится "под" мобом, чтобы можно было корректно её загораживать своим спрайтом
+/obj/machinery/light/floor/set_layer_by_dir()
+	return TRUE
+// BLUEMOON ADD END
 
 // attempts to set emergency lights
 /obj/machinery/light/proc/set_emergency_lights()


### PR DESCRIPTION
# About The Pull Request

Если лампочка смотрит "вниз", то она отображается позади персонажа.
![dreamseeker_i7cPQ3clw9](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/78963858/9fc0ada3-2053-4fdd-974f-2a3ab487f395)
![dreamseeker_a9hB7osD7u](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/78963858/30fec116-ec2b-4ac9-a2f3-766524fc5abc)
![dreamseeker_aBtmkPFLoo](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/78963858/b31d14d9-bc6d-46ae-bc21-0b03eaa85db8)
![dreamseeker_t04b0Y9hzc](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/78963858/7b74b948-9e78-4ca1-a585-b71f96b96ba4)



## Why It's Good For The Game

[Тема](https://discord.com/channels/875735187449847830/1162339181159252018/1162339181159252018)

## A Port?

<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
wip: still being worked on
experiment: experimental
tgs: has something to do with tgs
expansion: expands on something
qol: quality of life content
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
