### PR TITLE
Tweak: Оверлей видимости в темноте 

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -114,6 +114,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 		plane_masters["[instance.plane]"] = instance
 		instance.backdrop(mymob)
 
+	owner.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/special/see_through_darkness)
+
 	screentip_text = new(null, src)
 	static_inventory += screentip_text
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -208,7 +208,6 @@
 
 /datum/hud/human/New(mob/living/carbon/human/owner)
 	..()
-	owner.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/special/see_through_darkness)
 
 	var/widescreenlayout = FALSE //CIT CHANGE - adds support for different hud layouts depending on widescreen pref
 	if(owner.client && owner.client.prefs && owner.client.prefs.widescreenpref) //CIT CHANGE - ditto


### PR DESCRIPTION
# About The Pull Request

Добавляет оверлей видимости в темноте (который позволяет видеть своего персонажа при нулевом освещении) всем существам

До:
![before](https://github.com/user-attachments/assets/f910a7de-20aa-40e8-88a1-4b41ec679e76)

После:
![after](https://github.com/user-attachments/assets/12f85590-65e5-4ed3-855b-88640a42818f)

## Why It's Good For The Game

Такая особенность была только у людей. Теперь она будет у простых мобов

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


