### PR TITLE
Незначительные исправления карт

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2886,9 +2886,9 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	shuttle_id = "laborcamp_home";
 	name = "fore bay 1";
 	roundstart_template = /datum/map_template/shuttle/labour/box;
+	shuttle_id = "laborcamp_home";
 	width = 9
 	},
 /turf/open/space/basic,
@@ -5159,8 +5159,8 @@
 	dir = 8;
 	dwidth = 12;
 	height = 17;
-	shuttle_id = "syndicate_ne";
 	name = "northeast of station";
+	shuttle_id = "syndicate_ne";
 	width = 23
 	},
 /turf/open/space,
@@ -22468,7 +22468,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24700,9 +24700,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "mining_home";
 	name = "mining shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/box;
+	shuttle_id = "mining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -29098,7 +29098,7 @@
 /area/space/nearstation)
 "bVx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/maintenance/port/aft)
 "bVy" = (
 /obj/structure/disposalpipe/segment{
@@ -35972,8 +35972,8 @@
 "cpe" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
-	shuttle_id = "pod_lavaland2";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland2"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -38302,8 +38302,8 @@
 "cwV" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
-	shuttle_id = "pod_lavaland1";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland1"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -38334,8 +38334,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 13;
-	shuttle_id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -38394,8 +38394,8 @@
 	dir = 2;
 	dwidth = 11;
 	height = 22;
-	shuttle_id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Port";
+	shuttle_id = "whiteship_home";
 	width = 35
 	},
 /turf/open/space/basic,
@@ -38520,8 +38520,8 @@
 	dir = 8;
 	dwidth = 5;
 	height = 7;
-	shuttle_id = "supply_home";
 	name = "Cargo Bay";
+	shuttle_id = "supply_home";
 	width = 12
 	},
 /turf/open/space/basic,
@@ -38606,8 +38606,8 @@
 "czN" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
-	shuttle_id = "pod_lavaland4";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -39346,10 +39346,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cCS" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/engineering/atmos)
 "cCY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -39791,9 +39787,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 15;
-	shuttle_id = "arrivals_stationary";
 	name = "arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	shuttle_id = "arrivals_stationary";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -41182,10 +41178,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
 /area/space)
-"djd" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/port/aft)
 "djg" = (
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/glass/reinforced,
@@ -43218,11 +43210,6 @@
 	},
 /turf/closed/wall,
 /area/command/heads_quarters/ntr)
-"eAa" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/port)
 "eAe" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/white/side{
@@ -43302,7 +43289,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "eCR" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -44106,10 +44092,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"fbt" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/office)
 "fbw" = (
 /obj/machinery/camera{
 	c_tag = "Law Office";
@@ -46087,10 +46069,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
-"grT" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "gsi" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46724,7 +46702,7 @@
 "gNK" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/machinery/camera{
-	c_tag = "park";
+	c_tag = "Park";
 	dir = 1
 	},
 /turf/open/misc/grass,
@@ -46934,7 +46912,6 @@
 /turf/open/floor/wood/wood_diagonal,
 /area/security/prison/upper)
 "gUu" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -47668,10 +47645,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/detectives_office/private_investigators_office/investigators_room)
-"hBw" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/fore)
 "hCp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49862,8 +49835,8 @@
 "jdj" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
-	shuttle_id = "pod_lavaland3";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland3"
 	},
 /turf/open/space,
 /area/space)
@@ -51144,6 +51117,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/camera{
+	c_tag = "Blueshield";
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/command/blueshieldoffice)
 "jRQ" = (
@@ -51513,8 +51490,8 @@
 	dheight = 5;
 	dwidth = 5;
 	height = 10;
-	shuttle_id = "lambda_station";
 	name = "Lambda Shuttle Dock";
+	shuttle_id = "lambda_station";
 	width = 10
 	},
 /turf/open/space/basic,
@@ -52505,7 +52482,7 @@
 "kNt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
-	c_tag = "Brig EVA Storage";
+	c_tag = "Brig Firing Range";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -53761,13 +53738,6 @@
 "lJA" = (
 /turf/closed/wall,
 /area/security/prison/cells)
-"lJM" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_access_txt = "12"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lJQ" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -54593,10 +54563,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/wood,
 /area/command/bridge)
-"miv" = (
-/obj/structure/lattice/catwalk,
-/turf/closed/wall,
-/area/maintenance/port/aft)
 "miJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -54994,10 +54960,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Blueshield";
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/command/blueshieldoffice)
@@ -57513,11 +57475,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ofX" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "ogj" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -58091,7 +58048,7 @@
 /area/medical/medbay/central)
 "oxI" = (
 /obj/machinery/camera{
-	c_tag = "Sauna Room";
+	c_tag = "NTR Office";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -58521,8 +58478,8 @@
 	dir = 4;
 	dwidth = 12;
 	height = 18;
-	shuttle_id = "emergency_home";
 	name = "BoxStation emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 32
 	},
 /turf/open/space/basic,
@@ -58848,10 +58805,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"oXs" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/range)
 "oXz" = (
 /obj/structure/table/wood/fancy,
 /obj/item/paper_bin{
@@ -63267,9 +63220,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "commonmining_home";
 	name = "SS13: Common Mining Dock";
 	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	shuttle_id = "commonmining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -68305,11 +68258,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vCz" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space)
 "vCJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -69671,9 +69619,9 @@
 	dir = 8;
 	dwidth = 4;
 	height = 9;
-	shuttle_id = "aux_base_zone";
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	shuttle_id = "aux_base_zone";
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -70936,10 +70884,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
 /area/service/park)
-"xpr" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/service/chapel/office)
 "xpw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -72250,10 +72194,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/ntr)
-"yhZ" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "yjD" = (
 /obj/machinery/plate_press,
 /obj/effect/turf_decal/bot,
@@ -83533,10 +83473,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-vCz
-vCz
-yhZ
+gXs
+gJi
+gJi
+gJi
 aaa
 aaa
 aaa
@@ -83793,10 +83733,10 @@ aaa
 bCq
 fUt
 bLv
-yhZ
+gJi
 gXs
-aaa
-aaa
+gXs
+gXs
 bCq
 bCq
 bCq
@@ -84309,7 +84249,7 @@ bHE
 bLv
 aaa
 aaa
-aaa
+gXs
 aaa
 bCq
 bSn
@@ -84535,7 +84475,7 @@ bbb
 ayl
 beN
 arB
-eAa
+aPz
 aOb
 aPz
 aPz
@@ -90219,7 +90159,7 @@ xLB
 cAK
 bCq
 bCq
-miv
+bCq
 bVz
 bCq
 bHE
@@ -90474,7 +90414,7 @@ aaa
 bCq
 kWy
 bHE
-lJM
+cTF
 hmr
 puz
 kAk
@@ -90731,11 +90671,11 @@ aaa
 bCq
 bHE
 bHE
-miv
 bCq
-djd
+bCq
+bCq
 edo
-djd
+bCq
 cAK
 bCq
 aaa
@@ -90985,16 +90925,16 @@ aaa
 aaa
 aaf
 aaf
-djd
+bCq
 cTF
 cTF
-miv
+bCq
 aaa
 bVx
 caf
 bCq
 bHE
-djd
+bCq
 gXs
 gXs
 aaf
@@ -91912,7 +91852,7 @@ aaa
 aaa
 aaa
 eRz
-mWm
+gXs
 aaa
 aaa
 aaa
@@ -92162,7 +92102,7 @@ aaa
 aaa
 aaa
 aaa
-ktS
+gXs
 eRz
 eRz
 eRz
@@ -92418,12 +92358,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 eRz
 aaa
 aaa
 aaa
-mWm
+gXs
 aaa
 aaa
 aaa
@@ -92669,10 +92609,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 eRz
 eRz
 quT
@@ -92680,7 +92620,7 @@ aaa
 aaa
 aaa
 aaa
-mWm
+gXs
 aaa
 aaa
 aaa
@@ -93194,7 +93134,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -93451,7 +93391,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -93708,7 +93648,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -93952,8 +93892,8 @@ cNd
 cNd
 aaa
 aaa
-aaa
-aaa
+gXs
+gXs
 gXs
 aaa
 aaa
@@ -93965,7 +93905,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -94209,7 +94149,7 @@ cNd
 cNd
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -94981,7 +94921,7 @@ cNd
 aaa
 aaa
 eRz
-aaa
+gXs
 adI
 adI
 fzK
@@ -95550,7 +95490,7 @@ aiT
 dSv
 akI
 ybV
-hBw
+arP
 vLo
 gzY
 aqR
@@ -98579,7 +98519,7 @@ cNd
 aaa
 aaa
 eRz
-aaa
+gXs
 adI
 adI
 noG
@@ -99349,7 +99289,7 @@ cNd
 cNd
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -99606,7 +99546,7 @@ cNd
 cNd
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -99863,7 +99803,7 @@ cNd
 cNd
 aaa
 aaa
-aaa
+gXs
 eRz
 eRz
 aaa
@@ -100380,9 +100320,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
 quT
 eRz
 eRz
@@ -100401,7 +100341,7 @@ eRz
 eRz
 eRz
 gXs
-aaa
+gXs
 aaa
 pHj
 pHj
@@ -100658,7 +100598,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 vsh
 gXs
@@ -100915,7 +100855,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaT
 gXs
@@ -102203,7 +102143,7 @@ aaa
 aaa
 aaa
 adR
-fbt
+adR
 adR
 adR
 adR
@@ -103231,8 +103171,8 @@ aaa
 aaa
 aaa
 adR
-fbt
-fbt
+adR
+adR
 ujn
 wsI
 lHe
@@ -104258,10 +104198,10 @@ aaa
 aaa
 aaa
 aaa
-fbt
-fbt
-fbt
-fbt
+adR
+adR
+adR
+adR
 adR
 abq
 abq
@@ -106833,7 +106773,7 @@ aaa
 aaa
 sXV
 sXV
-oXs
+sXV
 wCz
 sXV
 sXV
@@ -107863,11 +107803,11 @@ aaa
 aaa
 gXs
 gXs
-ctv
+adR
 aaa
 aaa
 aaa
-ctv
+adR
 aaa
 aaa
 aaa
@@ -107964,9 +107904,9 @@ bQA
 bPj
 bOh
 cCQ
-cCS
+bMK
 chg
-cCS
+bMK
 aaf
 aoV
 aoV
@@ -108221,9 +108161,9 @@ ccC
 cdD
 bOh
 cCQ
-cCS
+bMK
 chg
-cCS
+bMK
 bMK
 bMK
 bMK
@@ -108898,7 +108838,7 @@ vae
 efO
 aaa
 lXr
-dHl
+lXr
 mxg
 hEy
 mes
@@ -108994,7 +108934,7 @@ bOh
 xcl
 wWi
 kil
-cCS
+bMK
 gXs
 tSo
 kcx
@@ -109148,11 +109088,11 @@ aaa
 aaa
 aaa
 aaa
-yhZ
+gJi
 gJi
 mWm
 gJi
-yhZ
+gJi
 aaa
 pgT
 dHl
@@ -120488,7 +120428,7 @@ aoV
 aoV
 atS
 aaf
-xpr
+aFw
 rwE
 tLS
 gYl
@@ -120748,7 +120688,7 @@ aaf
 aFw
 rwE
 oWH
-aHm
+aCR
 aHn
 dmX
 nLY
@@ -121005,7 +120945,7 @@ aaf
 aFw
 hqc
 mcK
-aHm
+aCR
 ldA
 dmX
 cNh
@@ -121261,8 +121201,8 @@ aaH
 aaf
 aFw
 aFw
-xpr
-aHm
+aFw
+aCR
 aNY
 aCR
 dmX
@@ -121337,7 +121277,7 @@ clu
 cmt
 cOe
 cOe
-grT
+cNW
 aaa
 aaa
 aaf
@@ -121515,7 +121455,7 @@ aoV
 aoV
 aoV
 atS
-ofX
+aaf
 aaf
 aaf
 gXs
@@ -121592,9 +121532,9 @@ cjE
 ckr
 clw
 cmu
-grT
-grT
-grT
+cNW
+cNW
+cNW
 aaf
 aaf
 aaf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7945,9 +7945,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "mining_home";
 	name = "mining shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/box;
+	shuttle_id = "mining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -7963,9 +7963,9 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	shuttle_id = "laborcamp_home";
 	name = "fore bay 1";
 	roundstart_template = /datum/map_template/shuttle/labour/box;
+	shuttle_id = "laborcamp_home";
 	width = 9
 	},
 /turf/open/space/basic,
@@ -43210,8 +43210,8 @@
 /area/science/xenobiology)
 "cSP" = (
 /obj/docking_port/stationary/random{
-	shuttle_id = "pod_lavaland1";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland1"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -43542,8 +43542,8 @@
 "cUL" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
-	shuttle_id = "pod_lavaland4";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -43608,8 +43608,8 @@
 	dir = 8;
 	dwidth = 5;
 	height = 7;
-	shuttle_id = "supply_home";
 	name = "Cargo Bay";
+	shuttle_id = "supply_home";
 	width = 12
 	},
 /turf/open/space/basic,
@@ -43668,8 +43668,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 13;
-	shuttle_id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -43901,8 +43901,8 @@
 	dir = 2;
 	dwidth = 9;
 	height = 25;
-	shuttle_id = "emergency_home";
 	name = "MetaStation emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 29
 	},
 /turf/open/space/basic,
@@ -46243,9 +46243,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 15;
-	shuttle_id = "arrivals_stationary";
 	name = "arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	shuttle_id = "arrivals_stationary";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -52725,15 +52725,15 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
 /obj/effect/spawner/lootdrop/syndicate_present,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fQx" = (
@@ -55307,7 +55307,7 @@
 /area/commons/dorms)
 "heo" = (
 /obj/machinery/camera{
-	c_tag = "Cryo Chambers";
+	c_tag = "NTR Office";
 	dir = 5
 	},
 /obj/structure/table/wood,
@@ -63300,8 +63300,8 @@
 	dir = 4;
 	dwidth = 5;
 	height = 10;
-	shuttle_id = "lambda_station";
 	name = "Lambda Shuttle Dock";
+	shuttle_id = "lambda_station";
 	width = 10
 	},
 /turf/open/space/basic,
@@ -65615,8 +65615,8 @@
 /area/hallway/primary/port)
 "lSH" = (
 /obj/docking_port/stationary/random{
-	shuttle_id = "pod_2_lavaland";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_2_lavaland"
 	},
 /turf/open/space,
 /area/space)
@@ -66715,9 +66715,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/storage/satellite)
 "mqC" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/port/aft)
+/turf/open/space,
+/area/space/nearstation)
 "mqX" = (
 /obj/effect/turf_decal/tile/green,
 /mob/living/simple_animal/pet/bumbles,
@@ -67389,13 +67392,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"mFH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/break_room)
 "mGK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain{
@@ -70303,9 +70299,9 @@
 	dheight = 4;
 	dwidth = 4;
 	height = 9;
-	shuttle_id = "aux_base_zone";
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	shuttle_id = "aux_base_zone";
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -72027,8 +72023,8 @@
 	dir = 2;
 	dwidth = 11;
 	height = 22;
-	shuttle_id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Port";
+	shuttle_id = "whiteship_home";
 	width = 35
 	},
 /turf/open/space/basic,
@@ -73686,9 +73682,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "commonmining_home";
 	name = "SS13: Common Mining Dock";
 	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	shuttle_id = "commonmining_home";
 	width = 7
 	},
 /turf/open/space,
@@ -79052,10 +79048,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"rZv" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/port/fore)
 "saf" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -79843,10 +79835,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel,
 /area/service/chapel/main)
-"sqe" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space/basic,
-/area/space/nearstation)
 "sqh" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
@@ -90949,8 +90937,8 @@
 	dir = 8;
 	dwidth = 12;
 	height = 17;
-	shuttle_id = "syndicate_nw";
 	name = "northwest of station";
+	shuttle_id = "syndicate_nw";
 	width = 23
 	},
 /turf/open/space/basic,
@@ -103521,7 +103509,7 @@ anS
 apq
 anS
 dne
-rZv
+dne
 dne
 dne
 sqA
@@ -103747,7 +103735,7 @@ oRp
 oRp
 oRp
 oRp
-aaa
+oRp
 oRp
 oRp
 oRp
@@ -105066,7 +105054,7 @@ dne
 cfA
 dne
 aaf
-rZv
+dne
 ogs
 paJ
 aDb
@@ -105324,7 +105312,7 @@ avL
 dne
 aaf
 dne
-rZv
+dne
 paJ
 aDb
 aDa
@@ -110794,7 +110782,7 @@ vVO
 aoH
 ceu
 dux
-mqC
+dux
 aaa
 aaa
 cBR
@@ -118909,7 +118897,7 @@ oRp
 aaa
 aaa
 aaa
-vLD
+lMJ
 aaa
 aaa
 aaa
@@ -119166,13 +119154,13 @@ oRp
 aaa
 aaa
 aaa
-vLD
-vLD
-vLD
-vLD
-vLD
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 aaa
-vLD
+lMJ
 aax
 xhP
 abe
@@ -119423,13 +119411,13 @@ oRp
 aaa
 aaa
 aaa
-vLD
+lMJ
 aaa
 aaa
 aaa
-vLD
+lMJ
 aaa
-vLD
+lMJ
 aax
 wiZ
 aax
@@ -119680,13 +119668,13 @@ oRp
 aaa
 aaa
 aaa
-vLD
-vLD
-vLD
-vLD
-vLD
-vLD
-vLD
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 ngt
 kMS
 ngt
@@ -132378,8 +132366,8 @@ ack
 aaf
 ykE
 idz
-sqe
-sqe
+idz
+idz
 idz
 idz
 idz
@@ -137984,7 +137972,7 @@ azd
 azd
 azd
 dgv
-mFH
+rEb
 iYP
 qiA
 osB
@@ -138498,7 +138486,7 @@ dgk
 dgk
 dgk
 dgv
-mFH
+rEb
 eTD
 jcA
 jDz
@@ -139012,7 +139000,7 @@ aye
 dgv
 aye
 dgv
-dgJ
+mqC
 aaa
 aaa
 aaa

--- a/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
+++ b/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
@@ -1277,9 +1277,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /turf/open/floor/carpet/black,
 /area/command/heads_quarters/hos)
 "ado" = (
@@ -2030,8 +2027,8 @@
 	dir = 4;
 	dwidth = 12;
 	height = 18;
-	shuttle_id = "emergency_home";
 	name = "BoxStation emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 32
 	},
 /turf/open/space/basic,
@@ -4071,6 +4068,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Blueshield";
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/command/blueshieldoffice)
@@ -6277,9 +6278,9 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	shuttle_id = "laborcamp_home";
 	name = "fore bay 1";
 	roundstart_template = /datum/map_template/shuttle/labour/box;
+	shuttle_id = "laborcamp_home";
 	width = 9
 	},
 /turf/open/space/basic,
@@ -7937,10 +7938,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Blueshield";
-	dir = 4
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/command/blueshieldoffice)
 "arW" = (
@@ -9158,8 +9155,8 @@
 	dir = 8;
 	dwidth = 12;
 	height = 17;
-	shuttle_id = "syndicate_ne";
 	name = "northeast of station";
+	shuttle_id = "syndicate_ne";
 	width = 23
 	},
 /turf/open/space,
@@ -13002,12 +12999,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/mineral/plastitanium,
 /area/service/chapel/office)
-"aHm" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/syndicate{
-	smooth = 2
-	},
-/area/service/chapel/main)
 "aHn" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -31734,7 +31725,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "bDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34277,9 +34268,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "mining_home";
 	name = "mining shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/box;
+	shuttle_id = "mining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -46271,8 +46262,8 @@
 "cpe" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
-	shuttle_id = "pod_lavaland2";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland2"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -48668,8 +48659,8 @@
 "cwV" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
-	shuttle_id = "pod_lavaland1";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland1"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -48683,8 +48674,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 13;
-	shuttle_id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -48736,8 +48727,8 @@
 	dir = 2;
 	dwidth = 11;
 	height = 22;
-	shuttle_id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Port";
+	shuttle_id = "whiteship_home";
 	width = 35
 	},
 /turf/open/space/basic,
@@ -48868,8 +48859,8 @@
 	dir = 8;
 	dwidth = 5;
 	height = 7;
-	shuttle_id = "supply_home";
 	name = "Cargo Bay";
+	shuttle_id = "supply_home";
 	width = 12
 	},
 /turf/open/space/basic,
@@ -48941,8 +48932,8 @@
 "czN" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
-	shuttle_id = "pod_lavaland4";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -49778,12 +49769,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cCS" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/syndicate{
-	smooth = 2
-	},
-/area/engineering/atmos)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -50220,9 +50205,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 15;
-	shuttle_id = "arrivals_stationary";
 	name = "arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	shuttle_id = "arrivals_stationary";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -51171,14 +51156,16 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/ntr)
 "dhO" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "63"
+/obj/docking_port/stationary{
+	dheight = 5;
+	dwidth = 5;
+	height = 10;
+	name = "Lambda Shuttle Dock";
+	shuttle_id = "lambda_station";
+	width = 10
 	},
-/turf/open/floor/plating,
-/area/security/office)
+/turf/open/space/basic,
+/area/space)
 "diq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -52221,7 +52208,6 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "eCR" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -53462,10 +53448,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/central)
-"fQl" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/turf/open/space/basic,
-/area/security/range)
 "fRe" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -53480,12 +53462,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/commons/locker)
-"fSk" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "fSO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -54261,7 +54237,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/command/gateway)
 "gUu" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -54533,12 +54508,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/command/gateway)
-"hpb" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "hqn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -54691,12 +54660,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/central)
-"hBw" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/syndicate{
-	smooth = 2
-	},
-/area/maintenance/fore)
 "hBA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/window/reinforced/tinted{
@@ -55700,8 +55663,8 @@
 "jdj" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
-	shuttle_id = "pod_lavaland3";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland3"
 	},
 /turf/open/space,
 /area/space)
@@ -57107,7 +57070,7 @@
 /area/command/blueshieldoffice)
 "kzd" = (
 /obj/effect/spawner/structure/window/plastitanium,
-/turf/open/space,
+/turf/open/floor/plating,
 /area/security/range)
 "kzn" = (
 /obj/effect/spawner/structure/window/plastitanium,
@@ -58102,12 +58065,6 @@
 	smooth = 2
 	},
 /area/maintenance/disposal/incinerator)
-"lKl" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
 "lLe" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/mineral/plastitanium,
@@ -59350,7 +59307,7 @@
 "nmF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
-	c_tag = "Brig EVA Storage";
+	c_tag = "Brig Firing Range";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -61640,9 +61597,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/service/chapel/main)
 "qCS" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plating,
+/area/security/office)
 "qEB" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -62029,12 +61991,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
 /area/security/processing)
-"rig" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall/syndicate{
-	smooth = 2
-	},
-/area/security/office)
 "rjq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -62690,9 +62646,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "commonmining_home";
 	name = "SS13: Common Mining Dock";
 	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	shuttle_id = "commonmining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -65242,17 +65198,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vCF" = (
-/obj/docking_port/stationary{
-	dheight = 5;
-	dwidth = 5;
-	height = 10;
-	shuttle_id = "lambda_station";
-	name = "Lambda Shuttle Dock";
-	width = 10
-	},
-/turf/open/space/basic,
-/area/space)
 "vCS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65782,13 +65727,6 @@
 	smooth = 2
 	},
 /area/service/lawoffice)
-"wnY" = (
-/obj/structure/lattice,
-/obj/effect/spawner/structure/window/plastitanium,
-/turf/closed/wall/r_wall/syndicate{
-	smooth = 2
-	},
-/area/security/range)
 "woR" = (
 /obj/machinery/cryopod/tele,
 /turf/open/floor/carpet,
@@ -65800,9 +65738,9 @@
 	dir = 8;
 	dwidth = 4;
 	height = 9;
-	shuttle_id = "aux_base_zone";
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	shuttle_id = "aux_base_zone";
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -90482,7 +90420,7 @@ aiT
 aiD
 gvX
 uFZ
-hBw
+arP
 vLo
 gzY
 aqR
@@ -92495,8 +92433,8 @@ aaa
 aaa
 eRz
 gXs
-piS
-piS
+gXs
+gXs
 gXs
 acd
 msp
@@ -96613,13 +96551,13 @@ aaa
 aaa
 eRz
 eRz
-eRz
+gXs
 acd
 acd
 acd
 acd
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -96876,7 +96814,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aoV
 aaa
@@ -97129,12 +97067,12 @@ aaa
 aaa
 iDo
 eRz
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eRz
+gXs
+eRz
+eRz
+eRz
+gXs
 abp
 abp
 abp
@@ -97385,12 +97323,12 @@ aaa
 aaa
 aaa
 aaa
-lKl
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 sZS
 ffT
@@ -97642,12 +97580,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 sZS
 vBW
@@ -97899,12 +97837,12 @@ aaa
 aaa
 aaa
 aaa
-hpb
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 abp
 abp
@@ -98156,12 +98094,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 aaa
 aaa
@@ -98413,12 +98351,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 abp
 abp
@@ -98670,12 +98608,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 spE
 vBW
@@ -98927,12 +98865,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 spE
 egV
@@ -99184,17 +99122,17 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
-rig
-rig
-rig
-rig
+abp
+abp
+abp
+abp
 abq
 abq
 abq
@@ -99441,12 +99379,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+eRz
 aaa
 aaa
 aaa
@@ -99698,12 +99636,12 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
@@ -99955,16 +99893,16 @@ aaa
 aaa
 aaa
 aaa
-fIs
+aaa
 aoV
 aaa
 aaa
 aaa
+aaf
 aaa
-aaa
-piS
-piS
-piS
+gXs
+gXs
+gXs
 aaf
 aaM
 abr
@@ -100212,16 +100150,16 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
-aoV
 aaa
-aoV
-aaa
-piS
-piS
+aag
+aaf
+aaf
+aaf
+aaf
+aaf
 aaf
 aaO
 adQ
@@ -100469,16 +100407,16 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
+aaf
 aaa
-piS
-piS
-piS
+gXs
+gXs
+gXs
 aaf
 abq
 aes
@@ -100726,15 +100664,15 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+eRz
+eRz
+eRz
+eRz
 sXV
 sXV
 abq
@@ -100983,7 +100921,6 @@ aaa
 aaa
 aaa
 aaa
-fIs
 aaa
 aaa
 aaa
@@ -100992,7 +100929,8 @@ aaa
 aaa
 aaa
 aaa
-fQl
+aaa
+kzd
 xxp
 xxp
 xxp
@@ -101240,7 +101178,7 @@ aaa
 aaa
 aaa
 aaa
-fIs
+aaa
 aaa
 aaa
 aaa
@@ -101497,16 +101435,16 @@ aaa
 aaa
 aaa
 aaa
-fSk
-fIs
-fIs
-fIs
-fIs
-gXs
 aaa
 aaa
 aaa
-fQl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+kzd
 xxp
 xxp
 xxp
@@ -101765,7 +101703,7 @@ aaa
 aaa
 sXV
 sXV
-wnY
+sXV
 ftI
 sXV
 sXV
@@ -102019,10 +101957,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-vCF
 dhO
+qCS
+rxQ
+rxQ
 rxQ
 rxQ
 sip
@@ -102277,8 +102215,8 @@ aaa
 aaa
 aoV
 aoV
-aoV
-aoV
+abp
+abp
 abp
 abp
 abp
@@ -102537,7 +102475,7 @@ aaa
 aaa
 aaa
 aaa
-qCS
+aaf
 abp
 wdv
 afp
@@ -102795,11 +102733,11 @@ aaa
 aaa
 aaa
 aaa
-atS
+abp
 aaa
 aaa
 aaa
-atS
+abp
 aaa
 aaa
 aaa
@@ -102896,9 +102834,9 @@ bQA
 bPj
 bOh
 cCQ
-cCS
+bLK
 chg
-cCS
+bLK
 aaf
 aoV
 aoV
@@ -103064,7 +103002,7 @@ aaa
 aaa
 aaa
 aaa
-ktS
+aaa
 dFX
 rpP
 wWW
@@ -103153,9 +103091,9 @@ ccC
 cdD
 bOh
 cCQ
-cCS
+bLK
 chg
-cCS
+bLK
 bLK
 bLK
 bLK
@@ -103926,7 +103864,7 @@ bOh
 xcl
 wWi
 kil
-cCS
+bLK
 gXs
 tSo
 kcx
@@ -104080,11 +104018,11 @@ aaa
 aaa
 aaa
 aaa
-uCA
+gJi
 gJi
 piS
 gJi
-uCA
+gJi
 aaa
 aaa
 aaa
@@ -115680,7 +115618,7 @@ aoV
 aoV
 aaf
 gXs
-aHm
+aCR
 aHn
 dmX
 aFz
@@ -115937,7 +115875,7 @@ aoV
 aoV
 aaf
 gXs
-aHm
+aCR
 aJV
 dmX
 csT
@@ -116194,7 +116132,7 @@ aoV
 aoV
 aoV
 gXs
-aHm
+aCR
 aNY
 aCR
 dmX

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3434,8 +3434,8 @@
 	dir = 8;
 	dwidth = 12;
 	height = 17;
-	shuttle_id = "syndicate_ne";
 	name = "northeast of station";
+	shuttle_id = "syndicate_ne";
 	width = 23
 	},
 /turf/open/space,
@@ -6050,9 +6050,9 @@
 /obj/docking_port/stationary{
 	dwidth = 2;
 	height = 6;
-	shuttle_id = "monastery_shuttle_station";
 	name = "Station";
 	roundstart_template = /datum/map_template/shuttle/escape_pod/large;
+	shuttle_id = "monastery_shuttle_station";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -10557,7 +10557,7 @@
 	pixel_x = -25
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
+	c_tag = "NTR Office";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -17599,8 +17599,8 @@
 	dir = 8;
 	dwidth = 4;
 	height = 15;
-	shuttle_id = "emergency_home";
 	name = "PubbyStation emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 20
 	},
 /turf/open/space/basic,
@@ -17906,8 +17906,8 @@
 	dir = 4;
 	dwidth = 5;
 	height = 7;
-	shuttle_id = "supply_home";
 	name = "Cargo Bay";
+	shuttle_id = "supply_home";
 	width = 12
 	},
 /turf/open/space/basic,
@@ -22929,9 +22929,9 @@
 	dir = 4;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "mining_home";
 	name = "mining shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	shuttle_id = "mining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -23307,9 +23307,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 13;
-	shuttle_id = "arrivals_stationary";
 	name = "pubby arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/pubby;
+	shuttle_id = "arrivals_stationary";
 	width = 6
 	},
 /turf/open/space/basic,
@@ -28776,8 +28776,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 13;
-	shuttle_id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -34984,8 +34984,8 @@
 /obj/docking_port/stationary{
 	dwidth = 2;
 	height = 6;
-	shuttle_id = "monastery_shuttle_asteroid";
 	name = "monastery";
+	shuttle_id = "monastery_shuttle_asteroid";
 	width = 5
 	},
 /turf/open/space,
@@ -43757,8 +43757,12 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "cbl" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/white,
 /area/command/blueshielquarters)
@@ -44083,10 +44087,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"ccs" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/department/cargo)
 "ccu" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/asteroid,
@@ -45644,8 +45644,8 @@
 	dir = 8;
 	dwidth = 11;
 	height = 22;
-	shuttle_id = "whiteship_home";
 	name = "monastery";
+	shuttle_id = "whiteship_home";
 	width = 35
 	},
 /turf/open/space/basic,
@@ -54253,14 +54253,11 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main/monastery)
 "izQ" = (
-/obj/structure/sink{
-	pixel_y = 25
-	},
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/structure/toilet/secret/low_loot{
-	dir = 8
+	pixel_y = 13
 	},
 /turf/open/floor/plasteel/white,
 /area/command/blueshielquarters)
@@ -56121,9 +56118,9 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	shuttle_id = "laborcamp_home";
 	name = "fore bay 1";
 	roundstart_template = /datum/map_template/shuttle/labour/box;
+	shuttle_id = "laborcamp_home";
 	width = 9
 	},
 /turf/open/space/basic,
@@ -57533,11 +57530,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/ntr)
-"nix" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/service/chapel/asteroid/monastery)
 "niy" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cookie,
@@ -58833,9 +58825,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "commonmining_home";
 	name = "SS13: Common Mining Dock";
 	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	shuttle_id = "commonmining_home";
 	width = 7
 	},
 /turf/open/space/basic,
@@ -60025,10 +60017,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"quc" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/space/basic,
-/area/space/nearstation)
 "quS" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60946,9 +60934,9 @@
 	dheight = 4;
 	dwidth = 4;
 	height = 9;
-	shuttle_id = "aux_base_zone";
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/small;
+	shuttle_id = "aux_base_zone";
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -63786,10 +63774,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"vHh" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/service/chapel/asteroid/monastery)
 "vHL" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/computer/security/telescreen{
@@ -81372,7 +81356,7 @@ cfN
 cfN
 cfN
 cfN
-vHh
+cfN
 aaa
 aaa
 aaa
@@ -81634,7 +81618,7 @@ aaa
 aaa
 aaa
 cfN
-vHh
+cfN
 cfN
 cfN
 cfN
@@ -81882,9 +81866,9 @@ aaa
 cfN
 cfN
 cfN
-vHh
 cfN
-vHh
+cfN
+cfN
 aaa
 aht
 aaa
@@ -82152,7 +82136,7 @@ aht
 aaa
 cfN
 cfN
-vHh
+cfN
 cfN
 cfN
 cfN
@@ -83956,7 +83940,7 @@ cyU
 aht
 aht
 aht
-vHh
+cfN
 cfN
 cfN
 aaa
@@ -85240,7 +85224,7 @@ cjp
 aht
 aht
 aht
-vHh
+cfN
 cfN
 cfN
 cfN
@@ -86009,7 +85993,7 @@ aht
 aht
 aht
 aht
-vHh
+cfN
 cfN
 cfN
 cfN
@@ -86770,7 +86754,7 @@ aaa
 aht
 cfN
 cfN
-vHh
+cfN
 cfN
 aht
 aaa
@@ -87024,14 +87008,14 @@ aaa
 aht
 aaa
 cfN
-vHh
 cfN
 cfN
 cfN
 cfN
-vHh
 cfN
-vHh
+cfN
+cfN
+cfN
 cfN
 cfN
 cfN
@@ -87278,7 +87262,7 @@ aaa
 aaa
 aaa
 aaa
-nix
+cfN
 cfN
 cfN
 cfN
@@ -88550,9 +88534,9 @@ aaa
 cAH
 lac
 tRZ
-quc
+cqX
 tRZ
-quc
+cqX
 iyP
 aaa
 aaa
@@ -88806,11 +88790,11 @@ aaa
 aaa
 aaa
 aaa
-mZE
 aaa
-mZE
 aaa
-mZE
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91622,7 +91606,7 @@ aaa
 aaa
 aaa
 aaa
-eNF
+afI
 aaa
 aaa
 aaa
@@ -91879,7 +91863,7 @@ aaa
 aaa
 aaa
 aaa
-eNF
+afI
 aaa
 aaa
 aaa
@@ -92136,7 +92120,7 @@ aaa
 aaa
 aaa
 aaa
-eNF
+afI
 aaa
 aaa
 aaa
@@ -110319,7 +110303,7 @@ aEl
 aEj
 aEj
 aht
-ccs
+aEj
 aEj
 aEl
 aEl

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -613,11 +613,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "rd_private"
 // BLUEMOON ADD START
 /area/command/heads_quarters/ntr
-	name = "Nanotrasen's Represantative Office"
+	name = "Nanotrasen's Representative Office"
 	icon_state = "ntr_office"
 
 /area/command/heads_quarters/ntr/private
-	name = "Nanotrasen's Represantative Private Quarters"
+	name = "Nanotrasen's Representative Private Quarters"
 	icon_state = "ntr_private"
 // BLUEMOON ADD END
 


### PR DESCRIPTION
# About The Pull Request

Затрагивает карты BoxStation, PeaceSyndicateStation, MetaStation и PubbyStation

1. Убирает большое количество сеток под стенами:
![b710a1d9c0215e8a6391](https://github.com/user-attachments/assets/5296de59-d4db-426a-b4dd-ae7d7cc09f4d)
2. Исправляет тег у камер в офисе НТР, чтобы оно обозначалось как "NTR Office", а не как "Chapel Crematorium"
3. Убирает лишние зоны nearstation, располагающиеся не на положенном месте

## Why It's Good For The Game

Мелочь, а приятно.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

