### PR TITLE
ID карты в ошейниках и улучшение кошельков

### DIFF
--- a/code/_rendering/atom_huds/data_huds.dm
+++ b/code/_rendering/atom_huds/data_huds.dm
@@ -246,6 +246,8 @@
 	holder.icon_state = "hudno_id"
 	if(wear_id?.GetID())
 		holder.icon_state = "hud[ckey(wear_id.get_job_name())]"
+	else if(wear_neck?.GetID())
+		holder.icon_state = "hud[ckey(wear_neck.get_job_name())]"
 	sec_hud_set_security_status()
 
 /mob/living/proc/sec_hud_set_implants()

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -26,14 +26,16 @@
 	. = ..()
 	can_hold = typecacheof(list(
 	/obj/item/reagent_containers/food/snacks/cookie,
-	/obj/item/reagent_containers/food/snacks/sugarcookie))
+	/obj/item/reagent_containers/food/snacks/sugarcookie,
+	/obj/item/card))
 
 /datum/component/storage/concrete/pockets/small/collar/locked/Initialize()
 	. = ..()
 	can_hold = typecacheof(list(
 	/obj/item/reagent_containers/food/snacks/cookie,
 	/obj/item/reagent_containers/food/snacks/sugarcookie,
-	/obj/item/key/collar))
+	/obj/item/key/collar,
+	/obj/item/card))
 
 /datum/component/storage/concrete/pockets/tiny
 	max_items = 1

--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -184,6 +184,8 @@
 		H.set_species(/datum/species/human)
 		H.real_name = H.client.prefs.custom_names["human"]
 		var/obj/item/card/id/ID = H.wear_id?.GetID()
+		if(!ID)
+			ID = H.wear_neck?.GetID()
 		if(ID)
 			ID.registered_name = H.real_name
 			ID.update_label()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -158,6 +158,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					continue
 
 				I = H.wear_id ? H.wear_id.GetID() : null
+				if(!I)
+					I = H.wear_neck ? H.wear_neck.GetID() : null
 
 				if (I)
 					name = I.registered_name

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -565,7 +565,7 @@ DEFINE_BITFIELD(turret_flags, list(
 			return 10
 
 	if(turret_flags & TURRET_FLAG_AUTH_WEAPONS)	//check for weapon authorization
-		if(isnull(perp.wear_id) || istype(perp.wear_id.GetID(), /obj/item/card/id/syndicate))
+		if((isnull(perp.wear_id) || istype(perp.wear_id.GetID(), /obj/item/card/id/syndicate)) && (isnull(perp.wear_neck.GetID()) || istype(perp.wear_neck.GetID(), /obj/item/card/id/syndicate)))
 
 			if(allowed(perp)) //if the perp has security access, return 0
 				return 0

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -141,6 +141,8 @@
 		var/crewmember_name = "Unknown"
 		if(H.wear_id)
 			var/obj/item/card/id/I = H.wear_id.GetID()
+			if(!I)
+				I = H.wear_neck.GetID()
 			if(I && I.registered_name)
 				crewmember_name = I.registered_name
 

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -51,6 +51,12 @@
 		/obj/item/gun/ballistic/derringer,
 		/obj/item/genital_equipment/condom))
 
+/obj/item/storage/wallet/get_examine_string(mob/user, thats)
+	. = ..()
+	if(front_id)
+		//. += " with [icon2html(front_id.get_cached_flat_icon(), user)] \a [front_id] on the front."
+		. += " with \a [front_id.get_examine_string(user)] on the front"
+
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()
 	refreshID()
@@ -64,6 +70,10 @@
 			front_id = I
 		LAZYINITLIST(combined_access)
 		combined_access |= I.access
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(H.wear_id == src)
+			H.sec_hud_set_ID()
 	update_icon()
 
 /obj/item/storage/wallet/Entered(atom/movable/AM)

--- a/code/modules/antagonists/bloodsucker/bloodsucker_objectives.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_objectives.dm
@@ -157,6 +157,8 @@
 		else if (V.owner.current && ishuman(V.owner.current))
 			var/mob/living/carbon/human/H = V.owner.current
 			var/obj/item/card/id/I =  H.wear_id ? H.wear_id.GetID() : null
+			if(!I)
+				I =  H.wear_neck ? H.wear_neck.GetID() : null
 			var/assign = GetJobName(I.assignment)
 			if (I && (assign in valid_jobs) && !(assign in counted_roles))
 				//to_chat(owner, "<span class='userdanger'>PROTEGE OBJECTIVE: (GET ID)</span>")

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -174,11 +174,17 @@
 	var/poly_colors = list("#00BBBB")
 	var/tagname = null
 	var/treat_path = /obj/item/reagent_containers/food/snacks/cookie
+	var/obj/item/card/id/access_id = null
+	var/list/collar_access
 
 /obj/item/clothing/neck/petcollar/Initialize(mapload)
 	. = ..()
 	if(treat_path)
 		new treat_path(src)
+
+/obj/item/clothing/neck/petcollar/Destroy()
+	QDEL_NULL(access_id)
+	return ..()
 
 /obj/item/clothing/neck/petcollar/ComponentInitialize()
 	. = ..()
@@ -186,9 +192,39 @@
 		return
 	AddElement(/datum/element/polychromic, poly_colors, poly_states)
 
+/obj/item/clothing/neck/petcollar/get_examine_string(mob/user, thats)
+	. = ..()
+	if(access_id)
+		//. += " with [icon2html(access_id.get_cached_flat_icon(), user)] \a [access_id] clipped onto it."
+		. += " with \a [access_id.get_examine_string(user)] clipped onto it"
+
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
 	tagname = stripped_input(user, "Would you like to change the name on the tag?", "Name your new pet", "Spot", MAX_NAME_LEN)
 	name = "[initial(name)] - [tagname]"
+
+/obj/item/clothing/neck/petcollar/Entered(atom/movable/AM)
+	. = ..()
+	if(istype(AM, /obj/item/card/id))
+		access_id = AM
+		refreshID()
+
+/obj/item/clothing/neck/petcollar/Exited(atom/movable/AM)
+	. = ..()
+	if(istype(AM, /obj/item/card/id))
+		access_id = null
+		refreshID()
+
+/obj/item/clothing/neck/petcollar/proc/refreshID()
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(H.wear_neck == src)
+			H.sec_hud_set_ID()
+
+/obj/item/clothing/neck/petcollar/GetAccess()
+	return access_id ? access_id.GetAccess() : ..()
+
+/obj/item/clothing/neck/petcollar/GetID()
+	return access_id ? access_id : ..()
 
 /obj/item/clothing/neck/petcollar/ribbon
 	name = "ribbon pet collar"

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -13,7 +13,7 @@
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_held_item()) || src.check_access(H.wear_id))
+		if(check_access(H.get_active_held_item()) || src.check_access(H.wear_id) || src.check_access(H.wear_neck))
 			return TRUE
 	else if(ismonkey(M) || isalienadult(M))
 		var/mob/living/carbon/george = M

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -211,8 +211,13 @@
 						var/allowed_access = null
 						var/obj/item/clothing/glasses/G = H.glasses
 						if (!(G.obj_flags & EMAGGED))
+							var/list/access = list()
 							if(H.wear_id)
-								var/list/access = H.wear_id.GetAccess()
+								access += H.wear_id.GetAccess()
+								if(ACCESS_SEC_DOORS in access)
+									allowed_access = H.get_authentification_name()
+							if(H.wear_neck)
+								access += H.wear_neck.GetAccess()
 								if(ACCESS_SEC_DOORS in access)
 									allowed_access = H.get_authentification_name()
 						else

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -67,6 +67,7 @@
 	var/obj/item/pda/pda = wear_id
 	var/obj/item/card/id/id = wear_id
 	var/obj/item/modular_computer/tablet/tablet = wear_id
+	var/obj/item/clothing/neck/petcollar/petcollar = wear_neck
 	if(istype(wallet))
 		id = wallet.front_id
 	if(istype(id))
@@ -77,6 +78,8 @@
 		var/obj/item/computer_hardware/card_slot/card_slot = tablet.all_components[MC_CARD]
 		if(card_slot?.stored_card)
 			. = card_slot.stored_card.registered_name
+	if(istype(petcollar))
+		id = petcollar.access_id
 	if(!.)
 		. = if_no_id	//to prevent null-names making the mob unclickable
 	return
@@ -90,6 +93,8 @@
 	var/obj/item/card/id/id_card = wear_id?.GetID()
 	if(!id_card)
 		id_card = belt?.GetID()
+	if(!id_card)
+		id_card = wear_neck?.GetID()
 	return id_card || .
 
 /mob/living/carbon/human/IsAdvancedToolUser()
@@ -102,7 +107,7 @@
 	// if it returns 0, it will run the usual on_mob_life for that reagent. otherwise, it will stop after running handle_chemicals for the species.
 
 /mob/living/carbon/human/can_track(mob/living/user)
-	if(wear_id && istype(wear_id.GetID(), /obj/item/card/id/syndicate))
+	if(wear_id && (istype(wear_id.GetID(), /obj/item/card/id/syndicate) || istype(wear_neck.GetID(), /obj/item/card/id/syndicate)))
 		return 0
 	if(istype(head, /obj/item/clothing/head))
 		var/obj/item/clothing/head/hat = head

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -126,6 +126,10 @@
 			wear_id = I
 			sec_hud_set_ID()
 			update_inv_wear_id()
+		if(ITEM_SLOT_NECK)
+			wear_neck = I
+			sec_hud_set_ID()
+			update_inv_neck()
 		// Sandstorm edit
 		if(ITEM_SLOT_EARS_LEFT)
 			ears = I
@@ -316,6 +320,11 @@
 		sec_hud_set_ID()
 		if(!QDELETED(src))
 			update_inv_wear_id()
+	else if(I == wear_neck)
+		wear_neck = null
+		sec_hud_set_ID()
+		if(!QDELETED(src))
+			update_inv_neck()
 	else if(I == r_store)
 		r_store = null
 		if(!QDELETED(src))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -15,6 +15,8 @@
 		var/obj/item/clothing/mask/chameleon/V = wear_mask
 		if(V.voice_change && wear_id)
 			var/obj/item/card/id/idcard = wear_id.GetID()
+			if(!idcard)
+				idcard = wear_neck.GetID()
 			if(istype(idcard))
 				return idcard.registered_name
 			else

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -79,8 +79,11 @@
 			head = I
 			head_update(I)
 		if(ITEM_SLOT_NECK)
-			wear_neck = I
-			update_inv_neck(I)
+			if(ishuman(src))
+				not_handled = TRUE
+			else
+				wear_neck = I
+				update_inv_neck(I)
 		if(ITEM_SLOT_HANDCUFFED)
 			handcuffed = I
 			update_handcuffed()
@@ -122,6 +125,8 @@
 		if(!QDELETED(src))
 			wear_mask_update(I, toggle_off = 1)
 	if(I == wear_neck)
+		if(ishuman(src))
+			return TRUE
 		wear_neck = null
 		if(!QDELETED(src))
 			update_inv_neck(I)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -560,7 +560,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_held_item()) || check_access(H.wear_id))
+		if(check_access(H.get_active_held_item()) || check_access(H.wear_id) || check_access(H.wear_neck))
 			return TRUE
 	else if(ismonkey(M))
 		var/mob/living/carbon/monkey/george = M

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -231,6 +231,8 @@
 		var/crewmember_name = "Unknown"
 		if(humanoid.wear_id)
 			var/obj/item/card/id/ID = humanoid.wear_id.GetID()
+			if(!ID)
+				ID = humanoid.wear_neck.GetID()
 			if(ID?.registered_name)
 				crewmember_name = ID.registered_name
 		var/list/crewinfo = list(

--- a/code/modules/newscaster/newscaster_machine.dm
+++ b/code/modules/newscaster/newscaster_machine.dm
@@ -655,6 +655,9 @@ GLOBAL_LIST_EMPTY(allCasters)
 				scanned_user ="[ID.registered_name] ([ID.assignment])"
 			else
 				scanned_user ="Unknown"
+		else if(human_user.wear_neck.GetID())
+			var/obj/item/card/id/ID = human_user.wear_neck.GetID()
+			scanned_user ="[ID.registered_name] ([ID.assignment])"
 		else
 			scanned_user ="Unknown"
 	else if(issilicon(user))

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -215,6 +215,7 @@
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
 		potential_items += H.wear_id
+		potential_items += H.wear_neck
 	else if(isanimal(host_mob))
 		potential_items += host_mob.pulling
 		var/mob/living/simple_animal/A = host_mob

--- a/modular_bluemoon/SmiLeY/venicle/spacepods/spacepod.dm
+++ b/modular_bluemoon/SmiLeY/venicle/spacepods/spacepod.dm
@@ -621,7 +621,7 @@
 
 	for(var/obj/machinery/door/poddoor/multi_tile/P in orange(3,src))
 		for(var/mob/living/carbon/human/O in contents)
-			if(P.check_access(O.get_active_held_item()) || P.check_access(O.wear_id))
+			if(P.check_access(O.get_active_held_item()) || P.check_access(O.wear_id) || P.check_access(O.wear_neck))
 				if(P.density)
 					P.open()
 					return TRUE

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -197,6 +197,7 @@
 	var/mob/living/carbon/human/human_micro = held_mob
 	if(istype(human_micro))
 		. += human_micro.wear_id?.GetAccess()
+		. += human_micro.wear_neck?.GetAccess()
 
 /obj/item/clothing/head/mob_holder/micro/GetID()
 	. = ..()

--- a/modular_splurt/code/datums/components/storage/concrete/pockets.dm
+++ b/modular_splurt/code/datums/components/storage/concrete/pockets.dm
@@ -3,4 +3,5 @@
 	can_hold = typecacheof(list(
 	/obj/item/reagent_containers/food/snacks/cookie,
 	/obj/item/reagent_containers/food/snacks/sugarcookie,
-	/obj/item/mind_controller))
+	/obj/item/mind_controller,
+	/obj/item/card))


### PR DESCRIPTION
- ID карты теперь можно полноценно носить в ошейниках/чокерах/etc (кроме особых ошейников по типу работоргевцев).
- При осмотре персонажа с ID картой в кошельке будет выводиться информация на карте (с ошейниками тоже самое).
- Фикс проблемы смены СБ худов с картой в кошельке.