### PR TITLE
Фикс размера и исправление легаси кода для красной королевы и серума роста

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1025,18 +1025,29 @@
 	if(prob(75))
 		return ..()
 	var/newsize = pick(0.5, 0.75, 1, 1.50, 2)
+	// BLUEMOON ADD START - нормализаторы не дружат с изменениями размера во время их ношения
+	if(H.GetComponent(/datum/component/size_normalized))
+		to_chat(H, span_warning("You normalization device fights any changes in size!"))
+		return
+	H.update_size(newsize)
+	// BLUEMOON ADD END
+	/* BLUEMOON REMOVAL START
 	newsize *= RESIZE_DEFAULT_SIZE
 	H.resize = newsize/current_size
 	current_size = newsize
 	H.update_transform()
+	/ BLUEMOON REMOVAL END */
 	if(prob(40))
 		H.emote("sneeze")
 	..()
 
 /datum/reagent/consumable/red_queen/on_mob_end_metabolize(mob/living/M)
+	/* BLUEMOON REMOVAL START
 	M.resize = RESIZE_DEFAULT_SIZE/current_size
 	current_size = RESIZE_DEFAULT_SIZE
 	M.update_transform()
+	/ BLUEMOON REMOVAL END */
+	M.update_size(RESIZE_DEFAULT_SIZE) // BLUEMOON ADD
 	..()
 
 /datum/reagent/consumable/milk/pinkmilk

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2232,7 +2232,24 @@
 	taste_description = "bitterness" // apparently what viagra tastes like
 
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
+	// BLUEMOON ADD START - нормализаторы не дружат с изменениями размера во время их ношения
+	if(H.GetComponent(/datum/component/size_normalized))
+		to_chat(H, span_warning("You normalization device fights any changes in size!"))
+		return
 	var/newsize = current_size
+	switch(volume)
+		if(0 to 19)
+			newsize = 1.25*RESIZE_DEFAULT_SIZE
+		if(20 to 49)
+			newsize = 1.5*RESIZE_DEFAULT_SIZE
+		if(50 to 99)
+			newsize = 2*RESIZE_DEFAULT_SIZE
+		if(100 to 199)
+			newsize = 2.5*RESIZE_DEFAULT_SIZE
+		if(200 to INFINITY)
+			newsize = 3*RESIZE_DEFAULT_SIZE
+	H.update_size(newsize)
+	/* BLUEMOON REMOVAL START
 	switch(volume)
 		if(0 to 19)
 			newsize = 1.25*RESIZE_DEFAULT_SIZE
@@ -2248,12 +2265,16 @@
 	H.resize = newsize/current_size
 	current_size = newsize
 	H.update_transform()
+	/ BLUEMOON REMOVAL END */
 	..()
 
 /datum/reagent/growthserum/on_mob_end_metabolize(mob/living/M)
+	/* BLUEMOON REMOVAL START
 	M.resize = RESIZE_DEFAULT_SIZE/current_size
 	current_size = RESIZE_DEFAULT_SIZE
 	M.update_transform()
+	/ BLUEMOON REMOVAL END */
+	M.update_size(RESIZE_DEFAULT_SIZE) // BLUEMOON ADD
 	..()
 
 /datum/reagent/plastic_polymers


### PR DESCRIPTION
- Красная королева и серум роста повышали размер персонажа не по механу сплюрта, а по механу сэндшторма, что приводило к игнорированию любых дополнительных эффектов от изменения размера (800% персонажа без замедления, доп ХП и т.п.).
- Выставлен максимальный возможный размер в более привычный, ровно как и актуализировано как они увеличивают рост.
- 