### PR TITLE
Убрал возможность варить мех сваркой изнутри

### DIFF
--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -296,6 +296,9 @@
 	if(user.a_intent == INTENT_HARM)
 		return
 	. = TRUE
+	if (user in occupants)
+		to_chat(user, "<span class='notice'>You can't reach damaged parts from inside!</span>")
+		return
 	if(internal_damage & MECHA_INT_TANK_BREACH)
 		if(!W.use_tool(src, user, 0, volume=50, amount=1))
 			return


### PR DESCRIPTION
Теперь при попытке ремонтировать мех сваркой пилоту будет выводиться сообщение, что он не может добраться до повреждённого оборудования изнутри.

_P.S. Возможно, есть другое решение проблемы, но пока сгодится и такое_

## Changelog

:cl:
fix: Убрана возможность ремонтировать мехи сваркой изнутри
/:cl: