### PR TITLE
Rampart armor kit fix

### DIFF
--- a/modular_splurt/code/game/objects/items/armor_kits.dm
+++ b/modular_splurt/code/game/objects/items/armor_kits.dm
@@ -117,11 +117,20 @@
 /obj/item/armorkit/security/afterattack(obj/item/target, mob/user, proximity_flag, click_parameters)
 	var/used = FALSE
 
+	// BLUEMOON ADD START
+	if(!isclothing(target))
+		return
+	// BLUEMOON ADD END
 	if(!(isobj(target) && target.slot_flags & ITEM_SLOT_OCLOTHING))
 		return
-
+	// BLUEMOON ADD START
+	if(target.type in typesof(/obj/item/clothing/suit/toggle/armor, /obj/item/clothing/suit/space, /obj/item/clothing/suit/armor))
+		to_chat(user, span_danger("You cannot modify [target], as it already has armor or is a part of special equipment."))
+		return
+	// BLUEMOON ADD END
 	var/obj/item/clothing/C = target
 
+	/* BLUEMOON REMOVAL START - убираем возможности абузов статов брони (например, риот даёт 60 защиты. Давая на него рампарт, у него остается 60 от мили и добавляется всё остальное)
 	if(C.armor.getRating(MELEE) < 30)
 		C.armor = C.armor.setRating(MELEE = 30)
 		used = TRUE
@@ -146,6 +155,19 @@
 	if(C.armor.getRating(WOUND) < 10)
 		C.armor = C.armor.setRating(WOUND = 10)
 		used = TRUE
+	/ BLUEMOON REMOVAL END */
+	// BLUEMOON ADD START
+	var/obj/item/clothing/suit/armor/vest/A = new /obj/item/clothing/suit/armor/vest(src)
+	C.set_armor(A.armor)
+	C.body_parts_covered = A.body_parts_covered
+	C.cold_protection = A.cold_protection
+	C.heat_protection = A.heat_protection
+	C.resistance_flags = A.resistance_flags
+	C.clothing_flags = A.clothing_flags
+	C.min_cold_protection_temperature = A.min_cold_protection_temperature
+	C.max_heat_protection_temperature = A.max_heat_protection_temperature
+	used = TRUE
+	// BLUEMOON ADD END
 
 	if(used)
 		C.allowed = GLOB.security_vest_allowed
@@ -169,11 +191,21 @@
 /obj/item/armorkit/security/helmet/afterattack(obj/item/target, mob/user, proximity_flag, click_parameters)
 	var/used = FALSE
 
+	// BLUEMOON ADD START
+	if(!isclothing(target))
+		return
+	// BLUEMOON ADD END
 	if(!(isobj(target) && target.slot_flags & ITEM_SLOT_HEAD))
 		return
+	// BLUEMOON ADD START
+	if(target.type in typesof(/obj/item/clothing/head/helmet))
+		to_chat(user, span_danger("You cannot modify [target], as it already has armor or is a part of special equipment."))
+		return
+	// BLUEMOON ADD END
 
 	var/obj/item/clothing/C = target
 
+	/* BLUEMOON REMOVAL START - убираем возможности абузов статов брони (например, риот даёт 60 защиты. Давая на него рампарт, у него остается 60 от мили и добавляется всё остальное)
 	if(C.armor.getRating(MELEE) < 40)
 		C.armor = C.armor.setRating(MELEE = 40)
 		used = TRUE
@@ -198,6 +230,19 @@
 	if(C.armor.getRating(WOUND) < 10)
 		C.armor = C.armor.setRating(WOUND = 10)
 		used = TRUE
+	/ BLUEMOON REMOVAL END */
+	// BLUEMOON ADD START
+	var/obj/item/clothing/head/helmet/sec/A = new /obj/item/clothing/head/helmet/sec(src)
+	C.set_armor(A.armor)
+	C.body_parts_covered = A.body_parts_covered
+	C.cold_protection = A.cold_protection
+	C.heat_protection = A.heat_protection
+	C.resistance_flags = A.resistance_flags
+	C.clothing_flags = A.clothing_flags
+	C.min_cold_protection_temperature = A.min_cold_protection_temperature
+	C.max_heat_protection_temperature = A.max_heat_protection_temperature
+	used = TRUE
+	// BLUEMOON ADD END
 
 	if(used)
 		user.visible_message("<span class = 'notice'>[user] reinforces [C] with [src].</span>", \


### PR DESCRIPTION
1. Рампарка теперь не оставляет статы старой брони. Она переносит статы бронежилета СБ.
2. Добавлены исключения для рампарки. Например, космические скафандры нельзя рампартнуть. Броню СБ так же нельзя рампартнуть для избежания потери комплекта впустую.
3. Добавлен перенос большого количества характеристик от бронежилета, таких как защита от температуры, защита определённых частей тела (чтобы куртка не защищала ещё и руки в отличии от бронежилета), защита от иголок.
4. ForNerds: добавлены проверки для предотвращения рантаймов.