### PR TITLE
Портальные трусы: один ко многим.

### DIFF
--- a/modular_sand/code/game/objects/items/fleshlight.dm
+++ b/modular_sand/code/game/objects/items/fleshlight.dm
@@ -578,7 +578,7 @@
 
 /obj/item/portallight/Destroy()
 	if(portalunderwear)
-		portalunderwear.portallight = null
+		portalunderwear.portallight -= src
 		if(isliving(portalunderwear.loc))
 			portalunderwear.audible_message("[icon2html(portalunderwear, hearers(portalunderwear))] *beep* *beep* *beep*")
 			playsound(portalunderwear, 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
@@ -596,7 +596,7 @@
 	icon_state = "portalpanties"
 	item_state = "fleshlight"
 	w_class = WEIGHT_CLASS_SMALL
-	var/obj/item/portallight/portallight
+	var/list/portallight = list()
 	var/targetting = CUM_TARGET_VAGINA
 	equip_delay_self = 2 SECONDS
 	equip_delay_other = 5 SECONDS
@@ -627,24 +627,32 @@
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/examine(mob/user)
 	. = ..()
-	if(!portallight)
+	if(!portallight.len)
 		. += "<span class='notice'>Устройство не сопряжено, для сопряжения проведите фонариком по этой паре портальных трусиков (TM). </span>"
 	else
-		. += "<span class='notice'>Устройство сопряжено и ожидает использования по прямому назначению. </span>"
+		. += "<span class='notice'>Устройство сопряжено и ожидает использования по прямому назначению. Количество сопряженных устройств: [portallight.len].</span>"
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/attackby(obj/item/I, mob/living/user) //pairing
 	if(istype(I, /obj/item/portallight))
 		var/obj/item/portallight/P = I
-		if(!portallight && !P.portalunderwear) //make sure it aint linked to someone else
-			portallight = P //pair the fleshlight
+		if(!P.portalunderwear) //make sure it aint linked to someone else
+			portallight += P //pair the fleshlight
 			P.portalunderwear = src //pair the panties on the fleshlight.
 			P.icon_state = "paired" //we are paired!
 			playsound(src, 'sound/machines/ping.ogg', 50, FALSE)
 			to_chat(user, "<span class='notice'>[P] был успешно связан.</span>")
 			update_portal()
 			RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/drop_out)
+		else if(P in portallight)
+			portallight -= P
+			P.portalunderwear = null
+			P.updatesleeve()
+			P.icon_state = "unpaired"
+			to_chat(user, "<span class='notice'>[P] был успешно отвязан.</span>")
+			if(!portallight.len)
+				UnregisterSignal(user, COMSIG_PARENT_QDELETING)
 		else
-			to_chat(user, "<span class='notice'>Один из этих предметов уже находится в паре.</span>")
+			to_chat(user, "<span class='notice'>[P] уже находится в паре. Отвяжите его от предыдущего устройства.</span>")
 	else
 		..() //just allows people to hit it with other objects, if they so wished.
 
@@ -680,7 +688,7 @@
 	. = ..()
 	switch(slot)
 		if(ITEM_SLOT_UNDERWEAR, ITEM_SLOT_MASK)
-			if(!portallight)
+			if(!portallight.len)
 				audible_message("[icon2html(src, hearers(src))] *beep* *beep* *beep*")
 				playsound(src, 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 				to_chat(user, "<span class='notice'>Трусики не связаны с Портальным Фонариком.</span>")
@@ -697,11 +705,11 @@
 	update_portal()
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/Destroy()
-	if(portallight)
-		var/obj/item/portallight/temp = portallight
+	if(portallight.len)
 		moveToNullspace() // loc cannot be human so let's destroy ourselves out of anything
-		portallight.portalunderwear = null
-		temp.updatesleeve()
+		for(var/obj/item/portallight/temp in portallight)
+			temp.portalunderwear = null
+			temp.updatesleeve()
 	. = ..()
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/proc/drop_out()
@@ -715,13 +723,13 @@
 	update_portal()
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/proc/update_portal()
-	if(portallight)
-		var/obj/item/portallight/P = portallight
-		if(targetting == CUM_TARGET_PENIS)
-			P.icon = 'modular_sand/icons/obj/dildo.dmi'
-		else
-			P.icon = 'modular_sand/icons/obj/fleshlight.dmi'
-		P.updatesleeve()
+	if(portallight.len)
+		for(var/obj/item/portallight/P in portallight)
+			if(targetting == CUM_TARGET_PENIS)
+				P.icon = 'modular_sand/icons/obj/dildo.dmi'
+			else
+				P.icon = 'modular_sand/icons/obj/fleshlight.dmi'
+			P.updatesleeve()
 
 /obj/item/storage/box/portallight
 	name =  "Portal Fleshlight and Underwear"

--- a/modular_sand/code/modules/vending/kinkmate.dm
+++ b/modular_sand/code/modules/vending/kinkmate.dm
@@ -1,5 +1,7 @@
 /obj/machinery/vending/kink/Initialize(mapload)
 	products += list(/obj/item/clothing/under/costume/loincloth/sensor = 4,
 					/obj/item/fleshlight = 4,
-					/obj/item/storage/box/portallight = 4)
+					/obj/item/storage/box/portallight = 4,
+					/obj/item/portallight = 4,
+					/obj/item/clothing/underwear/briefs/panties/portalpanties = 4)
 	. = ..()


### PR DESCRIPTION
- По заявкам телезрителей была реализована возможность коннектить несколько портальных фонариков к одним портальным трусам. Хоть 10 штук сразу. 
- Теперь портальные фонарики можно "отвязывать" от трусов по аналогии с "привязыванием".
- В розовых автоматах можно купить портальные трусы и фонарики по отдельности.