### PR TITLE
Дедгасп не провоцирует распыление у персонажей с квирком 1 жизнь

### DIFF
--- a/modular_bluemoon/krashly/code/datums/traits/negative.dm
+++ b/modular_bluemoon/krashly/code/datums/traits/negative.dm
@@ -10,23 +10,26 @@
 
 /datum/quirk/onelife/add()
 	RegisterSignal(quirk_holder, COMSIG_MOB_DEATH, .proc/get_rid_of_them)
-	RegisterSignal(quirk_holder, COMSIG_MOB_EMOTE, .proc/get_rid_of_them_emote)
+	//RegisterSignal(quirk_holder, COMSIG_MOB_EMOTE, .proc/get_rid_of_them_emote) //чтобы самоубиться можно использовать suicide
 
 /datum/quirk/onelife/remove()
 	remove_signals()
 
 /datum/quirk/onelife/proc/remove_signals()
 	if(!QDELETED(quirk_holder))
-		UnregisterSignal(quirk_holder, list(COMSIG_MOB_DEATH, COMSIG_MOB_EMOTE))
+		UnregisterSignal(quirk_holder, list(COMSIG_MOB_DEATH/*, COMSIG_MOB_EMOTE (чтобы самоубиться можно использовать suicide)*/))
 
 /datum/quirk/onelife/proc/get_rid_of_them(mob/user, list/emote_args)
 	if(quirk_holder.stat == DEAD)
 		remove_signals()
 		quirk_holder.dust(TRUE, TRUE)
 
+
+/*чтобы самоубиться можно использовать suicide
 /datum/quirk/onelife/proc/get_rid_of_them_emote(mob/user, list/emote_args)
 	var/datum/emote/E
 	E = E.emote_list[lowertext(emote_args[EMOTE_ACT])]
 	if(E.key == "deathgasp")
 		remove_signals()
 		quirk_holder.dust(TRUE, TRUE)
+*/


### PR DESCRIPTION
Причины:
1) Злоупотребление данной возможностью с целью избежания последствий
2) это отрицательный квирк на 6 очков, он не должен иметь плюсов (урезанный функционал импланта самоподрыва и фактически более лучшая замена suicide)
3) это крайне неочевидный момент который провоцирует рандомные смерти, сколько триггерится на "притвориться мёртвым"
4) персонажи с одной жизнью должны за эту жизнь держаться как можно крепче, а не распыляться в пыль от того, что рухнули на пол и перестали двигаться