### PR TITLE
tweak: снова энфорсер и магазины

### DIFF
--- a/modular_splurt/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/modular_splurt/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -230,9 +230,26 @@
 	name = "Extended Enforcer magazine"
 	id = "c45lethal"
 	build_type = AUTOLATHE | NO_PUBLIC_LATHE
-	materials = list(/datum/material/iron = 8000)
+	materials = list(/datum/material/iron = 17000)
 	build_path = /obj/item/ammo_box/magazine/e45/e45_extended
 	category = list("hacked", "Security")
+
+/datum/design/e45/e45_extended_empty
+	name = "Empty Extended Enforcer magazine"
+	id = "c45_empy_extended"
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
+	materials = list(/datum/material/iron = 1200)
+	build_path = /obj/item/ammo_box/magazine/e45/e45_extended/empty
+	category = list("hacked", "Security")
+
+/datum/design/e45/empty
+	name = "Empty Enforcer magazine"
+	id = "c45_empy"
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
+	materials = list(/datum/material/iron = 600)
+	build_path = /obj/item/ammo_box/magazine/e45/empty
+	category = list("hacked", "Security")
+
 //BLUEMOON ADD END
 
 

--- a/modular_splurt/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/modular_splurt/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -37,7 +37,17 @@
 	..()
 	icon_state = "enforcer-ext-[round(ammo_count())]"
 
+/obj/item/ammo_box/magazine/e45/e45_extended/empty
+	name = "Extended Enforcer magazine"
+	desc = "An extended Mk. 58 magazine."
+	start_empty = 1
+
 //BLUEMOON ADD END Добавление увеличенного магазина на инфорсер в билд.
+
+/obj/item/ammo_box/magazine/e45/empty
+	name = "Enforcer magazine"
+	desc = "A Mk. 58 magazine."
+	start_empty = 1
 
 /obj/item/ammo_box/magazine/e45/lethal
 	name = "Enforcer magazine (.45 Lethal)"


### PR DESCRIPTION
fix: исправил цену расширенного заряженного магазина на энфорсер, сейчас патрон в нём стоит в ~2,5 дешевле чем в коробке
add: добавил пустой магазин на энфорсер и расширенный пустой магазин на энфорсер во взломанный автолат. Чтобы сб не сорило патронами и при надобности печатало себе пустые для заполнения с коробок.