### PR TITLE
Изменил систему лимита аксессуаров

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -24,6 +24,7 @@
 	var/dummy_thick = FALSE // is able to hold accessories on its item
 	//SANDSTORM EDIT - Removed the old attached accessory system. We use a list of accessories instead.
 	var/max_accessories = 7 // BLUEMOON EDIT - расширено возможное количество аксессуаров с 3 до 7
+	var/max_restricted_accessories = 3 // BLUEMOON ADD - максимальное количество особых (боевых) аксессуаров
 	var/list/obj/item/clothing/accessory/attached_accessories = list()
 	var/list/mutable_appearance/accessory_overlays = list()
 	//SANDSTORM EDIT END
@@ -144,14 +145,47 @@
 	//
 	..()
 
+
 /obj/item/clothing/under/proc/attach_accessory(obj/item/I, mob/user, notifyAttach = 1)
 	. = FALSE
 	if(istype(I, /obj/item/clothing/accessory) && !istype(I, /obj/item/clothing/accessory/ring))
 		var/obj/item/clothing/accessory/A = I
+		// BLUEMOON EDIT START - изменение аксессуаров
+		// Проверка на общее количество
 		if(length(attached_accessories) >= max_accessories)
 			if(user)
 				to_chat(user, "<span class='warning'>[src] already has [length(attached_accessories)] accessories.</span>")
 			return
+		// Проверка на количество особых / боевых
+		if(A.restricted_accessory && length(attached_accessories))
+			var/restricted_accesories_count = 0
+			for(var/obj/item/clothing/accessory/already_attached in attached_accessories)
+				if(already_attached.restricted_accessory)
+					restricted_accesories_count++
+			if(restricted_accesories_count >= max_restricted_accessories)
+				if(user)
+					to_chat(user, "<span class='warning'> К [src] некуда прикреплять очередной боевой аксессуар, на ней их уже [restricted_accesories_count]</span>")
+				return
+		// Проверка на максимальное количество аксессуаров одного вида
+		if(A.max_stack != -1 && length(attached_accessories))
+			var/similar_accessory_count = 0
+			for(var/obj/item/clothing/accessory/already_attached in attached_accessories)
+				if(already_attached.max_stack == -1)
+					continue
+				// У обоих аксессуаров может быть указан родительский класс, все дочерние классы которого не могут стакаться
+				// друг с другом без ограничений
+				if(already_attached.max_stack_path && A.max_stack_path)
+					if(already_attached.max_stack_path == A.max_stack_path)
+						similar_accessory_count++
+				// Если не указан, проверяем, чтобы оба предмета не были дочерними классами друг друга
+				else if(istype(A, already_attached.type) || istype(already_attached.type, A))
+					similar_accessory_count++
+			if(similar_accessory_count >= A.max_stack)
+				if(user)
+					to_chat(user, "<span class='warning'> На [src] уже слишком много похожих на [A] аксессуаров!</span>")
+				return
+		// BLUEMOON EDIT END
+
 		if(dummy_thick)
 			if(user)
 				to_chat(user, "<span class='warning'>[src] is too bulky and cannot have accessories attached to it!</span>")

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -15,8 +15,17 @@
 	var/datum/component/storage/detached_pockets
 	//skyrat edit
 	var/current_uniform = null
-	var/list/access = list() // BLUEMOON EDIT - у некоторых акссессуаров теперь типо будет доступ. Костыль, да.
-	//
+	// BLUEMOON ADD START - изменение аксессуаров
+	// У некоторых акссессуаров теперь типо будет доступ. Костыль, да.
+	var/list/access = list()
+	// Для всех боевых аксессуаров, которые не должны стакать свои бонусы с кучей других боевых аксессуаров.
+	// Количество возможных боевых акссессуаров зависит от джампсьюта на персонаже, по умолчанию 3.
+	var/restricted_accessory = FALSE
+	// Максимальное количество аксессуаров этого вида, которые можно прицепить к джампсьюту. -1 означает отсутствие лимита.
+	var/max_stack = -1
+	// Родительский класс, все дочерние классы которого не могут стакаться друг с другом без ограничений
+	var/max_stack_path = null
+	// BLUEMOON ADD END
 
 /obj/item/clothing/accessory/proc/attach(obj/item/clothing/under/U, user)
 	var/datum/component/storage/storage = GetComponent(/datum/component/storage)
@@ -589,6 +598,7 @@
 	desc = "Can protect your clothing from ink stains, but you'll look like a nerd if you're using one."
 	icon_state = "pocketprotector"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/pocketprotector
+	max_stack = 3 // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/pocketprotector/full/Initialize(mapload)
 	. = ..()
@@ -610,6 +620,7 @@
 	desc = "A hunter's talisman, some say the old gods smile on those who wear it."
 	icon_state = "talisman"
 	armor = list(MELEE = 5, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 20, RAD = 5, FIRE = 0, ACID = 25)
+	restricted_accessory = TRUE // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/skullcodpiece
 	name = "skull codpiece"
@@ -617,6 +628,7 @@
 	icon_state = "skull"
 	above_suit = TRUE
 	armor = list(MELEE = 5, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 20, RAD = 5, FIRE = 0, ACID = 25)
+	restricted_accessory = TRUE // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/skullcodpiece/fake
 	name = "false codpiece"
@@ -624,6 +636,7 @@
 	icon_state = "skull"
 	above_suit = TRUE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
+	restricted_accessory = TRUE // BLUEMOON EDIT - изменение аксессуаров
 
 /////////////////////
 //Syndie Accessories//
@@ -635,6 +648,7 @@
 	icon_state = "padding"
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 5, BIO = 0, RAD = 0, FIRE = -20, ACID = 45) // BLUEMOON CHANGE нёрф защиты в два раза
 	flags_inv = HIDEACCESSORY //hidden from indiscrete mob examines.
+	restricted_accessory = TRUE // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/kevlar
 	name = "kevlar padding"
@@ -642,6 +656,7 @@
 	icon_state = "padding"
 	armor = list(MELEE = 0, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 25) // BLUEMOON CHANGE нёрф защиты в два раза
 	flags_inv = HIDEACCESSORY
+	restricted_accessory = TRUE // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/plastics
 	name = "ablative padding"
@@ -649,6 +664,7 @@
 	icon_state = "plastics"
 	armor = list(MELEE = 5, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 20, ACID = -40) // BLUEMOON CHANGE нёрф защиты в два раза
 	flags_inv = HIDEACCESSORY
+	restricted_accessory = TRUE // BLUEMOON EDIT - изменение аксессуаров
 
 //necklace
 /obj/item/clothing/accessory/necklace

--- a/code/modules/clothing/under/bodycam.dm
+++ b/code/modules/clothing/under/bodycam.dm
@@ -4,6 +4,7 @@
 	icon = 'modular_splurt/icons/obj/clothing/bodycam.dmi'
 	icon_state = "bodycamera"
 	var/obj/machinery/camera/builtInCamera = null
+	max_stack = 1 // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/bodycamera/attach(obj/item/clothing/under/U, user)
 	. = ..()

--- a/modular_sand/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/modular_sand/code/modules/mining/lavaland/necropolis_chests.dm
@@ -616,6 +616,7 @@
 	var/stored_resistance_flags = 0
 	var/stored_heat_protection = 0
 	var/stored_max_heat_protection_temperature = 0
+	max_stack = 1 // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/fireresist/attach(obj/item/clothing/under/U, user)
 	. = ..()
@@ -645,6 +646,7 @@
 	var/datum/action/cooldown/lavawalk/lavawalk
 	var/effectduration = 10 SECONDS
 	var/timer
+	max_stack = 1 // BLUEMOON EDIT - изменение аксессуаров
 
 /obj/item/clothing/accessory/lavawalk/ComponentInitialize()
 	. = ..()

--- a/modular_splurt/code/game/objects/items/weapon_permits.dm
+++ b/modular_splurt/code/game/objects/items/weapon_permits.dm
@@ -9,6 +9,8 @@ GLOBAL_VAR_INIT(weapon_permits_issued, 0)
 	mob_overlay_icon = 'icons/mob/clothing/accessories.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FIRE_PROOF
+	max_stack = 2
+	max_stack_path = /obj/item/clothing/accessory/permit
 	var/permit_id
 	var/owner_name = ""
 	var/owner_assignment = ""


### PR DESCRIPTION
Теперь аксессуары, влияющие на боевые возможности персонажа (на броню джампсьюта, например) имеют свой отдельный лимит, равный трём (то есть можно носить 3 боевых и 4 обычных аксессуара в одно время).

Также некоторые аксессуары ограничены в возможности стакаться с похожими на себя.