### PR TITLE
Бесконечный автотрейтор

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -64,7 +64,7 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain")
 	required_candidates = 1
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
-	weight = 0 //BLUEMOON CHANGES
+	weight = 0.001 //BLUEMOON CHANGES. Такое значнеие нужно, чтобы опцию возможно было форсануть админскими кнопками
 	cost = 0 //BLUEMOON CHANGES - бесконечные предатели с автотрейтора
 	requirements = list(101,40,25,20,15,10,10,10,10,10)
 	repeatable = TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -64,8 +64,8 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain")
 	required_candidates = 1
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
-	weight = 6  //BLUEMOON CHANGES
-	cost = 6 //BLUEMOON CHANGES
+	weight = 0 //BLUEMOON CHANGES
+	cost = 0 //BLUEMOON CHANGES - бесконечные предатели с автотрейтора
 	requirements = list(101,40,25,20,15,10,10,10,10,10)
 	repeatable = TRUE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -56,7 +56,7 @@
 //////////////////////////////////////////////
 
 /datum/dynamic_ruleset/latejoin/infiltrator
-	name = "InteQ Infiltrator"
+	name = "InteQ Infiltrator (Late-Join Autotraitor)"
 	antag_datum = /datum/antagonist/traitor
 	antag_flag = "traitor late"
 	antag_flag_override = ROLE_TRAITOR

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -193,18 +193,18 @@
 	restricted_roles = list("Cyborg", "AI", "Positronic Brain")
 	required_candidates = 1
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
-	weight = 0  //BLUEMOON CHANGES
-	cost = 8  //BLUEMOON CHANGES
+	weight = 0  //BLUEMOON CHANGES - это автр-трейтор, его не должен выбирать режим сам по себе
+	cost = 0  //BLUEMOON CHANGES - бесконечные трейторы
 	requirements = list(101,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
 	/// Whether or not this instance of sleeper agent should be randomly acceptable.
 	/// If TRUE, then this has a threat level% chance to succeed.
-	var/has_failure_chance = TRUE
+	var/has_failure_chance = FALSE // BLUEMOON CHANGES - было TRUE
 
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(population = 0, threat = 0)
 	var/player_count = mode.current_players[CURRENT_LIVING_PLAYERS].len
 	var/antag_count = mode.current_players[CURRENT_LIVING_ANTAGS].len
-	var/max_traitors = round(player_count / 16) + 1 //BLUEMOON CNANGES - 1 предатель на каждые 16 человек
+	var/max_traitors = round(player_count / 15) + 1 //BLUEMOON CNANGES - 1 предатель на каждые 15 играющих персонажей
 
 	// adding traitors if the antag population is getting low
 	var/too_little_antags = antag_count < max_traitors

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -181,7 +181,7 @@
 //////////////////////////////////////////////
 
 /datum/dynamic_ruleset/midround/autotraitor
-	name = "InteQ Sleeper Agent"
+	name = "InteQ Sleeper Agent (Autotraitor)"
 	antag_datum = /datum/antagonist/traitor
 	antag_flag = "traitor mid"
 	antag_flag_override = ROLE_TRAITOR // BLUEMOON ADD
@@ -200,12 +200,16 @@
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(population = 0, threat = 0)
 	var/player_count = mode.current_players[CURRENT_LIVING_PLAYERS].len
 	var/antag_count = mode.current_players[CURRENT_LIVING_ANTAGS].len
-	var/max_traitors = round(player_count / 15) + 1 //BLUEMOON CNANGES - 1 предатель на каждые 15 играющих персонажей
+	var/max_antagonists = round(player_count / 15) + 1 // BLUEMOON EDIT - 1 антагонист на каждые 15 играющих персонажей + 1
+	// BLUEMOON ADD START
+	if(GLOB.master_mode == ROUNDTYPE_DYNAMIC_LIGHT)
+		max_antagonists = clamp(round(player_count / 13), 0, 5) // 1 антагонист на каждые 15 играющих персонажей с округлением вниз
+	// BLUEMOON ADD END
 
 	// adding traitors if the antag population is getting low
-	var/too_little_antags = antag_count < max_traitors
+	var/too_little_antags = antag_count < max_antagonists
 	if (!too_little_antags)
-		message_admins("DYNAMIC: Too many living antags compared to living players ([antag_count] living antags, [player_count] living players, [max_traitors] max traitors)")
+		message_admins("DYNAMIC: Too many living antags compared to living players ([antag_count] living antags, [player_count] living players, [max_antagonists] max traitors)")
 		return FALSE
 
 	if (has_failure_chance && !prob(mode.threat_level))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -197,7 +197,6 @@
 	cost = 8  //BLUEMOON CHANGES
 	requirements = list(101,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
-
 	/// Whether or not this instance of sleeper agent should be randomly acceptable.
 	/// If TRUE, then this has a threat level% chance to succeed.
 	var/has_failure_chance = TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -69,11 +69,6 @@
 			if ((exclusive_roles.len > 0) && !(M.mind.assigned_role in exclusive_roles)) // Is the rule exclusive to their job?
 				trimmed_list.Remove(M)
 				continue
-			// BLUEMOON ADD START
-			if(!(M.client.prefs.toggles & MIDROUND_ANTAG) && required_type != /mob/dead/observer) // У игрока отключен преф "быть антагонистом посреди раунда" и это не запрос для гостов
-				trimmed_list.Remove(M)
-				continue
-			// BLUEMOON ADD END
 	return trimmed_list
 
 // You can then for example prompt dead players in execute() to join as strike teams or whatever
@@ -189,11 +184,12 @@
 	name = "InteQ Sleeper Agent"
 	antag_datum = /datum/antagonist/traitor
 	antag_flag = "traitor mid"
+	antag_flag_override = ROLE_TRAITOR // BLUEMOON ADD
 	protected_roles = list("Expeditor", "Prisoner", "Shaft Miner", "NanoTrasen Representative", "Internal Affairs Agent", "Blueshield", "Peacekeeper", "Brig Physician", "Security Officer", "Warden", "Detective", "Head of Security","Bridge Officer", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director")  //BLUEMOON CHANGES
 	restricted_roles = list("Cyborg", "AI", "Positronic Brain")
 	required_candidates = 1
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
-	weight = 0  //BLUEMOON CHANGES - это автр-трейтор, его не должен выбирать режим сам по себе
+	weight = 0.001 //BLUEMOON CHANGES. Такое значнеие нужно, чтобы опцию возможно было форсануть админскими кнопками
 	cost = 0  //BLUEMOON CHANGES - бесконечные трейторы
 	requirements = list(101,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
@@ -209,11 +205,11 @@
 	// adding traitors if the antag population is getting low
 	var/too_little_antags = antag_count < max_traitors
 	if (!too_little_antags)
-		log_game("DYNAMIC: Too many living antags compared to living players ([antag_count] living antags, [player_count] living players, [max_traitors] max traitors)")
+		message_admins("DYNAMIC: Too many living antags compared to living players ([antag_count] living antags, [player_count] living players, [max_traitors] max traitors)")
 		return FALSE
 
 	if (has_failure_chance && !prob(mode.threat_level))
-		log_game("DYNAMIC: Random chance to roll autotraitor failed, it was a [mode.threat_level]% chance.")
+		message_admins("DYNAMIC: Random chance to roll autotraitor failed, it was a [mode.threat_level]% chance.")
 		return FALSE
 
 	..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -15,7 +15,7 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain") //BLUEMOON CHANGES
 	required_candidates = 1
 	weight = 999 //BLUEMOON CHANGES - автотрейтор практически гарантирован в каждый динамик. Стоит мало очков, даёт движ и бесконечных антагонистов
-	cost = 0 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
+	cost = 1 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
 	requirements = list(101,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
 	antag_cap = list("denominator" = 8, "offset" = 1) //BLUEMOON CHANGES - реди жмёт малое количество людей

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -15,7 +15,8 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain") //BLUEMOON CHANGES
 	required_candidates = 1
 	weight = 999 //BLUEMOON CHANGES - автотрейтор практически гарантирован в каждый динамик. Стоит мало очков, даёт движ и бесконечных антагонистов
-	scaling_cost = 1 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
+	cost = 1 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
+	flags = LONE_RULESET // BLUEMOON ADD
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
 	requirements = list(101,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
 	antag_cap = list("denominator" = 8, "offset" = 1) //BLUEMOON CHANGES - реди жмёт малое количество людей

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -33,9 +33,10 @@
 	var/num_traitors = get_antag_cap(population) * (scaled_times + 1)
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick_n_take(candidates)
-		assigned += M.mind
-		M.mind.special_role = ROLE_TRAITOR
-		M.mind.restricted_roles = restricted_roles
+		if(M) // BLUEMOON ADD - защита от рантаймов
+			assigned += M.mind
+			M.mind.special_role = ROLE_TRAITOR
+			M.mind.restricted_roles = restricted_roles
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/traitor/rule_process()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -43,11 +43,14 @@
 /datum/dynamic_ruleset/roundstart/traitor/rule_process()
 	if (COOLDOWN_FINISHED(src, autotraitor_cooldown_check))
 		COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
-		log_game("DYNAMIC: Checking if we can turn someone into a traitor.")
-		if(prob(50)) // BLUEMOON ADD
-			mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
-		else // BLUEMOON ADD
-			mode.picking_specific_rule(/datum/dynamic_ruleset/latejoin/infiltrator) // BLUEMOON ADD
+		message_admins("DYNAMIC: Проверка возможности добавить в раунд автотрейтор.")
+		if(!mode.forced_latejoin_rule)
+			if(prob(50))
+				mode.forced_latejoin_rule = /datum/dynamic_ruleset/latejoin/infiltrator
+			else
+				mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor, TRUE)
+		else
+			mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor, TRUE)
 
 //////////////////////////////////////////
 //                                      //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -15,7 +15,7 @@
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain") //BLUEMOON CHANGES
 	required_candidates = 1
 	weight = 999 //BLUEMOON CHANGES - автотрейтор практически гарантирован в каждый динамик. Стоит мало очков, даёт движ и бесконечных антагонистов
-	cost = 1 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
+	scaling_cost = 1 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
 	requirements = list(101,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
 	antag_cap = list("denominator" = 8, "offset" = 1) //BLUEMOON CHANGES - реди жмёт малое количество людей

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -14,13 +14,12 @@
 	protected_roles = list("Expeditor", "Shaft Miner", "NanoTrasen Representative", "Internal Affairs Agent", "Security Officer", "Blueshield", "Peacekeeper", "Brig Physician", "Warden", "Detective", "Head of Security","Bridge Officer", "Captain", "Head of Personnel", "Quartermaster", "Chief Engineer", "Chief Medical Officer", "Research Director") //BLUEMOON CHANGES
 	restricted_roles = list("AI", "Cyborg", "Positronic Brain") //BLUEMOON CHANGES
 	required_candidates = 1
-	weight = 13 //BLUEMOON CHANGES
-	cost = 8 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
-	scaling_cost = 9
+	weight = 999 //BLUEMOON CHANGES - автотрейтор практически гарантирован в каждый динамик. Стоит мало очков, даёт движ и бесконечных антагонистов
+	cost = 0 // Avoid raising traitor threat above 10, as it is the default low cost ruleset.
 	required_round_type = list(ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
 	requirements = list(101,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
-	antag_cap = list("denominator" = 20) //BLUEMOON CHANGES
-	var/autotraitor_cooldown = (30 MINUTES) //BLUEMOON CHANGES
+	antag_cap = list("denominator" = 8, "offset" = 1) //BLUEMOON CHANGES - реди жмёт малое количество людей
+	var/autotraitor_cooldown = (12 MINUTES) //BLUEMOON CHANGES
 	COOLDOWN_DECLARE(autotraitor_cooldown_check)
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)
@@ -43,7 +42,10 @@
 	if (COOLDOWN_FINISHED(src, autotraitor_cooldown_check))
 		COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
 		log_game("DYNAMIC: Checking if we can turn someone into a traitor.")
-		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
+		if(prob(50)) // BLUEMOON ADD
+			mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
+		else // BLUEMOON ADD
+			mode.picking_specific_rule(/datum/dynamic_ruleset/latejoin/infiltrator) // BLUEMOON ADD
 
 //////////////////////////////////////////
 //                                      //


### PR DESCRIPTION
# Суть такова

Каждый динамик в игре имеется автотрейтор, который не имеет цены по очкам и не может выпадать сам по себе.

Автотрейтор ролится каждые 12 минут и даёт либо одному из людей в раунде с префами роль трейтора, либо одну из прилетающих с теми же условиями.

При выставленных настройках, рассчитано:
- Требуется 15 человек на 1 роль.
- Если на 15 человек не достаёт роли, то она достаётся трейтору.
- Другие режимы не имеют такой же проверки и ролят независимо от того, есть на 15 человек 1 роль или нет (то есть, трейтор не жрёт чужие слоты).

# Преимущества

- Даже если раунд идёт 5 часов и уже не осталось очков на какие-либо роли, трейтор всё равно должен ролиться по мере ухода трейторов в крио, их смерти или иных условий, что позволяет продолжить игру и не создавать классическую для ССки ситуацию "все антаги убиты, пора звать шаттл".

- Трейторы получают больше возможностей для рола игрокам. Как один из самых простых и гибких в плане целей и инструментов антагонистов, на мой взгляд, отличный вариант.