### PR TITLE
Выбор звука для deathgasp

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -242,3 +242,20 @@ GLOBAL_LIST_INIT(announcer_keys, list(
 	ANNOUNCER_IROD,
 	ANNOUNCER_LAMBDA
 ))
+
+// Возможные звуки эмоции *deathgasp
+GLOBAL_LIST_INIT(deathgasp_sounds, list(
+	"По умолчанию" =		null,
+	"Беззвучный" =			-1,
+	"Классический (1)" =	'sound/voice/deathgasp1.ogg',
+	"Классический (2)" =	'sound/voice/deathgasp2.ogg',
+	"Киборг" =				'sound/voice/borg_deathsound.ogg',
+	"Демон" =				'sound/magic/demon_dies.ogg',
+	"Имп" =					'modular_sand/sound/misc/impdies.wav',
+	"Гладиатор" =			'modular_sand/sound/effects/gladiatordeathsound.ogg',
+	"Посох Смерти" =		'sound/magic/WandODeath.ogg',
+	"Проклятие" =			'sound/magic/curse.ogg',
+	"Конструкт Ратвара" =	'sound/magic/clockwork/anima_fragment_death.ogg',
+	"Ксеноморф" =			'sound/voice/hiss6.ogg',
+	"Свинья" =				'modular_bluemoon/SmiLeY/code/mob/pig/death.ogg'
+	))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -255,6 +255,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 "silicon_flavor_text" = "",
 "custom_species_lore" = "",
 "custom_deathgasp" = "застывает и падает без сил, глаза мертвы и безжизненны...", // BLUEMOON ADD - пользовательский эмоут смерти
+"custom_deathsound" = "По умолчанию", // BLUEMOON ADD - пользовательский эмоут смерти
 "ooc_notes" = "",
 "meat_type" = "Mammalian",
 "body_model" = MALE,
@@ -278,6 +279,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/bark_pitch = 1
 	var/bark_variance = 0.2
 	COOLDOWN_DECLARE(bark_previewing)
+	COOLDOWN_DECLARE(deathsound_preview)
 
 	/// Security record note section
 	var/security_records
@@ -677,6 +679,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							dat += "[html_encode(features["custom_deathgasp"])]<BR>"
 					else
 						dat += "[TextPreview(html_encode(features["custom_deathgasp"]))]...<BR>"
+					dat += "<h2>Custom Deathgasp Sound</h2>"
+					dat += "<a href='?_src_=prefs;preference=custom_deathsound;task=input'><b>Set Custom Deathsound</b></a><br>"
+					dat += "[features["custom_deathsound"]]<BR>"
+					dat += "<BR><a href='?_src_=prefs;preference=deathsoundpreview;task=input''>Preview Deathsound</a><BR>"
 					// BLUEMOON ADD END
 					dat += "<h2>Silicon Flavor Text</h2>"
 					dat += "<a href='?_src_=prefs;preference=silicon_flavor_text;task=input'><b>Set Silicon Examine Text</b></a><br>"
@@ -2378,6 +2384,32 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/msg = input(usr, "Задайте эмоцию, которая будет проигрываться при смерти вашего персонажа!", "Сообщение О Смерти", features["custom_deathgasp"]) as message|null
 					if(!isnull(msg))
 						features["custom_deathgasp"] = strip_html_simple(msg, MAX_DEATHGASP_LEN, TRUE)
+				if("custom_deathsound")
+					var/sound_name = input(user, "Выберите звук смерти персонажа!", "Звук Смерти") as null|anything in GLOB.deathgasp_sounds
+					if(sound_name)
+						features["custom_deathsound"] = sound_name
+				if("deathsoundpreview")
+					if(SSticker.current_state == GAME_STATE_STARTUP) //Timers don't tick at all during game startup, so let's just give an error message
+						to_chat(user, "<span class='warning'>Deathgasp sound previews can't play during initialization!</span>")
+						return
+					if(!COOLDOWN_FINISHED(src, deathsound_preview))
+						return
+					if(!user)
+						return
+					COOLDOWN_START(src, deathsound_preview, (3 SECONDS))
+					var/picked_deathsound_name = features["custom_deathsound"]
+					var/picked_deathsound_path
+					if(picked_deathsound_name)
+						if(picked_deathsound_name == "По умолчанию")
+							picked_deathsound_path = pick('sound/voice/deathgasp1.ogg', 'sound/voice/deathgasp2.ogg')
+						if(picked_deathsound_name == "Беззвучный")
+							picked_deathsound_path = 0
+						if(GLOB.deathgasp_sounds[picked_deathsound_name])
+							picked_deathsound_path = GLOB.deathgasp_sounds[picked_deathsound_name]
+					if(picked_deathsound_path)
+						user.playsound_local(user, picked_deathsound_path, 60)
+					else
+						to_chat(user, "<span class='warning'>Вы выбрали беззвучный deathgasp или выбранный вами звук отсутствует!</span>")
 				// BLUEMOON ADD END
 				if("ooc_notes")
 					var/msg = stripped_multiline_input(usr, "Установите всегда видимые OOC-заметки, связанные с вашими предпочтениями.", "ООС-Заметки", html_decode(features["ooc_notes"]), MAX_FLAVOR_LEN, TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/bark_pitch = 1
 	var/bark_variance = 0.2
 	COOLDOWN_DECLARE(bark_previewing)
-	COOLDOWN_DECLARE(deathsound_preview)
+	COOLDOWN_DECLARE(deathsound_preview) // BLUEMOON ADD - пользовательский эмоут смерти
 
 	/// Security record note section
 	var/security_records

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1071,6 +1071,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//end
 	//death emote
 	S["feature_custom_deathgasp"] >> features["custom_deathgasp"] // BLUEMOON ADD - пользовательский эмоут смерти
+	S["feature_custom_deathsound"] >> features["custom_deathsound"] // BLUEMOON ADD - пользовательский эмоут смерти
 	// Barks
 	S["bark_id"] >> bark_id
 	S["bark_speed"] >> bark_speed
@@ -1270,6 +1271,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	features["flavor_text"]	= copytext_char(features["flavor_text"], 1, MAX_FLAVOR_LEN)
 	features["naked_flavor_text"] = copytext_char(features["naked_flavor_text"], 1, MAX_FLAVOR_LEN) //SPLURT edit
 	features["custom_deathgasp"] = copytext_char(features["custom_deathgasp"], 1, MAX_DEATHGASP_LEN) // BLUEMOON ADD - пользовательский эмоут смерти
+	features["custom_deathsound"] = copytext_char(features["custom_deathsound"], 1, MAX_DEATHGASP_LEN) // BLUEMOON ADD - пользовательский эмоут смерти
 	features["silicon_flavor_text"] = copytext_char(features["silicon_flavor_text"], 1, MAX_FLAVOR_LEN)
 	features["custom_species_lore"] = copytext_char(features["custom_species_lore"], 1, MAX_FLAVOR_LEN) //SPLURT edit
 	features["ooc_notes"] = copytext_char(features["ooc_notes"], 1, MAX_FLAVOR_LEN)
@@ -1432,6 +1434,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["medical_records"]			, medical_records)
 
 	WRITE_FILE(S["feature_custom_deathgasp"]		, features["custom_deathgasp"]) // BLUEMOON ADD - пользовательский эмоут смерти
+	WRITE_FILE(S["feature_custom_deathsound"]		, features["custom_deathsound"]) // BLUEMOON ADD - пользовательский эмоут смерти
 	WRITE_FILE(S["feature_mcolor"]					, features["mcolor"])
 	WRITE_FILE(S["feature_lizard_tail"]				, features["tail_lizard"])
 	WRITE_FILE(S["feature_human_tail"]				, features["tail_human"])

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -107,27 +107,37 @@
 	message_larva = "выпускает воздух с тошнотворным шипением и падает на пол...."
 	message_monkey = "издает свой последний крик, когда последние частицы души уходят из тела и наконец-то... перестает двигаться..."
 	message_simple =  "прекращает всякое движение..."
+	emote_cooldown = 9 SECONDS // BLUEMOON EDIT - повысил кулдаун эмоута в связи с возможно слишком долгими/громкими кастомными звуками
 	stat_allowed = UNCONSCIOUS
 
+// BLUEMOON EDIT START - настройки эмоута смерти в преференсах
 /datum/emote/living/deathgasp/run_emote(mob/user, params)
-    var/mob/living/simple_animal/S = user
-	// BLUEMOON ADD START - пользовательский эмоут смерти
-    if(user?.client?.prefs?.features["custom_deathgasp"])
-        message = user.client.prefs.features["custom_deathgasp"]
-	// BLUEMOON ADD END
-    if(istype(S) && S.deathmessage)
-        message_simple = S.deathmessage
-    . = ..()
-    message = initial(message) // BLUEMOON ADD - пользовательский эмоут смерти
-    message_simple = initial(message_simple)
-    if(. && user.deathsound)
-        if(isliving(user))
-            var/mob/living/L = user
-            if(!L.can_speak_vocal() || L.oxyloss >= 50)
-                return //stop the sound if oxyloss too high/cant speak
-        playsound(user, pick(user.deathsound), 200, 0, 0)
-    if(. && isalienadult(user))
-        playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
+	var/mob/living/simple_animal/S = user
+	if(user?.client?.prefs?.features["custom_deathgasp"])
+		message = user.client.prefs.features["custom_deathgasp"]
+	if(istype(S) && S.deathmessage)
+		message_simple = S.deathmessage
+	. = ..()
+	message = initial(message)
+	message_simple = initial(message_simple)
+	if(!.)
+		return
+	var/deathsound = pick(user.deathsound)
+	if(isalienadult(user))
+		deathsound = 'sound/voice/hiss6.ogg'
+	if(user?.client?.prefs?.features["custom_deathsound"]) // Если у клиента выбран соответствующий преференс - он приоритетнее всего
+		var/preference_deathsound = GLOB.deathgasp_sounds[user.client.prefs.features["custom_deathsound"]]
+		if(preference_deathsound == -1) // Беззвучный
+			return
+		if(preference_deathsound)
+			deathsound = preference_deathsound
+	if(deathsound)
+		if(isliving(user))
+			var/mob/living/L = user
+			if(!L.can_speak_vocal() || (L.oxyloss >= 50 && !HAS_TRAIT(L, TRAIT_NOBREATH)))
+				return //stop the sound if oxyloss too high/cant speak
+		playsound(user, deathsound, 200, 0, 0)
+// BLUEMOON EDIT END
 
 /datum/emote/living/drool
 	key = "drool"


### PR DESCRIPTION
Теперь можно в преференсах выбрать не только текст эмоута *deathgasp, но и его звук из небольшого списка.
