### PR TITLE
Fix bonus reagents in snacks

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -80,6 +80,13 @@ All foods are distributed among various categories. Use common sense.
 					reagents.add_reagent(rid, amount, tastes.Copy())
 				else
 					reagents.add_reagent(rid, amount)
+		if(bonus_reagents)
+			for(var/rid in bonus_reagents)
+				var/amount = bonus_reagents[rid]
+				if(rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin)
+					reagents.add_reagent(rid, amount, tastes.Copy())
+				else
+					reagents.add_reagent(rid, amount)
 	else
 		..()
 


### PR DESCRIPTION
Added bonus reagents to reagents list

<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

В еде, как в /reagent_containers/ есть два списка: list_reagents и bonus_reagents. В /code/modules/food_and_drinks/food
/snacks.dm есть комментарий по этому поводу: list_reagents для реагентов, которые соответствуют ингредиентам, а bonus_reagents - прибавка, за объединение реагентов в блюда. Проблема в том, что ни гриндер не воспринимает бонусные реагенты (если попытаться передробить еду получишь только то что в list_reagents), ни кукла (когда ест, насыщается только тем, что занесено в list_reagents).

Фикс вышеозначенного бага.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Changelog

:cl:
fix: fixed bonus_reagents in snacks
/:cl:
