### PR TITLE
balance update

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -279,7 +279,7 @@
 	icon_state = "beartrap"
 	desc = "A trap used to catch bears and other legged creatures."
 	var/armed = FALSE
-	var/trap_damage = 60
+	var/trap_damage = 20
 	var/ignore_weight = FALSE //BLUEMOON ADD капканы реагируют на вес карбонов
 
 /obj/item/restraints/legcuffs/beartrap/prearmed

--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -291,7 +291,7 @@
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Semi-Auto Rifle Crate"
 	desc = "Содержит две мощные полуавтоматические винтовки с калибром 4,6x30 мм. Для открытия требуется доступ к оружейной."
-	cost = 2550
+	cost = 3000
 	contains = list(/obj/item/gun/ballistic/automatic/wt550,
 					/obj/item/gun/ballistic/automatic/wt550)
 	crate_name = "auto rifle crate"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/ballistic/automatic
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	var/alarmed = 0
 	var/select = 1
 	var/automatic_burst_overlay = TRUE
@@ -75,6 +75,7 @@
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	burst_shot_delay = 2
 	burst_size = 2
+	w_class = WEIGHT_CLASS_NORMAL
 	pin = /obj/item/firing_pin/implant/pindicate
 	can_bayonet = TRUE
 	knife_x_offset = 26
@@ -109,6 +110,10 @@
 	knife_x_offset = 25
 	knife_y_offset = 12
 	automatic_burst_overlay = FALSE
+
+/obj/item/gun/ballistic/automatic/wt550/Initialize(mapload)
+	..()
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
 
 /obj/item/gun/ballistic/automatic/wt550/afterattack()
 	. = ..()
@@ -450,6 +455,10 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/lasgun.ogg'
 	casing_ejector = FALSE
+
+/obj/item/gun/ballistic/automatic/laser/lasgun/Initialize(mapload)
+	..()
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
 
 /obj/item/gun/ballistic/automatic/laser/lasgun/update_icon_state()
 	icon_state = "boarding"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/ballistic/automatic
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	var/alarmed = 0
 	var/select = 1
 	var/automatic_burst_overlay = TRUE
@@ -104,6 +104,7 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	can_suppress = FALSE
 	weapon_weight = WEAPON_HEAVY
+	w_class = WEIGHT_CLASS_BULKY
 	burst_size = 2
 	burst_shot_delay = 1
 	can_bayonet = TRUE
@@ -449,6 +450,8 @@
 	item_state = "laser-wielded"
 	mag_type = /obj/item/ammo_box/magazine/recharge/lasgun
 	automatic_burst_overlay = FALSE
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	fire_delay = 2
 	can_suppress = FALSE
 	burst_size = 1

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -4,6 +4,7 @@
 	icon_state = "energy"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+	w_class = WEIGHT_CLASS_BULKY
 	modifystate = 1
 	can_flashlight = 1
 	ammo_x_offset = 3
@@ -58,6 +59,7 @@
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/ion/hos, /obj/item/ammo_casing/energy/electrode/hos)
 	ammo_x_offset = 4
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/last_altfire = 0
 	var/altfire_delay = CLICK_CD_RANGE // BLUEMOON EDIT - WAS 0 (фикс отсутствия КД при стрельбе оружия ГСБ)
@@ -83,6 +85,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
+	w_class = WEIGHT_CLASS_NORMAL
 	modifystate = FALSE
 	can_flashlight = 0
 	ammo_x_offset = 1

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -4,7 +4,7 @@
 	icon_state = "energy"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	modifystate = 1
 	can_flashlight = 1
 	ammo_x_offset = 3

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -3,7 +3,7 @@
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
 	item_state = "laser"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
@@ -59,6 +59,7 @@
 	item_state = "caplaser"
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10
+	w_class = WEIGHT_CLASS_NORMAL
 	ammo_x_offset = 3
 	selfcharge = EGUN_SELFCHARGE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -3,7 +3,7 @@
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
 	item_state = "laser"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -22,6 +22,7 @@
 	icon_state = "advtaser"
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/electrode/security = FALSE)
 	ammo_x_offset = 2
+	w_class = WEIGHT_CLASS_NORMAL
 	// Not enough guns have altfire systems like this yet for this to be a universal framework.
 	var/last_altfire = 0
 	var/altfire_delay = CLICK_CD_RANGE
@@ -57,6 +58,7 @@
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
 	item_state = null
+	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -101,7 +101,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 36
+	damage = 30
 	damage_type = STAMINA
 	flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -23,9 +23,8 @@
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
-	damage = 25
-	wound_bonus = -20
-	bare_wound_bonus = 40
+	wound_bonus = 8
+	bare_wound_bonus = 12
 
 /obj/item/projectile/beam/laser/lasgun
 	damage = 12.5
@@ -35,7 +34,7 @@
 /obj/item/projectile/beam/laser/hellfire
 	name = "hellfire laser"
 	wound_bonus = 15
-	damage = 30
+	damage = 25
 	fire_hazard = TRUE
 
 /obj/item/projectile/beam/laser/hellfire/Initialize(mapload)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -23,8 +23,9 @@
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
-	wound_bonus = 8
-	bare_wound_bonus = 12
+	damage = 25
+	wound_bonus = -20
+	bare_wound_bonus = 40
 
 /obj/item/projectile/beam/laser/lasgun
 	damage = 12.5
@@ -34,7 +35,7 @@
 /obj/item/projectile/beam/laser/hellfire
 	name = "hellfire laser"
 	wound_bonus = 15
-	damage = 25
+	damage = 30
 	fire_hazard = TRUE
 
 /obj/item/projectile/beam/laser/hellfire/Initialize(mapload)

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -71,14 +71,14 @@
 /obj/item/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
 	damage = 17
-	wound_bonus = 6
-	bare_wound_bonus = 7
+	wound_bonus = -5
+	bare_wound_bonus = 5
 	embed_falloff_tile = -4
 
 /obj/item/projectile/bullet/c46x30mm_ap
 	name = "4.6x30mm armor-piercing bullet"
-	damage = 15.5
-	armour_penetration = 40
+	damage = 14
+	armour_penetration = 50
 	embedding = null
 
 /obj/item/projectile/bullet/incendiary/c46x30mm

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1353,6 +1353,10 @@
 	M.adjustOxyLoss(-15, FALSE)
 	M.adjustToxLoss(-5*REM, FALSE)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15*REM)
+	M.adjustCloneLoss(-3*REM, FALSE)
+	M.adjustStaminaLoss(-25*REM,FALSE)
+	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
+		M.adjust_integration_blood(40) // blood fall out man bad
 	..()
 	. = 1
 
@@ -1372,6 +1376,10 @@
 	M.adjustOxyLoss(-10*REM, FALSE)
 	M.adjustToxLoss(-4*REM, FALSE)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -10*REM)
+	M.adjustCloneLoss(-3*REM, FALSE)
+	M.adjustStaminaLoss(-8*REM,FALSE)
+	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
+		M.adjust_integration_blood(3)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1149,7 +1149,7 @@
 	name = "Stimulants"
 	description = "Increases stun resistance and movement speed in addition to restoring minor damage and weakness. Overdose causes weakness and toxin damage."
 	color = "#78008C"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 60
 	pH = 8.7
 	can_synth = FALSE //BLUEMOON CHANGE ролькоприколы остаются у ролек
@@ -1160,24 +1160,22 @@
 	..()
 	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulants)
 	ADD_TRAIT(L, TRAIT_TASED_RESISTANCE, type)
-	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 
 /datum/reagent/medicine/stimulants/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulants)
 	REMOVE_TRAIT(L, TRAIT_TASED_RESISTANCE, type)
-	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	..()
 
 /datum/reagent/medicine/stimulants/on_mob_life(mob/living/carbon/M)
-	M.adjustOxyLoss(-8*REM, FALSE)
-	M.adjustToxLoss(-4*REM, FALSE)
-	M.adjustBruteLoss(-4*REM, FALSE)
-	M.adjustFireLoss(-4*REM, FALSE)
-	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
-		M.adjust_integration_blood(40) // blood fall out man bad
-	M.AdjustAllImmobility(-60, FALSE)
-	M.AdjustUnconscious(-60, FALSE)
+	if(M.health < 50 && M.health > 0)
+		M.adjustOxyLoss(-1 * REM, FALSE)
+		M.adjustToxLoss(-1 * REM, FALSE)
+		M.adjustBruteLoss(-1 * REM, FALSE)
+		M.adjustFireLoss(-1 * REM, FALSE)
+	M.AdjustAllImmobility(-80, FALSE)
+	M.AdjustParalyzed(-40, FALSE)
 	M.AdjustKnockdown(-40, FALSE)
+	M.AdjustImmobilized(-40, FALSE)
 	M.adjustStaminaLoss(-40*REM, FALSE)
 	..()
 	. = 1
@@ -1355,10 +1353,6 @@
 	M.adjustOxyLoss(-15, FALSE)
 	M.adjustToxLoss(-5*REM, FALSE)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15*REM)
-	M.adjustCloneLoss(-3*REM, FALSE)
-	M.adjustStaminaLoss(-25*REM,FALSE)
-	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
-		M.adjust_integration_blood(40) // blood fall out man bad
 	..()
 	. = 1
 
@@ -1378,10 +1372,6 @@
 	M.adjustOxyLoss(-10*REM, FALSE)
 	M.adjustToxLoss(-4*REM, FALSE)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -10*REM)
-	M.adjustCloneLoss(-3*REM, FALSE)
-	M.adjustStaminaLoss(-8*REM,FALSE)
-	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
-		M.adjust_integration_blood(3)
 	..()
 	. = 1
 
@@ -1441,7 +1431,7 @@
 	M.adjustToxLoss(-3 * REM, FALSE, TRUE) //Heals TOXINLOVERS
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * REM, 150) //This does, after all, come from ambrosia, and the most powerful ambrosia in existence, at that!
 	M.adjustCloneLoss(-1 * REM, FALSE)
-	M.adjustStaminaLoss(-13 * REM, FALSE)
+	M.adjustStaminaLoss(-1 * REM, FALSE)
 	M.jitteriness = min(max(0, M.jitteriness + 3), 30)
 	M.druggy = min(max(0, M.druggy + 10), 15) //See above
 	..()

--- a/modular_bluemoon/SmiLeY/blastwave_outfits/code/cargo_packs.dm
+++ b/modular_bluemoon/SmiLeY/blastwave_outfits/code/cargo_packs.dm
@@ -50,7 +50,7 @@
 /datum/supply_pack/security/lasguns
 	name = "Lasgun's Kit"
 	desc = "Коробочка с автоматическими лазерными винтовками."
-	cost = 16000
+	cost = 10000
 	contains = list(/obj/item/gun/ballistic/automatic/laser/lasgun,
 					/obj/item/gun/ballistic/automatic/laser/lasgun,
 					/obj/item/gun/ballistic/automatic/laser/lasgun,

--- a/modular_bluemoon/kovac_shitcode/code/modules/guns/weapons.dm
+++ b/modular_bluemoon/kovac_shitcode/code/modules/guns/weapons.dm
@@ -89,6 +89,7 @@
 	lefthand_file = 'modular_bluemoon/kovac_shitcode/icons/mob/weapons/weapons_l.dmi'
 	righthand_file = 'modular_bluemoon/kovac_shitcode/icons/mob/weapons/weapons_r.dmi'
 	mag_type = /obj/item/ammo_box/magazine/m10mm_large
+	w_class = WEIGHT_CLASS_NORMAL
 	can_suppress = FALSE
 	burst_size = 4
 	fire_delay = 3


### PR DESCRIPTION
Даное изменение затронет как обычных игроков, так СБ и антагонистов
Оружие:
Большинство энергетического и лазерного оружия в игре получило размер BULKY(что значит что теперь офицер не сможет ходить с половиной арсенала), не касается антикварки, мультифаза и драгнетов

ВТ550
Скорость стрельбы в автоматическом режиме снижена, и чуть быстрее стрельбы одиночными выстрелами

обычные пули на ВТ имеют сниженые показатели wound-а

АП пули на ВТ получают сниженый урон но выше бронепробитие
15.5 => 14
40% => 50%

Будет стоить 3000 в карго вместо 2500

Лазган
По аналогии с ВТ снижена скорость стрельбы в автоматическом режиме и теперь чуть быстрее чем одиночными выстрелами

Стоимость в карго снижена до 10000
(офк так же получает размер BULKY что не позволит носить в рюкзаке)

Урон по стамине от дизейблеров снижен 36 => 30
Медицинские реагенты:
Стимулянты
теперь выводятся в 2 раза быстрее

Лечат по 1 всего урона если хп от 0 до 50
Лучше снимают всякого рода ограничивающие статус эффекты(не болы, а разные станы и т.д.)
Больше не дают иммунитет ко сну

синдикатовские наниты(включая низшие)
Теперь не восстанавливают стамину, кровь, генетический урон, исключительно лечат все типы урона и органы

кровь земли
снижено восстановление стамины 13 => 1

Другое:
Капканы наносят меньше урона 60 => 20, все так же сильные, но больше не получится за 1 капкан в крит