### PR TITLE
Обновление для heigh medipen

### DIFF
--- a/code/__SANDCODE/DEFINES/sizecode.dm
+++ b/code/__SANDCODE/DEFINES/sizecode.dm
@@ -2,6 +2,7 @@
 //alright bet -BoxBoy
 #define RESIZE_MACRO 6
 #define RESIZE_HUGE 4
+#define RESIZE_LARGE 3 // BLUEMOON ADD - добавляю сюда для наглядности
 #define RESIZE_BIG 2
 #define RESIZE_NORMAL 1
 #define RESIZE_SMALL 0.75

--- a/modular_bluemoon/size_tool/size_tool.dm
+++ b/modular_bluemoon/size_tool/size_tool.dm
@@ -60,12 +60,14 @@
 
 /obj/item/melee/sizetool/examine(mob/user)
 	. = ..()
+	. += "<hr>"
+	. += span_info("You can use it in ghostcafe to make someone even bigger than 200%.")
 	if(cell)
-		. += span_info("[src] is [round(cell.percent())]% charged.")
 		. += span_info("Its cell can be removed with a screwdriver.")
+		. += span_info("[src] is [round(cell.percent())]% charged.")
 	else
-		. += span_warning("[src] does not have a power source installed.")
-	. += span_info("Current prefered size set to [size_set_to * 100]%")
+		. += span_danger("[src] does not have a power source installed.")
+	. += span_info("Current prefered size set to <b>[size_set_to * 100]%</b>.")
 
 /obj/item/melee/sizetool/proc/check_for_ghostcafe() // Вы можете использовать весь функционал (в виде повышения размера до 800%) в госткафе
 	if(istype(get_area(src), /area/centcom/holding))

--- a/modular_sand/code/modules/resize/sizechems.dm
+++ b/modular_sand/code/modules/resize/sizechems.dm
@@ -76,7 +76,7 @@
 
 /datum/reagent/growthchem/on_mob_life(mob/living/M)
 	var/size = get_size(M)
-	if(size < RESIZE_MACRO)
+	if(size < RESIZE_LARGE) // BLUEMOON EDIT - было RESIZE_MACRO
 		M.update_size(size + 0.025)
 		M.visible_message("<span class='danger'>[pick("[M] grows!", "[M] expands in size!", "[M] pushes outwards in stature!")]</span>", "<span class='danger'>[pick("You feel your body fighting for space and growing!", "The world contracts inwards in every direction!", "You feel your muscles expand, and your surroundings shrink!")]</span>")
 	..()


### PR DESCRIPTION
- Максимальный размер, доступный для повышения размера персонажа, 300%, а не 600% (3 тайла в высоту против 6).
- Слегка изменено описание у size tool для большей наглядности и раскрытия механик. Осуждаю девелопера, что убирал это.