### PR TITLE
Больше вариантов HUD для миротворцев.

### DIFF
--- a/modular_citadel/code/modules/client/loadout/_security.dm
+++ b/modular_citadel/code/modules/client/loadout/_security.dm
@@ -67,4 +67,4 @@
 /datum/gear/glasses/sechud
 	name = "Security Hud"
 	path = /obj/item/clothing/glasses/hud/security
-	restricted_roles = list("Security Officer", "Warden", "Head of Security")
+	restricted_roles = list("Peacekeeper", "Security Officer", "Warden", "Head of Security")

--- a/modular_splurt/code/modules/client/loadout/glasses.dm
+++ b/modular_splurt/code/modules/client/loadout/glasses.dm
@@ -1,12 +1,12 @@
 /datum/gear/glasses/security/sunglasses/aviators
 	name = "Secuirity HUD Aviators"
 	path = /obj/item/clothing/glasses/hud/security/sunglasses/aviators
-	restricted_roles = list("Security Officer", "Warden", "Head of Security")
+	restricted_roles = list("Peacekeeper", "Security Officer", "Warden", "Head of Security")
 
 /datum/gear/glasses/security/sunglasses/aviators/prescription
 	name = "Prescription Secuirity HUD Aviators"
 	path = /obj/item/clothing/glasses/hud/security/sunglasses/aviators/prescription
-	restricted_roles = list("Security Officer", "Warden", "Head of Security")
+	restricted_roles = list("Peacekeeper", "Security Officer", "Warden", "Head of Security")
 
 /datum/gear/glasses/health/sunglasses/aviators
 	name = "Medical HUD Aviators"
@@ -50,12 +50,12 @@
 /datum/gear/glasses/security/sunglasses/holo
 	name = "Holo Secuirity HUD Glasses"
 	path = /obj/item/clothing/glasses/hud/security/sunglasses/holo
-	restricted_roles = list("Security Officer", "Warden", "Head of Security")
+	restricted_roles = list("Peacekeeper", "Security Officer", "Warden", "Head of Security")
 
 /datum/gear/glasses/security/sunglasses/holo/prescription
 	name = "Prescription Holo Secuirity HUD Glasses"
 	path = /obj/item/clothing/glasses/hud/security/sunglasses/holo/prescription
-	restricted_roles = list("Security Officer", "Warden", "Head of Security")
+	restricted_roles = list("Peacekeeper", "Security Officer", "Warden", "Head of Security")
 
 //NON-RESTRICTED
 


### PR DESCRIPTION
Просто позволяет авиаторам, голографическим HUD и СБ HUD быть доступными для миротворцев в loadout. Не знаю, почему это не было сделано раньше.

Первый PR. Если сделал что-то не так, бейте меня по голове ботинком.