### PR TITLE
Квирк синтетикам: "Сложное техобслуживание"

### DIFF
--- a/code/__BLUEMOONCODE/_DEFINES/traits.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/traits.dm
@@ -1,17 +1,23 @@
 #define TRAIT_BLUEMOON_HEAVY				"heavy"
 #define TRAIT_BLUEMOON_HEAVY_SUPER			"heavy_super"
-#define TRAIT_BLUEMOON_DEVOURER			"giant_body"
+#define TRAIT_BLUEMOON_DEVOURER				"giant_body"
 #define TRAIT_BLUEMOON_LIGHT				"light"
 #define TRAIT_BLUEMOON_ANTI_NORMALIZER		"anti_normalizer"
 #define TRAIT_BLUEMOON_HIGH_PAIN_THRESHOLD	"high_pain_threshold"
 #define TRAIT_BLUEMOON_FEAR_OF_SURGEONS		"fear_of_surgeons"
 #define TRAIT_BLUEMOON_SHRIEK				"shriek"
 #define TRAIT_BLUEMOON_SHOWER_NEED			"shower_need"
+#define TRAIT_BLUEMOON_COMPLEX_MAINTENANCE	"high_quality_maintenance"
 
 // Отдельные наименования для квирков, чтобы не повторять их в настройках
-#define BLUEMOON_TRAIT_NAME_SHRIEK			"Крикун"
+#define BLUEMOON_TRAIT_NAME_SHRIEK				"Крикун"
 
-#define BLUEMOON_TRAIT_NAME_SHOWER_NEED		"Потребность в душе"
+#define BLUEMOON_TRAIT_NAME_SHOWER_NEED			"Потребность в душе"
+
+#define BLUEMOON_TRAIT_NAME_COMPLEX_MAINTENANCE "Сложное обслуживание"
 
 // Трейты для рас
 #define CAN_BE_OPERATED_WITHOUT_PAIN		"can_be_operated_without_pain"
+
+// Трейты для профессий
+#define QUALIFIED_ROBOTIC_MAINTER			"qualified_robotic_maintner"

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -88,6 +88,11 @@
 			prob_chance = implements[implement_type]
 		prob_chance *= surgery.get_propability_multiplier()
 		// BLUEMOON ADD START - самооперирование - чертовски сложное дело
+		if(HAS_TRAIT(target, TRAIT_BLUEMOON_COMPLEX_MAINTENANCE)) // только роботехники, РД и борги могут ремонтировать таких роботов
+			if(HAS_TRAIT(target, TRAIT_ROBOTIC_ORGANISM))
+				if(!HAS_TRAIT(user.mind, QUALIFIED_ROBOTIC_MAINTER) && !user.mind.antag_datums) // гост роли и обученный персонал могут оперировать таких синтов
+					to_chat(user, span_warning("Этот протез выглядит слишком сложно... Здесь необходим специалист!"))
+					prob_chance = 0
 		if(target == user)
 			if(HAS_TRAIT(target, CAN_BE_OPERATED_WITHOUT_PAIN)) // Роботам и некоторым другим расам даётся проще. Они не чувствуют боли
 				display_results(target, self_message = "<span class='notice'>Вы пытаетесь [HAS_TRAIT(target, TRAIT_ROBOTIC_ORGANISM) ? "отремонтироваться" : "вылечитья"] самостоятельно. Это не так сложно, как было бы [HAS_TRAIT(target, TRAIT_ROBOTIC_ORGANISM) ? "органикам" : "другим расам"], но неудобно.</span>")

--- a/modular_bluemoon/maintenance_quirk/maintenance_quirk.dm
+++ b/modular_bluemoon/maintenance_quirk/maintenance_quirk.dm
@@ -1,0 +1,28 @@
+/datum/quirk/high_quality_maintenance
+	name = BLUEMOON_TRAIT_NAME_COMPLEX_MAINTENANCE
+	desc = "ТОЛЬКО ДЛЯ СИНТЕТИКОВ! Ваше тело слишком сложно устроено, чтобы его мог оперировать кто угодно, кроме роботехника, РД (или антагонистов/гост-ролей)."
+	gain_text = span_warning("Эти новые протезы такие классные... И дорогие! И сложные в обслуживании... И дорогие!")
+	lose_text = span_notice("??")
+	value = -4
+	mob_trait = TRAIT_BLUEMOON_COMPLEX_MAINTENANCE
+	on_spawn_immediate = FALSE // иначе on_spawn из-за потенциального удаления квирка ломается
+
+/datum/quirk/high_quality_maintenance/on_spawn()
+	. = ..()
+	if(!HAS_TRAIT(quirk_holder, TRAIT_ROBOTIC_ORGANISM)) // только персонажи-синтетики могут пользоваться этим квирком
+		to_chat(quirk_holder, span_warning("Все квирки были сброшены, т.к. квирк [src] не подходит виду персонажа."))
+		var/list/user_quirks = quirk_holder.roundstart_quirks
+		user_quirks -= src
+		for(var/datum/quirk/Q as anything in user_quirks)
+			qdel(Q)
+		qdel(src)
+
+/datum/job/roboticist/New()
+	var/list/extra_mind_traits = list(QUALIFIED_ROBOTIC_MAINTER)
+	LAZYADD(mind_traits, extra_mind_traits)
+	. = ..()
+
+/datum/job/rd/New()
+	var/list/extra_mind_traits = list(QUALIFIED_ROBOTIC_MAINTER)
+	LAZYADD(mind_traits, extra_mind_traits)
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4387,6 +4387,7 @@
 #include "modular_bluemoon\krashly\modulars\clownfart\code.dm"
 #include "modular_bluemoon\lazybodia\code\snouts.dm"
 #include "modular_bluemoon\loadout_rings\rings.dm"
+#include "modular_bluemoon\maintenance_quirk\maintenance_quirk.dm"
 #include "modular_bluemoon\phenyamomota\code\modules\cargo\packs\engineering.dm"
 #include "modular_bluemoon\phenyamomota\code\modules\clothing\labcoat.dm"
 #include "modular_bluemoon\phenyamomota\code\modules\clothing\under_med.dm"


### PR DESCRIPTION
# Опять бафы?

Квирк, дающий 4 очка в замен на то, что операции на синтетике могут проводить только роботехники, РД и антагонисты.

Если его возьмет обычный член экипажа, с его квирками случится смешное.

# Зачем?

Желание кечиться в ИЦ, какие дорогие в ремонте протезы + ролевая игра, что протезы может обслуживать только специалист.

Фикс 

