### PR TITLE
Fix disposals teleports

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -62,12 +62,15 @@
 		trunk.linked = null
 	return ..()
 
+//BLUEMOON ADD START
+//При смещении мусорного бака и мусорного входа разъединяет связь с трубой под ним
 /obj/machinery/disposal/Move()
 	eject()
 	if(trunk)
 		trunk.linked = null
 		trunk = null
 	return ..()
+//BLUEMOON ADD END
 
 /obj/machinery/disposal/singularity_pull(S, current_size)
 	..()

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -62,6 +62,13 @@
 		trunk.linked = null
 	return ..()
 
+/obj/machinery/disposal/Move()
+	eject()
+	if(trunk)
+		trunk.linked = null
+		trunk = null
+	return ..()
+
 /obj/machinery/disposal/singularity_pull(S, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -36,12 +36,15 @@
 	QDEL_NULL(stored)
 	return ..()
 
+//BLUEMOON ADD START
+//При смещении мусорного выхода разъединяет связь с трубой под ним
 /obj/structure/disposaloutlet/Move()
 	if(trunk)
 		trunk.linked = null
 		trunk = null
 	QDEL_NULL(stored)
 	return ..()
+//BLUEMOON ADD END
 
 // expel the contents of the holder object, then delete it
 // called when the holder exits the outlet

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -36,6 +36,13 @@
 	QDEL_NULL(stored)
 	return ..()
 
+/obj/structure/disposaloutlet/Move()
+	if(trunk)
+		trunk.linked = null
+		trunk = null
+	QDEL_NULL(stored)
+	return ..()
+
 // expel the contents of the holder object, then delete it
 // called when the holder exits the outlet
 /obj/structure/disposaloutlet/proc/expel(obj/structure/disposalholder/H)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/launchpad,
 		/obj/machinery/disposal,
 		/obj/structure/disposalpipe,
+		//BLUEMOON ADD Добавлен запрет на отправку мусорного выхода наравне с другими мусорными трубами и входами
 		/obj/structure/disposaloutlet,
 		/obj/item/mail,
 		/obj/item/hilbertshotel,

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -29,8 +29,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/launchpad,
 		/obj/machinery/disposal,
 		/obj/structure/disposalpipe,
-		//BLUEMOON ADD Добавлен запрет на отправку мусорного выхода наравне с другими мусорными трубами и входами
-		/obj/structure/disposaloutlet,
+		/obj/structure/disposaloutlet, //BLUEMOON ADD Добавлен запрет на отправку мусорного выхода наравне с другими мусорными трубами и входами
 		/obj/item/mail,
 		/obj/item/hilbertshotel,
 		/obj/machinery/camera,

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/launchpad,
 		/obj/machinery/disposal,
 		/obj/structure/disposalpipe,
+		/obj/structure/disposaloutlet,
 		/obj/item/mail,
 		/obj/item/hilbertshotel,
 		/obj/machinery/camera,


### PR DESCRIPTION
При сдвиге мусорного бака, входа или выхода (к примеру с помощью драконьей формы), они оставались связанными с мусорными трубами даже находясь далеко от трубы. Фикс исправляет это недоразумение и теперь при сдвиге объекта они перестают быть соединёнными.

Также в чёрный список шаттла был добавлен мусорный выход, поскольку с его помощью можно было попасть на ЦК через транспортный шаттл.
