### PR TITLE
Фикс покатушек на спинке

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -169,6 +169,8 @@
 	#define COMSIG_ATOM_BLOCKS_BSA_BEAM (1<<0)
 ///from base of atom/setDir(): (old_dir, new_dir). Called before the direction changes.
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"
+///from base of atom/setDir(): (old_dir, new_dir). Called after the direction changes.
+#define COMSIG_ATOM_DIR_AFTER_CHANGE "atom_dir_after_change"
 ///from base of atom/handle_atom_del(): (atom/deleted)
 #define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"
 ///from base of atom/has_gravity(): (turf/location, list/forced_gravities)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -7,6 +7,7 @@
 	. = ..()
 	if(ismousemovement)
 		update_pixel_shifting()
+	SEND_SIGNAL(src, COMSIG_ATOM_DIR_AFTER_CHANGE, dir, newdir)
 
 /mob/living/proc/update_pixel_shifting(moved = FALSE)
 	if(combat_flags & COMBAT_FLAG_ACTIVE_BLOCKING)

--- a/modular_sand/code/datums/components/riding.dm
+++ b/modular_sand/code/datums/components/riding.dm
@@ -1,8 +1,15 @@
 /datum/component/riding/human/Initialize()
 	. = ..()
-	RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, .proc/update_dir)
+	RegisterSignal(parent, COMSIG_ATOM_DIR_AFTER_CHANGE, .proc/update_dir)
 
 /datum/component/riding/human/proc/update_dir(mob/source, dir, newdir)
-	var/mob/living/carbon/human/H = source
-	for(var/mob/living/L in H.buckled_mobs)
-		L.setDir(newdir)
+	handle_vehicle_offsets(newdir)
+	handle_vehicle_layer(newdir)
+
+/datum/component/riding/cyborg/Initialize()
+	. = ..()
+	RegisterSignal(parent, COMSIG_ATOM_DIR_AFTER_CHANGE, .proc/update_dir)
+
+/datum/component/riding/cyborg/proc/update_dir(mob/source, dir, newdir)
+	handle_vehicle_offsets(newdir)
+	handle_vehicle_layer(newdir)


### PR DESCRIPTION
Теперь катания на спинках правильно обрабатывают отображение слоев и позиций спрайтов персонажей при разворотах.