### PR TITLE
Fix browser refreshing before input is closed

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -762,7 +762,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						dat += "<img src='[features["headshot_link1"]]' style='border: 1px solid black' width='140px' height='140px'>"
 					dat += "<br><br>"
 
-					dat += "<h2>Headshot 2 Image</h2>"
+					dat += "<h2>Headshot 3 Image</h2>"
 					dat += "<a href='?_src_=prefs;preference=headshot2'><b>Set Headshot 3 Image</b></a><br>"
 					if(features["headshot_link2"])
 						dat += "<img src='[features["headshot_link2"]]' style='border: 1px solid black' width='140px' height='140px'>"

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -5,21 +5,15 @@
 
 
 /datum/preferences/process_link(mob/user, list/href_list)
-	. = ..()
-
-	if (href_list["task"] == "input" || href_list["task"] == "random")
-		return
-
 	switch(href_list["preference"])
 		if ("headshot")
 			set_headshot_link(user, "headshot_link")
-			return TRUE
 		if ("headshot1")
 			set_headshot_link(user, "headshot_link1")
-			return TRUE
 		if ("headshot2")
 			set_headshot_link(user, "headshot_link2")
-			return TRUE
+
+	return ..()
 
 
 /datum/preferences/proc/set_headshot_link(mob/user, link_id)


### PR DESCRIPTION
Тупой бесячий баг из-за неожиданной мной странной реализации хендлинга обновления браузера.

В общем, теперь при нажатии на кнопку установки хедшота, поле ввода не будет закрываться лодаутом.