### PR TITLE
Ремонт флаворов, акт второй

### DIFF
--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -44,33 +44,17 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	data["character_ref"] = examine_panel_screen.assigned_map
 	data["directory_visible"] = M?.client?.prefs?.show_in_directory
 
-	var/list/headshots = list()
-	if (M?.client?.prefs)
-		if (M.client.prefs.features["headshot_link"])
-			headshots.Add(M.client.prefs.features["headshot_link"])
-		if (M.client.prefs.features["headshot_link1"])
-			headshots.Add(M.client.prefs.features["headshot_link1"])
-		if (M.client.prefs.features["headshot_link2"])
-			headshots.Add(M.client.prefs.features["headshot_link2"])
+	// BLUEMOON EDIT START - перепривязка к ДНК и майнду флаворов
+	if (issilicon(M))
+		data["flavortext"] = M?.mind?["silicon_flavor_text"] || ""
 
-	data["headshot_links"] = headshots
-
-	if (istype(M, /mob/living/silicon))
-		data["flavortext"] = M?.client?.prefs.features["silicon_flavor_text"] || ""
-
-	data["oocnotes"] = M?.client?.prefs?.features["ooc_notes"] || ""
-
-	// BLUEMOON EDIT START
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		data["species_name"] = H.dna?.custom_species || H.dna?.species
-		data["custom_species_lore"] = H.dna?.custom_species_lore || ""
-	else
-		data["species_name"] = M?.client?.prefs?.custom_species || M // BLUEMOON EDIT - после || замениил "космонавтик" на имя самого моба
-	data["custom_species_lore"] = M?.client?.prefs.features["custom_species_lore"] || "" // BLUEMOON EDIT - если нет кастомного лора, то там 3 чёрточки
+	if(iscarbon(M))
+		var/mob/living/carbon/H = M
+		data["oocnotes"] = H.dna?.ooc_notes || ""
 	if (isobserver(user))
 		data["security_records"] = M?.client?.prefs.security_records || "" //BLUEMOON ADD - призраки видят базы данных в описании персонажей
 		data["medical_records"] = M?.client?.prefs.medical_records || "" //BLUEMOON ADD - призраки видят базы данных в описании персонажей
+	// BLUEMOON EDIT END
 	data["vore_tag"] = M?.client?.prefs?.vorepref || "No"
 	data["erp_tag"] = M?.client?.prefs?.erppref || "No"
 	data["mob_tag"] = M?.client?.prefs?.mobsexpref || "No"
@@ -87,15 +71,19 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	var/data[0]
 	var/mob/living/M = host.resolve()
 	var/unknown = FALSE
+	// BLUEMOON EDIT START - правка видимости текстов персонажа и привязка их к ДНК
 	if (iscarbon(M))
 		var/mob/living/carbon/C = M
 		unknown = (C.wear_mask && (C.wear_mask.flags_inv & HIDEEYES) && !isobserver(user)) || (C.head && (C.head.flags_inv & HIDEEYES) && !isobserver(user))
 		data["flavortext"] = (!unknown) ? (C.dna?.flavor_text || "") : "Скрыто"
-		data["headshot_link"] = (!unknown) ? (C.dna?.headshot_link || "") : ""
+		data["headshot_links"] = (!unknown) ? (C.dna.headshot_links.Copy() || "") : ""
+		data["species_name"] = (!unknown) ? (C.dna?.custom_species || C.dna?.species) : "????"
+		data["custom_species_lore"] = (!unknown) ? (C.dna?.custom_species_lore || "")  : ""
 		if (istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = C
 			var/can_see_naked = !(unknown || (H.w_uniform || H.wear_suit))
 			data["flavortext_naked"] = can_see_naked ? (C.dna?.naked_flavor_text || "") : ""
+	// BLUEMOON EDIT END
 
 	data["is_unknown"] = unknown
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -24,7 +24,8 @@ GLOBAL_DATUM(dna_for_copying, /datum/dna)
 	// BLUEMOON EDIT START - привязка флавора к ДНК
 	var/flavor_text
 	var/naked_flavor_text
-	var/headshot_link
+	var/ooc_notes // hate this
+	var/list/headshot_links = list()
 	// BLUEMOON EDIT END
 
 /datum/dna/New(mob/living/new_holder)
@@ -79,7 +80,8 @@ GLOBAL_DATUM(dna_for_copying, /datum/dna)
 		// BLUEMOON EDIT START - привязка флавора к ДНК
 		destination.dna.flavor_text = flavor_text
 		destination.dna.naked_flavor_text = naked_flavor_text
-		destination.dna.headshot_link = headshot_link
+		destination.dna.ooc_notes = ooc_notes
+		destination.dna.headshot_links = headshot_links.Copy()
 		// BLUEMOON EDIT END
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
@@ -111,7 +113,8 @@ GLOBAL_DATUM(dna_for_copying, /datum/dna)
 	// BLUEMOON EDIT START - привязка флавора к ДНК
 	new_dna.flavor_text = flavor_text
 	new_dna.naked_flavor_text = naked_flavor_text
-	new_dna.headshot_link = headshot_link
+	new_dna.ooc_notes = ooc_notes
+	new_dna.headshot_links = headshot_links.Copy()
 	// BLUEMOON EDIT END
 
 //See mutation.dm for what 'class' does. 'time' is time till it removes itself in decimals. 0 for no timer

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -138,61 +138,90 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			onclose(usr, "[target.name]")
 		return TRUE
 
+// BLUEMOON EDIT START - заменил систему ингейм смены флаворов на более простую и релевантную
 /mob/proc/manage_flavor_tests()
 	set name = "Manage Flavor Texts"
 	set desc = "Used to manage your various flavor texts."
 	set category = "IC"
 
-	var/list/L = GLOB.mobs_with_editable_flavor_text[src]
-
-	if(length(L) == 1)
-		var/datum/element/flavor_text/F = L[1]
-		F.set_flavor(src)
+	if(!src || !iscarbon(src))
+		if(issilicon(src))
+			var/mob/living/silicon/our_borgy = src
+			if(our_borgy.mind)
+				var/new_text = tgui_input_text(our_borgy, "Введите новый синт-флавор (максимум [MAX_FLAVOR_LEN] символов). Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Новый синт-флавор", our_borgy.mind.silicon_flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
+				if(new_text)
+					our_borgy.mind.silicon_flavor_text = new_text
+		return
+	var/mob/living/carbon/our_mob = src
+	if(!our_mob.dna)
 		return
 
-	var/list/choices = list()
-
-	for(var/i in L)
-		var/datum/element/flavor_text/F = i
-		choices[F.flavor_name] = F
-
-	var/chosen = input(src, "Which flavor text would you like to modify?") as null|anything in choices
+	var/list/changeable_texts = list(
+		"Флавор",
+		"Обнажённый Флавор",
+		"Лор Расы",
+		"OOC-заметки",
+		"Хедшоты"
+	)
+	var/chosen = tgui_input_list(our_mob, "Выберите параметр, который должен быть изменён. Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Управление флавор-текстами", changeable_texts, changeable_texts[1])
 	if(!chosen)
 		return
-	var/datum/element/flavor_text/F = choices[chosen]
-	if(F.flavor_name == "Headshot")
-		handle_headshot_flavor(F) // Directly handle headshot flavor
-	else
-		F.set_flavor(src) // Handle all other flavor texts
+	switch(chosen)
+		if("Флавор")
+			var/new_text = tgui_input_text(our_mob, "Введите новый флавор (максимум [MAX_FLAVOR_LEN] символов).", "Новый флавор", our_mob.dna.flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
+			if(new_text)
+				our_mob.dna.flavor_text = new_text
+		if("Обнажённый Флавор")
+			var/new_text = tgui_input_text(our_mob, "Введите новый флавор обнажённого тела своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новый обнажённый флавор", our_mob.dna.naked_flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
+			if(new_text)
+				our_mob.dna.naked_flavor_text = new_text
+		if("Лор Расы")
+			var/new_text = tgui_input_text(our_mob, "Введите новый лор биологического (или не совсем биологического) вида своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новый лор расы", our_mob.dna.custom_species_lore, MAX_FLAVOR_LEN, TRUE, TRUE)
+			if(new_text)
+				our_mob.dna.custom_species_lore = new_text
+		if("OOC-заметки")
+			var/new_text = tgui_input_text(our_mob, "Введите новые ООС-заметки своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новый лор расы", our_mob.dna.custom_species_lore, MAX_FLAVOR_LEN, TRUE, TRUE)
+			if(new_text)
+				our_mob.dna.ooc_notes = new_text
+		if("Хедшоты")
+			var/chosen_headshot_id = tgui_input_list(our_mob, "Выберите номер хедшота, который хотите изменить.", "Управление флавор-текстами", list("1", "2", "3"), "1")
+			var/max_headshots = 3
+			if(!chosen_headshot_id || !isnum(text2num(chosen_headshot_id)))
+				return
+			chosen_headshot_id = text2num(chosen_headshot_id)
+			if(chosen_headshot_id >= our_mob.dna.headshot_links.len)
+				chosen_headshot_id = our_mob.dna.headshot_links.len || 1
+			var/old_link = our_mob.dna.headshot_links[chosen_headshot_id]
+			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg')", "Headshot Image", old_link, 100, FALSE, FALSE)
+			if(isnull(usr_input))
+				return
 
-// New proc to handle headshot flavor text specifically (In manage-flavour-texts while in-game)
-/mob/proc/handle_headshot_flavor(datum/element/flavor_text/F)
-	var/old_headshot = F.texts_by_atom[src]
-	var/new_headshot = input(src, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. For example: '&.jpg/.png/.jpeg')", "Headshot Image", old_headshot) as text|null
-	if(isnull(new_headshot))
-		return
-	if(!new_headshot)
-		F.texts_by_atom[src] = null
-		to_chat(src, "Your headshot has been cleared.")
-		return
+			if(!usr_input)
+				our_mob.dna.headshot_links[chosen_headshot_id] = null
+				listclearnulls(our_mob.dna.headshot_links)
+				return
 
-	// Validate the headshot URL
-	var/static/link_regex = regex("https://i\\.gyazo\\.com|https://media\\.discordapp\\.net|https://cdn\\.discordapp\\.com|https://media\\.discordapp\\.net$|https://static1\\.e621\\.net")
-	var/static/end_regex = regex("\\.jpg|\\.png|\\.jpeg$")
+			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/)")
+			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg)$")
 
-	if(!findtext(new_headshot, link_regex))
-		to_chat(src, span_warning("The link needs to be an unshortened Gyazo, E621, or Discordapp link!"))
-		return
-	if(!findtext(new_headshot, end_regex))
-		to_chat(src, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the link!"))
-		return
+			if(!findtext(usr_input, link_regex))
+				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621 link!"))
+				return
 
-	// Update the headshot URL if it's different
-	if(old_headshot != new_headshot)
-		F.texts_by_atom[src] = new_headshot
-		to_chat(src, span_notice("Your headshot has been updated."))
-		to_chat(src, span_notice("If the photo doesn't show up properly in-game, ensure that it's a direct image link that opens properly in a browser."))
-		to_chat(src, span_notice("Keep in mind that the photo will be downsized to 250x250 pixels, so the more square the photo, the better it will look."))
+			if(!findtext(usr_input, end_regex))
+				to_chat(our_mob, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the end of the link!"))
+				return
+
+			var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
+			var/new_link = sanitize(usr_input, repl_chars)
+			if(our_mob.dna.headshot_links[chosen_headshot_id] == new_link)
+				return
+
+			to_chat(our_mob, span_notice("Если картинка не отображается в игре должным образом, убедитесь, что это прямая ссылка на изображение, которая правильно открывается в обычном браузере."))
+			to_chat(our_mob, span_notice("Имейте в виду, что размер фотографии будет уменьшен до 256x256 пикселей, поэтому чем квадратнее фотография, тем лучше она будет выглядеть."))
+
+			our_mob.dna.headshot_links[chosen_headshot_id] = new_link
+// BLUEMOON EDIT END
 
 /mob/proc/set_pose()
 	set name = "Set Pose"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -4487,7 +4487,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.dna.custom_species_lore = features["custom_species_lore"]
 	character.dna.flavor_text = features["flavor_text"]
 	character.dna.naked_flavor_text = features["naked_flavor_text"]
-	character.dna.headshot_link = features["headshot_link"]
+	if (features["headshot_link"])
+		character.dna.headshot_links.Add(features["headshot_link"])
+	if (features["headshot_link1"])
+		character.dna.headshot_links.Add(features["headshot_link1"])
+	if (features["headshot_link2"])
+		character.dna.headshot_links.Add(features["headshot_link2"])
+	character.dna.ooc_notes = features["ooc_notes"]
 	character.dna.species.exotic_blood_color = blood_color //а раньше эта строчка была немного выше и всё ломалось, думайте, когда делаете врезки
 	// BLUEMOON EDIT END
 


### PR DESCRIPTION
Теперь тройной хедшот, сделанный Юджином, снова привязан к ДНК.

Лобби говнокрадов победило, теперь ООС заметки тоже привязаны к ДНК...

Теперь IC -> Manage Flavor Text экшуалли работает, будучи переделанным с нуля под новые реалии. Только новые флаворы нельзя добавлять, лишь изменять и удалять. Ещё вроде синтофлаворы там можно менять (они теперь привязаны к майнду), но я не тестил :trollface: 