### PR TITLE
убираем манчерские вещи из техов

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -77,21 +77,21 @@
 	lootdoubles = FALSE
 	loot = list(
 				/obj/item/poster/random_contraband = 120,
-				/obj/item/reagent_containers/hypospray/medipen/magillitis = 2,
-				/obj/item/storage/box/syndie_kit/space = 3,
+//				/obj/item/reagent_containers/hypospray/medipen/magillitis = 2, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
+//				/obj/item/storage/box/syndie_kit/space = 3, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
 				/obj/item/storage/toolbox/syndicate = 5,
-				/obj/item/clothing/shoes/chameleon/noslip = 6,
-				/obj/item/grenade/clusterbuster/soap/inteq = 6,
+//				/obj/item/clothing/shoes/chameleon/noslip = 6, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
+//				/obj/item/grenade/clusterbuster/soap/inteq = 6, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
 				/obj/item/soap/syndie = 8,
-				/obj/item/pen/sleepy = 12,
+//				/obj/item/pen/sleepy = 12, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
 				/obj/item/storage/backpack/duffelbag/syndie = 3,
 				/obj/item/storage/box/syndie_kit/chameleon = 4,
 				/obj/item/storage/toolbox/inteq = 1,
 				/obj/item/storage/backpack/duffelbag/syndie/inteq = 1,
-				/obj/item/storage/box/syndie_kit/space/inteq = 1,
+//				/obj/item/storage/box/syndie_kit/space/inteq = 1, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
 				/obj/item/soap/inteq = 4,
 				/obj/item/sign/flag/inteq = 1,
-				/obj/item/storage/fancy/cigarettes/cigpack_inteq = 1,
+//				/obj/item/storage/fancy/cigarettes/cigpack_inteq = 1, / BLUEMOON REMOVAL - убираем манчерские вещи из техов
 				)
 
 /obj/effect/spawner/lootdrop/prison_contraband


### PR DESCRIPTION
- Стимулятор из аплинка дает 25-40 минут (поправка на лаги, там 0.1 потребление в тик, а тик 2~ секунды или 5 с учётом лагов).
- Космический скафандр халявный без серьезного замедления и с броней
- Нослипы просто предмет для манча по причине МАНЧ
- Слип пены могут очень серьезно испортить игру
- Кластербенг то же самое. Во время погони это не 1 мыло.
- Сигареты с омнизином, халявный хил

По итогу убраны все причины идти туда манчеров. Оставлены референсы на синдикат и интекью, дающие возможность внести ролевое событие в раунд.
