### PR TITLE
Fix: Кабель на Пабби

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2204,9 +2204,7 @@
 	name = "test chamber blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "alB" = (
@@ -71020,8 +71018,7 @@
 	pixel_y = 28
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -72101,8 +72098,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72144,8 +72140,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
+++ b/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
@@ -2942,10 +2942,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	dir = 1
-	},
 /obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "agP" = (
@@ -60157,11 +60155,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/security/prison)
 "oqn" = (
-/obj/structure/cable{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/medical/surgery)
 "oqO" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -51366,9 +51366,7 @@
 	name = "Nanotrasen Representative APC";
 	pixel_y = -23
 	},
-/obj/structure/cable{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/ntr)
 "ezJ" = (
@@ -61932,11 +61930,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "tfw" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "tfx" = (
@@ -63097,11 +63094,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "uMe" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
 /obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "uMf" = (


### PR DESCRIPTION
# About The Pull Request

Исправляет это недоразумение. Это действительно заслуживает отдельного пулл-реквеста
![изображение](https://github.com/user-attachments/assets/98963571-86ce-4c31-9189-a4ba485b9a26)

Дополнительно убраны переменные pixel_x/pixel_y и dir, которые были присвоены кабелям на картах, так как они ни на что не влияют
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
