### PR TITLE
Добавил возможность повесить кулер на МОД

### DIFF
--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -53,7 +53,7 @@
 	visor_flags = STOPSPRESSUREDAMAGE
 	visor_flags_inv = HIDEJUMPSUIT
 	item_flags = IMMUTABLE_SLOW
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/device/cooler)
 	resistance_flags = NONE
 	var/obj/item/mod/control/mod
 	mutantrace_variation = STYLE_DIGITIGRADE


### PR DESCRIPTION
Теперь PCU / ПОУ / Portable Cooling Unit, нужный для существования синтетикам-космонавтам и синтетикам-шахтёрам, можно повесить на нагрудник МОД-сьюта (в самый левый слот инвентаря, если кто не в курсе).
QoL.