### PR TITLE
Меняю стены на аванпосте InteQ, дубль 2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -1669,6 +1669,10 @@
 "jI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
+/obj/machinery/fax{
+	fax_name = "Unknown Fax";
+	name = "KK-28 Fax Machine"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "jK" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -4170,6 +4170,16 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
+"yy" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Recreation";
+	req_one_access_txt = "152"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/inteq_forgotten_outpost)
 "yA" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -11507,7 +11517,7 @@ VY
 lV
 zf
 zf
-Ir
+yy
 fi
 vg
 ok

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -627,11 +627,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/orange,
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "dL" = (
 /obj/structure/fans/tiny,
@@ -667,7 +667,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "ea" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "eg" = (
 /obj/machinery/recharge_station,
@@ -770,12 +770,6 @@
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "eL" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -783,6 +777,9 @@
 /obj/item/clothing/head/helmet/sec{
 	pixel_x = -33;
 	pixel_y = -1
+	},
+/obj/machinery/power/apc/auto_name{
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
@@ -820,7 +817,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "fs" = (
 /obj/item/ammo_casing/c45{
@@ -991,6 +988,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
+"fQ" = (
+/obj/structure/sign/flag/inteq,
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/inteq_forgotten_outpost)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -1000,6 +1001,9 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
+"fT" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/inteq_forgotten_outpost)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable/yellow{
@@ -1544,7 +1548,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "jn" = (
 /obj/effect/turf_decal/stripes{
@@ -1720,6 +1724,9 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
+"jZ" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "kc" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -2169,7 +2176,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "mG" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "mH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2712,14 +2719,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "oY" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "pc" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
 "pd" = (
 /obj/effect/turf_decal/tile/brown/half{
@@ -3145,14 +3152,11 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name{
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
@@ -3580,9 +3584,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/deployable_barricade/metal,
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "vh" = (
@@ -3934,12 +3935,6 @@
 	dir = 4;
 	icon_state = "manifold-2"
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = 24;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -4208,7 +4203,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "yG" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_vault)
 "yH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -4664,7 +4659,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "Bz" = (
 /mob/living/simple_animal/hostile/nanotrasen/ranged/assault,
@@ -5437,6 +5432,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
+"GM" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	armor = list("melee" = 80, "bullet" = 40, "laser" = 60, "energy" = 60, "bomb" = 60, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100);
+	dir = 4;
+	faction = list("InteQ");
+	name = "InteQ Ship Turret";
+	shot_delay = 10
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/inteq_forgotten_ship)
 "GQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -5618,6 +5623,9 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
+"HZ" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
 "Ia" = (
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
@@ -5684,7 +5692,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "Ir" = (
 /obj/machinery/door/airlock/grunge{
@@ -5697,7 +5705,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "IE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -6055,7 +6063,7 @@
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "KP" = (
 /obj/structure/sign/warning/fire,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "KR" = (
 /obj/machinery/computer/med_data/syndie{
@@ -8035,14 +8043,11 @@
 	pixel_y = 10
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name{
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
@@ -8224,12 +8229,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "YJ" = (
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = 24;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -9891,11 +9890,11 @@ lO
 lO
 lO
 ye
-qT
+fT
 tH
 tH
 tH
-qT
+fT
 WL
 Jc
 Jc
@@ -9966,16 +9965,16 @@ lO
 lO
 lO
 lO
-qT
+fT
 Ex
 Pl
 Yp
-qT
-qT
-qT
-qT
-qT
-qT
+fT
+fT
+fT
+fT
+fT
+fT
 WP
 sz
 sz
@@ -10041,16 +10040,16 @@ lO
 lO
 lO
 lO
-qT
+fT
 Hm
 Pl
 Pl
 Pl
 dT
-qT
+fT
 Em
 yA
-qT
+fT
 sz
 sz
 sz
@@ -10107,25 +10106,25 @@ pc
 pc
 pc
 pc
-FX
-FX
-FX
-FX
-FX
+HZ
+HZ
+HZ
+HZ
+HZ
 ye
 ye
 lO
 lO
-qT
+fT
 CP
 pq
 cc
 Rj
 wx
-qT
+fT
 dc
 Ql
-qT
+fT
 sz
 sz
 sz
@@ -10186,22 +10185,22 @@ PC
 zQ
 Aa
 sg
-FX
-FX
-FX
-FX
-FX
-qT
-qT
+HZ
+HZ
+HZ
+HZ
+HZ
+fT
+fT
 bk
-qT
-qT
-qT
-qT
-qT
+fT
+fT
+fT
+fT
+fT
 Hy
-qT
-qT
+fT
+fT
 sz
 sz
 sz
@@ -10261,12 +10260,12 @@ Ey
 GK
 EC
 lD
-FX
+HZ
 rb
 kz
 gV
 Yv
-qT
+fT
 MJ
 qR
 VU
@@ -10276,7 +10275,7 @@ yo
 Ml
 vw
 Yp
-qT
+fT
 sz
 sz
 sz
@@ -10341,7 +10340,7 @@ Ry
 XN
 wH
 qm
-qT
+fT
 SH
 MX
 Bu
@@ -10349,11 +10348,11 @@ rD
 Qr
 gq
 xG
-qT
-qT
-qT
-qT
-qT
+fT
+fT
+fT
+fT
+fT
 WP
 sz
 Jc
@@ -10411,20 +10410,20 @@ FX
 ap
 Vf
 To
-FX
+HZ
 Rm
 ca
 ZO
 kA
-qT
+fT
 Bj
 ah
 Ca
-qT
-qT
-qT
-qT
-qT
+fT
+fT
+fT
+fT
+fT
 aX
 Xm
 Sy
@@ -10486,16 +10485,16 @@ PY
 nB
 VP
 cd
-FX
+HZ
 vY
 YJ
 mq
 zA
-qT
+fT
 Lm
 ah
 gt
-qT
+fT
 wY
 Rj
 Ml
@@ -10561,20 +10560,20 @@ jC
 Pm
 YP
 Fl
-FX
-FX
-FX
-FX
-FX
-qT
+HZ
+HZ
+HZ
+HZ
+HZ
+fT
 qp
 Yr
 iA
-qT
+fT
 zj
 zi
 ZI
-qT
+fT
 LP
 hu
 Sy
@@ -10636,24 +10635,24 @@ jC
 VT
 Vn
 ge
-FX
+HZ
 jO
 mf
 so
 MY
-qT
+fT
 jx
 ZZ
 WU
 aw
 GW
-qT
-qT
-qT
-qT
-qT
-qT
-qT
+fT
+fT
+fT
+fT
+fT
+fT
+fT
 WP
 sz
 lO
@@ -10716,18 +10715,18 @@ Mr
 Tx
 vk
 Nm
-qT
+fT
 uC
 nV
 Ca
-qT
-qT
-qT
+fT
+fT
+fT
 iL
 Pl
 Pl
 Yp
-qT
+fT
 sz
 sz
 sz
@@ -10784,25 +10783,25 @@ VM
 pc
 UN
 fA
-FX
-FX
+HZ
+HZ
 FX
 Hf
 QE
 WR
 LO
-qT
+fT
 MD
 qR
 gt
-qT
-qT
+fT
+fT
 Rf
 Pl
-qT
+fT
 Hy
-qT
-qT
+fT
+fT
 sz
 Vp
 Vp
@@ -10866,18 +10865,18 @@ Am
 hK
 AU
 df
-qT
+fT
 rp
 XT
 iA
-qT
+fT
 IK
 xE
 xE
-qT
+fT
 Fj
 TJ
-qT
+fT
 sz
 cC
 cC
@@ -10941,7 +10940,7 @@ Fp
 wN
 mE
 LX
-qT
+fT
 Db
 Cj
 Bu
@@ -10949,10 +10948,10 @@ Rz
 qi
 AG
 Ml
-qT
+fT
 dU
 ay
-qT
+fT
 Vp
 PU
 kn
@@ -11010,24 +11009,24 @@ pc
 XO
 mQ
 bO
-FX
-FX
+HZ
+HZ
 TM
 Oc
 fY
 JY
-qT
+fT
 Tz
 qR
 Tv
-qT
+fT
 sG
 Pl
 Tc
-qT
-qT
-qT
-qT
+fT
+fT
+fT
+fT
 PU
 PU
 be
@@ -11071,9 +11070,9 @@ Lg
 Nr
 sz
 lO
-qT
+fT
 nl
-qT
+fT
 Jc
 Jc
 pc
@@ -11085,14 +11084,14 @@ pc
 MC
 MC
 FX
-FX
-FX
-FX
+HZ
+HZ
+HZ
 MT
 MC
 MC
-qT
-qT
+fT
+fT
 LC
 mG
 mG
@@ -11146,11 +11145,11 @@ hh
 Nr
 sz
 sz
-qT
+fT
 Nf
-qT
+fT
 Jc
-qT
+fT
 pc
 pc
 pl
@@ -11219,18 +11218,18 @@ Nr
 Nr
 Nr
 gu
-Zr
-qT
-qT
+GM
+fT
+fT
 WH
-qT
-qT
-qT
+fT
+fT
+fT
 ac
 RO
 Ar
 mc
-qT
+fT
 yQ
 Ji
 bL
@@ -11300,12 +11299,12 @@ pI
 yw
 lH
 yD
-Tk
+fQ
 Pk
 WT
 Gj
 BE
-qT
+fT
 YS
 ty
 wg
@@ -11380,7 +11379,7 @@ ED
 cf
 Mt
 Nt
-qT
+fT
 ux
 rr
 QQ
@@ -11450,7 +11449,7 @@ eC
 jT
 Rq
 EI
-qT
+fT
 SF
 Ze
 IE
@@ -11530,7 +11529,7 @@ fi
 vg
 ok
 Ym
-qT
+fT
 YH
 Cn
 QQ
@@ -11600,12 +11599,12 @@ rH
 bD
 bD
 AO
-Tk
+fQ
 mc
 oT
 mc
 mc
-qT
+fT
 QC
 Oq
 SK
@@ -11670,17 +11669,17 @@ Pq
 jE
 gu
 Zr
-qT
-qT
+fT
+fT
 YW
 YW
-qT
-qT
+fT
+fT
 qT
 ew
-qT
-qT
-qT
+fT
+fT
+fT
 yG
 yG
 yG
@@ -11746,11 +11745,11 @@ Nr
 Nr
 sz
 Jc
-qT
+fT
 nb
 VQ
-qT
-qT
+fT
+fT
 ej
 xP
 yG
@@ -11821,11 +11820,11 @@ sz
 sz
 sz
 Jc
-qT
+fT
 rX
 Bz
 IS
-qT
+fT
 fy
 zv
 yG
@@ -11837,7 +11836,7 @@ fV
 CB
 CN
 Hs
-bY
+jZ
 IW
 Oq
 YX
@@ -11896,7 +11895,7 @@ Nr
 Nr
 Nr
 Jc
-qT
+fT
 pd
 Xy
 mS
@@ -11912,22 +11911,22 @@ GT
 yG
 TS
 oJ
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
-bY
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
+jZ
 WL
 lO
 Jc
@@ -11971,11 +11970,11 @@ oK
 CS
 Nr
 lO
-qT
+fT
 Tp
 jx
 dk
-qT
+fT
 mk
 gP
 yG
@@ -11987,7 +11986,7 @@ pV
 cs
 FJ
 Xl
-bY
+jZ
 wl
 Gf
 Im
@@ -11998,12 +11997,12 @@ SX
 Zb
 oY
 Cd
-bY
+jZ
 Bl
-bY
+jZ
 JR
-bY
-bY
+jZ
+jZ
 KP
 Jc
 ye
@@ -12046,13 +12045,13 @@ Ni
 xq
 Nr
 sz
+fT
 qT
 qT
 qT
-qT
-qT
-qT
-qT
+fT
+fT
+fT
 yG
 XF
 lb
@@ -12062,7 +12061,7 @@ ei
 yG
 bY
 AS
-bY
+jZ
 aH
 KT
 ks
@@ -12152,8 +12151,8 @@ fm
 XR
 dH
 LS
-bY
-bY
+jZ
+jZ
 KP
 ye
 sz
@@ -12203,7 +12202,7 @@ Jc
 ye
 ye
 Jc
-bY
+jZ
 aL
 hD
 yk
@@ -12225,9 +12224,9 @@ hJ
 ZV
 dG
 Ix
-bY
+jZ
 qq
-bY
+jZ
 WP
 sz
 sz
@@ -12278,17 +12277,17 @@ Jc
 ye
 ye
 ye
-bY
+jZ
 RN
 yX
-bY
+jZ
 id
 sy
 zk
 JZ
 Xw
-bY
-bY
+jZ
+jZ
 dt
 Cl
 oX
@@ -12353,17 +12352,17 @@ Jc
 Jc
 Jc
 Jc
-bY
+jZ
 aD
 Jz
-bY
+jZ
 Fc
 JZ
-bY
+jZ
 BV
 lx
-bY
-bY
+jZ
+jZ
 Wr
 Kn
 oX
@@ -12428,17 +12427,17 @@ lO
 Jc
 Jc
 Jc
-bY
+jZ
 US
 CI
-bY
+jZ
 Gu
 ne
-bY
-bY
-bY
-bY
-bY
+jZ
+jZ
+jZ
+jZ
+jZ
 MI
 wV
 oX
@@ -12503,24 +12502,24 @@ sz
 lO
 lO
 Jc
-bY
-bY
-bY
-bY
+jZ
+jZ
+jZ
+jZ
 AL
 sk
-bY
+jZ
 lO
 lO
 Jc
-bY
-bY
+jZ
+jZ
 jj
 Iq
-bY
+jZ
 jj
 Iq
-bY
+jZ
 jj
 Iq
 oX
@@ -12581,10 +12580,10 @@ lO
 Qx
 wX
 pw
-bY
+jZ
 dt
 dt
-bY
+jZ
 Jc
 Jc
 ye

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -6107,11 +6107,11 @@
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
-/obj/item/card/id/syndicate,
-/obj/item/card/id/syndicate,
-/obj/item/card/id/syndicate,
-/obj/item/card/id/syndicate,
-/obj/item/card/id/syndicate,
+/obj/item/card/id/inteq,
+/obj/item/card/id/inteq,
+/obj/item/card/id/inteq,
+/obj/item/card/id/inteq,
+/obj/item/card/id/inteq,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_vault)
 "Lm" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -391,6 +391,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
+/obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "bY" = (
@@ -1231,6 +1232,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/shotgun/loaded/buckshot,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "hu" = (
@@ -1748,6 +1750,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "kz" = (
@@ -1890,6 +1893,8 @@
 	dir = 1;
 	piping_layer = 3
 	},
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "lq" = (
@@ -3385,6 +3390,7 @@
 	dir = 4;
 	icon_state = "manifold-2"
 	},
+/obj/item/gun/ballistic/shotgun,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "tu" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -409,12 +409,6 @@
 /area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
 "cc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = 24;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
@@ -1083,12 +1077,6 @@
 "gq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
-	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = 24;
-	start_charge = 45
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/carpet/royalblack,
@@ -5473,12 +5461,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = 24;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
@@ -5725,13 +5707,6 @@
 /obj/structure/dresser,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
-	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = -11;
-	pixel_y = 32;
-	start_charge = 45
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -953,6 +953,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
+/obj/machinery/power/apc/syndicate{
+	dir = 4;
+	name = "InteQ Listening Post APC";
+	pixel_x = -32;
+	start_charge = 45
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "fK" = (
@@ -3760,12 +3766,6 @@
 /turf/open/floor/circuit/green,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "wl" = (
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/effect/mob_spawn/human/inteqspace{
 	dir = 4
 	},
@@ -4271,6 +4271,7 @@
 "ze" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 8;
+	faction = list("InteQ");
 	pixel_x = 31
 	},
 /turf/open/floor/holofloor/asteroid,
@@ -6872,6 +6873,7 @@
 "Qx" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 8;
+	faction = list("InteQ");
 	pixel_x = -30
 	},
 /turf/open/floor/holofloor/asteroid,

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -394,9 +394,6 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
-"bY" = (
-/turf/closed/indestructible/syndicate,
-/area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "ca" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -621,11 +618,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/orange,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "dL" = (
 /obj/structure/fans/tiny,
@@ -660,8 +657,14 @@
 /obj/structure/deployable_barricade/metal,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
+"dY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "ea" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "eg" = (
 /obj/machinery/recharge_station,
@@ -811,7 +814,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "fs" = (
 /obj/item/ammo_casing/c45{
@@ -944,12 +947,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = -32;
-	start_charge = 45
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "fK" = (
@@ -984,7 +981,7 @@
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "fQ" = (
 /obj/structure/sign/flag/inteq,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -996,7 +993,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "fT" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1063,14 +1060,14 @@
 	dir = 1;
 	icon_state = "delivery_red"
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/syndicate{
+	dir = 1;
+	name = "InteQ Post APC";
+	pixel_y = 32;
+	start_charge = 35
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_vault)
@@ -2032,14 +2029,14 @@
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "mk" = (
 /obj/structure/closet/syndicate/inteq/personal,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/syndicate{
+	dir = 1;
+	name = "InteQ Post APC";
+	pixel_y = 32;
+	start_charge = 35
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
@@ -2164,7 +2161,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "mG" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "mH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2707,14 +2704,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "oY" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "pc" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
 "pd" = (
 /obj/effect/turf_decal/tile/brown/half{
@@ -2936,9 +2933,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
-"qT" = (
-/turf/closed/indestructible/syndicate,
-/area/ruin/space/has_grav/inteq_forgotten_outpost)
 "qW" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Recreation";
@@ -3142,9 +3136,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name{
-	pixel_y = 29
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
@@ -3837,6 +3828,7 @@
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "wU" = (
 /obj/structure/window/shuttle/tinted,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "wV" = (
@@ -4191,7 +4183,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "yG" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_vault)
 "yH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -4647,7 +4639,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "Bz" = (
 /mob/living/simple_animal/hostile/nanotrasen/ranged/assault,
@@ -4861,12 +4853,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-1"
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_x = 24;
-	start_charge = 45
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
@@ -5006,14 +4992,14 @@
 /obj/structure/chair/wood/normal{
 	dir = 8
 	},
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/syndicate{
+	dir = 1;
+	name = "InteQ Post APC";
+	pixel_y = 32;
+	start_charge = 35
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
@@ -5305,12 +5291,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/syndicate{
-	dir = 1;
-	name = "InteQ Post APC";
-	pixel_x = 32;
-	start_charge = 35
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -5606,7 +5586,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
 "HZ" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
 "Ia" = (
 /obj/effect/turf_decal/tile/brown/anticorner{
@@ -5674,7 +5654,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "Ir" = (
 /obj/machinery/door/airlock/grunge{
@@ -5687,7 +5667,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "IE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -6038,7 +6018,7 @@
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "KP" = (
 /obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "KR" = (
 /obj/machinery/computer/med_data/syndie{
@@ -6194,14 +6174,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "LN" = (
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = 32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/syndicate{
+	dir = 1;
+	name = "InteQ Post APC";
+	pixel_y = 32;
+	start_charge = 35
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
@@ -6277,12 +6257,6 @@
 "LX" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "InteQ Listening Post APC";
-	pixel_y = -32;
-	start_charge = 45
-	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
@@ -6744,9 +6718,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
 "PC" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -8021,8 +7993,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name{
-	pixel_y = 29
+/obj/machinery/power/apc/syndicate{
+	dir = 1;
+	name = "InteQ Post APC";
+	pixel_y = 32;
+	start_charge = 35
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_medbay)
@@ -8183,6 +8158,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
+"YE" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8;
+	pixel_x = 14
+	},
+/turf/template_noop,
+/area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "YF" = (
 /obj/machinery/power/smes,
 /turf/open/floor/pod/light,
@@ -8379,6 +8361,9 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bar)
+"Zx" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "Zz" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Syndciate Dorm 2";
@@ -10244,7 +10229,7 @@ fT
 MJ
 qR
 VU
-qT
+fT
 KI
 yo
 Ml
@@ -10760,7 +10745,7 @@ UN
 fA
 HZ
 HZ
-FX
+HZ
 Hf
 QE
 WR
@@ -10927,12 +10912,12 @@ fT
 dU
 ay
 fT
-Vp
+YE
 PU
 kn
 kn
 PU
-Vp
+YE
 "}
 (34,1,1) = {"
 sz
@@ -11650,7 +11635,7 @@ YW
 YW
 fT
 fT
-qT
+fT
 ew
 fT
 fT
@@ -11811,7 +11796,7 @@ fV
 CB
 CN
 Hs
-jZ
+Zx
 IW
 Oq
 YX
@@ -11886,22 +11871,22 @@ GT
 yG
 TS
 oJ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
-jZ
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
+Zx
 WL
 lO
 Jc
@@ -11961,7 +11946,7 @@ pV
 cs
 FJ
 Xl
-jZ
+Zx
 wl
 Gf
 Im
@@ -11972,12 +11957,12 @@ SX
 Zb
 oY
 Cd
-jZ
+Zx
 Bl
 jZ
 JR
-jZ
-jZ
+Zx
+Zx
 KP
 Jc
 ye
@@ -12021,9 +12006,9 @@ xq
 Nr
 sz
 fT
-qT
-qT
-qT
+fT
+fT
+fT
 fT
 fT
 fT
@@ -12034,9 +12019,9 @@ aO
 hL
 ei
 yG
-bY
+Zx
 AS
-jZ
+Zx
 aH
 KT
 ks
@@ -12126,8 +12111,8 @@ fm
 XR
 dH
 LS
-jZ
-jZ
+Zx
+Zx
 KP
 ye
 sz
@@ -12177,7 +12162,7 @@ Jc
 ye
 ye
 Jc
-jZ
+Zx
 aL
 hD
 yk
@@ -12199,9 +12184,9 @@ hJ
 ZV
 dG
 Ix
-jZ
+Zx
 qq
-jZ
+Zx
 WP
 sz
 sz
@@ -12252,17 +12237,17 @@ Jc
 ye
 ye
 ye
-jZ
+Zx
 RN
 yX
-jZ
+Zx
 id
 sy
 zk
 JZ
 Xw
-jZ
-jZ
+Zx
+Zx
 dt
 Cl
 oX
@@ -12327,17 +12312,17 @@ Jc
 Jc
 Jc
 Jc
-jZ
+Zx
 aD
 Jz
-jZ
+Zx
 Fc
 JZ
-jZ
+Zx
 BV
 lx
-jZ
-jZ
+Zx
+Zx
 Wr
 Kn
 oX
@@ -12402,17 +12387,17 @@ lO
 Jc
 Jc
 Jc
-jZ
+Zx
 US
 CI
-jZ
+Zx
 Gu
 ne
-jZ
-jZ
-jZ
-jZ
-jZ
+Zx
+Zx
+Zx
+Zx
+Zx
 MI
 wV
 oX
@@ -12477,25 +12462,25 @@ sz
 lO
 lO
 Jc
-jZ
-jZ
-jZ
-jZ
+Zx
+Zx
+Zx
+Zx
 AL
 sk
-jZ
+Zx
 lO
 lO
 Jc
-jZ
-jZ
+Zx
+Zx
 jj
 Iq
-jZ
-jj
+Zx
+dY
 Iq
-jZ
-jj
+Zx
+dY
 Iq
 oX
 WL
@@ -12555,10 +12540,10 @@ lO
 Qx
 wX
 pw
-jZ
+Zx
 dt
 dt
-jZ
+Zx
 Jc
 Jc
 ye

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -4096,10 +4096,6 @@
 	name = "Recreation";
 	req_one_access_txt = "152"
 	},
-/obj/machinery/door/airlock/grunge{
-	name = "Recreation";
-	req_one_access_txt = "152"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/powered/inteq_forgotten_atmos)
 "yo" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -472,7 +472,7 @@
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/nosmooth,
+/turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "cG" = (
 /obj/effect/mob_spawn/human/inteqspace{
@@ -6810,7 +6810,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "PU" = (
-/turf/closed/wall/mineral/titanium/nosmooth,
+/turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_bridge)
 "PV" = (
 /obj/machinery/door/airlock/grunge{

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -5028,6 +5028,7 @@
 	dir = 4;
 	pixel_x = -27
 	},
+/obj/machinery/mecha_part_fabricator/offstation,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "Dh" = (
@@ -7443,10 +7444,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
-"UH" = (
-/obj/machinery/mecha_part_fabricator/offstation,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/powered/inteq_forgotten_rnd)
 "UN" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/dark,
@@ -11445,7 +11442,7 @@ Be
 AX
 TG
 rn
-UH
+QN
 wF
 oW
 bn

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -2710,9 +2710,6 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
 	},
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -3567,6 +3564,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/deployable_barricade/metal,
+/obj/machinery/airalarm/syndicate{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "vh" = (
@@ -7261,6 +7261,9 @@
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
+	},
+/obj/machinery/airalarm/syndicate{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_outpost)

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -5700,6 +5700,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 4;
 	name = "InteQ Listening Post APC";
+	pixel_x = -11;
 	pixel_y = 32;
 	start_charge = 45
 	},


### PR DESCRIPTION
Я по глупости заменил старые багованные стены, на стены шаттла, где каждый угл скругляется. Выглядит это,мягко говоря, не уместно, поэтому тот ПР поправит данную проблему.