### PR TITLE
Чистка мисскликов маппинга Интекью гостроли

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -50,9 +50,6 @@
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
 "au" = (
@@ -280,7 +277,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/gibs/human/down,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "bs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -399,9 +396,6 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/vomit,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
 "cs" = (
@@ -569,7 +563,7 @@
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "dL" = (
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "dS" = (
 /obj/effect/turf_decal/bluemoon_decals/enclave/top/right,
@@ -1037,7 +1031,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2{
+	req_access = list()
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
 "hb" = (
@@ -1623,6 +1619,9 @@
 	pixel_y = 32;
 	start_charge = 35
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/inteq_forgotten_bridge)
 "kw" = (
@@ -1866,7 +1865,8 @@
 "lQ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/power/emitter/prototype{
-	dir = 1
+	dir = 1;
+	anchored = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -1975,7 +1975,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mecha_wreckage/gygax,
 /obj/effect/gibspawner/robot,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "mu" = (
 /obj/structure/fans/tiny,
@@ -1999,7 +1999,7 @@
 	},
 /obj/structure/fans/tiny,
 /obj/item/ammo_casing/c45,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "mx" = (
 /obj/structure/fans/tiny,
@@ -2068,7 +2068,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/item/ammo_casing/c45,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "mI" = (
 /obj/structure/closet/crate/secure/gear{
@@ -2242,7 +2242,7 @@
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
 "nE" = (
 /obj/item/ammo_casing/c45,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "nH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -2474,6 +2474,18 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
+"ot" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/inteq_forgotten_bridge)
 "ox" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1;
@@ -2608,7 +2620,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "oY" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -2790,7 +2802,7 @@
 /area/ruin/space/has_grav/inteq_forgotten_outpost)
 "qq" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux{
-	id = "inteqpostsss_auxvent"
+	id = "inteqpost_auxvent"
 	},
 /turf/open/floor/engine/vacuum,
 /area/ruin/space/has_grav/inteq_forgotten_atmos)
@@ -2948,7 +2960,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "rn" = (
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "rp" = (
 /obj/structure/table/wood,
@@ -3061,7 +3073,7 @@
 /area/ruin/space/has_grav/inteq_forgotten_bar)
 "rP" = (
 /obj/item/ammo_casing/c45,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_bridge)
 "rS" = (
 /obj/structure/chair/stool/bar/directional/north,
@@ -3357,7 +3369,7 @@
 "tu" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/screwdriver/nuke/inteq,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_bridge)
 "ty" = (
 /obj/structure/cable/yellow{
@@ -4206,7 +4218,7 @@
 /area/ruin/space/has_grav/inteq_forgotten_bar)
 "za" = (
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_bridge)
 "zc" = (
 /obj/machinery/light/floor,
@@ -4360,8 +4372,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_ship)
 "zQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
@@ -4373,7 +4385,7 @@
 "Aa" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
@@ -4490,7 +4502,7 @@
 	pixel_x = -32
 	},
 /obj/item/ammo_casing/c45,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_bridge)
 "AC" = (
 /obj/structure/window/reinforced/spawner,
@@ -4747,7 +4759,7 @@
 	pixel_x = -6;
 	pixel_y = -24;
 	req_access = list();
-	id = "inteqpostssss_auxvent"
+	id = "inteqpost_auxvent"
 	},
 /obj/machinery/button/door/incinerator_vent_syndicatelava_main{
 	pixel_x = 6;
@@ -5064,12 +5076,6 @@
 /mob/living/simple_animal/hostile/carp,
 /turf/template_noop,
 /area/template_noop)
-"DL" = (
-/obj/machinery/power/turbine{
-	luminosity = 2
-	},
-/turf/template_noop,
-/area/template_noop)
 "DM" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -5159,9 +5165,6 @@
 "EC" = (
 /obj/effect/turf_decal/stripes/line,
 /mob/living/simple_animal/hostile/nanotrasen/ranged/assault,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
 "ED" = (
@@ -5847,7 +5850,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
 "JP" = (
@@ -6772,7 +6777,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/inteq_forgotten_vault)
 "PK" = (
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_bridge)
 "PM" = (
 /obj/machinery/light,
@@ -7544,9 +7549,6 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/inteq_forgotten_medbay)
@@ -8383,7 +8385,7 @@
 	dir = 8
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel/damturf/platdmg1,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/inteq_forgotten_rnd)
 "Zu" = (
 /obj/structure/chair/stool/bar/directional/north,
@@ -11386,7 +11388,7 @@ om
 Zg
 Et
 ys
-OI
+ot
 Li
 oz
 VZ
@@ -12437,7 +12439,7 @@ JQ
 lO
 lO
 sz
-DL
+sz
 sz
 sz
 sz


### PR DESCRIPTION
Последний ПР замержился, захожу на сервер и вижу, что поставил кусок турбины в космосе возле поста интеков. Теперь убрал и подчистил еще пару косяков. Например, раньше на мостике не было вентиляции. Теперь есть. Надеюсь, больше косяков не увижу, ведь локалка что-то сломалась после перехода на 515 и протестить нормально возможности нет.