### PR TITLE
Сделал пропаганду интекью менее доставучей

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -71,7 +71,7 @@
 ///Heretics --
 GLOBAL_LIST_EMPTY(living_heart_cache)	//A list of all living hearts in existance, for us to iterate through.
 
-#define IS_INTEQ(mob) (mob.mind?.has_antag_datum(/datum/antagonist/traitor) || mob.mind?.has_antag_datum(/datum/antagonist/raiders) || mob.mind?.has_antag_datum(/datum/antagonist/nukeop) || mob.mind?.has_antag_datum(/datum/antagonist/ghost_role))
+#define IS_INTEQ(mob) (mob.mind?.has_antag_datum(/datum/antagonist/traitor) || mob.mind?.has_antag_datum(/datum/antagonist/raiders) || mob.mind?.has_antag_datum(/datum/antagonist/nukeop) || (ROLE_INTEQ in mob.faction))
 
 #define IS_HERETIC(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic))
 #define IS_HERETIC_MONSTER(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic_monster))

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -126,11 +126,21 @@
 	forceMove(P)
 	return P
 
+// BLUEMOON EDIT START - проверка, можно ли повесить постер, зависящая от самого постера. Для пропаганды InteQ
+/obj/item/poster/proc/poster_place_check(mob/user, turf/closed/wall)
+	return TRUE
+// BLUEMOON EDIT END
+
 //separated to reduce code duplication. Moved here for ease of reference and to unclutter r_wall/attackby()
 /turf/closed/wall/proc/place_poster(obj/item/poster/P, mob/user)
 	if(!P.poster_structure)
 		to_chat(user, "<span class='warning'>[P] has no poster... inside it? Inform a coder!</span>")
 		return
+
+	// BLUEMOON EDIT START - проверка, можно ли повесить постер, зависящая от самого постера. Для пропаганды InteQ
+	if(!P.poster_place_check(user, src))
+		return
+	// BLUEMOON EDIT END
 
 	// Deny placing posters on currently-diagonal walls, although the wall may change in the future.
 	if (smooth & SMOOTH_DIAGONAL)

--- a/modular_bluemoon/Fink/code/datums/components/demoraliser.dm
+++ b/modular_bluemoon/Fink/code/datums/components/demoraliser.dm
@@ -5,60 +5,148 @@
  * - Does not re-apply mood to people who already have it.
  * - Sends a signal if a mood is successfully applied.
  */
+
+#define FEAR_LEVEL_CAPTAIN 1
+#define FEAR_LEVEL_SECURITY 2
+#define FEAR_LEVEL_HEADS 3
+#define FEAR_LEVEL_MINDSHIELD 4
+#define FEAR_LEVEL_CHAPLAIN 5
+#define FEAR_LEVEL_OTHERS 6
+
+// Чтобы из-за 10 плакатов все вокруг не охуевали каждые 5 наносекунд. Не самое лучшее решение, ну и ладно
+/mob/living/carbon/human
+	/// Last fear effect apply. Primarily used in inteq propaganda
+	var/was_scared = 0
+
 /datum/proximity_monitor/advanced/demoraliser
-	var/next_check = 0
 	var/next_scare = 0
 
 
 /datum/proximity_monitor/advanced/demoraliser/New(atom/_host, range, _ignore_if_not_on_turf = TRUE)
 	. = ..()
+	host = _host
 	RegisterSignal(_host, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 
 /datum/proximity_monitor/advanced/demoraliser/proc/on_examine(datum/source, mob/examiner)
 	SIGNAL_HANDLER
-	if (isliving(examiner))
+	if(isliving(examiner))
 		pugach(examiner)
 
 /datum/proximity_monitor/advanced/demoraliser/proc/pugach(mob/living/viewer)
-	var/message = pick("spooks you to the bone", "shakes you up", "terrifies you", "sends you into a panic", "sends chills down your spine")
-
-	if (viewer.stat != CONSCIOUS)
-		return
-	if(viewer.is_blind())
-		return
 	if(!ishuman(viewer))
 		return
-	if(HAS_TRAIT(viewer, TRAIT_FEARLESS))
+	var/mob/living/carbon/human/beholder = viewer
+	if(beholder.was_scared > world.time)
 		return
-	if(IS_INTEQ(viewer))
+	if (beholder.stat != CONSCIOUS)
 		return
-	if(viewer.mind && (viewer.mind?.antag_datums)) // все антажки
+	if(beholder.is_blind())
 		return
-	else
-		to_chat(viewer, "<span class='userdanger'>Seeing propagand of Inteq [message]!</span>")
-		var/reaction = rand(1,5)
-		switch(reaction)
-			if(1)
-				to_chat(viewer, "<span class='warning'>You are paralyzed with fear!</span>")
-				viewer.Stun(70)
-				viewer.Jitter(8)
-			if(2)
-				viewer.emote("scream")
-				viewer.Jitter(5)
-				viewer.say("AAAAH!!", forced = "phobia")
-				viewer.pointed(src)
-			if(3)
-				viewer.emote("realagony")
-				viewer.Jitter(5)
-				viewer.say("AAAAH!!", forced = "phobia")
-				viewer.pointed(src)
-			if(4)
-				viewer.emote("chill")
-				viewer.Jitter(5)
-				viewer.pointed(src)
-			if(5)
-				viewer.dizziness += 10
-				viewer.confused += 10
-				viewer.Jitter(10)
-				viewer.stuttering += 10
+	if(!beholder.mind)
+		return
+	if(HAS_TRAIT(beholder, TRAIT_FEARLESS))
+		return
+	if(IS_INTEQ(beholder))
+		SEND_SIGNAL(beholder, COMSIG_ADD_MOOD_EVENT, "inteq_propagand", /datum/mood_event/inteq_happy)
+		return
+	if(beholder.mind.antag_datums) // все антажки
+		return
+	beholder.was_scared = world.time + 5 SECONDS
+	var/fear_level = get_fear_level(beholder)
+	SEND_SIGNAL(beholder, COMSIG_ADD_MOOD_EVENT, "inteq_propagand", /datum/mood_event/inteq_scared, fear_level)
+	if(prob(50))
+		var/message = pick("крайне вас напрягает.", "напоминает вам, что вы тут не в безопасности.", "просто отвратительно!", "возмутительно!")
+		to_chat(beholder, "<span class='warning'>Судя по [host], наёмники из InteQ уже рядом! Это [message]</span>")
 
+	// Эффекты, помимо муда, стакающиеся друг с другом. Чем страшнее челику, тем больше стакается эффектов
+	// Эффекты для глав и круче
+	if(prob(30))
+		beholder.emote("scowl")
+		beholder.pointed(host)
+	if(fear_level < FEAR_LEVEL_MINDSHIELD)
+		return
+
+	// Эффекты для остальных сильных духом
+	if(prob(30))
+		beholder.Jitter(7)
+		beholder.emote("chill")
+	if(fear_level < FEAR_LEVEL_OTHERS)
+		return
+
+	// Эффекты для вообще остальных
+	var/reaction = rand(1,5)
+	switch(reaction)
+		if(1)
+			beholder.Confused(15)
+			beholder.pointed(host)
+			beholder.say("Какого чёрта?!", forced="phobia")
+		if(2)
+			beholder.emote("tremble")
+			beholder.Jitter(15)
+			beholder.say("Наёмники уже близко!!", forced = "phobia")
+			beholder.pointed(host)
+		if(3)
+			beholder.emote("scream")
+			beholder.Jitter(15)
+			beholder.say("InteQ уже здесь!! Куда смотрят офицеры?!!", forced = "phobia")
+			beholder.pointed(host)
+		if(4)
+			beholder.emote("mumbles")
+			beholder.stuttering += 15
+			beholder.pointed(host)
+		if(5)
+			beholder.Confused(20)
+
+/datum/proximity_monitor/advanced/demoraliser/proc/get_fear_level(mob/living/carbon/human/victim)
+	if(victim.mind.assigned_role == "Captain")
+		return FEAR_LEVEL_CAPTAIN
+	if(victim.mind.assigned_role in list("Head of Security","Warden","Security Officer","Brig Physisician","Detective", "Blueshield"))
+		return FEAR_LEVEL_SECURITY
+	if(victim.mind.assigned_role in list("NanoTrasen Representative","Head Of Personnel","Research Director","Chief Medical Officer","Chief Engineer","Quartermaster","Bridge Officer"))
+		return FEAR_LEVEL_HEADS
+	if(HAS_TRAIT(victim, TRAIT_MINDSHIELD))
+		return FEAR_LEVEL_MINDSHIELD
+	if(victim.mind.assigned_role == "Chaplain")
+		return FEAR_LEVEL_CHAPLAIN
+	return FEAR_LEVEL_OTHERS
+
+/datum/mood_event/inteq_scared
+	description = "InteQ на борту!"
+	mood_change = -1
+	timeout = 7 MINUTES
+
+/datum/mood_event/inteq_scared/add_effects(fear_level)
+	var/message = "InteQ на борту!"
+	switch(fear_level)
+		if(FEAR_LEVEL_CAPTAIN)
+			message = "Кто развешивает эти тряпки на МОЕЙ станции?! Кишки на гафель намотаю!"
+			mood_change = -2
+		if(FEAR_LEVEL_SECURITY)
+			message = "Наёмники на борту. Нужно смотреть в оба!"
+			mood_change = -4
+		if(FEAR_LEVEL_HEADS)
+			message = "Проклятые наёмники среди нас! А вдруг это кто-то из моих подчинённых?..."
+			mood_change = -6
+		if(FEAR_LEVEL_MINDSHIELD)
+			message = "Среди нас гуляют убийцы и бандиты! Хорошо, что имплант у меня в голове меня немножко успокаивает..."
+			mood_change = -8
+		if(FEAR_LEVEL_CHAPLAIN)
+			message = "Алчные убийцы прячутся среди прихожан. Проклят гнев их, ибо жесток, и ярость их, ибо свирепа."
+			mood_change = -10
+		if(FEAR_LEVEL_OTHERS)
+			message = "InteQ где-то рядом!!! Я на это не подписывался!! КУДА СМОТРИТ СЛУЖБА БЕЗОПАСНОСТИ?!!"
+			mood_change = -18
+	description = span_boldwarning(message)
+
+
+/datum/mood_event/inteq_happy
+	description = span_greenannounce("Да здравствует Адмирал Браун!")
+	mood_change = 18
+	timeout = 7 MINUTES
+
+#undef FEAR_LEVEL_CAPTAIN
+#undef FEAR_LEVEL_SECURITY
+#undef FEAR_LEVEL_HEADS
+#undef FEAR_LEVEL_MINDSHIELD
+#undef FEAR_LEVEL_CHAPLAIN
+#undef FEAR_LEVEL_OTHERS


### PR DESCRIPTION
Касается постеров и флагов InteQ.

- Теперь намного меньше боятся пропаганды: Капитан, СБ, главы, имплантированные майндшилдом и капеллан. Чем ближе ролька к началу списка, тем слабее на неё действуют эффекты.
- Теперь пропаганда интекью даёт очень сильный дебафф к муду у обычных ребят, более слабый у вышеперечисленных, а также очень хороший бафф к муду у самих интекьюшников.
- Эффекты сменены на менее доставучие. Теперь не будет криков REALAGONY от того, что кто-то заметил бумажку на стене, но настроение микрочелам будет портить знатно.
- Теперь не антагонисты, не члены интекью и не гострольки слишком бояться вешать плакаты и флаги.