### PR TITLE
Сообщение, что человек прожал succumb

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -483,6 +483,7 @@
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
 		updatehealth()
 		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
+		visible_message(span_boldnotice("Кажется, [src] [gender == MALE ? "сдался" : "сдалась"].")) // BLUEMOON - SUCCUMB_MESSAGE - ADD
 		death()
 
 /mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, check_immobilized = FALSE, ignore_stasis = FALSE)


### PR DESCRIPTION
Если человек прожимает succumb, в чат выдаётся сообщение, что он сдался.

Нужно для предотвращения ситуаций, когда человека пытаются взять живым, а он дерётся до смерти и по итогу прожимает сдачу, выставляя кого-либо как убийц.