### PR TITLE
Превью иконок в лодауте

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1372,6 +1372,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 									var/class_link = ""
 									var/list/loadout_item = has_loadout_gear(loadout_slot, "[gear.type]")
 									var/extra_loadout_data = ""
+									if(gear.base64icon)
+										extra_loadout_data += "<center><img src=data:image/jpeg;base64,[gear.base64icon]></center>"
 									if(loadout_item)
 										class_link = "style='white-space:normal;' class='linkOn' href='?_src_=prefs;preference=gear;toggle_gear_path=[html_encode(name)];toggle_gear=0'"
 										if(gear.loadout_flags & LOADOUT_CAN_COLOR_POLYCHROMIC)

--- a/modular_bluemoon/code/modules/clothing/suits/poly_cape.dm
+++ b/modular_bluemoon/code/modules/clothing/suits/poly_cape.dm
@@ -14,3 +14,4 @@
 	path = /obj/item/clothing/neck/cloak/poly_cape
 	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION | LOADOUT_CAN_COLOR_POLYCHROMIC
 	loadout_initial_colors = list("#0d8dc0", "#ffffff", "#ffe600")
+	item_icon_state = "poly_cape-1" // BLUEMOON EDIT - багованная иконка

--- a/modular_citadel/code/modules/client/loadout/_loadout.dm
+++ b/modular_citadel/code/modules/client/loadout/_loadout.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(loadout_whitelist_ids)
 	var/subcategory = LOADOUT_SUBCATEGORY_NONE
 	var/slot
 	var/description
-	var/path //item-to-spawn path
+	var/atom/path //item-to-spawn path // BLUEMOON EDIT - превращено в атом чтобы адекватнее работать с иконками
 	var/cost = 1 //normally, each loadout costs a single point.
 	var/geargroupID //defines the ID that the gear inherits from the config
 	var/loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION
@@ -70,13 +70,27 @@ GLOBAL_LIST_EMPTY(loadout_whitelist_ids)
 
 	var/restricted_desc
 
+	// BLUEMOON EDIT START - превью для вещей в лодауте
+	// Автоматически гененерируемая base64 иконка для превью в лодауте
+	var/base64icon
+	// Возможный оверрайд иконки
+	var/item_icon = null
+	// Возможный оверрайд стейта иконки
+	var/item_icon_state = null
+	// BLUEMOON EDIT END
+
 /datum/gear/New()
 	if(isnull(donoritem))
 		if(donator_group_id || ckeywhitelist)
 			donoritem = TRUE
+	// BLUEMOON EDIT START - превью для вещей в лодауте
 	if(!description && path)
-		var/obj/O = path
-		description = initial(O.desc)
+		description = initial(path.desc)
+	var/init_icon = item_icon ? item_icon : initial(path.icon)
+	var/init_icon_state = item_icon_state ? item_icon_state : initial(path.icon_state)
+	base64icon = icon2base64(icon(init_icon, init_icon_state, SOUTH, 1, FALSE))
+	// BLUEMOON EDIT END
+
 
 //a comprehensive donator check proc is intentionally not implemented due to the fact that we (((might))) have job-whitelists for donator items in the future and I like to stay on the safe side.
 

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -63,6 +63,7 @@
 	path= /obj/item/clothing/head/maid/polychromic
 	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION | LOADOUT_CAN_COLOR_POLYCHROMIC
 	loadout_initial_colors = list("#333333", "#FFFFFF")
+	item_icon_state = "maid" // BLUEMOON EDIT - багованная иконка
 
 /datum/gear/head/bunnyears
 	name = "Bunny Ears"
@@ -195,6 +196,7 @@
 	path = /obj/item/clothing/head/cowboyhat/polychromic
 	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION | LOADOUT_CAN_COLOR_POLYCHROMIC
 	loadout_initial_colors = list("#5F5F5F", "#DDDDDD")
+	item_icon_state = "cowboyhat" // BLUEMOON EDIT - багованная иконка
 
 /datum/gear/head/wkepi
 	name = "white kepi"


### PR DESCRIPTION
Теперь в лодауте можно видеть иконки предметов.
К сожалению, всякие губные помады и серёжки отличаются только цветом, поэтому иконки у них выводит одинаковые.
~~Спизжено~~ вдохновлено [этим](https://github.com/ss220-space/Paradise/pull/4507)

![изображение](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/assets/110334878/5e433e48-b018-49a6-aaa6-9a55c52cfdc1)
