### PR TITLE
Добавляет список рецептов напитков в КПК персонала отеля

### DIFF
--- a/modular_bluemoon/FlaurosStuff/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/modular_bluemoon/FlaurosStuff/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -1,0 +1,4 @@
+/obj/item/pda/hotelstaff
+	name = "hotel staff PDA"
+	default_cartridge = /obj/item/cartridge/hotelstaff
+	inserted_item = /obj/item/pen/fountain

--- a/modular_bluemoon/FlaurosStuff/code/game/objects/items/devices/PDA/cart.dm
+++ b/modular_bluemoon/FlaurosStuff/code/game/objects/items/devices/PDA/cart.dm
@@ -1,0 +1,5 @@
+/obj/item/cartridge/hotelstaff
+	name = "\improper Twin Nexus cartridge"
+	desc = "The customer is always right! Except for when they're not."
+	icon_state = "cart-bar"
+	access = CART_BARTENDER

--- a/modular_splurt/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_splurt/code/game/objects/structures/ghost_role_spawners.dm
@@ -114,7 +114,11 @@
 	uniform = /obj/item/clothing/under/suit/red
 	shoes = /obj/item/clothing/shoes/laceup
 	head = /obj/item/clothing/head/hotel
+	/* BlueMoon Edit Start: Giving hotel staff their own version of bartender PDA - Flauros
 	r_pocket = /obj/item/pda
+	*/ 
+	r_pocket = /obj/item/pda/hotelstaff
+	// BlueMoon Edit End
 	back = /obj/item/storage/backpack/satchel
 	ears = /obj/item/radio/headset/headset_srv/hotel
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4156,6 +4156,8 @@
 #include "modular_bluemoon\Fink\code\vending\autodrobe.dm"
 #include "modular_bluemoon\Fink\code\vending\engivend.dm"
 #include "modular_bluemoon\FlaurosStuff\code\modules\antagonists\qareen\qareen_abilities.dm"
+#include "modular_bluemoon\FlaurosStuff\code\game\objects\items\devices\PDA\cart.dm"
+#include "modular_bluemoon\FlaurosStuff\code\game\objects\items\devices\PDA\PDA_types.dm"
 #include "modular_bluemoon\fluffs\code\accessories.dm"
 #include "modular_bluemoon\fluffs\code\donator.dm"
 #include "modular_bluemoon\fluffs\code\guns.dm"


### PR DESCRIPTION
Персоналу отеля теперь выдаётся КПК с возможностью просматривать рецепты, как в КПК бармена, но без доступа к манифесту станции. QoL для отеля, достаточно сказано.