### PR TITLE
Изменение скорости силиконов

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -742,9 +742,9 @@
 			if (0) //default speed
 				user.vtec = initial(user.vtec) //"vtec" value is negative and the lesser it is the faster we move.
 			if (1) //slightly faster than runnung
-				user.vtec = initial(user.vtec) - 1.25 //cyborg sprinting is roughly -2. don't forget we can't sprint with vtec.
+				user.vtec = initial(user.vtec) - 0.75 //cyborg sprinting is roughly -2. don't forget we can't sprint with vtec.  //BLUEMOON EDIT Снижение модификатора скорости со стандартных -1,25 до -0,75 для второго режима VTEC
 			if (2) //overclocking module
-				user.vtec = initial(user.vtec) - 1.75 //while changing this value check /mob/living/silicon/robot/proc/use_power() to maintain proper power drain
+				user.vtec = initial(user.vtec) - 1 //while changing this value check /mob/living/silicon/robot/proc/use_power() to maintain proper power drain //BLUEMOON EDIT Снижение модификатора скорости со стандартных -1,75 до -1 для третьего режима VTEC
 
 	action.button_icon_state = "Chevron_State_[currentState]"
 	action.UpdateButtons()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -16,11 +16,11 @@
 /mob/living/silicon/robot/Move(NewLoc, direct)
 	. = ..()
 	if(. && (combat_flags & COMBAT_FLAG_SPRINT_ACTIVE) && !(movement_type & FLYING) && CHECK_ALL_MOBILITY(src, MOBILITY_STAND | MOBILITY_MOVE))
-		if(!(cell?.use(25)))
+		if(!(cell?.use(15))) //BLUEMOON EDIT Снижение потребления энергии за спринт силиконам со стандартных 25 до 15
 			default_toggle_sprint(TRUE)
 
 /mob/living/silicon/robot/movement_delay()
 	. = ..()
 	if(!resting && !(combat_flags & COMBAT_FLAG_SPRINT_ACTIVE))
-		. += 1
+		. += 0.5
 	. += vtec_disabled? 0 : vtec

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -22,5 +22,5 @@
 /mob/living/silicon/robot/movement_delay()
 	. = ..()
 	if(!resting && !(combat_flags & COMBAT_FLAG_SPRINT_ACTIVE))
-		. += 0.5
+		. += 0.5 //BLUEMOON EDIT Снижение модификатора скорости спринта со стандартных 1 до 0.5
 	. += vtec_disabled? 0 : vtec

--- a/code/modules/mob/living/silicon/robot/robot_sprint.dm
+++ b/code/modules/mob/living/silicon/robot/robot_sprint.dm
@@ -3,7 +3,7 @@
 		disable_intentional_sprint_mode()
 		return
 	var/current = (combat_flags & COMBAT_FLAG_SPRINT_ACTIVE)
-	if(current || shutdown || !cell || (cell.charge < 25) || !cansprint)
+	if(current || shutdown || !cell || (cell.charge < 15) || !cansprint) //BLUEMOON EDIT Снижение порога проверки заряда батареи со стандартных 25 до 15
 		disable_intentional_sprint_mode()
 		if(CHECK_MULTIPLE_BITFIELDS(mobility_flags, MOBILITY_STAND|MOBILITY_MOVE))
 			if(shutdown)


### PR DESCRIPTION
# About The Pull Request

Уменьшение модификатора скорости силиконов при спринте (с 1 до 0.5)
Уменьшение модификатора скорости силиконов при активном VTEC (с 1.25 до 0.75 во втором режиме,  1.75 до 1 в третьем режиме)
Также было снижено потребление энергии батареи при спринте (с 25 до 15 на клетку)

## Why It's Good For The Game

Киборги перестанут молниеносно передвигаться по станции, но всё ещё остаются быстрее среднестатистического космонавтика без химии. А снижение потребления энергии при спринте не даст разрядится стандартной батареи слишком быстро.