### PR TITLE
Револьверный патрон для Нагана во взломанный автолат

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -226,6 +226,14 @@
 	materials = list(/datum/material/iron = 50000)
 	build_path = /obj/item/ammo_box/a762x39
 	category = list("hacked", "Security")
+
+/datum/design/a762x38
+	name = "Revolver Bullet (7.62x38R)"
+	id = "a762x38R"
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/n762
+	category = list("hacked", "Security")
 //BlueMoon edit end
 
 /datum/design/electropack


### PR DESCRIPTION
Добавлена возможность печатать патрон 7.62x38R для револьвера Наган во взломанном автолате, поскольку нет каких-либо способов приобрести или напечатать патроны для данного оружия отдельно.

_Сделано по просьбе игрока kiro6882_