### PR TITLE
Update smg.dm

### DIFF
--- a/modular_splurt/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/modular_splurt/code/modules/projectiles/projectile/bullets/smg.dm
@@ -8,8 +8,8 @@
 
 /obj/item/projectile/bullet/c45/lethal
 	name = ".45 bullet"
-	damage = 20 // 30 before
-	wound_bonus = 4 // 6 before
+	damage = 25 // 30 before
+	wound_bonus = 6 // 6 before
 	stamina = 0
 	wound_falloff_tile = -10
 	sharpness = NONE // AHUY
@@ -29,7 +29,7 @@
 
 /obj/item/projectile/bullet/c45/trac
 	name = ".45 TRAC bullet"
-	damage = 10 // 15 before
+	damage = 15 // 15 before
 	stamina = 0
 
 /obj/item/projectile/bullet/c45/ion
@@ -48,7 +48,7 @@
 
 /obj/item/projectile/bullet/c45/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".45 Hot Shot bullet"
-	damage = 15 // 20 before
+	damage = 20 // 20 before
 	stamina = 0
 	sharpness = SHARP_EDGED
 


### PR DESCRIPTION
Инфорсеру опустили урон с 30 до 20, делая его урон равным тяжёлому лому, или заточенным очкам СБ, так абсолютно не должно быть, ведь даже в сравнении с 9мм пистолетом в карго, инфорсер проигрывал во всём. Теперь урон поднят слегка, на 5 единиц, а так же затронуты некоторые его дальнейшие пули в изучении, что ПОТЕНЦИАЛЬНО сделает его снова играбельным оружием, а не тем, с которого смеются бывалые игроки, когда видят его у офицера.

сравнение 9мм из карго и инфорсера актуального билда, без баффа
↓

кол-во пуль в магазине
9мм  - 10 
инфорсер - 7
до крита с нелетала голым
9мм - 5
инфорсер - 5
до крита с нелетала сб броня
9мм - 6
инфорсер - 7
до крита летал голым
9мм - 5
инфорсер -5
до крита летал сб броня
9мм - 7
инфорсер - 8