### PR TITLE
Нерф адвактиватора интегралок и доступов принтера

### DIFF
--- a/code/datums/components/ntnet_interface.dm
+++ b/code/datums/components/ntnet_interface.dm
@@ -7,7 +7,7 @@
 
 /datum/proc/ntnet_send(datum/netdata/data, netid)
 	var/datum/component/ntnet_interface/NIC = GetComponent(/datum/component/ntnet_interface)
-	if(!NIC)
+	if(!NIC || NIC.blocked) //Bluemoon ADD (NIC.blocked) - Возможность заблокировать отправку любого устройства.
 		return FALSE
 	return NIC.__network_send(data, netid)
 
@@ -16,6 +16,7 @@
 	var/network_name = ""			//text
 	var/list/networks_connected_by_id = list()		//id = datum/ntnet
 	var/differentiate_broadcast = TRUE				//If false, broadcasts go to ntnet_receive. NOT RECOMMENDED.
+	var/blocked 			//Bluemoon ADD. Если это значение TRUE, все действия с этого адреса не будут выполняться.
 
 /datum/component/ntnet_interface/Initialize(force_name = "NTNet Device", autoconnect_station_network = TRUE)			//Don't force ID unless you know what you're doing!
 	hardware_id = "[SSnetworks.get_next_HID()]"

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -105,10 +105,14 @@
 
 /obj/item/integrated_circuit_printer/attack_self(mob/living/carbon/human/user)
 	var/user_job = user.mind.assigned_role
-	if(upgraded & user_job == "Robotist" || user_job == "Research Director" || user_job == "Scientist" || user.mind?.has_antag_datum(/datum/antagonist/ghost_role))
-		interact(user)
-	else
-		to_chat(user, "<span class='warning'>Улучшения сделали этот принтер сложным и непонятным для вас!")
+	if(upgraded)
+		if(user_job == "Robotist" || user_job == "Research Director" || user_job == "Scientist" || user.mind?.has_antag_datum(/datum/antagonist/ghost_role))
+			interact(user)
+			return
+		else
+			to_chat(user, "<span class='warning'>Улучшения сделали этот принтер сложным и непонятным для вас!")
+			return
+	interact(user)
 
 /obj/item/integrated_circuit_printer/interact(mob/user)
 	if(!(in_range(src, user) || issilicon(user)))

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -106,7 +106,7 @@
 /obj/item/integrated_circuit_printer/attack_self(mob/living/carbon/human/user)
 	var/user_job = user.mind.assigned_role
 	if(upgraded)
-		if(user_job == "Robotist" || user_job == "Research Director" || user_job == "Scientist" || user.mind?.has_antag_datum(/datum/antagonist/ghost_role))
+		if(user_job == "Roboticist" || user_job == "Research Director" || user_job == "Scientist" || user.mind?.has_antag_datum(/datum/antagonist/ghost_role))
 			interact(user)
 			return
 		else

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -103,8 +103,12 @@
 
 	return ..()
 
-/obj/item/integrated_circuit_printer/attack_self(mob/user)
-	interact(user)
+/obj/item/integrated_circuit_printer/attack_self(mob/living/carbon/human/user)
+	var/user_job = user.mind.assigned_role
+	if(upgraded & user_job == "Robotist" || user_job == "Research Director" || user_job == "Scientist" || user.mind?.has_antag_datum(/datum/antagonist/ghost_role))
+		interact(user)
+	else
+		to_chat(user, "<span class='warning'>Улучшения сделали этот принтер сложным и непонятным для вас!")
 
 /obj/item/integrated_circuit_printer/interact(mob/user)
 	if(!(in_range(src, user) || issilicon(user)))

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -49,7 +49,14 @@
 				return
 			SSnetworks.station_network.toggle_function(text2num(params["id"]))
 			return TRUE
-
+		//BLUEMOON ADD Start
+		if("block_toggle_by_adress")
+			var/datum/component/ntnet_interface/adress = SSnetworks.station_network.connected_interfaces_by_id[(params["adress"])]
+			if(!adress.blocked)
+				adress.blocked = FALSE
+			else
+				adress.blocked = TRUE
+		//BLUEMOON ADD END
 /datum/computer_file/program/ntnetmonitor/ui_data(mob/user)
 	if(!SSnetworks.station_network)
 		return

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -49,14 +49,7 @@
 				return
 			SSnetworks.station_network.toggle_function(text2num(params["id"]))
 			return TRUE
-		//BLUEMOON ADD Start
-		if("block_toggle_by_adress")
-			var/datum/component/ntnet_interface/adress = SSnetworks.station_network.connected_interfaces_by_id[(params["adress"])]
-			if(!adress.blocked)
-				adress.blocked = FALSE
-			else
-				adress.blocked = TRUE
-		//BLUEMOON ADD END
+
 /datum/computer_file/program/ntnetmonitor/ui_data(mob/user)
 	if(!SSnetworks.station_network)
 		return

--- a/modular_sand/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/modular_sand/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -30,7 +30,7 @@
 	cooldown_per_use = 1
 	complexity = 10
 
-	inputs = list("target" = IC_PINTYPE_REF, "action" = IC_PINTYPE_STRING, "param_key_1" = IC_PINTYPE_STRING, "param_value_1" = IC_PINTYPE_ANY, "param_key_2" = IC_PINTYPE_STRING, "param_value_2" = IC_PINTYPE_ANY, "param_key_3" = IC_PINTYPE_STRING, "param_value_3" = IC_PINTYPE_ANY)
+	inputs = list("target" = IC_PINTYPE_REF, "action" = IC_PINTYPE_STRING, "param_key_1" = IC_PINTYPE_STRING, "param_value_1" = IC_PINTYPE_ANY, "param_key_2" = IC_PINTYPE_STRING, "param_value_2" = IC_PINTYPE_ANY, "param_key_3" = IC_PINTYPE_STRING, "param_value_3" = IC_PINTYPE_ANY, "passkey" = IC_PINTYPE_STRING)
 	activators = list(
 		"pulse in" = IC_PINTYPE_PULSE_IN,
 		"pulse out" = IC_PINTYPE_PULSE_OUT
@@ -39,10 +39,19 @@
 	power_draw_per_use = 50
 	ext_cooldown = 1
 	var/max_grab = GRAB_PASSIVE
+	var/datum/component/ntnet_interface/net
+
+/obj/item/integrated_circuit/manipulation/advactivator/Initialize(mapload)
+	. = ..()
+	net = LoadComponent(/datum/component/ntnet_interface)
+	var/address = net.hardware_id
+	net.differentiate_broadcast = FALSE
+	desc += "<br>This circuit's NTNet hardware address is: [address]"
 
 /obj/item/integrated_circuit/manipulation/advactivator/do_work(ord)
 	var/obj/acting_object = get_pin_data_as_type(IC_INPUT, 1, /obj/)
 	var/action = get_pin_data(IC_INPUT, 2)
+	var/passkey = get_pin_data(IC_INPUT, 9)
 	//var/key = get_pin_data(IC_INPUT, 3)
 	//var/value = get_pin_data(IC_INPUT, 4)
 	var/params = list(
@@ -55,5 +64,25 @@
 		if(key && value)
 			params["[key]"] = value
 	if(acting_object)
-		acting_object.ui_act(action, params)
-		activate_pin(2)
+		var/datum/ntnet/my_ntnet = SSnetworks.station_network
+		var/user = assembly.loc
+		var/mob/living/carbon/human/realuser = user //Интегралка может лежать на полу, но если она все же в руках игрока, то это позволит определить кто это
+		if(my_ntnet.check_relay_operation(2) & !net.blocked)//Если на станции отключен NTnet то и гост-рольки не смогут тыкать адвактиватором. Увы. Логичное объяснение - NTnet один с сервером на станции. Практическое объяснение - гострольки не должны через камеры бесоебить шлюзы на станции
+			if(acting_object.GetComponent(/datum/component/ntnet_interface)) //Шлюзы и стеклянные панели имеют NTnet интерфейс
+				if(!passkey) //Если пасскей не введен вовсе и взаимодействие происходит с шлюзом, то ничего не произойдет. Адвактиватор не отработает
+					return
+				var/obj/machinery/door/target_airlock = acting_object
+				if(target_airlock.check_access_list(assembly.access_card.access))
+					acting_object.ui_act(action, params) //позволяем  трогать шлюз, если есть доступ
+				else
+					return
+			if(ishuman(user))
+				user = realuser.real_name //Станция должна знать своих героев(в данный момент сломана кодировка имени в отправке \u041c\u0430\u0440)
+			var/datum/netdata/message = new
+			var/location = "[realuser.x], [realuser.y], [realuser.z]"
+			message.data = "[acting_object] has been activated by [realuser] in [location]"
+
+			if(!acting_object.GetComponent(/datum/component/ntnet_interface))//Проверка istype() на тип шлюза не работает почему-то. Зато на компонент работает.
+				acting_object.ui_act(action, params)
+			ntnet_send(message)//Используется только в целях логгирования в консоль РД, т.к все отправки записываются в Wirecamp
+			activate_pin(2)

--- a/modular_sand/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/modular_sand/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -67,7 +67,7 @@
 		var/datum/ntnet/my_ntnet = SSnetworks.station_network
 		var/user = assembly.loc
 		var/mob/living/carbon/human/realuser = user //Интегралка может лежать на полу, но если она все же в руках игрока, то это позволит определить кто это
-		if(my_ntnet.check_relay_operation(2) & !net.blocked)//Если на станции отключен NTnet то и гост-рольки не смогут тыкать адвактиватором. Увы. Логичное объяснение - NTnet один с сервером на станции. Практическое объяснение - гострольки не должны через камеры бесоебить шлюзы на станции
+		if(my_ntnet.check_relay_operation(acting_object.z) & my_ntnet.check_relay_operation(assembly.z) & !net.blocked)//Если на станции отключен NTnet то и гост-рольки не смогут тыкать адвактиватором. Увы. Логичное объяснение - NTnet один с сервером на станции. Практическое объяснение - гострольки не должны через камеры бесоебить шлюзы на станции
 			if(acting_object.GetComponent(/datum/component/ntnet_interface)) //Шлюзы и стеклянные панели имеют NTnet интерфейс
 				if(!passkey) //Если пасскей не введен вовсе и взаимодействие происходит с шлюзом, то ничего не произойдет. Адвактиватор не отработает
 					return

--- a/tgui/packages/tgui/interfaces/NtosNetMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosNetMonitor.js
@@ -1,10 +1,12 @@
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, NoticeBox, NumberInput, Section } from '../components';
+import { Box, Button, LabeledList, NoticeBox, NumberInput, Section, TextArea} from '../components';
 import { NtosWindow } from '../layouts';
+import { Input } from '../paracode_components';
 
 export const NtosNetMonitor = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    input,
     ntnetrelays,
     ntnetstatus,
     config_softwaredownload,
@@ -80,6 +82,21 @@ export const NtosNetMonitor = (props, context) => {
                   selected={config_systemcontrol}
                   onClick={() => act('toggle_function', { id: "4" })} />
               )} />
+              <LabeledList.Item
+              label="Block by adress"
+              const input
+              buttons={(
+                <Button
+                  icon={config_systemcontrol ? 'power-off' : 'times'}
+                  onClick={() => act('blocked_by_adress')} />
+              )}/>
+                <TextArea
+                height="50px"
+                value={input}
+                onInput={(_, value) => {
+                  setInput(value.substring(0, 20));
+                }}
+                />
           </LabeledList>
         </Section>
         <Section title="Security Systems">

--- a/tgui/packages/tgui/interfaces/NtosNetMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosNetMonitor.js
@@ -83,19 +83,17 @@ export const NtosNetMonitor = (props, context) => {
                   onClick={() => act('toggle_function', { id: "4" })} />
               )} />
               <LabeledList.Item
-              label="Block by adress"
+              label="Block/Unblock by adress"
               const input
+              adress = ""
               buttons={(
                 <Button
                   icon={config_systemcontrol ? 'power-off' : 'times'}
-                  onClick={() => act('blocked_by_adress')} />
+                  onClick={() => act('block_toggle_by_adress', adress = input)} />
               )}/>
                 <TextArea
-                height="50px"
-                value={input}
-                onInput={(_, value) => {
-                  setInput(value.substring(0, 20));
-                }}
+                height="30px"
+                adress={input}
                 />
           </LabeledList>
         </Section>

--- a/tgui/packages/tgui/interfaces/NtosNetMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosNetMonitor.js
@@ -83,17 +83,19 @@ export const NtosNetMonitor = (props, context) => {
                   onClick={() => act('toggle_function', { id: "4" })} />
               )} />
               <LabeledList.Item
-              label="Block/Unblock by adress"
+              label="Block by adress"
               const input
-              adress = ""
               buttons={(
                 <Button
                   icon={config_systemcontrol ? 'power-off' : 'times'}
-                  onClick={() => act('block_toggle_by_adress', adress = input)} />
+                  onClick={() => act('blocked_by_adress')} />
               )}/>
                 <TextArea
-                height="30px"
-                adress={input}
+                height="50px"
+                value={input}
+                onInput={(_, value) => {
+                  setInput(value.substring(0, 20));
+                }}
                 />
           </LabeledList>
         </Section>


### PR DESCRIPTION
Этот ПР делает интегральный компонент адвактиватор зависимым от станционного NTnet-а и доступов. Теперь нельзя раундстартом получать полный доступ и проникать куда не следовало бы. 

Отныне, **улучшенным** принтером интегральных плат могут пользоваться только ученые или гост роли. Это зависит от роли в переменной mind, а значит, что нельзя устроится с ассистента на ученого через ГП и познать интегральные платы. Обычный принтер, без продвинутых компонентов, доступен каждому.

Ветка запроса с обсуждением этого нерфа: https://discord.com/channels/875735187449847830/1219030790550196224

Сделаны задатки под блокирование любого NTnet устройства по ID. Я плохо разбираюсь в UI, поэтому пока что лишь наброски, которые никак не мешают.