### PR TITLE
Переваривание мобов с хп меньше максимума в 100 занимает больше времени

### DIFF
--- a/code/modules/vore/eating/bellymodes.dm
+++ b/code/modules/vore/eating/bellymodes.dm
@@ -111,7 +111,12 @@
 
 				// Deal digestion damage (and feed the pred)
 				if(!(M.status_flags & GODMODE))
-					M.adjustFireLoss(digest_burn)
+					//BLUEMOON EDIT STARTS
+					var/damage_mod = 1
+					if(M.maxHealth < 100) //big guy перевариваются дольше
+						damage_mod = M.maxHealth * 0.01 //1 процент от максимума хп при хп меньше 100
+					M.adjustFireLoss(digest_burn * damage_mod)
+					//BLUEMOON EDIT ENDS
 					owner.adjust_nutrition(1)
 
 			//Contaminate or gurgle items


### PR DESCRIPTION
попросту пчела с размером 25 кидает в крит за 10 тиков, за это время даже эмоут не отписать нормально.
(так хоть будет как у обычного хумана 100 тиков перед неизбежным)
(хп больше 100 всё так-же долго перевариваются)