### PR TITLE
Возможный фикс ночного зрения

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -232,7 +232,8 @@
 	gain_text = "<span class='notice'>Тени кажутся светлее.</span>"
 	lose_text = "<span class='danger'>Всё кажется чуточку темнее.</span>"
 
-/datum/quirk/night_vision/on_spawn()
+/datum/quirk/night_vision/post_add() //BLUEMOON EDIT
+	. = ..()						 //BLUEMOON ADD
 	var/mob/living/carbon/human/H = quirk_holder
 	H.update_sight()
 


### PR DESCRIPTION
Окей, это не в полевых ситуациях сервера не проверить, но если проще для понимания зачем
ночное зрение работает, но есть один плот твист в том, что он работает только после обновления зрения
на сервере из-за большого пролага это обновление зрения не срабатывает и челам с ночным зрением нужно сперва обновить его (нацепить пожарным шлем) и тогда всё заработает.
поэтому ВТЕОРИИ этот фикс решает проблему с ночным зрением (сколько локалка из-за отсутствия пролага так и так работает)