### PR TITLE
Fix: Cверхтяжёлых персонажей можно было таскать за собой

### DIFF
--- a/modular_splurt/code/game/objects/items/lewd_items/rope.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/rope.dm
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(bondage_rope_slowdowns, list(
 				apply_legs(C)
 
 	// BLUEMOON ADD START - сверхтяжёлых персонажей нельзя таскать за собой
-	if((!HAS_TRAIT(C, TRAIT_BLUEMOON_HEAVY_SUPER)))
+	if(HAS_TRAIT(C, TRAIT_BLUEMOON_HEAVY_SUPER))
 		to_chat(user, span_warning("[C] is too heavy to be moved on ropes. It would be useless."))
 		return
 	// BLUEMOON ADD END


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Обычного персонажа (без квирка - Cверхтяжёлый) нельзя было привязать веревкой к предмету и таскать за собой, хотя по коду приходит сообщение, что персонаж слишком тяжелый. (related commit: https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/issues/554)
Тогда как сверхтяжёлых - можно.
Fixed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Changelog

fix: 
Логическая ошибка

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
