### PR TITLE
Изменение речи и эмоутов в крите

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -2,6 +2,7 @@
 	key = "blush"
 	key_third_person = "blushes"
 	message = "краснеет."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/blush/run_emote(mob/user, params)
 	. = ..()
@@ -20,6 +21,7 @@
 	key_third_person = "chokes"
 	message = "задыхается!"
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/choke/run_emote(mob/user, params)
 	. = ..()
@@ -35,12 +37,14 @@
 	key_third_person = "crosses"
 	message = "скрещивает свои руки."
 	restraint_check = TRUE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/chuckle
 	key = "chuckle"
 	key_third_person = "chuckles"
 	message = "усмехается."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 	emote_cooldown = 3 SECONDS
 
 /datum/emote/living/chuckle/run_emote(mob/user, params)
@@ -68,6 +72,7 @@
 	key = "cough"
 	key_third_person = "coughs"
 	message = "кашляет!"
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/cough/can_run_emote(mob/user, status_check = TRUE , intentional)
@@ -133,11 +138,13 @@
 	key = "drool"
 	key_third_person = "drools"
 	message = "пускает слюни."
+	stat_allowed = SOFT_CRIT // BLUEMOON ADD - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/faint
 	key = "faint"
 	key_third_person = "faints"
 	message = "падает без сознания."
+	stat_allowed = SOFT_CRIT
 
 /datum/emote/living/faint/run_emote(mob/user, params)
 	. = ..()
@@ -176,6 +183,7 @@
 	key = "frown"
 	key_third_person = "frowns"
 	message = "хмурится."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/gag
 	key = "gag"
@@ -237,6 +245,7 @@
 	message = "смотрит с ненавистью."
 	message_param = "смотрит с ненавистью на %t."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/grin
 	key = "grin"
@@ -326,6 +335,7 @@
 	key_third_person = "chitters"
 	message = "бубнит."
 	message_mime = "тихо бубнит."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/audio_emote/chitter/run_emote(mob/user, params)
 	. = ..()
@@ -339,12 +349,14 @@
 	key_third_person = "looks"
 	message = "смотрит."
 	message_param = "смотрит на %t."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/nod
 	key = "nod"
 	key_third_person = "nods"
 	message = "кивает головой."
 	message_param = "кивает головой в согласии с %t."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/point
 	key = "point"
@@ -371,6 +383,7 @@
 	key_third_person = "pouts"
 	message = "дуется."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/scream
 	key = "scream"
@@ -391,18 +404,21 @@
 	key_third_person = "shakes"
 	message = "качает своей головой в отрицании."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/shiver
 	key = "shiver"
 	key_third_person = "shiver"
 	message = "вздрагивает."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sigh
 	key = "sigh"
 	key_third_person = "sighs"
 	message = "вздыхает."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sigh/run_emote(mob/user, params)
 	. = ..()
@@ -421,17 +437,20 @@
 	key = "smile"
 	key_third_person = "smiles"
 	message = "улыбается."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/smirk
 	key = "smirk"
 	key_third_person = "smirks"
 	message = "ухмыляется."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sneeze
 	key = "sneeze"
 	key_third_person = "sneezes"
 	message = "чихает."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sneeze/run_emote(mob/user, params)
 	. = ..()
@@ -445,12 +464,14 @@
 	key = "smug"
 	key_third_person = "smugs"
 	message = "самодовольно ухмыляется."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sniff
 	key = "sniff"
 	key_third_person = "sniffs"
 	message = "sniffs."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sniff/run_emote(mob/user, params)
 	. = ..()
@@ -473,16 +494,19 @@
 	key_third_person = "stares"
 	message = "пристально смотрит."
 	message_param = "пристально смотрит на %t."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/strech
 	key = "stretch"
 	key_third_person = "stretches"
 	message = "вытягивает руки."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/sulk
 	key = "sulk"
 	key_third_person = "sulks"
 	message = "печально опускает руки."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/surrender
 	key = "surrender"
@@ -511,15 +535,18 @@
 	key = "tremble"
 	key_third_person = "trembles"
 	message = "дрожит от страха!"
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/twitch
 	key = "twitch"
 	key_third_person = "twitches"
 	message = "сильно дёргается."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/twitch_s
 	key = "twitch_s"
 	message = "дёргается."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/wave
 	key = "wave"
@@ -536,12 +563,14 @@
 	key = "wsmile"
 	key_third_person = "wsmiles"
 	message = "слабо улыбается."
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 
 /datum/emote/living/yawn
 	key = "yawn"
 	key_third_person = "yawns"
 	message = "зевает."
 	emote_type = EMOTE_AUDIBLE
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 	emote_cooldown = 3 SECONDS
 
 /datum/emote/living/yawn/run_emote(mob/user, params)
@@ -557,6 +586,7 @@
 	key = "me"
 	key_third_person = "custom"
 	message = null
+	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 	emote_type = EMOTE_BOTH
 
 /datum/emote/living/custom/proc/check_invalid(mob/user, input)
@@ -589,6 +619,7 @@
 
 /datum/emote/living/help
 	key = "help"
+	stat_allowed = DEAD
 
 /datum/emote/living/help/run_emote(mob/user, params)
 	var/list/keys = list()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	set waitfor = FALSE
-	var/static/list/crit_allowed_modes = list(MODE_WHISPER = TRUE, MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
+	var/static/list/special_crit_modes = list(MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
 	var/static/list/unconscious_allowed_modes = list(MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
 	var/talk_key = get_key(message)
 
@@ -143,9 +143,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(check_emote(original_message) || !can_speak_basic(original_message, ignore_spam))
 		return
 
-	if(in_critical)
-		if(!(crit_allowed_modes[message_mode]))
-			return
 	else if(stat == UNCONSCIOUS)
 		if(!(unconscious_allowed_modes[message_mode]))
 			return
@@ -180,11 +177,14 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/succumbed = FALSE
 
 	var/fullcrit = InFullCritical()
-	if((InCritical() && !fullcrit) || message_mode == MODE_WHISPER)
+	if(in_critical && !(message_mode in special_crit_modes))
 		message_range = 1
 		message_mode = MODE_WHISPER
 		src.log_talk(message, LOG_WHISPER)
 		if(fullcrit)
+			var/confirm = alert("You are in full crit and can't talk, but you can whisper it in your last breath and succumb to death. Proceed?", "Last Breath", "Yes", "Cancel")
+			if(confirm == "Cancel")
+				return
 			var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 			// If we cut our message short, abruptly end it with a-..
 			var/message_len = length_char(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -91,7 +91,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	set waitfor = FALSE
-	var/static/list/special_crit_modes = list(MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
+	// Данные режимы обходят проверку на крит и не превращаются в разговор "на последнем вздохе"
+	var/static/list/special_crit_modes = list(MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)  // BLUEMOON EDIT - правки last breath'а
 	var/static/list/unconscious_allowed_modes = list(MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
 	var/talk_key = get_key(message)
 
@@ -118,7 +119,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/message_mode = get_message_mode(message)
 	var/original_message = message
 	var/in_critical = InCritical()
-	var/fullcrit = InFullCritical()
+	var/fullcrit = InFullCritical() // BLUEMOON EDIT - правки last breath'а
 
 	if(one_character_prefix[message_mode])
 		message = copytext_char(message, 2)
@@ -144,7 +145,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(check_emote(original_message) || !can_speak_basic(original_message, ignore_spam))
 		return
 
-	else if(stat == UNCONSCIOUS && !fullcrit)
+	else if(stat == UNCONSCIOUS && !fullcrit) // BLUEMOON EDIT - правки last breath'а
 		if(!(unconscious_allowed_modes[message_mode]))
 			return
 
@@ -177,7 +178,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	var/succumbed = FALSE
 
-	if(in_critical && !unconscious_allowed_modes[message_mode])
+	// BLUEMOON EDIT START - правки last breath'а
+	if(in_critical && !special_crit_modes[message_mode])
 		message_range = 2
 		message_mode = MODE_WHISPER
 		src.log_talk(message, LOG_WHISPER)
@@ -192,6 +194,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			message = Ellipsis(message, 10, 1)
 			message_mode = MODE_WHISPER_CRIT
 			succumbed = TRUE
+	// BLUEMOON EDIT END
 	else
 		src.log_talk(message, LOG_SAY, forced_by=forced)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -118,6 +118,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/message_mode = get_message_mode(message)
 	var/original_message = message
 	var/in_critical = InCritical()
+	var/fullcrit = InFullCritical()
 
 	if(one_character_prefix[message_mode])
 		message = copytext_char(message, 2)
@@ -143,7 +144,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(check_emote(original_message) || !can_speak_basic(original_message, ignore_spam))
 		return
 
-	else if(stat == UNCONSCIOUS)
+	else if(stat == UNCONSCIOUS && !fullcrit)
 		if(!(unconscious_allowed_modes[message_mode]))
 			return
 
@@ -176,14 +177,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	var/succumbed = FALSE
 
-	var/fullcrit = InFullCritical()
-	if(in_critical && !(message_mode in special_crit_modes))
+	if(in_critical && !unconscious_allowed_modes[message_mode])
 		message_range = 2
 		message_mode = MODE_WHISPER
 		src.log_talk(message, LOG_WHISPER)
 		if(fullcrit)
-			var/confirm = alert("You are in full crit and can't talk, but you can whisper it in your last breath and succumb to death. Proceed?", "Last Breath", "Yes", "Cancel")
-			if(confirm == "Cancel")
+			var/confirm = alert(src, "You are in full crit and can't talk, but you can whisper it in your last breath and succumb to death. Proceed?", "Last Breath", "Yes", "Cancel")
+			if(!confirm || confirm == "Cancel")
 				return
 			var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
 			// If we cut our message short, abruptly end it with a-..

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	var/fullcrit = InFullCritical()
 	if(in_critical && !(message_mode in special_crit_modes))
-		message_range = 1
+		message_range = 2
 		message_mode = MODE_WHISPER
 		src.log_talk(message, LOG_WHISPER)
 		if(fullcrit)


### PR DESCRIPTION
/me и несколько эмоутов теперь можно использовать в софткрите
Теперь речь в софткрите автоматически превращается в шёпот, слышно его на один тайл дальше, чем раньше (итого два тайла). 
При хардкрите раньше персонаж, попытавшись что-то сказать, умирал, прошептав это на своём последнем вздохе, теперь перед этим у игрока спрашивают подтверждение.
Теперь *help можно юзать будучи мёртвым