### PR TITLE
Переход урона с одной конечности на грудь при превышении максимального

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -317,7 +317,7 @@
 		if(can_inflict <= 5)
 			if(body_zone != BODY_ZONE_CHEST)
 				var/obj/item/bodypart/chest/chest = owner.get_bodypart(BODY_ZONE_CHEST)
-				chest.receive_damage((brute-can_inflict)*0,65, (burn-can_inflict)*0,65, stamina, blocked, updating_health, required_status, wound_bonus, bare_wound_bonus, sharpness)
+				chest.receive_damage(max(0,(brute-can_inflict)*0.65), max(0,(burn-can_inflict)*0.65), stamina, blocked, updating_health, required_status, wound_bonus, bare_wound_bonus, sharpness) // наносится 65% урона. Оно не проверяет броню повторно, иначе нужно было бы перелопачивать весь код
 		// BLUEMOON ADD END
 		brute = round(brute * (can_inflict/total_damage), DAMAGE_PRECISION) // BLUEMOON EDIT - фикс нанесения единовременного увеличенного в N раз урона после достижения конечности максимального урона - WAS brute = round(brute * (max_damage / total_damage),DAMAGE_PRECISION)
 		burn = round(burn * (can_inflict/total_damage), DAMAGE_PRECISION) // BLUEMOON EDIT - фикс нанесения единовременного увеличенного в N раз урона после достижения конечности максимального урона - WAS burn = round(burn * (max_damage / total_damage),DAMAGE_PRECISION)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -317,7 +317,7 @@
 		if(can_inflict <= 5)
 			if(body_zone != BODY_ZONE_CHEST)
 				var/obj/item/bodypart/chest/chest = owner.get_bodypart(BODY_ZONE_CHEST)
-				chest.receive_damage(brute-can_inflict, burn-can_inflict, stamina, blocked, updating_health, required_status, wound_bonus, bare_wound_bonus, sharpness)
+				chest.receive_damage((brute-can_inflict)*0,65, (burn-can_inflict)*0,65, stamina, blocked, updating_health, required_status, wound_bonus, bare_wound_bonus, sharpness)
 		// BLUEMOON ADD END
 		brute = round(brute * (can_inflict/total_damage), DAMAGE_PRECISION) // BLUEMOON EDIT - фикс нанесения единовременного увеличенного в N раз урона после достижения конечности максимального урона - WAS brute = round(brute * (max_damage / total_damage),DAMAGE_PRECISION)
 		burn = round(burn * (can_inflict/total_damage), DAMAGE_PRECISION) // BLUEMOON EDIT - фикс нанесения единовременного увеличенного в N раз урона после достижения конечности максимального урона - WAS burn = round(burn * (max_damage / total_damage),DAMAGE_PRECISION)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -313,8 +313,14 @@
 	var/total_damage = brute + burn
 
 	if(total_damage > can_inflict && total_damage > 0) // TODO: the second part of this check should be removed once disabling is all done
-		brute = round(brute * (max_damage / total_damage),DAMAGE_PRECISION)
-		burn = round(burn * (max_damage / total_damage),DAMAGE_PRECISION)
+		// BLUEMOON ADD START - добавляем перенос урона в грудь, если урон по конечности дальше уже не может проходить
+		if(can_inflict <= 5)
+			if(body_zone != BODY_ZONE_CHEST)
+				var/obj/item/bodypart/chest/chest = owner.get_bodypart(BODY_ZONE_CHEST)
+				chest.receive_damage(brute-can_inflict, burn-can_inflict, stamina, blocked, updating_health, required_status, wound_bonus, bare_wound_bonus, sharpness)
+		// BLUEMOON ADD END
+		brute = round(brute * (can_inflict/total_damage), DAMAGE_PRECISION) // BLUEMOON EDIT - фикс нанесения единовременного увеличенного в N раз урона после достижения конечности максимального урона - WAS brute = round(brute * (max_damage / total_damage),DAMAGE_PRECISION)
+		burn = round(burn * (can_inflict/total_damage), DAMAGE_PRECISION) // BLUEMOON EDIT - фикс нанесения единовременного увеличенного в N раз урона после достижения конечности максимального урона - WAS burn = round(burn * (max_damage / total_damage),DAMAGE_PRECISION)
 
 	if(can_inflict <= 0)
 		return FALSE


### PR DESCRIPTION
А также фикс нанесение пятикратного единовременного урона оружия в конечность при достижении порога урона.

![dreamseeker_JGkoIrZAlA](https://github.com/user-attachments/assets/0d3b7f30-10ca-4508-a4da-c71df70af182)

Развёрнуто:
- Исправлен пятикратный мгновенный урон.
- Добавлен переход 65% урона с поврежденной конечности в торс.