### PR TITLE
Микробаг вскрыл подводные камни

### DIFF
--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -137,6 +137,10 @@
 	if(isitem(AM))
 		var/obj/item/removed_item = AM
 		removed_item.item_flags &= ~IN_STORAGE
+		if(istype(removed_item, /obj/item/clothing/accessory)) //evading quantum entanglement of accessories
+			var/obj/item/clothing/accessory/acc = removed_item
+			if(acc.current_uniform)
+				acc.detach(acc.current_uniform, usr) //Это полный пиздос, вообще всю одежду чинить надо, usr вообще не доложно тут быть
 		if(ismob(parent.loc))
 			var/mob/carrying_mob = parent.loc
 			removed_item.dropped(carrying_mob, TRUE)

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -213,13 +213,13 @@
 /obj/item/clothing/under/misc/gear_harness/Entered(atom/movable/AM, atom/oldLoc)
 	. = ..()
 	var/obj/item/genital_equipment/condom/C = AM
-	if(C.reagents.total_volume >= 1)
+	if(C.reagents?.total_volume >= 1)
 		filled_condoms_counter++
 
 /obj/item/clothing/under/misc/gear_harness/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()
 	var/obj/item/genital_equipment/condom/C = AM
-	if(C.reagents.total_volume >= 1)
+	if(C.reagents?.total_volume >= 1)
 		filled_condoms_counter--
 
 /obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()


### PR DESCRIPTION
Shi Scot оформил шустрый багрепорт через атикеты, и по выделенной линии личных сообщений это дело дошло до меня. Ковыряясь в микротрабле, я обнаружил просто КЛАДЕЗЬ ПИЗДЕЦА. 
Ну вот просто шок, у нас, оказывается, просто убиты аксессуары вообще, типа ты можешь снимать/надевать аксессуар на одежду, которую ты держишь в руках, а эффекты ношения будут применяться/сниматься с тебя (roflanpizdec). 
И даже пузырьки разговора над башкой персонажа сломаны, найдено было через значок адвоката (который не фурычит офк). 
А одежда не понимает, надета ли она на кого то или нет. Типа ты будешь в руках держать = носить. (ну или что-то типа того). А потом костыли придумывают для хардсьютов, где опосля носителя находят. мдаааа. 
Ах да.. заплаточку на gear harness оформил...