### PR TITLE
Датчики на тактикуул униформы и одежду экспедитора

### DIFF
--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -40,6 +40,7 @@
 	desc = "Just looking at it makes you want to buy an SKS, go into the woods, and -operate-."
 	icon_state = "tactifool"
 	item_state = "bl_suit"
+	has_sensor = HAS_SENSORS //BLUEMOON CHANGE красота не должна требовать жертв
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 5)
 
 /obj/item/clothing/under/syndicate/tacticool/skirt
@@ -66,6 +67,7 @@
 	can_adjust = FALSE
 
 /obj/item/clothing/under/syndicate/camo/cosmetic
+	has_sensor = HAS_SENSORS //BLUEMOON CHANGE красота не должна требовать жертв
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/under/syndicate/soviet

--- a/code/modules/jobs/job_types/research/expeditor.dm
+++ b/code/modules/jobs/job_types/research/expeditor.dm
@@ -93,6 +93,7 @@
 	desc = "Standart combat turtleneck with printed expiditionary marks."
 	icon_state = "exp_corps"
 	item_state = "exp_corps"
+	has_sensor = HAS_SENSORS //BLUEMOON CHANGE они являются станционным персоналом
 	mutantrace_variation = STYLE_DIGITIGRADE|USE_SNEK_CLIP_MASK|USE_QUADRUPED_CLIP_MASK
 
 /obj/item/clothing/shoes/combat/exp


### PR DESCRIPTION
униформы тактикуул (одежды синдиката без брони) имеют датчики (ибо они красивые, но при этом за это приходилось платить лишением брони) (ну и для камо (если нужно - выключат))
униформа экспедитора имеет датчики - они всё ещё станционный персонал и у всех станционных проф должны быть оные