### PR TITLE
Даём клоуну спелл на создание пирогов, пироги в алинк для клоуна и мима, удаляем книгу для пирогов из лодаута

### DIFF
--- a/code/modules/jobs/job_types/service/clown.dm
+++ b/code/modules/jobs/job_types/service/clown.dm
@@ -25,6 +25,13 @@
 	family_heirlooms = list(
 		/obj/item/bikehorn/golden
 	)
+// BLUEMOON ADD START - спелл на вызов пирогов у клоуна раундстартом
+/datum/job/clown/after_spawn(mob/living/H, client/C)
+	. = ..()
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/targeted/conjure_item/summon_pie/S = new
+		H.mind.AddSpell(S)
+// BLUEMOON ADD END
 
 /datum/outfit/job/clown
 	name = "Clown"

--- a/html/changelogs/AutoChangeLog-pr-843.yml
+++ b/html/changelogs/AutoChangeLog-pr-843.yml
@@ -1,0 +1,4 @@
+author: Darkest08
+delete-after: true
+changes:
+  - tgs: has something to do with tgs

--- a/modular_bluemoon/clown_pie_book/clown_pie_book.dm
+++ b/modular_bluemoon/clown_pie_book/clown_pie_book.dm
@@ -1,0 +1,6 @@
+/datum/uplink_item/role_restricted/pie_book
+	name = "Book: Summon Pie"
+	desc = "A book which grants its user ability to summon a pie. It would be a perfect combo with silly jokes."
+	item = /obj/item/book/granter/spell/summon_pie
+	cost = 5
+	restricted_roles = list("Clown", "Mime")

--- a/modular_bluemoon/clown_pie_book/clown_pie_book.dm
+++ b/modular_bluemoon/clown_pie_book/clown_pie_book.dm
@@ -1,6 +1,6 @@
 /datum/uplink_item/role_restricted/pie_book
 	name = "Book: Summon Pie"
-	desc = "A book which grants its user ability to summon a pie. It would be a perfect combo with silly jokes."
+	desc = "A book which grants its user ability to summon a pie. It would be a perfect combo with silly jokes with others."
 	item = /obj/item/book/granter/spell/summon_pie
-	cost = 5
+	cost = 1 // возможность засрать ими бар и ывзвать у СБ проблемы с закидывающими их ассистентами
 	restricted_roles = list("Clown", "Mime")

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -43,7 +43,7 @@
 	ckeywhitelist = list()
 	cost = 4
 	donator_group_id = DONATOR_GROUP_TIER_1
-
+/*
 /datum/gear/donator/summon_pie
 	name = "Book: Summon Pie"
 	slot = ITEM_SLOT_BACKPACK
@@ -51,7 +51,7 @@
 	ckeywhitelist = list()
 	cost = 6
 	donator_group_id = DONATOR_GROUP_TIER_1
-
+*/
 /datum/gear/donator/purple_zippo
 	name = "Purple Zippo"
 	slot = ITEM_SLOT_BACKPACK

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4121,6 +4121,7 @@
 #include "modular_bluemoon\bloodsuckers_upgrade\bloodsucker_objectives.dm"
 #include "modular_bluemoon\bloodsuckers_upgrade\bloodsuckers_defines.dm"
 #include "modular_bluemoon\bloodsuckers_upgrade\bloodsuckers_frenzy.dm"
+#include "modular_bluemoon\clown_pie_book\clown_pie_book.dm"
 #include "modular_bluemoon\code\_HELPERS\text.dm"
 #include "modular_bluemoon\code\controllers\configuration\entries\silicon.dm"
 #include "modular_bluemoon\code\datums\dna.dm"


### PR DESCRIPTION
Дарк, не делай больше /:cl: в своих ПРах пожалуйста.

Мим и клоун при наличии аплинка могут за 1(!) ТК выдавать себе книги, позволяющие сделать любому абилку на закидывание пирогами. В теории, должно вызывать проблемы у СБ и командования, отвлекая от ролей. Да и просто silly war.

Клоун получает эту абилку раундстартом.

А по теме сабжа с выпилом книги из лодаута:
<details>

1. Арбзуная штука, которую можно (и которую применяют) во время задержания или робаста. Роняние на пол заставляет чела мыть низкомобильным достаточное количество времени, чтобы подбежать и предпринять действия, пока он не носится как гоночный боллид.
2. Пироги повышают сытость персонажа, что вызывает особенную фрустрацию из-за переедания. И как бы, с этим не было проблемы, т.к. их не было так много раньше.
3. Халявная еда. Всегда можно бустануть настроение. Не очень круто.
4. Можно стакать пироги в сумке, в нужный момент закидывая противника дешевым станом.
5. Дебафают муд персонажа. И как бы, с этим не было проблемы, т.к. их не было так много раньше.
6. Это бывает смешно, но обычно не очень приятно. Не крутое ролевое взаимодействие.
</details>