### PR TITLE
Gear Harness: Улучшайзинг

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -182,13 +182,52 @@
 	item_state = "gear_harness"
 	can_adjust = TRUE
 	body_parts_covered = CHEST|GROIN
+	var/filled_condoms_counter = 0
+
+/obj/item/clothing/under/misc/gear_harness/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = AddComponent(/datum/component/storage/concrete)
+	STR.max_w_class = WEIGHT_CLASS_TINY
+	STR.max_combined_w_class = WEIGHT_CLASS_TINY*100
+	STR.max_items = 100
+	STR.can_hold = typecacheof(list(/obj/item/genital_equipment/condom))
+	STR.insert_preposition = "on"
+	STR.display_numerical_stacking = TRUE
+	STR.click_gather = TRUE
+	STR.allow_quick_empty = TRUE
+
+/obj/item/clothing/under/misc/gear_harness/examine(mob/user)
+	. = ..()
+	. += "You can clip condoms onto it."
+	. += "<b>Alt-Click</b> to adjust coverage of your body."
+	if(filled_condoms_counter > 1)
+		. += "There are <b>[filled_condoms_counter]</b> filled condoms clipped onto it."
+	else if(filled_condoms_counter == 1)
+		. += "There is <b>[filled_condoms_counter]</b> filled condom clipped onto it."
+
+/obj/item/clothing/under/misc/gear_harness/get_examine_string(mob/user, thats)
+	. = ..()
+	if(filled_condoms_counter)
+		. += " with <span class='love'>[filled_condoms_counter] filled condom[filled_condoms_counter > 1 ? "s" : ""]</span> clipped onto it"
+
+/obj/item/clothing/under/misc/gear_harness/Entered(atom/movable/AM, atom/oldLoc)
+	. = ..()
+	var/obj/item/genital_equipment/condom/C = AM
+	if(C.reagents.total_volume >= 1)
+		filled_condoms_counter++
+
+/obj/item/clothing/under/misc/gear_harness/Exited(atom/movable/AM, atom/newLoc)
+	. = ..()
+	var/obj/item/genital_equipment/condom/C = AM
+	if(C.reagents.total_volume >= 1)
+		filled_condoms_counter--
 
 /obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)
-		to_chat(usr, "<span class='notice'>Your gear harness is now covering your chest and groin.</span>")
+		to_chat(usr, "<span class='notice'>Gear harness is now covering chest and groin.</span>")
 		body_parts_covered = CHEST|GROIN
 	else
-		to_chat(usr, "<span class='notice'>Your gear harness is no longer covering anything.</span>")
+		to_chat(usr, "<span class='notice'>Gear harness is no longer covering anything.</span>")
 		body_parts_covered = NONE
 	return TRUE
 

--- a/modular_sand/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_sand/code/modules/clothing/under/miscellaneous.dm
@@ -1,8 +1,0 @@
-/obj/item/clothing/under/misc/gear_harness
-	can_adjust = FALSE
-	body_parts_covered = NONE
-
-/obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
-	// Alert user and return
-	to_chat(usr, span_notice("[src] cannot be adjusted!"))
-	return FALSE

--- a/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/condom.dm
@@ -48,7 +48,7 @@
 
 /obj/item/genital_equipment/condom/update_icon()
 	switch(reagents.total_volume)
-		if(0 to 49)
+		if(1 to 49)
 			icon_state = "b_condom_inflated"
 		if(50 to 100)
 			icon_state = "b_condom_inflated_med"
@@ -56,6 +56,8 @@
 			icon_state = "b_condom_inflated_large"
 		if(250 to 300)
 			icon_state = "b_condom_inflated_huge"
+		else
+			icon_state = "b_condom"
 	..()
 
 /obj/item/genital_equipment/condom/on_reagent_change()

--- a/modular_splurt/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/under/miscellaneous.dm
@@ -345,9 +345,6 @@
 	desc = "An utilitarian uniform of rugged warfare, with yellow insignias."
 	icon_state = "goner_uniform_y"
 
-/obj/item/clothing/under/misc/gear_harness
-	body_parts_covered = NONE
-
 /obj/item/clothing/under/misc/leia_outfit
 	name = "space princess outfit"
 	desc = "Chain for your Master's erotic asphyxiation not included."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4683,7 +4683,6 @@
 #include "modular_sand\code\modules\clothing\suits\miscellaneous.dm"
 #include "modular_sand\code\modules\clothing\under\_under.dm"
 #include "modular_sand\code\modules\clothing\under\costumes.dm"
-#include "modular_sand\code\modules\clothing\under\miscellaneous.dm"
 #include "modular_sand\code\modules\clothing\under\uniform.dm"
 #include "modular_sand\code\modules\clothing\underwear\_underwear.dm"
 #include "modular_sand\code\modules\clothing\underwear\boxers.dm"


### PR DESCRIPTION
Главный реворк - появилась возможность цеплять на gear harness заполненные презервативы - прямо как в тех самых артах/хентаях! (можно и пустые, но зачем...) Их количество будет видно ВСЕМ осматривающим вашего персонажа. Работает как дефолтное вместилище для вещей, ну разберетесь, не тупые.
(Это чистый механ. Я его дам. Спрайтов на персонажей нет. Спрайты я не дам.)
Еще появилась возможность на alt+click прикрывать или оголять срамные места.
А также: устранение конфликтов в коде, микроправки.
![1365565](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/73897677/68c342ce-65c2-4a06-9be3-d4ed6849c446)
