### PR TITLE
maptweak(DS2) Мелкоизменения карты для удобства

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -811,11 +811,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "cG" = (
-/obj/structure/bed/double,
 /obj/item/bedsheet/qm/double{
 	name = "corporate liaison's bedsheet";
 	desc = "It is decorated with the Donk Co. logo."
 	},
+/obj/structure/bed/double,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "cI" = (
@@ -2770,9 +2770,9 @@
 	heat_proof = 1
 	},
 /obj/machinery/door/poddoor/shutters{
-	dir = 8;
+	name = "Corporate Liaison Shutters";
 	id = "ds2corpliaison";
-	name = "Corporate Liaison Shutters"
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -2855,8 +2855,8 @@
 "li" = (
 /obj/structure/table/glass,
 /obj/item/storage/pill_bottle/mannitol{
-	pixel_x = -8;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = -8
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -2982,8 +2982,8 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 5;
-	level = 1
+	level = 1;
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -3037,8 +3037,8 @@
 	name = "Restroom Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -24;
-	pixel_y = -24;
-	specialfunctions = 4
+	specialfunctions = 4;
+	pixel_y = -24
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -3167,8 +3167,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/door/window/survival_pod{
-	dir = 4;
-	req_access_txt = "151"
+	req_access_txt = "151";
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3179,12 +3179,12 @@
 	},
 /obj/item/folder/red,
 /obj/item/paper{
-	pixel_x = -3;
-	pixel_y = -4
+	pixel_y = -4;
+	pixel_x = -3
 	},
 /obj/item/paper{
-	pixel_x = 4;
-	pixel_y = -6
+	pixel_y = -6;
+	pixel_x = 4
 	},
 /obj/item/pen{
 	pixel_y = -4
@@ -3444,8 +3444,8 @@
 /obj/item/storage/fancy/egg_box,
 /obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -3549,8 +3549,8 @@
 	dir = 1
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = -3;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = -3
 	},
 /obj/structure/table/glass,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -3683,8 +3683,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "oZ" = (
 /obj/machinery/camera/xray/directional/west{
-	c_tag = "DS-2 Lounge";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Lounge"
 	},
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -3769,8 +3769,8 @@
 "pk" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	icon_state = "box_1";
-	state = 2
+	state = 2;
+	icon_state = "box_1"
 	},
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 4
@@ -3786,8 +3786,8 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -3873,8 +3873,8 @@
 /obj/effect/turf_decal/tile/dark_red/half,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/machinery/camera/xray/directional/north{
-	c_tag = "DS-2 Hangar North";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Hangar North"
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 4
@@ -3928,8 +3928,8 @@
 	dir = 1
 	},
 /obj/item/storage/box/firingpins/syndicate{
-	pixel_x = -2;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = -2
 	},
 /obj/item/storage/box/firingpins/syndicate{
 	pixel_x = 2
@@ -4137,8 +4137,8 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -4501,16 +4501,16 @@
 "sc" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "se" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/soymilk,
@@ -4547,8 +4547,8 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/camera/xray/directional/south{
-	c_tag = "DS-2 Long-Term Brig Access";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Long-Term Brig Access"
 	},
 /obj/item/card/id/syndicate/advanced/prisoner,
 /obj/item/card/id/syndicate/advanced/prisoner{
@@ -4638,11 +4638,11 @@
 	dir = 8
 	},
 /obj/structure/showcase/cyborg{
-	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
-	dir = 4;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "synd_sec";
 	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 4;
 	pixel_x = -6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -4668,8 +4668,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "sV" = (
 /obj/item/storage/box/beakers/bluespace{
-	pixel_x = -2;
-	pixel_y = 8
+	pixel_y = 8;
+	pixel_x = -2
 	},
 /obj/item/storage/box/beakers/bluespace{
 	pixel_x = 2
@@ -4798,8 +4798,8 @@
 	dir = 1
 	},
 /obj/machinery/camera/xray/directional/west{
-	c_tag = "DS-2 Security Checkpoint";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Security Checkpoint"
 	},
 /obj/machinery/computer/crew/syndie{
 	dir = 1
@@ -4829,8 +4829,8 @@
 	pixel_x = 4
 	},
 /obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 1
+	pixel_y = 1;
+	pixel_x = 3
 	},
 /obj/effect/turf_decal/tile/dark_blue/full,
 /obj/effect/turf_decal/siding/white{
@@ -5149,8 +5149,8 @@
 "vd" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	icon_state = "box_1";
-	state = 2
+	state = 2;
+	icon_state = "box_1"
 	},
 /obj/item/circuitboard/machine/cyborgrecharger,
 /obj/effect/turf_decal/siding/dark{
@@ -5255,8 +5255,8 @@
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/accessory/medal/gold{
-	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of an Admiral to the Sothran Syndicate, and their undisputable authority over their crew.";
-	name = "medal of admiralty"
+	name = "medal of admiralty";
+	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of an Admiral to the Sothran Syndicate, and their undisputable authority over their crew."
 	},
 /obj/item/gun/ballistic/revolver/mateba,
 /obj/item/ammo_box/a357,
@@ -5297,8 +5297,8 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -5517,8 +5517,8 @@
 "wz" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/computer/security{
-	dir = 4;
-	network = list("ds2")
+	network = list("ds2");
+	dir = 4
 	},
 /obj/structure/sign/flag/syndicate/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
@@ -5744,8 +5744,8 @@
 "yd" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	id = "smasteratarms";
-	name = "Master At Arms Shutters"
+	name = "Master At Arms Shutters";
+	id = "smasteratarms"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
@@ -5844,12 +5844,12 @@
 "yA" = (
 /obj/docking_port/stationary{
 	dir = 4;
-	dwidth = 6;
 	height = 16;
-	id = "ds2_syndicate";
 	name = "DS-2 Hangar";
-	roundstart_template = /datum/map_template/shuttle/ruin/ds_shuttle;
-	width = 16
+	width = 16;
+	id = "ds2_syndicate";
+	dwidth = 6;
+	roundstart_template = /datum/map_template/shuttle/ruin/ds_shuttle
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
@@ -5889,8 +5889,8 @@
 /obj/structure/chair,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera/xray/directional/west{
-	c_tag = "DS-2 Dormitories";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Dormitories"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -5912,11 +5912,11 @@
 	dir = 4
 	},
 /obj/structure/showcase/cyborg{
-	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
-	dir = 8;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "synd_sec";
 	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 8;
 	pixel_x = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -6003,8 +6003,8 @@
 	},
 /obj/structure/frame/machine{
 	anchored = 1;
-	icon_state = "box_1";
-	state = 2
+	state = 2;
+	icon_state = "box_1"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -6161,8 +6161,8 @@
 	dir = 2
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -6307,11 +6307,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "AG" = (
 /obj/structure/closet/secure_closet{
-	anchored = 1;
-	icon = 'icons/obj/closet.dmi';
 	icon_state = "riot";
 	name = "armory munitions locker";
-	req_access_txt = "151"
+	req_access_txt = "151";
+	icon = 'icons/obj/closet.dmi';
+	anchored = 1
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -6412,8 +6412,8 @@
 /obj/item/circuitboard/machine/spaceship_navigation_beacon,
 /obj/structure/frame/machine{
 	anchored = 1;
-	icon_state = "box_1";
-	state = 2
+	state = 2;
+	icon_state = "box_1"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
@@ -6456,8 +6456,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/xray/directional/north{
-	c_tag = "DS-2 Transit Tube";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Transit Tube"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -6624,8 +6624,8 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/window/survival_pod{
-	name = "Diner";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	name = "Diner"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6869,8 +6869,8 @@
 	pixel_x = 5
 	},
 /obj/item/choice_beacon/music{
-	pixel_x = -3;
-	pixel_y = -4
+	pixel_y = -4;
+	pixel_x = -3
 	},
 /obj/structure/closet/crate/wooden,
 /obj/structure/window/reinforced/survival_pod{
@@ -6903,12 +6903,12 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -8;
-	pixel_y = 24;
-	specialfunctions = 4
+	specialfunctions = 4;
+	pixel_y = 24
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/wood/wood_tiled,
@@ -7011,12 +7011,12 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "DZ" = (
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/medical1{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
@@ -7055,9 +7055,9 @@
 	},
 /obj/machinery/button/door{
 	id = "ds2cargo";
-	name = "Cargo Blastdoor Control";
 	pixel_x = 24;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	name = "Cargo Blastdoor Control"
 	},
 /obj/structure/railing{
 	pixel_y = -2
@@ -7072,8 +7072,8 @@
 	},
 /obj/structure/rack/shelf,
 /obj/item/tank/internals/emergency_oxygen/double{
-	pixel_x = -2;
-	pixel_y = 3
+	pixel_y = 3;
+	pixel_x = -2
 	},
 /obj/item/clothing/mask/gas/glass/alt{
 	pixel_x = -2
@@ -7082,8 +7082,8 @@
 	pixel_x = 6
 	},
 /obj/item/clothing/mask/gas/glass/alt{
-	pixel_x = 6;
-	pixel_y = -3
+	pixel_y = -3;
+	pixel_x = 6
 	},
 /obj/item/tank/internals/emergency_nitrogen/double,
 /obj/item/tank/internals/emergency_nitrogen/double,
@@ -7104,8 +7104,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 5;
-	level = 1
+	level = 1;
+	dir = 5
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -7140,12 +7140,12 @@
 	pixel_y = 10
 	},
 /obj/item/grenade/barrier{
-	pixel_x = 4;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = 4
 	},
 /obj/item/grenade/barrier{
-	pixel_x = -4;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = -4
 	},
 /obj/item/grenade/barrier{
 	pixel_y = 2
@@ -7320,9 +7320,9 @@
 "Fk" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	dir = 4;
+	name = "Master At Arms Shutters";
 	id = "smasteratarms";
-	name = "Master At Arms Shutters"
+	dir = 4
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
@@ -7377,8 +7377,8 @@
 "Fy" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/poddoor/shutters{
-	id = "ds2armory";
-	name = "Armory Shutters"
+	name = "Armory Shutters";
+	id = "ds2armory"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
@@ -7580,8 +7580,8 @@
 	pixel_y = 11
 	},
 /obj/item/choice_beacon/ingredients{
-	pixel_x = -5;
-	pixel_y = 2
+	pixel_y = 2;
+	pixel_x = -5
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/item/clothing/accessory/armband/hydro{
@@ -7590,8 +7590,8 @@
 	pixel_x = 15
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 17;
-	pixel_y = 8
+	pixel_y = 8;
+	pixel_x = 17
 	},
 /obj/item/storage/belt/military/snack,
 /turf/open/floor/iron/kitchen{
@@ -7674,12 +7674,12 @@
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/toy/crayon/spraycan{
-	pixel_x = -5;
-	pixel_y = 9
+	pixel_y = 9;
+	pixel_x = -5
 	},
 /obj/item/toy/crayon/spraycan{
-	pixel_x = 4;
-	pixel_y = 9
+	pixel_y = 9;
+	pixel_x = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -7747,8 +7747,8 @@
 "Ha" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/survival_pod{
-	dir = 4;
-	req_access_txt = "151"
+	req_access_txt = "151";
+	dir = 4
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/smooth_large,
@@ -7785,8 +7785,8 @@
 	pixel_y = 5
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -8088,8 +8088,8 @@
 /obj/item/circuitboard/machine/destructive_analyzer,
 /obj/structure/frame/machine{
 	anchored = 1;
-	icon_state = "box_1";
-	state = 2
+	state = 2;
+	icon_state = "box_1"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -8097,30 +8097,30 @@
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_x = 6;
-	pixel_y = 3
+	pixel_y = 3;
+	pixel_x = 6
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
 	pixel_y = 3
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_x = -6;
-	pixel_y = -3
+	pixel_y = -3;
+	pixel_x = -6
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4;
 	pixel_x = 4
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_x = -6;
-	pixel_y = -3
+	pixel_y = -3;
+	pixel_x = -6
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
 	pixel_y = 3
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_x = 6;
-	pixel_y = 3
+	pixel_y = 3;
+	pixel_x = 6
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
@@ -8130,8 +8130,8 @@
 	dir = 8
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = -3;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = -3
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/carpet/blackred,
@@ -8142,8 +8142,8 @@
 "IU" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	icon_state = "box_1";
-	state = 2
+	state = 2;
+	icon_state = "box_1"
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -8289,8 +8289,8 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/item/clothing/mask/gas/sechailer/syndicate,
 /obj/item/clothing/accessory/medal/silver{
-	desc = "The Sothran Syndicate's dictionary defines excellence as \"the ability to crush NT scum under one's boot\". This is awarded to those rare operatives who fit that definition.";
-	name = "Military Excellence Medal"
+	name = "Military Excellence Medal";
+	desc = "The Sothran Syndicate's dictionary defines excellence as \"the ability to crush NT scum under one's boot\". This is awarded to those rare operatives who fit that definition."
 	},
 /obj/item/gun/ballistic/revolver/mateba,
 /obj/item/ammo_box/a357,
@@ -8335,15 +8335,15 @@
 	dir = 8
 	},
 /obj/item/aiModule/reset{
-	pixel_x = -2;
-	pixel_y = -7
+	pixel_y = -7;
+	pixel_x = -2
 	},
 /obj/item/aiModule/reset/purge{
 	pixel_y = -4
 	},
 /obj/item/aiModule/supplied/freeform{
-	pixel_x = -2;
-	pixel_y = 4
+	pixel_y = 4;
+	pixel_x = -2
 	},
 /obj/item/aiModule/core/full/syndicate{
 	pixel_y = 7
@@ -8380,8 +8380,8 @@
 	desc = "To keep the void away.";
 	id = "ds2bridge";
 	name = "Bridge Blast Door Control";
-	pixel_y = 32;
-	req_access_txt = "151"
+	req_access_txt = "151";
+	pixel_y = 32
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -8713,10 +8713,10 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
-	icon_door = "eng_weld";
 	icon_state = "eng";
 	name = "welding supplies locker";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	icon_door = "eng_weld"
 	},
 /obj/item/weldingtool/largetank{
 	pixel_y = 4
@@ -8786,11 +8786,11 @@
 	pixel_y = -11
 	},
 /obj/structure/closet/secure_closet{
-	anchored = 1;
-	icon = 'icons/obj/closet.dmi';
 	icon_state = "riot";
 	name = "armory gear locker";
-	req_access_txt = "151"
+	req_access_txt = "151";
+	icon = 'icons/obj/closet.dmi';
+	anchored = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
@@ -8800,8 +8800,8 @@
 "Lx" = (
 /obj/machinery/door/airlock/security{
 	hackProof = 1;
-	id_tag = "smasteratarms";
-	name = "Master At Arms' Office"
+	name = "Master At Arms' Office";
+	id_tag = "smasteratarms"
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
@@ -8891,13 +8891,13 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/item/poster/random_contraband{
-	pixel_x = 5;
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = 5
 	},
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband{
-	pixel_x = 2;
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = 2
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -8909,8 +8909,8 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -8925,16 +8925,16 @@
 "LY" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/camera/xray/directional/south{
-	c_tag = "DS-2 Armory";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Armory"
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
 /obj/item/storage/box/pinpointer_pairs{
-	pixel_x = -4;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = -4
 	},
 /obj/item/storage/box/pinpointer_pairs,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9003,9 +9003,9 @@
 "ME" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	dir = 4;
+	name = "Admiral Shutters";
 	id = "ds2admiral";
-	name = "Admiral Shutters"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
@@ -9032,8 +9032,8 @@
 /obj/machinery/recharger,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/xray/directional/east{
-	c_tag = "DS-2 EVA";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 EVA"
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
@@ -9088,11 +9088,11 @@
 	},
 /obj/structure/sign/flag/syndicate/directional/north,
 /obj/structure/showcase/cyborg{
-	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
-	dir = 4;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "synd_sec";
 	name = "syndicate cyborg showcase";
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 4;
 	pixel_x = -6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -9122,8 +9122,8 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "dorms-view";
-	name = "Dorms Blast Door Control";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	name = "Dorms Blast Door Control"
 	},
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
@@ -9149,8 +9149,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Nk" = (
 /obj/machinery/door/airlock/command{
-	hackProof = 1;
-	name = "Bridge"
+	name = "Bridge";
+	hackProof = 1
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -9236,14 +9236,14 @@
 	dir = 8
 	},
 /obj/machinery/button/door/incinerator_vent_syndicatelava_aux{
-	name = "Combustion Chamber Blast Door Control";
+	pixel_y = 24;
 	pixel_x = -6;
-	pixel_y = 24
+	name = "Combustion Chamber Blast Door Control"
 	},
 /obj/machinery/button/door/incinerator_vent_syndicatelava_main{
-	name = "Turbine Exterior Vent Control";
 	pixel_x = -6;
-	pixel_y = -24
+	pixel_y = -24;
+	name = "Turbine Exterior Vent Control"
 	},
 /obj/machinery/door/window/survival_pod{
 	dir = 8;
@@ -9260,8 +9260,8 @@
 "NG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/airalarm/syndicate{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -9322,8 +9322,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash/handheld{
-	pixel_x = 3;
-	pixel_y = 10
+	pixel_y = 10;
+	pixel_x = 3
 	},
 /obj/item/crowbar/red,
 /obj/machinery/recharger,
@@ -9369,8 +9369,8 @@
 	pixel_y = 3
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
 	pixel_x = 24;
+	dir = 8;
 	req_access = list(151)
 	},
 /turf/open/floor/iron/dark,
@@ -9433,8 +9433,8 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/east,
 /obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = -6;
-	pixel_y = -7
+	pixel_y = -7;
+	pixel_x = -6
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -9477,8 +9477,8 @@
 	pixel_y = 17
 	},
 /obj/item/assembly/flash/handheld{
-	pixel_x = 3;
-	pixel_y = 10
+	pixel_y = 10;
+	pixel_x = 3
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -9519,8 +9519,8 @@
 	dir = 10
 	},
 /obj/item/clothing/accessory/armband{
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
-	name = "brig officer armband"
+	name = "brig officer armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -9694,8 +9694,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/camera/xray/directional/west{
-	c_tag = "DS-2 Engineering";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Engineering"
 	},
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -9895,8 +9895,8 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
 	pixel_x = 24;
+	dir = 8;
 	req_access = list(151)
 	},
 /turf/open/floor/iron/white/small,
@@ -9948,8 +9948,8 @@
 "Qw" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 8
@@ -10006,8 +10006,8 @@
 	desc = "To keep your food away from the carp.";
 	id = "diner-view";
 	name = "Diner Blast Door Control";
-	pixel_y = -24;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	pixel_y = -24
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -10178,8 +10178,8 @@
 "Rh" = (
 /obj/machinery/vending/cola/red,
 /obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -10257,8 +10257,8 @@
 /obj/structure/table,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /obj/effect/spawner/lootdrop/pizzaparty{
 	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
@@ -10331,11 +10331,12 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	desc = "Keep out the paperwork.";
 	id = "ds2corpliaison";
+	req_access_txt = "151";
 	name = "Shutters control";
-	pixel_x = -32;
+	desc = "Keep out the paperwork.";
 	pixel_y = 24;
+	pixel_x = -32
 	req_access_txt = "151"
 	},
 /obj/item/paper_bin/carbon{
@@ -10367,8 +10368,8 @@
 /obj/item/folder/syndicate/red,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/xray/directional/north{
-	c_tag = "DS-2 Vault";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Vault"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
@@ -10449,8 +10450,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/xray/directional/south{
-	c_tag = "DS-2 Bridge";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Bridge"
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/textured_half,
@@ -10820,12 +10821,12 @@
 	req_access_txt = "150"
 	},
 /obj/item/clothing/accessory/armband/engine{
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
-	name = "engine technician armband"
+	name = "engine technician armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
 	},
 /obj/item/clothing/accessory/armband/engine{
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
-	name = "engine technician armband"
+	name = "engine technician armband";
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
 	},
 /obj/item/clothing/glasses/meson/night,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -10882,8 +10883,8 @@
 	pixel_x = -7
 	},
 /obj/item/clothing/suit/toggle/labcoat/syndicate{
-	pixel_x = -3;
-	pixel_y = 4
+	pixel_y = 4;
+	pixel_x = -3
 	},
 /obj/item/clothing/neck/stethoscope{
 	pixel_x = 12;
@@ -10986,8 +10987,8 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = 3;
-	pixel_y = 6
+	pixel_y = 6;
+	pixel_x = 3
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -11001,8 +11002,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/command{
-	hackProof = 1;
-	name = "Bridge"
+	name = "Bridge";
+	hackProof = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -11189,8 +11190,8 @@
 "UX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/survival_pod{
-	dir = 1;
-	req_access_txt = "151"
+	req_access_txt = "151";
+	dir = 1
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/smooth_large,
@@ -11220,16 +11221,16 @@
 	id = "smasteratarms";
 	name = "Master at Arms' room bolt";
 	normaldoorcontrol = 1;
-	pixel_x = 6;
 	req_access_txt = "151";
-	specialfunctions = 4
+	specialfunctions = 4;
+	pixel_x = 6
 	},
 /obj/machinery/button/door/directional/south{
 	desc = "Keep out the Officers.";
 	id = "smasteratarms";
 	name = "Master at Arms' shutters control";
-	pixel_x = -6;
-	req_access_txt = "151"
+	req_access_txt = "151";
+	pixel_x = -6
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
@@ -11363,8 +11364,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "VC" = (
 /obj/machinery/camera/xray/directional/north{
-	c_tag = "DS-2 Interrogation Room";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Interrogation Room"
 	},
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
@@ -11470,9 +11471,9 @@
 "VX" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	dir = 8;
+	name = "Corporate Liaison Shutters";
 	id = "ds2corpliaison";
-	name = "Corporate Liaison Shutters"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -11508,8 +11509,8 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/stockparts/deluxe{
-	pixel_x = 3;
-	pixel_y = -4
+	pixel_y = -4;
+	pixel_x = 3
 	},
 /obj/structure/closet/crate/engineering,
 /obj/item/t_scanner,
@@ -11518,8 +11519,8 @@
 	pixel_y = -3
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
@@ -11579,14 +11580,14 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/door/window/survival_pod{
+	req_access_txt = "151";
 	dir = 8;
-	name = "Isolation Cell";
-	req_access_txt = "151"
+	name = "Isolation Cell"
 	},
 /obj/machinery/door/window/survival_pod{
+	req_access_txt = "151";
 	dir = 4;
-	name = "Isolation Cell";
-	req_access_txt = "151"
+	name = "Isolation Cell"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "gaybabyjail"
@@ -11625,8 +11626,8 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/syndicate{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	dir = 1
 	},
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -11684,8 +11685,8 @@
 /obj/effect/turf_decal/vg_decals/atmos/air,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10;
-	level = 2;
-	piping_layer = 1
+	piping_layer = 1;
+	level = 2
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
@@ -11709,8 +11710,8 @@
 	pixel_y = 5
 	},
 /obj/item/pen{
-	pixel_x = -2;
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = -2
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -11742,18 +11743,18 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
-	icon_door = "eng_elec";
 	icon_state = "eng";
 	name = "electrical supplies locker";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	icon_door = "eng_elec"
 	},
 /obj/item/electronics/airlock{
-	pixel_x = 5;
-	pixel_y = -7
+	pixel_y = -7;
+	pixel_x = 5
 	},
 /obj/item/electronics/airlock{
-	pixel_x = -5;
-	pixel_y = -7
+	pixel_y = -7;
+	pixel_x = -5
 	},
 /obj/item/storage/toolbox/electrical{
 	pixel_y = -7
@@ -11763,30 +11764,30 @@
 	pixel_y = 5
 	},
 /obj/item/electronics/firelock{
-	pixel_x = -6;
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = -6
 	},
 /obj/item/electronics/airalarm{
 	pixel_x = 2
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_x = -8;
+	pixel_y = -8;
+	pixel_x = -8
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_y = -8;
+	pixel_x = -4
+	},
+/obj/item/stock_parts/cell/high{
 	pixel_y = -8
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_x = -4;
-	pixel_y = -8
+	pixel_y = -8;
+	pixel_x = 4
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_y = -8
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 4;
-	pixel_y = -8
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = -8
+	pixel_y = -8;
+	pixel_x = 8
 	},
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron/dark/side{
@@ -11817,8 +11818,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/hatch{
-	id_tag = "DS2incineratorHatch";
-	name = "Incinerator Hatch"
+	name = "Incinerator Hatch";
+	id_tag = "DS2incineratorHatch"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
@@ -11846,16 +11847,16 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Xl" = (
 /obj/machinery/power/smes/engineering{
-	charge = 4.5e+006;
-	input_level = 150000
+	input_level = 150000;
+	charge = 4.5e+006
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4;
 	pixel_x = 4
 	},
 /obj/item/aicard/aitater{
-	pixel_x = 3;
-	pixel_y = 11
+	pixel_y = 11;
+	pixel_x = 3
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -12021,8 +12022,8 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -12062,8 +12063,8 @@
 "XY" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /obj/machinery/power/apc/auto_name/west{
-	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "150";
+	req_access = null
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/smooth_large,
@@ -12214,8 +12215,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/xray/directional/west{
-	c_tag = "DS-2 Research";
-	network = list("ds2")
+	network = list("ds2");
+	c_tag = "DS-2 Research"
 	},
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/iron/dark,
@@ -12369,8 +12370,8 @@
 	icon_state = "control_kill";
 	lethal = 1;
 	name = "DS2 turret controls";
-	pixel_x = -30;
-	req_access_txt = 0
+	req_access_txt = 0;
+	pixel_x = -30
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -430,10 +430,10 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "bt" = (
-/obj/structure/bed{
+/obj/structure/bed/double{
 	dir = 1
 	},
-/obj/item/bedsheet/syndie{
+/obj/item/bedsheet/syndie/double{
 	name = "station admiral's bedsheet";
 	dir = 1
 	},
@@ -811,11 +811,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "cG" = (
-/obj/item/bedsheet/qm{
+/obj/structure/bed/double,
+/obj/item/bedsheet/qm/double{
 	name = "corporate liaison's bedsheet";
 	desc = "It is decorated with the Donk Co. logo."
 	},
-/obj/structure/bed,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "cI" = (
@@ -1933,6 +1933,11 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	icon_state = "box_1";
+	state = 2
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "hy" = (
@@ -2494,13 +2499,8 @@
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "jJ" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
-/obj/item/circuitboard/machine/mechfab,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "jK" = (
@@ -2770,9 +2770,9 @@
 	heat_proof = 1
 	},
 /obj/machinery/door/poddoor/shutters{
-	name = "Corporate Liaison Shutters";
+	dir = 8;
 	id = "ds2corpliaison";
-	dir = 8
+	name = "Corporate Liaison Shutters"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -2855,8 +2855,8 @@
 "li" = (
 /obj/structure/table/glass,
 /obj/item/storage/pill_bottle/mannitol{
-	pixel_y = 6;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 6
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -2982,8 +2982,8 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1;
-	dir = 5
+	dir = 5;
+	level = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -3037,8 +3037,8 @@
 	name = "Restroom Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -24;
-	specialfunctions = 4;
-	pixel_y = -24
+	pixel_y = -24;
+	specialfunctions = 4
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -3167,8 +3167,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "151";
-	dir = 4
+	dir = 4;
+	req_access_txt = "151"
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3179,12 +3179,12 @@
 	},
 /obj/item/folder/red,
 /obj/item/paper{
-	pixel_y = -4;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = -4
 	},
 /obj/item/paper{
-	pixel_y = -6;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -6
 	},
 /obj/item/pen{
 	pixel_y = -4
@@ -3444,8 +3444,8 @@
 /obj/item/storage/fancy/egg_box,
 /obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -3549,8 +3549,8 @@
 	dir = 1
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_y = 6;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /obj/structure/table/glass,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -3683,8 +3683,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "oZ" = (
 /obj/machinery/camera/xray/directional/west{
-	network = list("ds2");
-	c_tag = "DS-2 Lounge"
+	c_tag = "DS-2 Lounge";
+	network = list("ds2")
 	},
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -3769,8 +3769,8 @@
 "pk" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 4
@@ -3786,8 +3786,8 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -3873,8 +3873,8 @@
 /obj/effect/turf_decal/tile/dark_red/half,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/machinery/camera/xray/directional/north{
-	network = list("ds2");
-	c_tag = "DS-2 Hangar North"
+	c_tag = "DS-2 Hangar North";
+	network = list("ds2")
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 4
@@ -3928,8 +3928,8 @@
 	dir = 1
 	},
 /obj/item/storage/box/firingpins/syndicate{
-	pixel_y = 6;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 6
 	},
 /obj/item/storage/box/firingpins/syndicate{
 	pixel_x = 2
@@ -4137,8 +4137,8 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -4204,9 +4204,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/chair/office/light{
-	dir = 1
+/obj/structure/frame/machine{
+	anchored = 1;
+	icon_state = "box_1";
+	state = 2
 	},
+/obj/item/circuitboard/machine/mechfab,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "qY" = (
@@ -4498,16 +4501,16 @@
 "sc" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "se" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/soymilk,
@@ -4544,8 +4547,8 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/camera/xray/directional/south{
-	network = list("ds2");
-	c_tag = "DS-2 Long-Term Brig Access"
+	c_tag = "DS-2 Long-Term Brig Access";
+	network = list("ds2")
 	},
 /obj/item/card/id/syndicate/advanced/prisoner,
 /obj/item/card/id/syndicate/advanced/prisoner{
@@ -4635,11 +4638,11 @@
 	dir = 8
 	},
 /obj/structure/showcase/cyborg{
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 4;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "synd_sec";
 	name = "syndicate cyborg showcase";
-	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
-	dir = 4;
 	pixel_x = -6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -4665,8 +4668,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "sV" = (
 /obj/item/storage/box/beakers/bluespace{
-	pixel_y = 8;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 8
 	},
 /obj/item/storage/box/beakers/bluespace{
 	pixel_x = 2
@@ -4795,8 +4798,8 @@
 	dir = 1
 	},
 /obj/machinery/camera/xray/directional/west{
-	network = list("ds2");
-	c_tag = "DS-2 Security Checkpoint"
+	c_tag = "DS-2 Security Checkpoint";
+	network = list("ds2")
 	},
 /obj/machinery/computer/crew/syndie{
 	dir = 1
@@ -4826,8 +4829,8 @@
 	pixel_x = 4
 	},
 /obj/item/storage/firstaid/regular{
-	pixel_y = 1;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/dark_blue/full,
 /obj/effect/turf_decal/siding/white{
@@ -5146,8 +5149,8 @@
 "vd" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/item/circuitboard/machine/cyborgrecharger,
 /obj/effect/turf_decal/siding/dark{
@@ -5252,8 +5255,8 @@
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/accessory/medal/gold{
-	name = "medal of admiralty";
-	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of an Admiral to the Sothran Syndicate, and their undisputable authority over their crew."
+	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of an Admiral to the Sothran Syndicate, and their undisputable authority over their crew.";
+	name = "medal of admiralty"
 	},
 /obj/item/gun/ballistic/revolver/mateba,
 /obj/item/ammo_box/a357,
@@ -5294,8 +5297,8 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_y = -24;
-	dir = 1
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -5514,8 +5517,8 @@
 "wz" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/computer/security{
-	network = list("ds2");
-	dir = 4
+	dir = 4;
+	network = list("ds2")
 	},
 /obj/structure/sign/flag/syndicate/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
@@ -5741,8 +5744,8 @@
 "yd" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	name = "Master At Arms Shutters";
-	id = "smasteratarms"
+	id = "smasteratarms";
+	name = "Master At Arms Shutters"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
@@ -5841,12 +5844,12 @@
 "yA" = (
 /obj/docking_port/stationary{
 	dir = 4;
-	height = 16;
-	name = "DS-2 Hangar";
-	width = 16;
-	id = "ds2_syndicate";
 	dwidth = 6;
-	roundstart_template = /datum/map_template/shuttle/ruin/ds_shuttle
+	height = 16;
+	id = "ds2_syndicate";
+	name = "DS-2 Hangar";
+	roundstart_template = /datum/map_template/shuttle/ruin/ds_shuttle;
+	width = 16
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
@@ -5886,8 +5889,8 @@
 /obj/structure/chair,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera/xray/directional/west{
-	network = list("ds2");
-	c_tag = "DS-2 Dormitories"
+	c_tag = "DS-2 Dormitories";
+	network = list("ds2")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -5909,11 +5912,11 @@
 	dir = 4
 	},
 /obj/structure/showcase/cyborg{
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 8;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "synd_sec";
 	name = "syndicate cyborg showcase";
-	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
-	dir = 8;
 	pixel_x = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -6000,8 +6003,8 @@
 	},
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -6096,15 +6099,7 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "zD" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/carbon{
-	pixel_y = 3;
-	pixel_x = -5
-	},
-/obj/item/pen{
-	pixel_y = 3;
-	pixel_x = -5
-	},
+/obj/machinery/photocopier,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "zH" = (
@@ -6166,8 +6161,8 @@
 	dir = 2
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -6312,11 +6307,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "AG" = (
 /obj/structure/closet/secure_closet{
+	anchored = 1;
+	icon = 'icons/obj/closet.dmi';
 	icon_state = "riot";
 	name = "armory munitions locker";
-	req_access_txt = "151";
-	icon = 'icons/obj/closet.dmi';
-	anchored = 1
+	req_access_txt = "151"
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -6417,8 +6412,8 @@
 /obj/item/circuitboard/machine/spaceship_navigation_beacon,
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
@@ -6461,8 +6456,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/xray/directional/north{
-	network = list("ds2");
-	c_tag = "DS-2 Transit Tube"
+	c_tag = "DS-2 Transit Tube";
+	network = list("ds2")
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -6629,8 +6624,8 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "150";
-	name = "Diner"
+	name = "Diner";
+	req_access_txt = "150"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6874,8 +6869,8 @@
 	pixel_x = 5
 	},
 /obj/item/choice_beacon/music{
-	pixel_y = -4;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = -4
 	},
 /obj/structure/closet/crate/wooden,
 /obj/structure/window/reinforced/survival_pod{
@@ -6908,12 +6903,12 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = -8;
-	specialfunctions = 4;
-	pixel_y = 24
+	pixel_y = 24;
+	specialfunctions = 4
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/wood/wood_tiled,
@@ -7016,12 +7011,12 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "DZ" = (
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/structure/closet/secure_closet/medical1{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
@@ -7060,9 +7055,9 @@
 	},
 /obj/machinery/button/door{
 	id = "ds2cargo";
+	name = "Cargo Blastdoor Control";
 	pixel_x = 24;
-	req_access_txt = "150";
-	name = "Cargo Blastdoor Control"
+	req_access_txt = "150"
 	},
 /obj/structure/railing{
 	pixel_y = -2
@@ -7077,8 +7072,8 @@
 	},
 /obj/structure/rack/shelf,
 /obj/item/tank/internals/emergency_oxygen/double{
-	pixel_y = 3;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 3
 	},
 /obj/item/clothing/mask/gas/glass/alt{
 	pixel_x = -2
@@ -7087,8 +7082,8 @@
 	pixel_x = 6
 	},
 /obj/item/clothing/mask/gas/glass/alt{
-	pixel_y = -3;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -3
 	},
 /obj/item/tank/internals/emergency_nitrogen/double,
 /obj/item/tank/internals/emergency_nitrogen/double,
@@ -7109,8 +7104,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1;
-	dir = 5
+	dir = 5;
+	level = 1
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -7145,12 +7140,12 @@
 	pixel_y = 10
 	},
 /obj/item/grenade/barrier{
-	pixel_y = 6;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 6
 	},
 /obj/item/grenade/barrier{
-	pixel_y = 6;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /obj/item/grenade/barrier{
 	pixel_y = 2
@@ -7325,9 +7320,9 @@
 "Fk" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	name = "Master At Arms Shutters";
+	dir = 4;
 	id = "smasteratarms";
-	dir = 4
+	name = "Master At Arms Shutters"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
@@ -7382,8 +7377,8 @@
 "Fy" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/poddoor/shutters{
-	name = "Armory Shutters";
-	id = "ds2armory"
+	id = "ds2armory";
+	name = "Armory Shutters"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
@@ -7570,6 +7565,11 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/structure/frame/machine{
+	anchored = 1;
+	icon_state = "box_1";
+	state = 2
+	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Gl" = (
@@ -7580,8 +7580,8 @@
 	pixel_y = 11
 	},
 /obj/item/choice_beacon/ingredients{
-	pixel_y = 2;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 2
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/item/clothing/accessory/armband/hydro{
@@ -7590,8 +7590,8 @@
 	pixel_x = 15
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 8;
-	pixel_x = 17
+	pixel_x = 17;
+	pixel_y = 8
 	},
 /obj/item/storage/belt/military/snack,
 /turf/open/floor/iron/kitchen{
@@ -7674,12 +7674,12 @@
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/toy/crayon/spraycan{
-	pixel_y = 9;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 9
 	},
 /obj/item/toy/crayon/spraycan{
-	pixel_y = 9;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 9
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -7747,8 +7747,8 @@
 "Ha" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "151";
-	dir = 4
+	dir = 4;
+	req_access_txt = "151"
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/smooth_large,
@@ -7785,8 +7785,8 @@
 	pixel_y = 5
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -8088,8 +8088,8 @@
 /obj/item/circuitboard/machine/destructive_analyzer,
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -8097,30 +8097,30 @@
 /obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_y = 3;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 3
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
 	pixel_y = 3
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_y = -3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -3
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4;
 	pixel_x = 4
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_y = -3;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -3
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
 	pixel_y = 3
 	},
 /obj/effect/spawner/lootdrop/healing_kits{
-	pixel_y = 3;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
@@ -8130,8 +8130,8 @@
 	dir = 8
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_y = 6;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 6
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/carpet/blackred,
@@ -8142,8 +8142,8 @@
 "IU" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -8289,8 +8289,8 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/item/clothing/mask/gas/sechailer/syndicate,
 /obj/item/clothing/accessory/medal/silver{
-	name = "Military Excellence Medal";
-	desc = "The Sothran Syndicate's dictionary defines excellence as \"the ability to crush NT scum under one's boot\". This is awarded to those rare operatives who fit that definition."
+	desc = "The Sothran Syndicate's dictionary defines excellence as \"the ability to crush NT scum under one's boot\". This is awarded to those rare operatives who fit that definition.";
+	name = "Military Excellence Medal"
 	},
 /obj/item/gun/ballistic/revolver/mateba,
 /obj/item/ammo_box/a357,
@@ -8335,15 +8335,15 @@
 	dir = 8
 	},
 /obj/item/aiModule/reset{
-	pixel_y = -7;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -7
 	},
 /obj/item/aiModule/reset/purge{
 	pixel_y = -4
 	},
 /obj/item/aiModule/supplied/freeform{
-	pixel_y = 4;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 4
 	},
 /obj/item/aiModule/core/full/syndicate{
 	pixel_y = 7
@@ -8380,8 +8380,8 @@
 	desc = "To keep the void away.";
 	id = "ds2bridge";
 	name = "Bridge Blast Door Control";
-	req_access_txt = "151";
-	pixel_y = 32
+	pixel_y = 32;
+	req_access_txt = "151"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -8713,10 +8713,10 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
+	icon_door = "eng_weld";
 	icon_state = "eng";
 	name = "welding supplies locker";
-	req_access_txt = "150";
-	icon_door = "eng_weld"
+	req_access_txt = "150"
 	},
 /obj/item/weldingtool/largetank{
 	pixel_y = 4
@@ -8786,11 +8786,11 @@
 	pixel_y = -11
 	},
 /obj/structure/closet/secure_closet{
+	anchored = 1;
+	icon = 'icons/obj/closet.dmi';
 	icon_state = "riot";
 	name = "armory gear locker";
-	req_access_txt = "151";
-	icon = 'icons/obj/closet.dmi';
-	anchored = 1
+	req_access_txt = "151"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
@@ -8800,8 +8800,8 @@
 "Lx" = (
 /obj/machinery/door/airlock/security{
 	hackProof = 1;
-	name = "Master At Arms' Office";
-	id_tag = "smasteratarms"
+	id_tag = "smasteratarms";
+	name = "Master At Arms' Office"
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
@@ -8891,13 +8891,13 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/item/poster/random_contraband{
-	pixel_y = 5;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /obj/item/poster/random_contraband,
 /obj/item/poster/random_contraband{
-	pixel_y = 5;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 5
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -8909,8 +8909,8 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -8925,16 +8925,16 @@
 "LY" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/camera/xray/directional/south{
-	network = list("ds2");
-	c_tag = "DS-2 Armory"
+	c_tag = "DS-2 Armory";
+	network = list("ds2")
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
 /obj/item/storage/box/pinpointer_pairs{
-	pixel_y = 6;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /obj/item/storage/box/pinpointer_pairs,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -9003,9 +9003,9 @@
 "ME" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	name = "Admiral Shutters";
+	dir = 4;
 	id = "ds2admiral";
-	dir = 4
+	name = "Admiral Shutters"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
@@ -9032,8 +9032,8 @@
 /obj/machinery/recharger,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/xray/directional/east{
-	network = list("ds2");
-	c_tag = "DS-2 EVA"
+	c_tag = "DS-2 EVA";
+	network = list("ds2")
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
@@ -9088,11 +9088,11 @@
 	},
 /obj/structure/sign/flag/syndicate/directional/north,
 /obj/structure/showcase/cyborg{
+	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
+	dir = 4;
 	icon = 'icons/mob/robots.dmi';
 	icon_state = "synd_sec";
 	name = "syndicate cyborg showcase";
-	desc = "A stand with the empty body of a Cybersun cyborg bolted to it.";
-	dir = 4;
 	pixel_x = -6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -9122,8 +9122,8 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "dorms-view";
-	req_access_txt = "150";
-	name = "Dorms Blast Door Control"
+	name = "Dorms Blast Door Control";
+	req_access_txt = "150"
 	},
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
@@ -9149,8 +9149,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Nk" = (
 /obj/machinery/door/airlock/command{
-	name = "Bridge";
-	hackProof = 1
+	hackProof = 1;
+	name = "Bridge"
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -9236,14 +9236,14 @@
 	dir = 8
 	},
 /obj/machinery/button/door/incinerator_vent_syndicatelava_aux{
-	pixel_y = 24;
+	name = "Combustion Chamber Blast Door Control";
 	pixel_x = -6;
-	name = "Combustion Chamber Blast Door Control"
+	pixel_y = 24
 	},
 /obj/machinery/button/door/incinerator_vent_syndicatelava_main{
+	name = "Turbine Exterior Vent Control";
 	pixel_x = -6;
-	pixel_y = -24;
-	name = "Turbine Exterior Vent Control"
+	pixel_y = -24
 	},
 /obj/machinery/door/window/survival_pod{
 	dir = 8;
@@ -9260,8 +9260,8 @@
 "NG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/airalarm/syndicate{
-	pixel_y = -24;
-	dir = 1
+	dir = 1;
+	pixel_y = -24
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -9322,8 +9322,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/assembly/flash/handheld{
-	pixel_y = 10;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 10
 	},
 /obj/item/crowbar/red,
 /obj/machinery/recharger,
@@ -9369,8 +9369,8 @@
 	pixel_y = 3
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
 	dir = 8;
+	pixel_x = 24;
 	req_access = list(151)
 	},
 /turf/open/floor/iron/dark,
@@ -9433,8 +9433,8 @@
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/east,
 /obj/item/reagent_containers/food/drinks/shaker{
-	pixel_y = -7;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -7
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -9477,8 +9477,8 @@
 	pixel_y = 17
 	},
 /obj/item/assembly/flash/handheld{
-	pixel_y = 10;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -9519,8 +9519,8 @@
 	dir = 10
 	},
 /obj/item/clothing/accessory/armband{
-	name = "brig officer armband";
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "brig officer armband"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -9694,8 +9694,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/camera/xray/directional/west{
-	network = list("ds2");
-	c_tag = "DS-2 Engineering"
+	c_tag = "DS-2 Engineering";
+	network = list("ds2")
 	},
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -9895,8 +9895,8 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
 	dir = 8;
+	pixel_x = 24;
 	req_access = list(151)
 	},
 /turf/open/floor/iron/white/small,
@@ -9948,8 +9948,8 @@
 "Qw" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 8
@@ -10006,8 +10006,8 @@
 	desc = "To keep your food away from the carp.";
 	id = "diner-view";
 	name = "Diner Blast Door Control";
-	req_access_txt = "150";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access_txt = "150"
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -10178,8 +10178,8 @@
 "Rh" = (
 /obj/machinery/vending/cola/red,
 /obj/machinery/airalarm/syndicate{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -10257,8 +10257,8 @@
 /obj/structure/table,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/spawner/lootdrop/pizzaparty{
 	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
@@ -10331,12 +10331,20 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	id = "ds2corpliaison";
-	req_access_txt = "151";
-	name = "Shutters control";
 	desc = "Keep out the paperwork.";
+	id = "ds2corpliaison";
+	name = "Shutters control";
+	pixel_x = -32;
 	pixel_y = 24;
-	pixel_x = -32
+	req_access_txt = "151"
+	},
+/obj/item/paper_bin/carbon{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -10359,8 +10367,8 @@
 /obj/item/folder/syndicate/red,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/xray/directional/north{
-	network = list("ds2");
-	c_tag = "DS-2 Vault"
+	c_tag = "DS-2 Vault";
+	network = list("ds2")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
@@ -10441,8 +10449,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/xray/directional/south{
-	network = list("ds2");
-	c_tag = "DS-2 Bridge"
+	c_tag = "DS-2 Bridge";
+	network = list("ds2")
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/textured_half,
@@ -10812,12 +10820,12 @@
 	req_access_txt = "150"
 	},
 /obj/item/clothing/accessory/armband/engine{
-	name = "engine technician armband";
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "engine technician armband"
 	},
 /obj/item/clothing/accessory/armband/engine{
-	name = "engine technician armband";
-	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to."
+	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
+	name = "engine technician armband"
 	},
 /obj/item/clothing/glasses/meson/night,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -10874,8 +10882,8 @@
 	pixel_x = -7
 	},
 /obj/item/clothing/suit/toggle/labcoat/syndicate{
-	pixel_y = 4;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 4
 	},
 /obj/item/clothing/neck/stethoscope{
 	pixel_x = 12;
@@ -10978,8 +10986,8 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_y = 6;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -10993,8 +11001,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/command{
-	name = "Bridge";
-	hackProof = 1
+	hackProof = 1;
+	name = "Bridge"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -11181,8 +11189,8 @@
 "UX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "151";
-	dir = 1
+	dir = 1;
+	req_access_txt = "151"
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/smooth_large,
@@ -11212,16 +11220,16 @@
 	id = "smasteratarms";
 	name = "Master at Arms' room bolt";
 	normaldoorcontrol = 1;
+	pixel_x = 6;
 	req_access_txt = "151";
-	specialfunctions = 4;
-	pixel_x = 6
+	specialfunctions = 4
 	},
 /obj/machinery/button/door/directional/south{
 	desc = "Keep out the Officers.";
 	id = "smasteratarms";
 	name = "Master at Arms' shutters control";
-	req_access_txt = "151";
-	pixel_x = -6
+	pixel_x = -6;
+	req_access_txt = "151"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
@@ -11355,8 +11363,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "VC" = (
 /obj/machinery/camera/xray/directional/north{
-	network = list("ds2");
-	c_tag = "DS-2 Interrogation Room"
+	c_tag = "DS-2 Interrogation Room";
+	network = list("ds2")
 	},
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
@@ -11462,9 +11470,9 @@
 "VX" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	name = "Corporate Liaison Shutters";
+	dir = 8;
 	id = "ds2corpliaison";
-	dir = 8
+	name = "Corporate Liaison Shutters"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -11500,8 +11508,8 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/stockparts/deluxe{
-	pixel_y = -4;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -4
 	},
 /obj/structure/closet/crate/engineering,
 /obj/item/t_scanner,
@@ -11510,8 +11518,8 @@
 	pixel_y = -3
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_y = -24;
-	dir = 1
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
@@ -11571,14 +11579,14 @@
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "151";
 	dir = 8;
-	name = "Isolation Cell"
+	name = "Isolation Cell";
+	req_access_txt = "151"
 	},
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "151";
 	dir = 4;
-	name = "Isolation Cell"
+	name = "Isolation Cell";
+	req_access_txt = "151"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "gaybabyjail"
@@ -11617,8 +11625,8 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/syndicate{
-	pixel_y = -24;
-	dir = 1
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -11676,8 +11684,8 @@
 /obj/effect/turf_decal/vg_decals/atmos/air,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10;
-	piping_layer = 1;
-	level = 2
+	level = 2;
+	piping_layer = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
@@ -11701,8 +11709,8 @@
 	pixel_y = 5
 	},
 /obj/item/pen{
-	pixel_y = 5;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -11734,18 +11742,18 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet{
+	icon_door = "eng_elec";
 	icon_state = "eng";
 	name = "electrical supplies locker";
-	req_access_txt = "150";
-	icon_door = "eng_elec"
+	req_access_txt = "150"
 	},
 /obj/item/electronics/airlock{
-	pixel_y = -7;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -7
 	},
 /obj/item/electronics/airlock{
-	pixel_y = -7;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -7
 	},
 /obj/item/storage/toolbox/electrical{
 	pixel_y = -7
@@ -11755,30 +11763,30 @@
 	pixel_y = 5
 	},
 /obj/item/electronics/firelock{
-	pixel_y = 5;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 5
 	},
 /obj/item/electronics/airalarm{
 	pixel_x = 2
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_y = -8;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -8
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_y = -8;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = -8
 	},
 /obj/item/stock_parts/cell/high{
 	pixel_y = -8
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_y = -8;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -8
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_y = -8;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = -8
 	},
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron/dark/side{
@@ -11809,8 +11817,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/hatch{
-	name = "Incinerator Hatch";
-	id_tag = "DS2incineratorHatch"
+	id_tag = "DS2incineratorHatch";
+	name = "Incinerator Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
@@ -11838,16 +11846,16 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Xl" = (
 /obj/machinery/power/smes/engineering{
-	input_level = 150000;
-	charge = 4.5e+006
+	charge = 4.5e+006;
+	input_level = 150000
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4;
 	pixel_x = 4
 	},
 /obj/item/aicard/aitater{
-	pixel_y = 11;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 11
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -12013,8 +12021,8 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -12054,8 +12062,8 @@
 "XY" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /obj/machinery/power/apc/auto_name/west{
-	req_access_txt = "150";
-	req_access = null
+	req_access = null;
+	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/smooth_large,
@@ -12206,8 +12214,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/xray/directional/west{
-	network = list("ds2");
-	c_tag = "DS-2 Research"
+	c_tag = "DS-2 Research";
+	network = list("ds2")
 	},
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/iron/dark,
@@ -12361,8 +12369,8 @@
 	icon_state = "control_kill";
 	lethal = 1;
 	name = "DS2 turret controls";
-	req_access_txt = 0;
-	pixel_x = -30
+	pixel_x = -30;
+	req_access_txt = 0
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -10337,7 +10337,6 @@
 	desc = "Keep out the paperwork.";
 	pixel_y = 24;
 	pixel_x = -32
-	req_access_txt = "151"
 	},
 /obj/item/paper_bin/carbon{
 	pixel_x = 6;


### PR DESCRIPTION
Внес небольшие изменения в ДС2, для удобства играющих там.
Изменения:
- В двух каютах заменены кровати и одеяла на двойные. Чтобы партнер не падал лишний раз на пол
- Машинфрейм и плата мехфаба переместилась ближе к РнД консоли, по причине невозможности подключения. Если ученый не идет к горе, то гора идет к ученому.
- В помещение турбины, к платам поставлены раундстартовые машинфреймы. На один шаг меньше для постройки источника энергии.
- В каюту  corporate liaison-а добавлен фотокопер заместо одного из столов. Больше документов богу документов.

Все изменения проверены и протестированы локально. Скриншоты прилагаются

![Screenshot_1](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/153349208/3f072279-7f0c-4cbd-b11c-71de5c296371)
![Screenshot_2](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/153349208/5d5dfb4e-a65b-4f5c-a49c-b0d6165543dc)
![Screenshot_3](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/153349208/e2094cb8-b52b-48ca-be03-4e07323db5b2)
