### PR TITLE
Нерфим тяжёлый лом

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -83,7 +83,7 @@
 /obj/item/crowbar/large/heavy
 	name = "heavy crowbar"
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big. It feels oddly heavy.."
-	force = 20
+	force = 14 // BLUEMOON - HEAVY_CROWBAR_DAMAGE_CHANGE - EDIT (было 20)
 	icon_state = "crowbar_powergame"
 
 /obj/item/crowbar/cyborg


### PR DESCRIPTION
1. Урон тяжёлого лома снижен с 20 до 14 единиц.
2. Потому что у другого менее доступного оружия урон ниже. Например, у копья при броске урон 40, но в двух руках 18. У кортика урон 14. У заточенного ножа сколько не считал.
3. Потому большой размер оружия компенсирует его лёгкое получение.