### PR TITLE
Fix: Юбки видны сквозь хардсьюты

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -107,9 +107,7 @@
 	var/helmettype = /obj/item/clothing/head/helmet/space/hardsuit
 	var/obj/item/tank/jetpack/suit/jetpack = null
 	var/hardsuit_type
-	flags_inv = HIDETAUR //bluemood add
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_SNEK_TAURIC //bluemood add
-
 
 /obj/item/clothing/suit/space/hardsuit/Initialize(mapload)
 	if(jetpack && ispath(jetpack))


### PR DESCRIPTION
Фиксит юбки, которые были видны через скафандры из-за неправильного указания флагов у хардсьютов.
![1265c1cb78a134b0c143698063578](https://github.com/user-attachments/assets/60ab0c9c-6a28-485d-9049-09516fe3f410)

Было:
![изображение](https://github.com/user-attachments/assets/9bd0de18-f342-4d1a-ace7-6ef666ab765f)

