### PR TITLE
Add modular directories for build to trigger

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -61,6 +61,7 @@ export const DmTarget = new Juke.Target({
     'html/**',
     'icons/**',
     'interface/**',
+    "modular_*/**", // BLUEMOON ADD
     `${DME_NAME}.dme`,
   ],
   outputs: [


### PR DESCRIPTION
Меняешь ты такой что-то в `modular_*` папке.
Жмякаешь <kbd>F5</kbd>.
И ничего не билдится! Билд запускается без изменений!

Просто потому что Juke не видит, что что-то поменялось, и думает что билдить ничего не надо:
![image](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/32931701/cdf19fed-3158-4d0d-82de-ace229b8ce94)

С этим изменением Juke научится видеть любые модификации файлов в папках `modular_*`