### PR TITLE
Боевой индикатор всем living мобам, а также замедление от модулей expand и shrink для киборгов

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -44,7 +44,7 @@
 	. = ..()
 	if(!CONFIG_GET(flag/disable_human_mood))
 		AddComponent(/datum/component/mood)
-	AddComponent(/datum/component/combat_mode)
+/*	AddComponent(/datum/component/combat_mode) / BLUEMOON REMOVAL - боевые индикаторы присваиваются всем мобам в другом файле */
 	AddElement(/datum/element/flavor_text/carbon/temporary, "", "Set Pose (Temporary Flavor Text)", "This should be used only for things pertaining to the current round!", _save_key = null)
 	AddElement(/datum/element/strippable, GLOB.strippable_human_items, /mob/living/carbon/human/.proc/should_strip)
 

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -87,13 +87,14 @@
 /datum/movespeed_modifier/human_carry
 	variable = TRUE
 
+// BLUEMOON ADD START - замедление для увеличившихся и уменьшившихся роботов
 /datum/movespeed_modifier/changed_robot_size
 	multiplicative_slowdown = 1
 	variable = TRUE
 
 /datum/movespeed_modifier/changed_robot_size/shrink
 	multiplicative_slowdown = 2
-
+// BLUEMOON ADD END
 /datum/movespeed_modifier/limbless
 	variable = TRUE
 	movetypes = GROUND

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -87,6 +87,13 @@
 /datum/movespeed_modifier/human_carry
 	variable = TRUE
 
+/datum/movespeed_modifier/changed_robot_size
+	multiplicative_slowdown = 1
+	variable = TRUE
+
+/datum/movespeed_modifier/changed_robot_size/shrink
+	multiplicative_slowdown = 2
+
 /datum/movespeed_modifier/limbless
 	variable = TRUE
 	movetypes = GROUND

--- a/modular_sand/code/game/objects/items/robot/robot_upgrades.dm
+++ b/modular_sand/code/game/objects/items/robot/robot_upgrades.dm
@@ -167,12 +167,14 @@
 		R.update_transform()
 		//R.update_size(ExpandSize/100)
 		R.hasExpanded = TRUE
+		R.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/changed_robot_size) // BLUEMOON ADD
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (. && R.hasExpanded)
 		R.transform = null
 		R.hasExpanded = FALSE
+		R.remove_movespeed_modifier(/datum/movespeed_modifier/changed_robot_size) // BLUEMOON ADD
 
 /obj/item/borg/upgrade/shrink
 	name = "borg shrinker"
@@ -211,7 +213,8 @@
 		R.mob_transforming = FALSE
 		R.resize = ShrinkSize/100
 		R.update_transform()
-		R.add_movespeed_modifier(/datum/movespeed_modifier/reagent/freon)
+/*		R.add_movespeed_modifier(/datum/movespeed_modifier/reagent/freon) / BLUEMOON REMOVAL - увеличиваем степень замедления роботов, уменьшенных или увеличенных в размере */
+		R.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/changed_robot_size/shrink) // BLUEMOON ADD
 		//R.update_size(ShrinkSize/100)
 		R.hasShrunk = TRUE
 
@@ -220,7 +223,9 @@
 	if (. && R.hasShrunk)
 		R.transform = null
 		R.hasShrunk = FALSE
-		R.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/freon)
+/*		R.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/freon) / BLUEMOON REMOVAL - увеличиваем степень замедления роботов, уменьшенных или увеличенных в размере */
+		R.remove_movespeed_modifier(/datum/movespeed_modifier/changed_robot_size/shrink) // BLUEMOON ADD
+
 
 /obj/item/borg/upgrade/transform/syndicatejack
     name = "borg module picker (Syndicate)"

--- a/modular_splurt/code/modules/mob/living/living_signals.dm
+++ b/modular_splurt/code/modules/mob/living/living_signals.dm
@@ -1,3 +1,4 @@
 /mob/living/ComponentInitialize()
 	. = ..()
 	RegisterSignal(src, SIGNAL_TRAIT(TRAIT_FLOORED), .proc/update_mobility)
+	AddComponent(/datum/component/combat_mode)

--- a/modular_splurt/code/modules/mob/living/living_signals.dm
+++ b/modular_splurt/code/modules/mob/living/living_signals.dm
@@ -1,4 +1,4 @@
 /mob/living/ComponentInitialize()
 	. = ..()
 	RegisterSignal(src, SIGNAL_TRAIT(TRAIT_FLOORED), .proc/update_mobility)
-	AddComponent(/datum/component/combat_mode)
+	AddComponent(/datum/component/combat_mode) // BLUEMOON ADD - боевой индикатор для всех мобов


### PR DESCRIPTION
# About The Pull Request

1. У всех living мобов появился боевой индикатор. Теперь киборги его имеют в т.ч., что позволяет применять к ним соответствующие части правил.
2. Модули expand для киборгов теперь дают умеренное замедление. Замедление от модуля shrink слегка усилено. 