### PR TITLE
Чиним workflow

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -12,14 +12,14 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore SpacemanDMM cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}
       - name: Restore Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -8,7 +8,7 @@ on:
     - master
 jobs:
   run_linters:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
     runs-on: ubuntu-20.04
     steps:
@@ -51,7 +51,7 @@ jobs:
           outputFile: output-annotations.txt
 
   compile_all_maps:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Compile Maps
     runs-on: ubuntu-20.04
     steps:
@@ -68,7 +68,7 @@ jobs:
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
 
   run_all_tests:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
     runs-on: ubuntu-22.04
     services:
@@ -117,7 +117,7 @@ jobs:
           bash tools/ci/run_server.sh
 
   test_windows:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Windows Build
     runs-on: windows-latest
     steps:

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install  dos2unix
       - name: "Checkout"
         if: steps.value_holder.outputs.CL_ENABLED
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 25
       - name: "Compile"

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           unset SECRET_EXISTS
           if [ -n $CHANGELOG_ENABLER ]; then SECRET_EXISTS='true' ; fi
-          echo ::set-output name=CL_ENABLED::${SECRET_EXISTS}
+          echo "CL_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
       - name: "Setup python"
         if: steps.value_holder.outputs.CL_ENABLED
         uses: actions/setup-python@v1
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 25
+          persist-credentials: false
       - name: "Compile"
         if: steps.value_holder.outputs.CL_ENABLED
         run: |

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -3,11 +3,14 @@ on:
   push:
     branches:
     - master
+permissions:
+  contents: read
 jobs:
   generate_documentation:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     runs-on: ubuntu-20.04
-    permissions: read-all|write-all
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 25
       - name: Python setup

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   MakeCL:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Пробую починить `Generate documentation` Workflow + обновил версии, чтобы убрать предупреждения.

А [`Compile changelogs`](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/blob/77d6dd330db21aef287a57562cf91b3f944f3a2c/.github/workflows/compile_changelogs.yml#L55) вечно падает из-за, кажется, отсутствия разрешения на запись у `secrets.GITHUB_TOKEN`. Надо бы либо пофиксить разрешения токена, либо убрать/выключить этот Workflow, а то смысл 7 месяцев на каждый PR запускается, отрабатывает и падает в конце...