### PR TITLE
Fix: Неработающие жукбоксы

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -2,23 +2,36 @@
 #define CHANNEL_LOBBYMUSIC 1024
 #define CHANNEL_ADMIN 1023
 #define CHANNEL_VOX 1022
+// BLUEMOON REMOVAL BEGIN - Increasing amount of jukebox channels
+/*
 #define CHANNEL_JUKEBOX 1021
 
 #define CHANNEL_JUKEBOX_START 1016 //The gap between this and CHANNEL_JUKEBOX determines the amount of free jukebox channels. This currently allows 6 jukebox channels to exist.
-#define CHANNEL_JUSTICAR_ARK 1015
-#define CHANNEL_HEARTBEAT 1014 //sound channel for heartbeats
-#define CHANNEL_AMBIENCE 1013
-#define CHANNEL_BUZZ 1012
-#define CHANNEL_BICYCLE 1011
-
+// BLUEMOON REMOVAL END
+*/
+// BLUEMOON EDIT - Jukebox channels
+#define CHANNEL_JUSTICAR_ARK 1021
+#define CHANNEL_HEARTBEAT 1020 //sound channel for heartbeats
+#define CHANNEL_AMBIENCE 1019
+#define CHANNEL_BUZZ 1018
+#define CHANNEL_BICYCLE 1017
 //CIT CHANNELS - TRY NOT TO REGRESS
-#define CHANNEL_PRED 1010
-#define CHANNEL_DIGEST 1009
-#define CHANNEL_PREYLOOP 1008
-
-
+#define CHANNEL_PRED 1016
+#define CHANNEL_DIGEST 1015
+#define CHANNEL_PREYLOOP 1014
 //Reactor Channel
-#define CHANNEL_REACTOR_ALERT 1007 // Is that radiation I hear? (ported from hyper)
+#define CHANNEL_REACTOR_ALERT 1013 // Is that radiation I hear? (ported from hyper)
+#define CHANNEL_JUKEBOX 1012
+#define CHANNEL_JUKEBOX_START 993
+
+//THIS SHOULD ALWAYS BE THE LOWEST ONE!
+//KEEP IT UPDATED
+
+#define CHANNEL_HIGHEST_AVAILABLE 992 //CIT CHANGE - COMPENSATES FOR VORESOUND CHANNELS
+
+// BLUEMOON EDIT END
+
+#define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
 ///Default range of a sound.
 #define SOUND_RANGE 17
@@ -36,12 +49,6 @@
 /// Default range at which sound distance multiplier applies
 #define SOUND_DEFAULT_MULTIPLIER_EFFECT_RANGE 7
 
-//THIS SHOULD ALWAYS BE THE LOWEST ONE!
-//KEEP IT UPDATED
-
-#define CHANNEL_HIGHEST_AVAILABLE 1007 //CIT CHANGE - COMPENSATES FOR VORESOUND CHANNELS
-
-#define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
 #define SOUND_MINIMUM_PRESSURE 10
 /// remove

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -201,6 +201,11 @@
 /obj/machinery/jukebox/proc/activate_music()
 	if(playing || !queuedplaylist.len)
 		return FALSE
+	// BLUEMOON ADD - Making sure not to play track if all jukebox channels are busy. That shouldn't happen.
+	if(!SSjukeboxes.freejukeboxchannels.len)
+		say("Cannot play song: limit of currently playing tracks has been exceeded.")
+		return FALSE
+	// BLUEMOON ADD END
 	playing = queuedplaylist[1]
 	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, playing, volume/35, one_area_play) //BLUEMOON EDIT
 	if(jukeboxslottotake)

--- a/code/game/machinery/dance_machine_handled.dm
+++ b/code/game/machinery/dance_machine_handled.dm
@@ -162,6 +162,11 @@
 /obj/item/jukebox/proc/activate_music()
 	if(playing || !queuedplaylist.len)
 		return FALSE
+	// BLUEMOON ADD - Making sure not to play track if all jukebox channels are busy. That shouldn't happen.
+	if(!SSjukeboxes.freejukeboxchannels.len)
+		say("Cannot play song: limit of currently playing tracks has been exceeded.")
+		return FALSE
+	// BLUEMOON ADD END
 	playing = queuedplaylist[1]
 	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, playing, volume/35, one_area_play) //BLUEMOON EDIT
 	if(jukeboxslottotake)

--- a/modular_bluemoon/Fink/code/items/moniq.dm
+++ b/modular_bluemoon/Fink/code/items/moniq.dm
@@ -162,6 +162,10 @@
 /obj/item/sign/moniq/proc/activate_music()
 	if(playing || !queuedplaylist.len)
 		return FALSE
+	// Making sure not to play track if all jukebox channels are busy. That shouldn't happen.
+	if(!SSjukeboxes.freejukeboxchannels.len)
+		say("Cannot play song: limit of currently playing tracks has been exceeded.")
+		return FALSE
 	playing = queuedplaylist[1]
 	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, playing, volume/35, one_area_play) //BLUEMOON EDIT
 	if(jukeboxslottotake)
@@ -368,6 +372,10 @@
 
 /obj/structure/sign/moniq/proc/activate_music()
 	if(playing || !queuedplaylist.len)
+		return FALSE
+	// Making sure not to play track if all jukebox channels are busy. That shouldn't happen.
+	if(!SSjukeboxes.freejukeboxchannels.len)
+		say("Cannot play song: limit of currently playing tracks has been exceeded.")
 		return FALSE
 	playing = queuedplaylist[1]
 	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, playing, volume/35, one_area_play) //BLUEMOON EDIT


### PR DESCRIPTION
# About The Pull Request

Одновременное проигрывание трэков у нескольких жукбоксов "ломает" другие жукбоксы, не давая их использовать и создает рантайм.

![b2a9cb4c07bc5a9b5bca](https://github.com/user-attachments/assets/7c48d73b-0cd7-4b74-98bd-990a9134cbaa)

Исправление заключается в "расширении" диапазона доступных каналов у проигрываемых треков и дополнительных проверках.

## Why It's Good For The Game

Не ломает жукбоксы. Жужж.

## A Port?

N

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

