### PR TITLE
Фикс флаворов, акт третий

### DIFF
--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -45,8 +45,6 @@ GLOBAL_LIST_EMPTY(cached_previews)
 	data["directory_visible"] = M?.client?.prefs?.show_in_directory
 
 	// BLUEMOON EDIT START - перепривязка к ДНК и майнду флаворов
-	if (issilicon(M))
-		data["flavortext"] = M?.mind?.silicon_flavor_text || ""
 
 	if(iscarbon(M))
 		var/mob/living/carbon/H = M

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	save_key = _save_key
 	examine_no_preview = _examine_no_preview
 
-	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/show_flavor)
+	//RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/show_flavor) BLUEMOON EDIT - перенос флаворов на хардкод
 
 	if(can_edit && ismob(target)) //but only mobs receive the proc/verb for the time being
 		var/mob/M = target
@@ -151,7 +151,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		"Временный Флавор (Поза)"
 	)
 	if(iscarbon(src))
-		if(!src.dna)
+		var/mob/living/carbon/our_mob = src
+		if(!our_mob.dna)
 			return
 		changeable_texts.Add("Флавор", "Обнажённый Флавор", "Лор Расы", "Хедшоты")
 
@@ -160,7 +161,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			return
 		changeable_texts.Add("Синтетический флавор")
 
-	var/chosen = tgui_input_list(our_mob, "Выберите параметр, который должен быть изменён. Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Управление флавор-текстами", changeable_texts, changeable_texts[1])
+	var/chosen = tgui_input_list(src, "Выберите параметр, который должен быть изменён. Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Управление флавор-текстами", changeable_texts, changeable_texts[1])
 	if(!chosen)
 		return
 	switch(chosen)
@@ -180,10 +181,18 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			if(new_text)
 				our_mob.dna.custom_species_lore = new_text
 		if("OOC-заметки")
-			var/new_text = tgui_input_text(our_mob, "Введите новые ООС-заметки своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новый лор расы", our_mob.dna.custom_species_lore, MAX_FLAVOR_LEN, TRUE, TRUE)
-			if(new_text)
-				our_mob.dna.ooc_notes = new_text
+			if(iscarbon(src))
+				var/mob/living/carbon/our_mob = src
+				var/new_text = tgui_input_text(our_mob, "Введите новые ООС-заметки своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новые ООС-заметки", our_mob.dna.custom_species_lore, MAX_FLAVOR_LEN, TRUE, TRUE)
+				if(new_text)
+					our_mob.dna.ooc_notes = new_text
+			if(issilicon(src))
+				var/mob/living/silicon/our_borgy = src
+				var/new_text = tgui_input_text(our_borgy, "Введите новые ООС-заметки своего киборга (максимум [MAX_FLAVOR_LEN] символов).", "Новые ООС-заметки", our_borgy.mind.ooc_notes, MAX_FLAVOR_LEN, TRUE, TRUE)
+				if(new_text)
+					our_borgy.mind.ooc_notes = new_text
 		if("Хедшоты")
+			var/mob/living/carbon/our_mob = src
 			var/chosen_headshot_id = tgui_input_list(our_mob, "Выберите номер хедшота, который хотите изменить.", "Управление флавор-текстами", list("1", "2", "3"), "1")
 			// var/max_headshots = 3
 			if(!chosen_headshot_id || !isnum(text2num(chosen_headshot_id)))
@@ -222,15 +231,9 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 
 			our_mob.dna.headshot_links[chosen_headshot_id] = new_link
 		if("Временный Флавор (Поза)")
-			var/list/L = GLOB.mobs_with_editable_flavor_text[src]
-			var/datum/element/flavor_text/carbon/temporary/T
-			for(var/i in L)
-				if(istype(i, /datum/element/flavor_text/carbon/temporary))
-					T = i
-			if(!T)
-				to_chat(src, "<span class='warning'>Your mob type does not support temporary flavor text.</span>")
-				return
-			T.set_flavor(src)
+			var/mob/living/our_mob = src
+			var/new_text = tgui_input_text(our_mob, "Введите новую позу своего персонажа (максимум 1024 символа).", "Новая поза", our_mob.tempflavor, 1024, TRUE, TRUE)
+			our_mob.tempflavor = new_text
 		if("Синтетический флавор")
 			var/mob/living/silicon/our_borgy = src
 			if(our_borgy.mind)
@@ -243,8 +246,14 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	set name = "Set Pose"
 	set desc = "Sets your temporary flavor text"
 	set category = "IC"
-
 	// BLUEMOON EDIT START - перенос темпфлавора на хардкод
+	var/mob/living/our_mob = src
+
+	if(!istype(our_mob))
+		return
+	var/new_text = tgui_input_text(our_mob, "Введите новую позу своего персонажа (максимум 1024 символа).", "Новая поза", our_mob.tempflavor, 1024, TRUE, TRUE)
+	our_mob.tempflavor = new_text
+
 	/*
 	var/list/L = GLOB.mobs_with_editable_flavor_text[src]
 	var/datum/element/flavor_text/carbon/temporary/T

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			return
 		changeable_texts.Add("Синтетический флавор")
 
-	var/chosen = tgui_input_list(src, "Выберите параметр, который должен быть изменён. Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Управление флавор-текстами", changeable_texts, changeable_texts[1])
+	var/chosen = tgui_input_list(src, "Выберите параметр, который должен быть изменён. Изменения действуют только в течении раунда и не затрагивают сами преференсы. Если вам нужно ввести многострочный текст с ENTER-ами, то лучше введите его вне игры и скопируйте сюда.", "Управление флавор-текстами", changeable_texts, changeable_texts[1])
 	if(!chosen)
 		return
 	switch(chosen)

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -144,38 +144,38 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	set desc = "Used to manage your various flavor texts."
 	set category = "IC"
 
-	if(!src || !iscarbon(src))
-		if(issilicon(src))
-			var/mob/living/silicon/our_borgy = src
-			if(our_borgy.mind)
-				var/new_text = tgui_input_text(our_borgy, "Введите новый синт-флавор (максимум [MAX_FLAVOR_LEN] символов). Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Новый синт-флавор", our_borgy.mind.silicon_flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
-				if(new_text)
-					our_borgy.mind.silicon_flavor_text = new_text
+	if(!isliving(src))
 		return
-	var/mob/living/carbon/our_mob = src
-	if(!our_mob.dna)
-		return
-
 	var/list/changeable_texts = list(
-		"Флавор",
-		"Обнажённый Флавор",
-		"Лор Расы",
 		"OOC-заметки",
-		"Хедшоты"
+		"Временный Флавор (Поза)"
 	)
+	if(iscarbon(src))
+		if(!src.dna)
+			return
+		changeable_texts.Add("Флавор", "Обнажённый Флавор", "Лор Расы", "Хедшоты")
+
+	else if(issilicon(src))
+		if(!src.mind)
+			return
+		changeable_texts.Add("Синтетический флавор")
+
 	var/chosen = tgui_input_list(our_mob, "Выберите параметр, который должен быть изменён. Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Управление флавор-текстами", changeable_texts, changeable_texts[1])
 	if(!chosen)
 		return
 	switch(chosen)
 		if("Флавор")
+			var/mob/living/carbon/our_mob = src
 			var/new_text = tgui_input_text(our_mob, "Введите новый флавор (максимум [MAX_FLAVOR_LEN] символов).", "Новый флавор", our_mob.dna.flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
 			if(new_text)
 				our_mob.dna.flavor_text = new_text
 		if("Обнажённый Флавор")
+			var/mob/living/carbon/our_mob = src
 			var/new_text = tgui_input_text(our_mob, "Введите новый флавор обнажённого тела своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новый обнажённый флавор", our_mob.dna.naked_flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
 			if(new_text)
 				our_mob.dna.naked_flavor_text = new_text
 		if("Лор Расы")
+			var/mob/living/carbon/our_mob = src
 			var/new_text = tgui_input_text(our_mob, "Введите новый лор биологического (или не совсем биологического) вида своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новый лор расы", our_mob.dna.custom_species_lore, MAX_FLAVOR_LEN, TRUE, TRUE)
 			if(new_text)
 				our_mob.dna.custom_species_lore = new_text
@@ -221,6 +221,22 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			to_chat(our_mob, span_notice("Имейте в виду, что размер фотографии будет уменьшен до 256x256 пикселей, поэтому чем квадратнее фотография, тем лучше она будет выглядеть."))
 
 			our_mob.dna.headshot_links[chosen_headshot_id] = new_link
+		if("Временный Флавор (Поза)")
+			var/list/L = GLOB.mobs_with_editable_flavor_text[src]
+			var/datum/element/flavor_text/carbon/temporary/T
+			for(var/i in L)
+				if(istype(i, /datum/element/flavor_text/carbon/temporary))
+					T = i
+			if(!T)
+				to_chat(src, "<span class='warning'>Your mob type does not support temporary flavor text.</span>")
+				return
+			T.set_flavor(src)
+		if("Синтетический флавор")
+			var/mob/living/silicon/our_borgy = src
+			if(our_borgy.mind)
+				var/new_text = tgui_input_text(our_borgy, "Введите новый синт-флавор (максимум [MAX_FLAVOR_LEN] символов). Изменения действуют только в течении раунда и не затрагивают сами преференсы.", "Новый синт-флавор", our_borgy.mind.silicon_flavor_text, MAX_FLAVOR_LEN, TRUE, TRUE)
+				if(new_text)
+					our_borgy.mind.silicon_flavor_text = new_text
 // BLUEMOON EDIT END
 
 /mob/proc/set_pose()

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -228,6 +228,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	set desc = "Sets your temporary flavor text"
 	set category = "IC"
 
+	// BLUEMOON EDIT START - перенос темпфлавора на хардкод
+	/*
 	var/list/L = GLOB.mobs_with_editable_flavor_text[src]
 	var/datum/element/flavor_text/carbon/temporary/T
 	for(var/i in L)
@@ -237,6 +239,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		to_chat(src, "<span class='warning'>Your mob type does not support temporary flavor text.</span>")
 		return
 	T.set_flavor(src)
+	*/
 
 /datum/element/flavor_text/proc/set_flavor(mob/user)
 	if(!(user in texts_by_atom))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -589,11 +589,11 @@
 	if(activity)
 		. += "Деятельность: [activity]"
 
-	if(tempflavor)
-		. += span_notice(tempflavor)
-
 	// send signal last so everything else prioritizes above
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) //This also handles flavor texts now
+
+	if(tempflavor) // BLUEMOON ADD - темпфлавор теперь захардкожен, увы
+		. += span_notice(tempflavor)
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!
 	var/list/dat = list()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -589,6 +589,9 @@
 	if(activity)
 		. += "Деятельность: [activity]"
 
+	if(tempflavor)
+		. += span_notice(tempflavor)
+
 	// send signal last so everything else prioritizes above
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) //This also handles flavor texts now
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -197,3 +197,4 @@
 
 	//for set_activity
 	var/activity = ""
+	var/tempflavor = "" // BLUEMOON ADD - перенос темпфлавора на хардкод (увы)

--- a/code/modules/mob/living/silicon/examine.dm
+++ b/code/modules/mob/living/silicon/examine.dm
@@ -1,4 +1,6 @@
-/mob/living/silicon/examine(mob/user) //Displays a silicon's laws to ghosts
+/mob/living/silicon/examine(mob/user) //Displays a silicon's laws to ghosts | BLUEMOON EDIT - и темпфлавор
+	if(tempflavor)
+		. += "\n[span_notice(tempflavor)]\n"
 	if(laws && isobserver(user))
 		. += "<b>[src] обладает следующими законами:</b>"
 		for(var/law in laws.get_law_list(include_zeroth = TRUE))

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -55,6 +55,9 @@
 	. += span_boldnotice("Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a>")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
 
+	if(tempflavor)
+		. += span_notice(tempflavor)
+
 	if(length(.) > 1)
 		.[1] += "<br>"
 

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,58 +1,58 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>, a [src.module.name] unit!")
+	. = list("<span class='info'>Это [icon2html(src, user)] \a <EM>[src]</EM>, a [src.module.name] юнит!")
 	if(desc)
 		. += "[desc]"
 
 	var/obj/act_module = get_active_held_item()
 	if(act_module)
-		. += "It is holding [icon2html(act_module, user)] \a [act_module]."
+		. += "В его манипуляторах [icon2html(act_module, user)] \a [act_module]."
 	var/effects_exam = status_effect_examines()
 	if(!isnull(effects_exam))
 		. += effects_exam
 	if (getBruteLoss())
 		if (getBruteLoss() < maxHealth*0.5)
-			. += "<span class='warning'>It looks slightly dented.</span>"
+			. += "<span class='warning'>Он выглядит слегка повреждённым.</span>"
 		else
-			. += "<span class='warning'><B>It looks severely dented!</B></span>"
+			. += "<span class='warning'><B>Он сильно повреждён!</B></span>"
 	if (getFireLoss() || getToxLoss())
 		var/overall_fireloss = getFireLoss() + getToxLoss()
 		if (overall_fireloss < maxHealth * 0.5)
-			. += "<span class='warning'>It looks slightly charred.</span>"
+			. += "<span class='warning'>Он выглядит слегка обгоревшим.</span>"
 		else
-			. += "<span class='warning'>It looks slightly charred.</span>"
+			. += "<span class='warning'><B>Он сильно обгорел!!</B></span>"
 	if (health < -maxHealth*0.5)
-		. += "<span class='warning'>It looks barely operational.</span>"
+		. += "<span class='warning'>Он вот-вот отключится.</span>"
 	if (fire_stacks < 0)
-		. += "<span class='warning'>It's covered in water.</span>"
+		. += "<span class='warning'>Он вымок в воде..</span>"
 	else if (fire_stacks > 0)
-		. += "<span class='warning'>It's coated in something flammable.</span>"
+		. += "<span class='warning'>Он покрыт чем-то горючим.</span>"
 
 	if(opened)
-		. += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>"
+		. += "<span class='warning'>Люк техобслуживания открыт, [cell ? "вы видите [icon2html(cell, user)] [cell] внутри " : "батарея отсутствует"].</span>"
 	else
-		. += "Its cover is closed[locked ? "" : ", and looks unlocked"]."
+		. += "Люк техобслуживания закрыт[locked ? "" : ", однако разблокирован"]."
 
 	if(cell && cell.charge <= 0)
-		. += "<span class='warning'>Its battery indicator is blinking red!</span>"
+		. += "<span class='warning'>Индикатор батареи горит красным!</span>"
 
 	if(is_servant_of_ratvar(src) && get_dist(user, src) <= 1 && !stat) //To counter pseudo-stealth by using headlamps
-		. += "<span class='warning'>Its eyes are glowing a blazing yellow!</span>"
+		. += "<span class='warning'>Его дисплей горит ярко-жёлтым цветом!</span>"
 
 	switch(stat)
 		if(CONSCIOUS)
 			if(shell)
-				. += "It appears to be an [deployed ? "active" : "empty"] AI shell."
+				. += "Видимо, это [deployed ? "активная" : "пустая"] оболочка ИИ."
 			else if(!client)
-				. += "It appears to be in stand-by mode." //afk
+				. += "Он в спящем режиме." //afk
 		if(UNCONSCIOUS)
-			. += "<span class='warning'>It doesn't seem to be responding.</span>"
+			. += "<span class='warning'>Похоже, он временно отключён.</span>"
 		if(DEAD)
-			. += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>"
+			. += "<span class='deadsay'>Система критически повреждена. Требуется перезагрузка.</span>"
 
 	if(LAZYLEN(.) > 1)
 		.[2] = "<hr>[.[2]]"
 
-	//. += span_boldnotice("Профиль Персонажа: <a href='?src=\ref[src];character_profile=1'>\[Осмотреть\]</a>") Доделать.
+	. += span_boldnotice("Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a>")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
 
 	if(length(.) > 1)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>Это [icon2html(src, user)] \a <EM>[src]</EM>, a [src.module.name] юнит!")
+	. = list("<span class='info'>Это [icon2html(src, user)] \a <EM>[src]</EM>, [src.module.name] юнит!")
 	if(desc)
 		. += "[desc]"
 
@@ -19,11 +19,11 @@
 		if (overall_fireloss < maxHealth * 0.5)
 			. += "<span class='warning'>Он выглядит слегка обгоревшим.</span>"
 		else
-			. += "<span class='warning'><B>Он сильно обгорел!!</B></span>"
+			. += "<span class='warning'><B>Он сильно обгорел!</B></span>"
 	if (health < -maxHealth*0.5)
 		. += "<span class='warning'>Он вот-вот отключится.</span>"
 	if (fire_stacks < 0)
-		. += "<span class='warning'>Он вымок в воде..</span>"
+		. += "<span class='warning'>Он вымок в воде.</span>"
 	else if (fire_stacks > 0)
 		. += "<span class='warning'>Он покрыт чем-то горючим.</span>"
 
@@ -52,7 +52,7 @@
 	if(LAZYLEN(.) > 1)
 		.[2] = "<hr>[.[2]]"
 
-	. += span_boldnotice("Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a>")
+	. += span_boldnotice("<br>Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a><br>")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
 
 	if(tempflavor)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -5,58 +5,58 @@
 
 	var/obj/act_module = get_active_held_item()
 	if(act_module)
-		. += "В его манипуляторах [icon2html(act_module, user)] \a [act_module]."
+		. += "В его манипуляторах [icon2html(act_module, user)] \a [act_module].\n"
 	var/effects_exam = status_effect_examines()
 	if(!isnull(effects_exam))
 		. += effects_exam
 	if (getBruteLoss())
 		if (getBruteLoss() < maxHealth*0.5)
-			. += "<span class='warning'>Он выглядит слегка повреждённым.</span>"
+			. += "<span class='warning'>Он выглядит слегка повреждённым.</span>\n"
 		else
-			. += "<span class='warning'><B>Он сильно повреждён!</B></span>"
+			. += "<span class='warning'><B>Он сильно повреждён!</B></span>\n"
 	if (getFireLoss() || getToxLoss())
 		var/overall_fireloss = getFireLoss() + getToxLoss()
 		if (overall_fireloss < maxHealth * 0.5)
-			. += "<span class='warning'>Он выглядит слегка обгоревшим.</span>"
+			. += "<span class='warning'>Он выглядит слегка обгоревшим.</span>\n"
 		else
-			. += "<span class='warning'><B>Он сильно обгорел!</B></span>"
+			. += "<span class='warning'><B>Он сильно обгорел!</B></span>\n"
 	if (health < -maxHealth*0.5)
-		. += "<span class='warning'>Он вот-вот отключится.</span>"
+		. += "<span class='warning'>Он вот-вот отключится.</span>\n"
 	if (fire_stacks < 0)
-		. += "<span class='warning'>Он вымок в воде.</span>"
+		. += "<span class='warning'>Он вымок в воде.</span>\n"
 	else if (fire_stacks > 0)
-		. += "<span class='warning'>Он покрыт чем-то горючим.</span>"
+		. += "<span class='warning'>Он покрыт чем-то горючим.</span>\n"
 
 	if(opened)
-		. += "<span class='warning'>Люк техобслуживания открыт, [cell ? "вы видите [icon2html(cell, user)] [cell] внутри " : "батарея отсутствует"].</span>"
+		. += "<span class='warning'>Люк техобслуживания открыт, [cell ? "вы видите [icon2html(cell, user)] [cell] внутри " : "батарея отсутствует"].\n</span>"
 	else
-		. += "Люк техобслуживания закрыт[locked ? "" : ", однако разблокирован"]."
+		. += "Люк техобслуживания закрыт[locked ? "" : ", однако разблокирован"].\n"
 
 	if(cell && cell.charge <= 0)
-		. += "<span class='warning'>Индикатор батареи горит красным!</span>"
+		. += "<span class='warning'>Индикатор батареи горит красным!</span>\n"
 
 	if(is_servant_of_ratvar(src) && get_dist(user, src) <= 1 && !stat) //To counter pseudo-stealth by using headlamps
-		. += "<span class='warning'>Его дисплей горит ярко-жёлтым цветом!</span>"
+		. += "<span class='brass'>Его дисплей горит ярко-жёлтым цветом!</span>\n"
 
 	switch(stat)
 		if(CONSCIOUS)
 			if(shell)
-				. += "Видимо, это [deployed ? "активная" : "пустая"] оболочка ИИ."
+				. += "Видимо, это [deployed ? "активная" : "пустая"] оболочка ИИ.\n"
 			else if(!client)
-				. += "Он в спящем режиме." //afk
+				. += "Позитронный мозг киборга не отвечает.\n" //afk
 		if(UNCONSCIOUS)
-			. += "<span class='warning'>Похоже, он временно отключён.</span>"
+			. += "<span class='warning'>Похоже, он временно отключён.</span>\n"
 		if(DEAD)
-			. += "<span class='deadsay'>Система критически повреждена. Требуется перезагрузка.</span>"
+			. += "<span class='deadsay'>Система критически повреждена. Требуется перезагрузка.</span>\n"
 
 	if(LAZYLEN(.) > 1)
 		.[2] = "<hr>[.[2]]"
 
-	. += span_boldnotice("<br>Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a><br>")
+	. += span_boldnotice("Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a>")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
 
 	if(tempflavor)
-		. += span_notice(tempflavor)
+		. += "\n[span_notice(tempflavor)]"
 
 	if(length(.) > 1)
 		.[1] += "<br>"

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -55,9 +55,6 @@
 	. += span_boldnotice("Профиль киборга: <a href='?src=\ref[src];cyborg_profile=1'>\[Осмотреть\]</a>")
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
 
-	if(tempflavor)
-		. += "\n[span_notice(tempflavor)]"
-
 	if(length(.) > 1)
 		.[1] += "<br>"
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -6,7 +6,6 @@
 	bubble_icon = "robot"
 	var/obj/item/pda/ai/aiPDA
 	var/flash_protect = FALSE
-	var/borg_profile =
 
 /mob/living/silicon/robot/get_cell()
 	return cell
@@ -126,7 +125,7 @@
 	. = ..()
 	// BLUEMOON ADD START - профиль для боргов
 	if(href_list["cyborg_profile"])
-		ui_interact(user)
+		ui_interact(usr)
 	// BLUEMOON ADD END
 	if(href_list["character_profile"])
 		if(!profile)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -6,6 +6,7 @@
 	bubble_icon = "robot"
 	var/obj/item/pda/ai/aiPDA
 	var/flash_protect = FALSE
+	var/borg_profile =
 
 /mob/living/silicon/robot/get_cell()
 	return cell
@@ -123,13 +124,42 @@
 
 /mob/living/silicon/robot/Topic(href, href_list)
 	. = ..()
-
+	// BLUEMOON ADD START - профиль для боргов
+	if(href_list["cyborg_profile"])
+		ui_interact(user)
+	// BLUEMOON ADD END
 	if(href_list["character_profile"])
 		if(!profile)
 			profile = new(src)
 		profile.ui_interact(usr)
 
 	return
+
+// BLUEMOON ADD START - профиль для боргов
+// Да, это проклято и должно быть перенесено в отдельный датум, но...
+/mob/living/silicon/robot/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "CyborgProfile", "Профиль юнита [src]")
+		ui.open()
+
+/mob/living/silicon/robot/ui_static_data(mob/user, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	var/data[0]
+	if(!src || !istype(src))
+		return
+	data["silicon_flavor_text"] = mind?.silicon_flavor_text || ""
+	data["oocnotes"] = mind?.ooc_notes || ""
+	data["vore_tag"] = client?.prefs?.vorepref || "No"
+	data["erp_tag"] = client?.prefs?.erppref || "No"
+	data["mob_tag"] = client?.prefs?.mobsexpref || "No"
+	data["nc_tag"] = client?.prefs?.nonconpref || "No"
+	data["unholy_tag"] = client?.prefs?.unholypref || "No"
+	data["extreme_tag"] = client?.prefs?.extremepref || "No"
+	data["very_extreme_tag"] = client?.prefs?.extremeharm || "No"
+
+	return data
+// BLUEMOON ADD END
 
 /mob/living/silicon/robot/proc/pick_module()
 	if(module.type != /obj/item/robot_module)

--- a/tgui/packages/tgui/interfaces/CyborgProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CyborgProfile.tsx
@@ -45,9 +45,10 @@ export const CyborgProfile = (props, context) => {
   ];
 
   return (
-    <Window resizable width={950} height={730}>
+    <Window resizable width={600} height={460}>
       <Window.Content scrollable>
         <Flex>
+          <Flex.Item pl="10px" grow>
             <Collapsible title="Описание Юнита" open>
               <Section>
                 <Flex direction="column">
@@ -62,7 +63,7 @@ export const CyborgProfile = (props, context) => {
                 {data.oocnotes || "Отсутствуют"}
               </Section>
             </Collapsible>
-              <Section title="Преференсы персонажа" width="100%">
+              <Section title="Преференсы киборга" width="100%">
                 <LabeledList>
                   {tags.map(tag => (
                     <LabeledList.Item
@@ -74,6 +75,7 @@ export const CyborgProfile = (props, context) => {
                   ))}
                 </LabeledList>
               </Section>
+          </Flex.Item>
         </Flex>
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/CyborgProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CyborgProfile.tsx
@@ -1,0 +1,81 @@
+// BLUEMOON ADDED
+import { Section, Flex, Divider, Collapsible, Box, Tooltip, LabeledList, ByondUi, Button } from "../components";
+import { Window } from "../layouts";
+import { useBackend } from "../backend";
+
+const getTagColor = (erptag) => {
+  switch (erptag) {
+    case "Yes":
+      return "green";
+    case "Ask":
+      return "blue";
+    case "No":
+      return "red";
+  }
+};
+
+// Ненавижу, блин, боргов
+// Когда-нибудь это можно будет переделать в что-то крутое
+
+interface CyborgProfileContext {
+
+  silicon_flavor_text: string;
+  oocnotes: string;
+  tempflavor: string;
+  vore_tag: string;
+  erp_tag: string;
+  mob_tag: string;
+  nc_tag: string;
+  unholy_tag: string;
+  extreme_tag: string;
+  very_extreme_tag: string;
+}
+
+export const CyborgProfile = (props, context) => {
+  const { act, data } = useBackend<CyborgProfileContext>(context);
+
+  const tags = [
+    { name: "ERP", title: "Эротический отыгрыш", value: data.erp_tag },
+    { name: "Non-Con", title: "Изнасилование", value: data.nc_tag },
+    { name: "Vore", title: "Поедание/Проглатывание", value: data.vore_tag },
+    { name: "Mob-Sex", title: "Совокупление с Мобами", value: data.mob_tag },
+    { name: "Unholy", title: "Грязный секс", value: data.unholy_tag },
+    { name: "Extreme", title: "Жестокий секс", value: data.extreme_tag },
+    { name: "Extreme Harm", title: "Очень жестокий секс", value: data.very_extreme_tag },
+  ];
+
+  return (
+    <Window resizable width={950} height={730}>
+      <Window.Content scrollable>
+        <Flex>
+            <Collapsible title="Описание Юнита" open>
+              <Section>
+                <Flex direction="column">
+                  {data.silicon_flavor_text
+                    ? (<Flex.Item style={{ "white-space": "pre-line" }}>{data.silicon_flavor_text}</Flex.Item>)
+                    : (<Box />)}
+                </Flex>
+              </Section>
+            </Collapsible>
+            <Collapsible title="Внеигровые заметки" open>
+              <Section style={{ "white-space": "pre-line" }}>
+                {data.oocnotes || "Отсутствуют"}
+              </Section>
+            </Collapsible>
+              <Section title="Преференсы персонажа" width="100%">
+                <LabeledList>
+                  {tags.map(tag => (
+                    <LabeledList.Item
+                      key={tag.name}
+                      color={getTagColor(tag.value)}
+                      label={tag.title}>
+                      <Tooltip content={tag.name}>{tag.value}</Tooltip>
+                    </LabeledList.Item>
+                  ))}
+                </LabeledList>
+              </Section>
+        </Flex>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/CyborgProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CyborgProfile.tsx
@@ -45,17 +45,13 @@ export const CyborgProfile = (props, context) => {
   ];
 
   return (
-    <Window resizable width={600} height={460}>
+    <Window resizable width={600} height={600}>
       <Window.Content scrollable>
         <Flex>
           <Flex.Item pl="10px" grow>
             <Collapsible title="Описание Юнита" open>
-              <Section>
-                <Flex direction="column">
-                  {data.silicon_flavor_text
-                    ? (<Flex.Item style={{ "white-space": "pre-line" }}>{data.silicon_flavor_text}</Flex.Item>)
-                    : (<Box />)}
-                </Flex>
+              <Section style={{ "white-space": "pre-line" }}>
+                {data.silicon_flavor_text || "———"}
               </Section>
             </Collapsible>
             <Collapsible title="Внеигровые заметки" open>


### PR DESCRIPTION
Перелопатил экзамайн боргов, теперь у них есть урезанная версия хумановского профиля. А ещё на русский перевёл для не самых умных робототехников.

Починил для них Manage Flavor Text. Наверное. Может быть.

Для умных: почти окончательно отказываюсь от компонента flavor_text, переводя всё на свойства майнда/самого моба/ДНК. Возможно, это не самое лучшее решение, но копаться в этом дерьме, намешанного с кучи билдов, у меня не так много сил.