### PR TITLE
переработка RSH-15 и повышение кучности buckshot выстрелов

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -90,7 +90,7 @@
 	targetitem = /obj/item/gun/energy/e_gun/hos
 	difficulty = 8
 	excludefromjob = list("Head Of Security")
-	altitems = list(/obj/item/gun/ballistic/revolver/mws, /obj/item/choice_beacon/hosgun, /obj/item/gun/ballistic/automatic/pistol/g22, /obj/item/gun/ballistic/shotgun/rsh12) //We now look for either the alt verson of the hos gun or the beacon picker.
+	altitems = list(/obj/item/gun/ballistic/revolver/mws, /obj/item/choice_beacon/hosgun, /obj/item/gun/ballistic/automatic/pistol/g22, /obj/item/gun/ballistic/shotgun/automatic/rsh12) //We now look for either the alt verson of the hos gun or the beacon picker.
 
 /datum/objective_item/steal/handtele
 	name = "Компактное Телепортирующее Устройство."

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -74,7 +74,7 @@
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 6
-	variance = 25
+	variance = 15
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -82,7 +82,7 @@
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
-	variance = 25
+	variance = 15
 	custom_materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/improvised
@@ -92,7 +92,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_improvised
 	custom_materials = list(/datum/material/iron=250)
 	pellets = 10
-	variance = 25
+	variance = 15
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"
@@ -109,7 +109,7 @@
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 6
-	variance = 35
+	variance = 20
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
@@ -162,5 +162,5 @@
 	icon_state = "bountyshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_incapacitate
 	pellets = 12//double the pellets, but half the stun power of each, which makes this best for just dumping right in someone's face.
-	variance = 25
+	variance = 15
 	custom_materials = list(/datum/material/iron=4000)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -246,7 +246,7 @@
 	playsound(src, "gun_dry_fire", 30, 1)
 	balloon_alert(user, "Щёлк!")
 
-/obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
+/obj/item/gun/proc/shoot_live_shot	(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
 	if(recoil)
 		directional_recoil(user, recoil*dir_recoil_amp, Get_Angle(user, pbtarget))
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 45
+	damage = 50
 	sharpness = SHARP_POINTY // SHARP_POINTY
 	wound_bonus = 6
 

--- a/modular_bluemoon/kovac_shitcode/code/modules/guns/weapons.dm
+++ b/modular_bluemoon/kovac_shitcode/code/modules/guns/weapons.dm
@@ -59,7 +59,7 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 6
 
-/obj/item/gun/ballistic/shotgun/rsh12
+/obj/item/gun/ballistic/shotgun/automatic/rsh12
 	name = "RSH-15"
 	desc = "A moden Russian-made semi-automatic revolver, intended to used with 12 gauge."
 	icon_state = "rsh12"
@@ -69,7 +69,7 @@
 	righthand_file = 'modular_bluemoon/kovac_shitcode/icons/mob/weapons/weapons_r.dmi'
 	fire_sound = 'modular_bluemoon/kovac_shitcode/sound/weapons/rsh12.ogg'
 	pumpsound = 'modular_bluemoon/kovac_shitcode/sound/weapons/rsh12_drum.ogg'
-	fire_delay = 5
+	fire_delay = 8
 	recoil = 5
 	spread = 3
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/rsh12
@@ -154,7 +154,7 @@
 	desc = "A storage case for a heavy revolver."
 
 /obj/item/storage/secure/briefcase/rsh12_box/PopulateContents()
-	new /obj/item/gun/ballistic/shotgun/rsh12(src)
+	new /obj/item/gun/ballistic/shotgun/automatic/rsh12(src)
 	new /obj/item/ammo_box/shotgun/loaded/rubbershot(src)
 	new /obj/item/ammo_box/shotgun/loaded/rubbershot(src)
 	new /obj/item/ammo_box/shotgun/loaded/buckshot(src)

--- a/modular_bluemoon/kovac_shitcode/code/rus.dm
+++ b/modular_bluemoon/kovac_shitcode/code/rus.dm
@@ -304,7 +304,7 @@
 	ears = /obj/item/radio/headset/nri/bowman/command
 	gloves = /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	neck = /obj/item/clothing/neck/cloak/nri_cloak
-	r_hand = /obj/item/gun/ballistic/shotgun/rsh12
+	r_hand = /obj/item/gun/ballistic/shotgun/automatic/rsh12
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/poster/nri=5, /obj/item/ammo_box/shotgun/loaded/buckshot=4)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////area


### PR DESCRIPTION
Вернул RSH-15 автоматический режим стрельбы
- снизил скорострельность rsh-15 с 5=>8 что 
Понизил разлёт всех buckshot выстрелов с дробовика, не трогая урон и понижение урона на расстоянии 
Повышен урон shotgun slug на 5 единиц, повышая общие ТТК по не бронированной цели с 3 до 2 выстрелов

