### PR TITLE
Изменил систему ротации карт и режимов в связи с крашами

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -30,6 +30,7 @@ SUBSYSTEM_DEF(autotransfer)
 /datum/controller/subsystem/autotransfer/fire()
 	if(world.time < targettime) // BLUEMOON EDIT - было if(REALTIMEOFDAY < targettime)
 		return
+	SSticker.midround_record_check()
 	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
 		SSvote.initiate_vote("transfer","server", votesystem=APPROVAL_VOTING, vote_time = 1800)
 		targettime = targettime + voteinterval

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -175,7 +175,10 @@ SUBSYSTEM_DEF(ticker)
 			for(var/client/C in GLOB.clients)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, "<span class='boldnotice'>Добро пожаловать на [station_name()]!</span>")
-			send2chat(new /datum/tgs_message_content("Новый раунд начинается на [SSmapping.config.map_name], голосование за режим полным ходом!"), CONFIG_GET(string/chat_announce_new_game))
+			if(!SSpersistence.CheckGracefulEnding())
+				send2chat(new /datum/tgs_message_content("Производится реролл карты в связи с крашем сервера..."), CONFIG_GET(string/chat_announce_new_game))
+			else
+				send2chat(new /datum/tgs_message_content("Новый раунд начинается на [SSmapping.config.map_name], голосование за режим полным ходом!"), CONFIG_GET(string/chat_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			//SPLURT EDIT - Bring back old panel
 			//Everyone who wants to be an observer is now spawned

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -247,14 +247,13 @@ SUBSYSTEM_DEF(ticker)
 				timeLeft = null
 				Master.SetRunLevel(RUNLEVEL_LOBBY)
 				SEND_SIGNAL(src, COMSIG_TICKER_ERROR_SETTING_UP)
-
-		if(GAME_STATE_PLAYING)
-			// BLUEMOON ADD START - пометка раунда, как ещё не завершившегося удачно, а также проверка на мидраундовую запись
-			if(!graceful_ending_unrecoreded)
+			// BLUEMOON ADD START - пометка раунда, как ещё не завершившегося удачно
+			else if(!graceful_ending_unrecoreded)
 				SSpersistence.UnrecordGracefulEnding()
 				graceful_ending_unrecoreded = TRUE
-			midround_record_check()
 			// BLUEMOON ADD END
+
+		if(GAME_STATE_PLAYING)
 			mode.process(wait * 0.1)
 			check_queue()
 			check_maprotate()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -412,6 +412,10 @@ SUBSYSTEM_DEF(vote)
 				log_admin("The map has been voted for and will change to: [VM.map_name]")
 				if(SSmapping.changemap(config.maplist[.]))
 					to_chat(world, "<span class='boldannounce'>The map vote has chosen [VM.map_name] for next round!</span>")
+				// BLUEMOON ADD START - перезагрузка сервера с ротацией карты в случае краша прошлого раунда
+				if(SSticker.mapvote_restarter_in_progress)
+					SSticker.Reboot("Map rotation was requested due to ungraceful ending of the last round.", null, 10)
+				// BLUEMOON ADD END
 			if("transfer") // austation begin -- Crew autotransfer vote
 				if(. == VOTE_TRANSFER)
 					SSshuttle.autoEnd()
@@ -762,6 +766,12 @@ SUBSYSTEM_DEF(vote)
 			return
 		if("cancel")
 			if(usr.client.holder)
+				if(SSticker.mapvote_restarter_in_progress)
+					SSticker.mapvote_restarter_in_progress = FALSE
+					SSpersistence.RecordGracefulEnding()
+					SSticker.start_immediately = FALSE
+					SSticker.SetTimeLeft(6000)
+					to_chat(world, span_boldwarning("Автоматическая ротация карты была отменена администрацией"))
 				reset()
 		if("toggle_restart")
 			if(usr.client.holder)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -245,6 +245,7 @@ GLOBAL_LIST(topic_status_cache)
 	else
 		to_chat(world, "<span class='boldannounce'>Rebooting world...</span>")
 		Master.Shutdown()	//run SS shutdowns
+	SSpersistence.RecordGracefulEnding() // BLUEMOON ADD - система запоминает, успешно ли завершился прошлый раунд, или крашнулся
 
 	TgsReboot()
 

--- a/modular_bluemoon/vlad0s_staff/code/midround_record.dm
+++ b/modular_bluemoon/vlad0s_staff/code/midround_record.dm
@@ -1,0 +1,27 @@
+/**
+ * Механика, введённая для того, чтобы краши сервера не вызывали бесконечные форсы одного и того же режима и карты.
+ * Теперь если раунд продлился более двух часов, карта и режим будут записаны в SSPersistance.
+ */
+
+GLOBAL_VAR_INIT(midround_recorded, FALSE)
+
+#define MIDROUND_RECORD_TIMEOUT 72000 // Два часа
+
+/datum/controller/subsystem/ticker/proc/midround_record_check()
+	if(GLOB.midround_recorded)
+		return
+	if(world.time < (SSautotransfer.starttime + MIDROUND_RECORD_TIMEOUT))
+		return
+	SSpersistence.RecordDynamicType()
+	SSpersistence.RecordMaps()
+	SSpersistence.CollectRoundtype(FALSE)
+	GLOB.midround_recorded = TRUE
+	var/message = "Часы пробили дважды."
+	message += " [SSmapping.config.map_name] отжила своё."
+	var/combo = SSvote.check_combo()
+	if(combo == "dynamic")
+		message += " Экста грядёт..."
+	else if (combo == "Extended")
+		message += " Динамик грядёт..."
+	to_chat(world, span_boldwarning(message))
+	message_admins("Мидраундовая запись режима и карты произведена.")

--- a/modular_bluemoon/vlad0s_staff/code/midround_record.dm
+++ b/modular_bluemoon/vlad0s_staff/code/midround_record.dm
@@ -1,22 +1,18 @@
 /**
  * Механика, введённая для того, чтобы краши сервера не вызывали бесконечные форсы одного и того же режима и карты.
- * Теперь если раунд продлился более двух часов, карта и режим будут записаны в SSPersistance.
+ * Теперь при первом голосовании за шаттл, вне зависимости от результата, карта и режим будут записаны в SSPersistence.
  */
 
 GLOBAL_VAR_INIT(midround_recorded, FALSE)
 
-#define MIDROUND_RECORD_TIMEOUT 72000 // Два часа
-
 /datum/controller/subsystem/ticker/proc/midround_record_check()
 	if(GLOB.midround_recorded)
-		return
-	if(world.time < (SSautotransfer.starttime + MIDROUND_RECORD_TIMEOUT))
 		return
 	SSpersistence.RecordDynamicType()
 	SSpersistence.RecordMaps()
 	SSpersistence.CollectRoundtype(FALSE)
 	GLOB.midround_recorded = TRUE
-	var/message = "Часы пробили дважды."
+	var/message = "Час пробил."
 	message += " [SSmapping.config.map_name] отжила своё."
 	var/combo = SSvote.check_combo()
 	if(combo == "dynamic")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4513,6 +4513,7 @@
 #include "modular_bluemoon\vagabond\code\wheelchair_resprite.dm"
 #include "modular_bluemoon\vagabond\code\modules\mob\dead\new_player\sprite_accessories\tails.dm"
 #include "modular_bluemoon\vlad0s_staff\code\backstab_knives.dm"
+#include "modular_bluemoon\vlad0s_staff\code\midround_record.dm"
 #include "modular_bluemoon\vlad0s_staff\code\robot_purge_reagents.dm"
 #include "modular_bluemoon\vlad0s_staff\code\synthdrinks\synth_drinks.dm"
 #include "modular_bluemoon\vlad0s_staff\code\synthdrinks\synth_drinks_containers.dm"


### PR DESCRIPTION
Теперь при первом воуте за шаттл, вне зависимости от его результата, карта и режим записываются в SSPersistence и будут учитываться в общем счёте, как учитывались бы при нормальном завершении раунда.

Теперь раунд имеет пометку, завершился он нормальным ребутом или крашем. В последнем случае после перезагрузки будет произведено голосование за карту, после которого сервер будет снова перезапущен, но уже на новой карте.