### PR TITLE
Теперь опыт за офицера мостика идёт также в счёт для разблокировки ГП

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -55,6 +55,7 @@ GLOBAL_LIST_INIT(civilian_positions, list(
 	"Chaplain",
 	"Clown",
 	"Mime",
+	"Bridge Officer", // BLUEMOON EDIT
 	"Prisoner",
 	"Assistant",
 	"Stowaway"))


### PR DESCRIPTION
Было бы логично, чтобы игра за личную горничную капитана и того, кто в нынешних условиях постоянно подменяет главу персонала, давала опыт для его разблокировки.