### PR TITLE
Убираем хард динамик и тимбазу из ротации динамика

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -389,7 +389,8 @@ SUBSYSTEM_DEF(vote)
 							dynamic_pick = list(ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) - SSpersistence.last_dynamic_gamemode
 
 						if(ROUNDTYPE_PLAYERCOUNT_DYNAMIC_HIGHPOP_MIN to INFINITY)
-							dynamic_pick = list(ROUNDTYPE_DYNAMIC_TEAMBASED, ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) - SSpersistence.last_dynamic_gamemode
+							// dynamic_pick = list(ROUNDTYPE_DYNAMIC_TEAMBASED, ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) - SSpersistence.last_dynamic_gamemode
+							dynamic_pick = list(ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) - SSpersistence.last_dynamic_gamemode // Убираем самые кровавые из режимов, оставляя их админам
 
 					if(dynamic_pick.len > 0)
 						. = pick(dynamic_pick)
@@ -645,16 +646,16 @@ SUBSYSTEM_DEF(vote)
 			. += "<br>Если побеждает [ROUNDTYPE_DYNAMIC], то берётся одна из вариаций динамика."
 
 			. += "<br><font size=1><small><b>[ROUNDTYPE_DYNAMIC_TEAMBASED]:</b></font></small>"
-			. += "<br><font size=1><small>55-100 угрозы, только командные и особые одиночные антагонисты, необходим минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_HIGHPOP_MIN] игрок;</font></small>"
+			. += "<br><font size=1><small>ТОЛЬКО ЧЕРЕЗ ВЫБОР АДМИНОВ. 75-100 угрозы, только командные и особые одиночные антагонисты, необходим минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_HIGHPOP_MIN] игрок;</font></small>"
 
 			. += "<br><font size=1><small><b>[ROUNDTYPE_DYNAMIC_HARD]:</b></font></small>"
-			. += "<br><font size=1><small>75-100 угрозы, необходим минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_HIGHPOP_MIN] игрок;</font></small>"
+			. += "<br><font size=1><small>ТОЛЬКО ЧЕРЕЗ ВЫБОР АДМИНОВ. 75-100 угрозы, необходим минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_HIGHPOP_MIN] игрок;</font></small>"
 
 			. += "<br><font size=1><small><b>[ROUNDTYPE_DYNAMIC_MEDIUM]:</b></font></small>"
-			. += "<br><font size=1><small>40-60 угрозы, необходим минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_MEDIUMPOP_MIN] игрок;</font></small>"
+			. += "<br><font size=1><small>50-75 угрозы, необходим минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_MEDIUMPOP_MIN] игрок;</font></small>"
 
 			. += "<br><font size=1><small><b>[ROUNDTYPE_DYNAMIC_LIGHT]:</b>:</font></small>"
-			. += "<br><font size=1><small>50-70 угрозы, без командных антагонистов, необходимо минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_LOWPOP_MIN] игроков;</font></small>"
+			. += "<br><font size=1><small>50-75 угрозы, без командных антагонистов, необходимо минимум [ROUNDTYPE_PLAYERCOUNT_DYNAMIC_LOWPOP_MIN] игроков;</font></small>"
 
 			. += "<br><font size=1><small><b>[ROUNDTYPE_EXTENDED]</b> (угрозы не спавнятся сами, только администрация может создавать их).</font></small>"
 			. += "<br>Вариация [ROUNDTYPE_DYNAMIC] из прошлого раунда в новом выпасть не может (кроме эксты)."

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -346,11 +346,11 @@ GLOBAL_VAR_INIT(round_type, ROUNDTYPE_DYNAMIC_MEDIUM)
 			GLOB.dynamic_type_threat_min = 75
 			GLOB.dynamic_type_threat_max = 100
 		if(ROUNDTYPE_DYNAMIC_MEDIUM)
-			GLOB.dynamic_type_threat_min = 40
-			GLOB.dynamic_type_threat_max = 60
+			GLOB.dynamic_type_threat_min = 50
+			GLOB.dynamic_type_threat_max = 75
 		if(ROUNDTYPE_DYNAMIC_LIGHT)
 			GLOB.dynamic_type_threat_min = 50
-			GLOB.dynamic_type_threat_max = 70
+			GLOB.dynamic_type_threat_max = 75
 		if(ROUNDTYPE_EXTENDED)
 			GLOB.dynamic_type_threat_min = 0
 			GLOB.dynamic_type_threat_max = 0


### PR DESCRIPTION
1. Повышено количество очков для медиум-динамика (было 40-60, стало 50-75).
2. Слегка повышен максимум для лайт-динамика (было 70, стало 75).
3. Тимбаза и хард динамик больше не могут выпасть в ротации. Это делают админы.