### PR TITLE
Всякое с оружием и мувспидом

### DIFF
--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -41,7 +41,7 @@ Key procs
 	/// Next two variables depend on this: Should we do advanced calculations?
 	var/complex_calculation = FALSE
 	/// Absolute max tiles we can boost to
-	var/absolute_max_tiles_per_second = INFINITY
+	var/absolute_max_tiles_per_second = 10
 	/// Max tiles per second we can boost
 	var/max_tiles_per_second_boost = INFINITY
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -47,7 +47,7 @@
 	/// The time between shots in burst.
 	var/burst_shot_delay = 3
 	/// The time between firing actions, this means between bursts if this is burst weapon. The reason this is 0 is because you are still, by default, limited by clickdelay.
-	var/fire_delay = 0
+	var/fire_delay = 2 // BLUEMOON EDIT - was 0 (фикс для слишком высокой скорострельности части оружия и отсутвия КД на клики у автоматического режима огня)
 	/// Last world.time this was fired
 	var/last_fire = 0
 	/// Currently firing, whether or not it's a burst or not.
@@ -218,6 +218,7 @@
 			to_chat(user, "<span class='notice'>You switch [src] to [burst_size]-round burst.</span>")
 		if(SELECT_FULLY_AUTOMATIC)
 			burst_size = 1
+			fire_delay = initial(fire_delay) // BLUEMOON ADD - чиним отсутствие КД на скорость стрельбы у целой кучи оружия без SELECT_BURST_FIRE
 			SEND_SIGNAL(src, COMSIG_GUN_AUTOFIRE_SELECTED, user)
 			to_chat(user, "<span class='notice'>You switch [src] to automatic.</span>")
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -247,6 +247,7 @@
 	automatic_burst_overlay = FALSE
 	can_suppress = FALSE
 	burst_size = 1
+	fire_delay = 5 // BLUEMOON EDIT - was NOTHING
 	pin = /obj/item/firing_pin/implant/pindicate
 	actions_types = list()
 

--- a/modular_bluemoon/krashly/code/game/objects/items/weaponry.dm
+++ b/modular_bluemoon/krashly/code/game/objects/items/weaponry.dm
@@ -125,7 +125,7 @@
 	can_suppress = FALSE
 	weapon_weight = WEAPON_HEAVY
 	burst_size = 3
-	fire_delay = 1
+	fire_delay = 2
 	fire_sound = 'modular_bluemoon/krashly/sound/ak12_fire.ogg'
 
 /obj/item/gun/ballistic/automatic/ak12/update_icon_state()


### PR DESCRIPTION
1. Пофикшено отсутствие КД у всего оружия. что не имеет бёрст фаера, но имеет автоматический режим стрельбы
2. Выставлена максимальная скорость в игре - 10 тайлов в секунду
3. Максимальную скорость для спринта нужно трогать в конфигах. Она перегружает этот параметр.

У бульдого теперь скорострельность боевого дробовика.
Калаш стреляет со скоростью ВТ (кроме розового, он как магнитка)

Хз на что ещё повлияло