### PR TITLE
tweak: поправлено снаряжение вторичных ОБР

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -243,6 +243,10 @@
 	name = "box of WT ammo"
 	ammo = /obj/item/ammo_box/magazine/wt550m9
 
+/obj/item/storage/box/ammo/holy
+	name = "some holy water"
+
+
 /obj/item/storage/box/ammo/PopulateContents()
 	..()
 	for(var/i in 1 to 5)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -509,18 +509,24 @@
 	name = "CentCom Official"
 
 	uniform = /obj/item/clothing/under/rank/centcom/officer
-	shoes = /obj/item/clothing/shoes/sneakers/black
+	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/black
-	ears = /obj/item/radio/headset/headset_cent
+	ears = /obj/item/radio/headset/headset_cent/alt
+	head = /obj/item/clothing/head/beret/sec/ntr_beret
 	glasses = /obj/item/clothing/glasses/sunglasses
-	belt = /obj/item/gun/energy/e_gun
+	belt = /obj/item/gun/energy/e_gun/nuclear/ert
 	back = /obj/item/storage/backpack/satchel
 	l_hand = /obj/item/clipboard
-	id = /obj/item/card/id
-	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,\
-
+	id = /obj/item/card/id/ert
+	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,
 		/obj/item/pda/heads=1,
 		/obj/item/pen=1)
+
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/deathrattle, /obj/item/implant/weapons_auth)
+
+	cybernetic_implants = list(/obj/item/organ/cyberimp/eyes/hud/security,
+	/obj/item/organ/cyberimp/chest/nutrimentextreme,
+	/obj/item/organ/cyberimp/chest/chem_implant)
 
 /datum/outfit/centcom_official/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
 	if(visualsOnly)
@@ -529,9 +535,6 @@
 	var/obj/item/radio/R = H.ears
 	R.set_frequency(FREQ_CENTCOM)
 	R.freqlock = TRUE
-
-	var/obj/item/implant/mindshield/L = new //Here you go Deuryn
-	L.implant(H, null, 1)
 
 	var/obj/item/card/id/W = H.wear_id
 	W.icon_state = "centcom"
@@ -543,41 +546,82 @@
 
 /datum/outfit/ert/commander/inquisitor
 	name = "Inquisition Commander"
-	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	l_hand = /obj/item/nullrod/scythe/talking/chainsword
-	r_hand = /obj/item/gun/ballistic/automatic/laser
-	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal
-	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,
 
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
+	glasses = /obj/item/clothing/glasses/hud/health/night/syndicate
+	l_hand = /obj/item/gun/ballistic/automatic/proto/unrestricted
+	r_hand = /obj/item/nullrod/scythe/talking/chainsword
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal
+	belt = /obj/item/storage/belt/military/ert_max
+	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,
 		/obj/item/storage/firstaid/regular=1,\
-		/obj/item/ammo_box/magazine/recharge=4)
+		/obj/item/storage/box/ammo/holy=1,
+		/obj/item/storage/box/ammo/smgap=1,
+		/obj/item/nullrod=1,
+		)
+
+	cybernetic_implants = list(
+		/obj/item/organ/cyberimp/eyes/hud/security,
+		/obj/item/organ/cyberimp/chest/nutrimentextreme,
+		/obj/item/organ/cyberimp/chest/chem_implant/plus,
+		/obj/item/organ/cyberimp/arm/shield,
+		/obj/item/organ/eyes/robotic/thermals,
+		/obj/item/organ/cyberimp/chest/thrusters,
+	)
+
 
 /datum/outfit/ert/security/inquisitor
 	name = "Inquisition Security"
 
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
+	glasses = /obj/item/clothing/glasses/hud/health/night/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
-	r_hand =  /obj/item/gun/ballistic/automatic/laser
+	l_hand = /obj/item/gun/ballistic/automatic/proto/unrestricted
+	r_hand = /obj/item/nullrod/scythe/talking/chainsword
+	belt = /obj/item/storage/belt/military/ert_max
 	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,
-
+		/obj/item/storage/firstaid/regular=1,
+		/obj/item/storage/box/ammo/smgap=1,
+		/obj/item/storage/box/ammo/holy=1,
 		/obj/item/storage/box/handcuffs=1,
-		/obj/item/ammo_box/magazine/recharge=4,\
-		/obj/item/melee/baton/loaded=1,
-		/obj/item/storage/ifak=1)
+		/obj/item/nullrod=1,
+		)
+
+	cybernetic_implants = list(
+		/obj/item/organ/cyberimp/eyes/hud/security,
+		/obj/item/organ/cyberimp/chest/nutrimentextreme,
+		/obj/item/organ/cyberimp/chest/chem_implant/plus,
+		/obj/item/organ/cyberimp/arm/shield,
+		/obj/item/organ/eyes/robotic/thermals,
+		/obj/item/organ/cyberimp/chest/thrusters,
+	)
+
 
 /datum/outfit/ert/medic/inquisitor
 	name = "Inquisition Medic"
 
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
+	glasses = /obj/item/clothing/glasses/hud/health/night/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
-	r_hand = /obj/item/gun/ballistic/automatic/laser
+	l_hand = /obj/item/gun/ballistic/automatic/proto/unrestricted
+	r_hand = /obj/item/nullrod/scythe/talking/chainsword
+	belt = /obj/item/defibrillator/compact/loaded_ert
 	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,
+		/obj/item/storage/box/ammo/smgap=1,\
+		/obj/item/storage/box/ammo/holy=1,
+		/obj/item/reagent_containers/hypospray/combat=1,\
+		/obj/item/gun/medbeam=1,\
+		/obj/item/roller=1,
+		/obj/item/nullrod=1,
+		)
 
-		/obj/item/melee/baton/loaded=1,
-		/obj/item/ammo_box/magazine/recharge=4,\
-		/obj/item/reagent_containers/hypospray/combat=1,
-		/obj/item/reagent_containers/hypospray/combat/heresypurge=1,
-		/obj/item/gun/medbeam=1)
+	cybernetic_implants = list(
+		/obj/item/organ/cyberimp/eyes/hud/security,
+		/obj/item/organ/cyberimp/chest/nutrimentextreme,
+		/obj/item/organ/cyberimp/chest/chem_implant,
+		/obj/item/organ/cyberimp/arm/surgery/advanced,
+		/obj/item/organ/cyberimp/chest/thrusters,
+	)
 
 /datum/outfit/ert/chaplain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
 	..()
@@ -600,7 +644,6 @@
 	belt = /obj/item/storage/belt/soulstone
 	r_hand = /obj/item/gun/ballistic/automatic/laser
 	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,
-
 		/obj/item/nullrod=1,
 		/obj/item/storage/firstaid/regular=1,\
 		/obj/item/ammo_box/magazine/recharge=4)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -385,25 +385,36 @@
 
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/hardsuit/deathsquad
-	shoes = /obj/item/clothing/shoes/combat/swat
+	shoes = /obj/item/clothing/shoes/magboots/syndie/advance
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	glasses = /obj/item/clothing/glasses/hud/toggle/thermal
-	back = /obj/item/storage/backpack/rucksack
+	glasses = /obj/item/clothing/glasses/hud/health/night/syndicate
+	back = /obj/item/storage/backpack/ert_commander/ert_security
 	l_pocket = /obj/item/melee/transforming/energy/sword/saber
 	r_pocket = /obj/item/shield/energy
-	suit_store = /obj/item/tank/internals/emergency_oxygen
+	suit_store = /obj/item/tank/internals/emergency_oxygen/double
 	belt = /obj/item/storage/belt/grenade/full
-	r_hand = /obj/item/gun/energy/pulse/loyalpin
+	r_hand = /obj/item/gun/energy/pulse/destroyer/annihilator
 	id = /obj/item/card/id/death
 	ears = /obj/item/radio/headset/headset_cent/alt
 
-	backpack_contents = list(/obj/item/storage/box/survival/security=1,\
+	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,\
 		/obj/item/storage/box/syndie_kit/revolver=1,\
 		/obj/item/storage/firstaid/tactical/slaver=1,\
 		/obj/item/storage/box/flashbangs/super=1,\
 		/obj/item/pinpointer/nuke=1,\
 		/obj/item/grenade/plastic/x4=1)
+
+	implants = list(/obj/item/implant/mindshield, /obj/item/implant/deathrattle, /obj/item/implant/weapons_auth)
+
+	cybernetic_implants = list(
+		/obj/item/organ/cyberimp/eyes/hud/security,
+		/obj/item/organ/cyberimp/chest/nutrimentextreme,
+		/obj/item/organ/cyberimp/chest/chem_implant/plus,
+		/obj/item/organ/cyberimp/arm/shield,
+		/obj/item/organ/eyes/robotic/thermals,
+		/obj/item/organ/cyberimp/chest/thrusters,
+	)
 
 	give_space_cooler_if_synth = TRUE // BLUEMOON ADD
 
@@ -414,9 +425,6 @@
 	var/obj/item/radio/R = H.ears
 	R.set_frequency(FREQ_CENTCOM)
 	R.freqlock = TRUE
-
-	var/obj/item/implant/mindshield/L = new //Here you go Deuryn
-	L.implant(H, null, 1)
 
 	var/obj/item/card/id/death/W = H.wear_id
 	W.access = get_all_accesses()//They get full station access.

--- a/modular_bluemoon/kovac_shitcode/code/modules/clothing/outfits/ert.dm
+++ b/modular_bluemoon/kovac_shitcode/code/modules/clothing/outfits/ert.dm
@@ -488,19 +488,16 @@
 	id = /obj/item/card/id/ert
 	uniform = /obj/item/clothing/under/rank/civilian/lawyer/black/alt
 	suit = /obj/item/clothing/suit/armor/vest/agent
-	//head = /obj/item/clothing/head/beret/sec/syndicate
+	head = /obj/item/clothing/head/beret/sec/syndicate
 	shoes = /obj/item/clothing/shoes/laceup
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	back = /obj/item/storage/backpack/hipbag
-	belt = /obj/item/storage/belt/security/full
-	r_hand = /obj/item/gun/ballistic/automatic/ar
+	glasses = /obj/item/clothing/glasses/hud/health/night/syndicate
+	back = /obj/item/storage/backpack/ert_commander/ert_security
+	belt = /obj/item/storage/belt/military/ert_min
 	l_pocket = /obj/item/clothing/accessory/lawyers_badge
-	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
+	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,\
 		/obj/item/stamp/syndicate=1,\
-		/obj/item/stamp/ntr=1,\
-		/obj/item/ammo_box/magazine/m556=3,\
-		/obj/item/storage/ifak=1)
-	l_pocket = /obj/item/melee/transforming/energy/sword/saber
+		/obj/item/stamp/ntr=1,
+		/obj/item/storage/firstaid/regular=1,)
 
 // BLUEMOON ADD START - командная коробочка для командира
 /datum/outfit/ert/ntr_ert_leader/pre_equip(mob/living/carbon/human/H, visualsOnly, client/preference_source)
@@ -527,15 +524,13 @@
 	uniform = /obj/item/clothing/under/syndicate/sniper
 	suit = /obj/item/clothing/suit/armor/vest/agent
 	shoes = /obj/item/clothing/shoes/laceup
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	back = /obj/item/storage/backpack/hipbag
-	belt = /obj/item/storage/belt/security/full
-	r_hand = /obj/item/gun/ballistic/automatic/wt550
+	glasses = /obj/item/clothing/glasses/hud/health/night/syndicate
+	back = /obj/item/storage/backpack/ert_commander/ert_security
+	belt = /obj/item/storage/belt/military/ert_min
 	l_pocket = /obj/item/clothing/accessory/lawyers_badge
-	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
-		/obj/item/stamp/law=1,\
-		/obj/item/ammo_box/magazine/wt550m9=3,\
-		/obj/item/storage/ifak=1)
+	backpack_contents = list(/obj/item/storage/box/survival/centcom=1,\
+		/obj/item/stamp/law=1,
+		/obj/item/storage/firstaid/regular=1,)
 
 /datum/outfit/ert/ntr_ert_agent/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
 	..()


### PR DESCRIPTION
1. ОБР инкивизиции снаряжено святой водой и прочим снаряжением аналогичным янтарному.
2. ОБР АВД снаряжено аналогично ОБР зелёного кода (по оружию и имплантам)
3. Эскадрон смерти получил импланты ОБР красного кода и некоторое улучшенное снаряжение.
4. Centcom Official получил минимальный набор имплантов и пистолет ОБР.