### PR TITLE
Рефакторинг эффекта клятвы Гиппократа

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -544,23 +544,18 @@
 			itemUser.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.5)
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
 		//Heal all those around you, unbiased
-		for(var/mob/living/L in view(7, owner))
-			if(L.health < L.maxHealth)
-				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
-			if(iscarbon(L))
-				L.adjustBruteLoss(-3.5)
-				L.adjustFireLoss(-3.5)
-				L.adjustToxLoss(-3.5, forced = TRUE) //Because Slime People are people too
-				L.adjustOxyLoss(-3.5)
-				L.adjustStaminaLoss(-3.5)
-				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5)
-				L.adjustCloneLoss(-1) //Becasue apparently clone damage is the bastion of all health
-			else if(issilicon(L))
-				L.adjustBruteLoss(-3.5)
-				L.adjustFireLoss(-3.5)
-			else if(isanimal(L))
-				var/mob/living/simple_animal/SM = L
-				SM.adjustHealth(-3.5, forced = TRUE)
+		owner.AddComponent( \
+			/datum/component/aura_healing, \
+			range = 7, \
+			brute_heal = 3.5, \
+			burn_heal = 3.5, \
+			toxin_heal = 3.5, \
+			suffocation_heal = 3.5, \
+			stamina_heal = 3.5, \
+			organ_healing = list(ORGAN_SLOT_BRAIN = 3.5), \
+			simple_heal = 3.5, \
+			healing_color = "#375637", \
+			)
 
 /atom/movable/screen/alert/status_effect/regenerative_core
 	name = "Reinforcing Tendrils"


### PR DESCRIPTION
Небольшой рефакторинг статус эффекта клятвы Гиппократа для подстановки под компонент ауры исцеления.


К сожалению из-за невозможности компонента лечить клеточный урон, аура была лишена этой возможности (если компонент не будет переработан позднее).
Остальное осталось без изменений.