### PR TITLE
Removal: Мобы-культисты с золотого экстракта

### DIFF
--- a/modular_splurt/code/modules/awaymissions/mission_code/AGRComplex.dm
+++ b/modular_splurt/code/modules/awaymissions/mission_code/AGRComplex.dm
@@ -337,7 +337,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	aggro_vision_range = 9
 	turns_per_move = 5
-	gold_core_spawnable = HOSTILE_SPAWN
+//	gold_core_spawnable = HOSTILE_SPAWN // BLUEMOON REMOVAL
 	faction = null
 	footstep_type = FOOTSTEP_MOB_SHOE
 	weather_immunities = list("ash")


### PR DESCRIPTION
# About The Pull Request

Убирает возможность спавнить мобов-культистов с помощью золотого экстракта слайма

## Why It's Good For The Game

Данные мобы предназначены только для задействования на гейтвей-уровне "AGR Complex", наверное такая возможность была допущена по невнимательности разработчика?

Их спавн через экстракт приводит к тому, что может заспавниться моб-культист (который нужен лишь для наследования для других типов мобов-культистов) без спрайта и "фракции", атакующий всех, а возможность спавна "выжившего культиста с комплекса" через ксенобиологию не выглядит логично...

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
