### PR TITLE
Небольшое обновление для больших персонажей

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -15,6 +15,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	var/martyr_compatible = FALSE		//If the objective is compatible with martyr objective, i.e. if you can still do it while dead.
 	var/objective_name = "Objective"	//name used in printing this objective (Objective #1)
 	var/reward = 5
+	var/include_superheavy_character = TRUE // BLUEMOON ADD - некоторые задачи практически невыполнимы, если нужно что-то делать со сверхтяжёлыми персонажами
 
 /datum/objective/New(var/text)
 	GLOB.objectives += src // CITADEL EDIT FOR CRYOPODS
@@ -117,7 +118,10 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 	for(var/datum/mind/possible_target in get_crewmember_minds())
 		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target))
 			if(!(possible_target in blacklist))
-				possible_targets += possible_target
+				// BLUEMOON ADD START - если персонаж сверхтяжёлый и установлена настройка, что сверхтяжёлые персонажи не могут быть по заданию, персонажа не добавляет в пулл
+				if(!(!include_superheavy_character && HAS_TRAIT(possible_target.current, TRAIT_BLUEMOON_HEAVY_SUPER)))
+					possible_targets += possible_target
+				// BLUEMOON ADD END
 	if(try_target_late_joiners)
 		var/list/all_possible_targets = possible_targets.Copy()
 		for(var/I in all_possible_targets)
@@ -1305,6 +1309,7 @@ GLOBAL_LIST_EMPTY(possible_sabotages)
 														/area/ruin/,	//thank you station space ruins
 														/area/science/test_area/,
 														/area/shuttle/))
+	include_superheavy_character = FALSE // BLUEMOON ADD - todo, вернуть задания, но назначить за такого персонажа повышенную награду
 
 /datum/objective/contract/proc/generate_dropoff()	// Generate a random valid area on the station that the dropoff will happen.
 	var/found = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -147,15 +147,15 @@
 	if(moving_diagonally)//no mob swap during diagonal moves.
 		return TRUE
 
-	// BLUEMOON ADDITION AHEAD - нельзя поменяться местами со сверхтяжёлым персонажем
-	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER))
-		return TRUE
-	// BLUEMOON ADDITION END
-
 	//handle micro bumping on help intent
 	if(a_intent == INTENT_HELP)
 		if(handle_micro_bump_helping(M))
 			return TRUE
+
+	// BLUEMOON ADDITION AHEAD - нельзя поменяться местами со сверхтяжёлым персонажем
+	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER))
+		return TRUE
+	// BLUEMOON ADDITION END
 
 	if(!M.buckled && !M.has_buckled_mobs())
 		var/mob_swap = FALSE

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -107,6 +107,7 @@
 	icon_state = ""
 	slot_flags = ITEM_SLOT_FEET | ITEM_SLOT_HEAD | ITEM_SLOT_ID | ITEM_SLOT_BACK | ITEM_SLOT_NECK
 	w_class = null //handled by their size
+	body_parts_covered = FEET // BLUEMOON ADD - чтобы нельзя было брать более 1 персонажа в ноги, TODO - сделать возможность брать несколько маленьких
 
 /obj/item/clothing/head/mob_holder/micro/container_resist(mob/living/user)
 	if(user.incapacitated())


### PR DESCRIPTION
# Большие персонажи:
- Если они кого-то тащат, то не могут протащить их через других персонажей, если они недостаточно малы. ~~Гномы будут мешать гигантам утаскивать.~~
- Захват больше не разрывается, если большой персонаж на кого-то наступает или перешагивает.
- Больше нельзя брать в ноги больше 1 персонажа. Связано как с ограничениями параметра (он не расчитан на +1 объект у себя и нельзя адекватно обращаться к ним через код в текущий момент, когда в ногах +1 персонаж), так и со здравым смыслом, чтобы не было БТР-труповозов на 5+ человек.
- Можно перешагивать через персонажей, которые больше стандартных на 5~ процентов.

# Сверхтяжёлые персонажи:
- Между ног у сверхтяжёлых персонажей можно бегать, как и у других больших. Невозможность сдвинуть с места неумышленно убрала возможность проходить через их тайл.
- Сверхтяжёлые персонажи временно не могут быть в списке целей для контрактов у предателей (которые из кита). Связано с тем, что такого персонажа крайне сложно при прочьих равных украсть, обращая внимание на резисты и неочевидные способы перемещения.

# Другое
- Сверхтяжёлые и тяжёлые персонажи: наступании на кого-то в агрессивном режиме, вместо стана (не дающей взаимодействовать, ходить и выкидывающая вещи из рук) дается иммобилизация, не дающая только ходить.