### PR TITLE
fix: devourer trait fix

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -1,4 +1,4 @@
 @echo off
 call "%~dp0\tools\build\build.bat" %*
-rem pause
+pause
 rem pausing is just annoying, don't

--- a/code/__BLUEMOONCODE/_DEFINES/traits.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/traits.dm
@@ -1,6 +1,6 @@
 #define TRAIT_BLUEMOON_HEAVY				"heavy"
 #define TRAIT_BLUEMOON_HEAVY_SUPER			"heavy_super"
-#define TRAIT_BLUEMOON_GIANT_BODY			"giant_body"
+#define TRAIT_BLUEMOON_DEVOURER			"giant_body"
 #define TRAIT_BLUEMOON_LIGHT				"light"
 #define TRAIT_BLUEMOON_ANTI_NORMALIZER		"anti_normalizer"
 #define TRAIT_BLUEMOON_HIGH_PAIN_THRESHOLD	"high_pain_threshold"

--- a/code/datums/components/edible.dm
+++ b/code/datums/components/edible.dm
@@ -119,7 +119,7 @@ Behavior that's still missing from this component that original food items had t
 			eater.visible_message(span_notice("[eater] жадно [eatverb] [parent].") , span_notice("Жадно пожираю [parent]."))
 		else if(fullness > 150 && fullness < 500)
 			eater.visible_message(span_notice("[eater] [eatverb] [parent].") , span_notice("Кушаю [parent]."))
-		else if(fullness > 500 && fullness < 600)
+		else if((fullness > 500 && fullness < 600) || HAS_TRAIT(eater, TRAIT_BLUEMOON_DEVOURER))
 			eater.visible_message(span_notice("[eater] нехотя [eatverb] кусочек [parent].") , span_notice("Нямкаю кусочек [parent]."))
 		else if(fullness > (600 * (1 + eater.overeatduration / (4000 SECONDS))))	// The more you eat - the more you can eat
 			eater.visible_message(span_warning("[eater] не может запихнуть [parent] в свою глотку!") , span_warning("В меня больше не лезет [parent]!"))

--- a/code/datums/components/edible.dm
+++ b/code/datums/components/edible.dm
@@ -110,7 +110,7 @@ Behavior that's still missing from this component that original food items had t
 		if(!do_mob(feeder, eater, eat_time)) //Gotta pass the minimal eat time
 			return
 		var/eatverb = pick(eatverbs)
-		if(junkiness && eater.satiety < -150 && eater.nutrition > NUTRITION_LEVEL_STARVING + 50 && !HAS_TRAIT(eater, TRAIT_VORACIOUS || TRAIT_BLUEMOON_GIANT_BODY))
+		if(junkiness && eater.satiety < -150 && eater.nutrition > NUTRITION_LEVEL_STARVING + 50 && !HAS_TRAIT(eater, TRAIT_VORACIOUS || TRAIT_BLUEMOON_DEVOURER))
 			to_chat(eater, span_warning("Не хочу я жрать эти отбросы!"))
 			return
 		else if(fullness <= 50)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -134,7 +134,7 @@ All foods are distributed among various categories. Use common sense.
 				user.visible_message("<span class='notice'>[user] hungrily takes a [eatverb] from \the [src].</span>", "<span class='notice'>You hungrily take a [eatverb] from \the [src].</span>")
 			else if(fullness > 150 && fullness < 500)
 				user.visible_message("<span class='notice'>[user] takes a [eatverb] from \the [src].</span>", "<span class='notice'>You take a [eatverb] from \the [src].</span>")
-			else if((fullness > 500 && fullness < 600) || HAS_TRAIT(user, TRAIT_BLUEMOON_GIANT_BODY))
+			else if((fullness > 500 && fullness < 600) || HAS_TRAIT(user, TRAIT_BLUEMOON_DEVOURER))
 				user.visible_message("<span class='notice'>[user] unwillingly takes a [eatverb] of a bit of \the [src].</span>", "<span class='warning'>You unwillingly take a [eatverb] of a bit of \the [src].</span>")
 			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
 				user.visible_message("<span class='warning'>[user] cannot force any more of \the [src] to go down [user.ru_ego()] throat!</span>", "<span class='danger'>You cannot force any more of \the [src] to go down your throat!</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1618,7 +1618,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	else
 		if(HAS_TRAIT(H, TRAIT_INCUBUS || TRAIT_SUCCUBUS))
 			return //SPLURT EDIT: Incubi and succubi don't get fat drawbacks (but can still be seen on examine)
-		if(H.overeatduration >= 100 && !HAS_TRAIT(H, TRAIT_BLUEMOON_GIANT_BODY))
+		if(H.overeatduration >= 100 && !HAS_TRAIT(H, TRAIT_BLUEMOON_DEVOURER))
 			to_chat(H, span_danger("Кажется, вы объелись!"))
 			ADD_TRAIT(H, TRAIT_FAT, OBESITY)
 			H.add_movespeed_modifier(/datum/movespeed_modifier/obesity)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -399,10 +399,7 @@
 	if(HAS_TRAIT(owner, TRAIT_EASYLIMBDISABLE))
 		damage *= 1.5
 	else
-		if (HAS_TRAIT(owner, TRAIT_BLUEMOON_GIANT_BODY))
-			damage/= 1.6*get_size(owner)/2 //что б конечности не отвалилвались от простого удара, для этого урон для проверки приводится к нормальному
-		else
-			damage = min(damage, WOUND_MAX_CONSIDERED_DAMAGE)
+		damage = min(damage, WOUND_MAX_CONSIDERED_DAMAGE)
 
 	var/base_roll = rand(max(damage/1.5,25), round(damage ** CONFIG_GET(number/wound_exponent))) + (get_damage()*CONFIG_GET(number/wound_damage_multiplier))
 	var/injury_roll = base_roll

--- a/modular_bluemoon/heavy_and_superheavy_quirks/traits.dm
+++ b/modular_bluemoon/heavy_and_superheavy_quirks/traits.dm
@@ -172,7 +172,7 @@
 
 		var/user_slowdown = (abs(new_size - 1) * CONFIG_GET(number/body_size_slowdown_multiplier))
 
-		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost, TRUE, user_slowdown * -0.6) // убираем 60% от замедления
+		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost, TRUE, user_slowdown * -0.8) // убираем 80% от замедления
 
 
 /datum/quirk/bluemoon_devourer/proc/check_mob_size()

--- a/modular_bluemoon/heavy_and_superheavy_quirks/traits.dm
+++ b/modular_bluemoon/heavy_and_superheavy_quirks/traits.dm
@@ -111,9 +111,8 @@
 
 /datum/quirk/bluemoon_devourer
 	name = "Пожиратель"
-	desc = "Вы крупны и очень прожорливы. Из-за особенностей вашей анатомии ваше тело крайне чувствительно к урону, однако передвигается на порядок быстрее. \
-	В дополнение к этому вы можете есть любую пищу и не толстеть, однако ваш голод силён, а переедание вызывает выделение в кровь особой смеси реагентов. \
-	Так же, по неизвестным науке причинам вы не можете быть сверхтяжёлым."
+	desc = "Ваши размеры огромны, а голод неутолим. Всё, что съедобно, для вас еда, а ожирение не помеха. Особенности вашей физиологии позволяют вам \
+	передвигаться на порядок быстрее, однако тело более восприимчиво к повреждениям. Вы не можете быть лёгким или сверхтяжёлым, а нормалазер на вас не действует."
 	value = 3
 	mob_trait = TRAIT_BLUEMOON_DEVOURER
 	medical_record_text = "Субъект проявляет признаки гигантизма и аномальной прожорливости, а также способность усваивать любую пищу."
@@ -127,27 +126,17 @@
 	var/datum/species/species = H.dna.species
 	species.disliked_food = null
 	H.physiology.hunger_mod *= 2
-	H.maxHealth *= 0.8
+	H.maxHealth *= 0.75 // -50% от доп хп.
 	// Действие на сборс сытости
 	var/datum/action/innate/vomit/act_vomit = new
 	act_vomit.Grant(H)
+
+	var/datum/action/innate/secrete_chemicals/act_secrete_chemicals = new
+	act_secrete_chemicals.Grant(H)
 	// Add examine text
 	RegisterSignal(quirk_holder, COMSIG_PARENT_EXAMINE, .proc/on_examine_holder)
+	ADD_TRAIT(H,TRAIT_BLUEMOON_ANTI_NORMALIZER, ROUNDSTART_TRAIT)
 
-// /datum/quirk/bluemoon_devourer/on_process()
-// 	var/mob/living/carbon/human/H = quirk_holder
-// 	//если персонаж объелся, он не толстеет, но начинаются очень весёлые последствия
-// 	if(H.nutrition >= NUTRITION_LEVEL_FAT)
-// 		var/cur_size = get_size(H)
-// 		var/reg_add = 0.1 * cur_size
-// 		H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, reg_add) // немного полезного реагента
-// 		H.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, reg_add) // тут всё понятно, накормили персонажа, он захотел... ну вы поняли)
-
-
-// 		if (H.get_lust() <= H.get_lust_tolerance() * 0.4) // небольшое возбуждение, но не более
-// 			H.add_lust(4)
-
-// 		H.adjust_nutrition(-0.02) //голод будет падать быстрее
 
 /datum/quirk/bluemoon_devourer/remove()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -161,12 +150,16 @@
 		H.remove_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost)
 
 		H.physiology.hunger_mod *= 0.5
-		H.maxHealth *= 1.25
+		H.maxHealth *= 1.34
 
 		var/datum/action/innate/vomit/act_vomit = locate() in H.actions
 		act_vomit.Remove(H)
 
+		var/datum/action/innate/secrete_chemicals/act_secrete_chemicals = locate() in H.actions
+		act_secrete_chemicals.Remove(H)
+
 		UnregisterSignal(quirk_holder, COMSIG_PARENT_EXAMINE)
+		REMOVE_TRAIT(H,TRAIT_BLUEMOON_ANTI_NORMALIZER, ROUNDSTART_TRAIT)
 
 // Quirk examine text
 /datum/quirk/bluemoon_devourer/proc/on_examine_holder(atom/examine_target, mob/living/carbon/human/examiner, list/examine_list)
@@ -179,7 +172,7 @@
 
 		var/user_slowdown = (abs(new_size - 1) * CONFIG_GET(number/body_size_slowdown_multiplier))
 
-		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost, TRUE, user_slowdown * -0.6) // убираем 80% от замедления
+		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost, TRUE, user_slowdown * -0.6) // убираем 60% от замедления
 
 
 /datum/quirk/bluemoon_devourer/proc/check_mob_size()
@@ -230,13 +223,18 @@
 	H.adjustToxLoss(-10)
 
 /datum/action/innate/secrete_chemicals
-	name = "Vomit"
-	desc = "Vomit some digested food from your body."
+	name = "Screte Chemicals"
+	desc = "Screte some chemicals into your blood."
 	icon_icon = 'icons/mob/actions/actions_xeno.dmi'
-	button_icon_state = "alien_barf"
+	button_icon_state = "alien_acid"
 
 /datum/action/innate/secrete_chemicals/Activate()
 	var/mob/living/carbon/human/H = owner
-	H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 10)
-	H.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, 10)
-	H.add_lust(20)
+	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+		H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 10)
+		H.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, 5)
+		H.add_lust(20)
+		H.adjust_nutrition(100)
+		to_chat(owner, "<span class='notice'>Вы разлагаете часть ваших пищевых запасов, выпуская в кровь смесь реагентов.</span>")
+	else
+		to_chat(owner, "<span class='notice'>Вы слишком голодны для этого.</span>")

--- a/modular_bluemoon/heavy_and_superheavy_quirks/traits.dm
+++ b/modular_bluemoon/heavy_and_superheavy_quirks/traits.dm
@@ -109,49 +109,47 @@
 	update_size_movespeed()
 	check_mob_size()
 
-/datum/quirk/bluemoon_giant_body
+/datum/quirk/bluemoon_devourer
 	name = "Пожиратель"
 	desc = "Вы крупны и очень прожорливы. Из-за особенностей вашей анатомии ваше тело крайне чувствительно к урону, однако передвигается на порядок быстрее. \
 	В дополнение к этому вы можете есть любую пищу и не толстеть, однако ваш голод силён, а переедание вызывает выделение в кровь особой смеси реагентов. \
 	Так же, по неизвестным науке причинам вы не можете быть сверхтяжёлым."
 	value = 3
-	mob_trait = TRAIT_BLUEMOON_GIANT_BODY
+	mob_trait = TRAIT_BLUEMOON_DEVOURER
 	medical_record_text = "Субъект проявляет признаки гигантизма и аномальной прожорливости, а также способность усваивать любую пищу."
 	gain_text = span_notice("Вы чувствуете неумалимый голод.")
 	lose_text = span_notice("Ваш голод проходит.")
 	processing_quirk = TRUE
 
-/datum/quirk/bluemoon_giant_body/add()
+/datum/quirk/bluemoon_devourer/add()
 	// да, кушать можно всё, но нужно сильно больше
 	var/mob/living/carbon/human/H = quirk_holder
 	var/datum/species/species = H.dna.species
 	species.disliked_food = null
 	H.physiology.hunger_mod *= 2
-	H.physiology.brute_mod *= 1.6 // убираем 60% от доп ХП (этап 1)
-	H.physiology.burn_mod *= 1.6  // убираем 60% от доп ХП (этап 1)
-	H.physiology.tox_mod *= 1.25
+	H.maxHealth *= 0.8
 	// Действие на сборс сытости
 	var/datum/action/innate/vomit/act_vomit = new
 	act_vomit.Grant(H)
 	// Add examine text
 	RegisterSignal(quirk_holder, COMSIG_PARENT_EXAMINE, .proc/on_examine_holder)
 
-/datum/quirk/bluemoon_giant_body/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
-	//если персонаж объелся, он не толстеет, но начинаются очень весёлые последствия
-	if(H.nutrition >= NUTRITION_LEVEL_FAT)
-		var/cur_size = get_size(H)
-		var/reg_add = 0.1 * cur_size
-		H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, reg_add) // немного полезного реагента
-		H.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, reg_add) // тут всё понятно, накормили персонажа, он захотел... ну вы поняли)
-		
+// /datum/quirk/bluemoon_devourer/on_process()
+// 	var/mob/living/carbon/human/H = quirk_holder
+// 	//если персонаж объелся, он не толстеет, но начинаются очень весёлые последствия
+// 	if(H.nutrition >= NUTRITION_LEVEL_FAT)
+// 		var/cur_size = get_size(H)
+// 		var/reg_add = 0.1 * cur_size
+// 		H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, reg_add) // немного полезного реагента
+// 		H.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, reg_add) // тут всё понятно, накормили персонажа, он захотел... ну вы поняли)
 
-		if (H.get_lust() >= H.get_lust_tolerance() * 0.4) // небольшое возбуждение, но не более
-			H.add_lust(4)
 
-		H.adjust_nutrition(-0.02) //голод будет падать быстрее
+// 		if (H.get_lust() <= H.get_lust_tolerance() * 0.4) // небольшое возбуждение, но не более
+// 			H.add_lust(4)
 
-/datum/quirk/bluemoon_giant_body/remove()
+// 		H.adjust_nutrition(-0.02) //голод будет падать быстрее
+
+/datum/quirk/bluemoon_devourer/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
 		var/datum/species/species = H.dna.species
@@ -163,10 +161,7 @@
 		H.remove_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost)
 
 		H.physiology.hunger_mod *= 0.5
-
-		H.physiology.brute_mod *= 0.625 * (get_size(H) / 2)
-		H.physiology.burn_mod *= 0.625 * (get_size(H) / 2)
-		H.physiology.tox_mod *= 0.8 * (get_size(H) / 2)
+		H.maxHealth *= 1.25
 
 		var/datum/action/innate/vomit/act_vomit = locate() in H.actions
 		act_vomit.Remove(H)
@@ -174,26 +169,20 @@
 		UnregisterSignal(quirk_holder, COMSIG_PARENT_EXAMINE)
 
 // Quirk examine text
-/datum/quirk/bluemoon_giant_body/proc/on_examine_holder(atom/examine_target, mob/living/carbon/human/examiner, list/examine_list)
+/datum/quirk/bluemoon_devourer/proc/on_examine_holder(atom/examine_target, mob/living/carbon/human/examiner, list/examine_list)
 	examine_list += "[quirk_holder.ru_ego(TRUE)] явно мучает голод."
 
 
-/datum/quirk/bluemoon_giant_body/proc/update_size_modifiers(new_size, cur_size)
+/datum/quirk/bluemoon_devourer/proc/update_size_modifiers(new_size, cur_size)
 	if (check_mob_size() && new_size != cur_size) // не даём уменьшиться, в т.ч. если мёртв
 		var/mob/living/carbon/human/H= quirk_holder
 
-		// убираем 80% от доп ХП (этап 2)
-		//чем больше существо, тем больше модификатор урона, начиная 2 и т.д., таким образом нивилируется эффект размера. Модификатор в 0.8 даётся изначально, что бы не ломать умножение тут
-		H.physiology.brute_mod *= max(new_size,2) / max(cur_size,2)
-		H.physiology.burn_mod *=  max(new_size,2) / max(cur_size,2)
-		H.physiology.tox_mod *=  max(new_size,2) / max(cur_size,2)
-
 		var/user_slowdown = (abs(new_size - 1) * CONFIG_GET(number/body_size_slowdown_multiplier))
 
-		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost, TRUE, user_slowdown * -0.8) // убираем 80% от замедления
+		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/giant_quirk_boost, TRUE, user_slowdown * -0.6) // убираем 80% от замедления
 
 
-/datum/quirk/bluemoon_giant_body/proc/check_mob_size()
+/datum/quirk/bluemoon_devourer/proc/check_mob_size()
 	if(!isliving(quirk_holder))
 		return FALSE
 
@@ -205,7 +194,7 @@
 		return FALSE
 	return TRUE
 
-/datum/quirk/bluemoon_giant_body/on_spawn()
+/datum/quirk/bluemoon_devourer/on_spawn()
 	. = ..()
 	var/mob/living/H = quirk_holder
 	update_size_modifiers(get_size(H), 1)
@@ -238,3 +227,16 @@
 /datum/action/innate/vomit/Activate()
 	var/mob/living/carbon/human/H = owner
 	H.vomit(lost_nutrition = 50, stun = FALSE)
+	H.adjustToxLoss(-10)
+
+/datum/action/innate/secrete_chemicals
+	name = "Vomit"
+	desc = "Vomit some digested food from your body."
+	icon_icon = 'icons/mob/actions/actions_xeno.dmi'
+	button_icon_state = "alien_barf"
+
+/datum/action/innate/secrete_chemicals/Activate()
+	var/mob/living/carbon/human/H = owner
+	H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 10)
+	H.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, 10)
+	H.add_lust(20)

--- a/modular_sand/code/modules/mob/living/living.dm
+++ b/modular_sand/code/modules/mob/living/living.dm
@@ -32,8 +32,8 @@
 		for(var/datum/quirk/bluemoon_heavy/quirk in roundstart_quirks)
 			quirk.update_size_movespeed()
 
-	if(HAS_TRAIT(src, TRAIT_BLUEMOON_GIANT_BODY))
-		for(var/datum/quirk/bluemoon_giant_body/quirk in roundstart_quirks)
+	if(HAS_TRAIT(src, TRAIT_BLUEMOON_DEVOURER))
+		for(var/datum/quirk/bluemoon_devourer/quirk in roundstart_quirks)
 			quirk.update_size_modifiers(new_size, cur_size)
 	// BLUEMOON ADDITION END
 


### PR DESCRIPTION
пофиксил эксплоит с нормалайзером для трейта пожиратель, дополнительно убрал лишние приколы с математикой и потиковые проверки, заменив их на действие.