### PR TITLE
Изменение ксенобиологии

### DIFF
--- a/_maps/map_files/FestiveBall/FestiveStation.dmm
+++ b/_maps/map_files/FestiveBall/FestiveStation.dmm
@@ -13906,10 +13906,6 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14303,7 +14299,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aHC" = (
@@ -14898,8 +14893,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -25894,13 +25889,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/commons/dorms)
-"bjr" = (
-/obj/machinery/power/apc/auto_name{
-	dir = 4;
-	pixel_x = -30
-	},
-/turf/open/floor/carpet/arcade,
-/area/commons/fitness/recreation)
 "bjs" = (
 /turf/open/floor/carpet/arcade,
 /area/commons/fitness/recreation)
@@ -60271,7 +60259,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -65263,9 +65250,6 @@
 	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Port";
@@ -86967,7 +86951,7 @@ bFs
 bHZ
 bhP
 biI
-bjr
+bjs
 alM
 bkf
 bkn

--- a/_maps/map_files/FestiveBall/FestiveStation.dmm
+++ b/_maps/map_files/FestiveBall/FestiveStation.dmm
@@ -12859,12 +12859,14 @@
 /area/science)
 "aDT" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aDU" = (
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
 "aDV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aDW" = (
@@ -13254,6 +13256,7 @@
 	name = "Creature Cell #6"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFl" = (
@@ -13272,7 +13275,6 @@
 	id = "xeno6";
 	name = "Creature Cell #6"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -13297,6 +13299,7 @@
 	id = "xeno5";
 	name = "Creature Cell #5"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFo" = (
@@ -13315,7 +13318,6 @@
 	id = "xeno5";
 	name = "Creature Cell #5"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -13371,6 +13373,7 @@
 	id = "xeno4";
 	name = "Creature Cell #4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFv" = (
@@ -13389,7 +13392,6 @@
 	id = "xeno4";
 	name = "Creature Cell #4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -13414,6 +13416,7 @@
 	id = "xeno3";
 	name = "Creature Cell #3"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFy" = (
@@ -13432,7 +13435,6 @@
 	id = "xeno3";
 	name = "Creature Cell #3"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -13457,6 +13459,7 @@
 	id = "xeno2";
 	name = "Creature Cell #2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFB" = (
@@ -13475,7 +13478,6 @@
 	id = "xeno2";
 	name = "Creature Cell #2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -13504,6 +13506,7 @@
 	id = "xeno1";
 	name = "Creature Cell #1"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFF" = (
@@ -13522,7 +13525,6 @@
 	id = "xeno1";
 	name = "Creature Cell #1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -13921,6 +13923,7 @@
 	req_access_txt = "55"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGI" = (
@@ -13932,7 +13935,6 @@
 	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -13957,6 +13959,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGL" = (
@@ -13980,6 +13983,7 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGN" = (
@@ -13993,6 +13997,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGO" = (
@@ -14006,6 +14011,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGP" = (
@@ -14019,6 +14025,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGQ" = (
@@ -14368,7 +14375,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aHJ" = (
@@ -14583,9 +14592,9 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIj" = (
@@ -14596,6 +14605,9 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14615,7 +14627,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIm" = (
@@ -14626,12 +14640,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/requests_console{
 	department = "Xenobiology Lab";
 	name = "Xenobiology RC";
 	receive_ore_updates = 1;
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14668,9 +14684,7 @@
 /obj/item/slime_extract/grey,
 /obj/item/slime_extract/grey,
 /obj/item/slime_extract/grey,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIr" = (
@@ -14678,7 +14692,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIs" = (
@@ -14730,6 +14746,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/science/xenobiology)
 "aIx" = (
@@ -14893,9 +14912,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIQ" = (
@@ -14904,9 +14920,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14923,9 +14936,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14947,9 +14957,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aIT" = (
@@ -14964,9 +14971,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15200,9 +15204,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -15219,9 +15220,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -15235,9 +15233,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -15357,6 +15352,9 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -19188,9 +19186,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -19324,9 +19319,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19343,12 +19335,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/science/xenobiology)
 "aSD" = (
@@ -19872,11 +19862,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aTS" = (
@@ -32253,9 +32239,6 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58397,7 +58380,6 @@
 /turf/open/floor/plasteel,
 /area/edina)
 "dgP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -59036,8 +59018,10 @@
 /area/medical/exam_room)
 "ekL" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "elG" = (
@@ -59048,9 +59032,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -59421,7 +59402,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -59746,18 +59727,14 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fyZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fBZ" = (
@@ -59767,6 +59744,9 @@
 "fCo" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fCF" = (
@@ -60380,12 +60360,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "gNY" = (
@@ -60431,6 +60409,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
+"gUj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
+/area/science/xenobiology)
 "gXr" = (
 /obj/effect/festive/street/streetlinewest,
 /obj/effect/turf_decal/arrows/white{
@@ -60987,6 +60971,14 @@
 /obj/structure/bed/dogbed,
 /turf/open/floor/grass,
 /area/edina/crew_quarters/store/pet)
+"hUg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/festive/whitebrick{
+	color = "#555555"
+	},
+/area/science/xenobiology)
 "hUh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61099,6 +61091,13 @@
 	},
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/intersection/servsuppaux)
+"icB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "idg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -61156,7 +61155,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "iir" = (
@@ -61223,7 +61221,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ilI" = (
@@ -61469,9 +61466,7 @@
 /area/medical/genetics)
 "iFP" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "iGc" = (
@@ -61669,7 +61664,9 @@
 /turf/open/floor/plasteel/checker,
 /area/maintenance/bar/cafe)
 "iVZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/science/xenobiology)
 "iXm" = (
@@ -63214,9 +63211,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/carpet/red,
 /area/science/xenobiology)
 "lVR" = (
@@ -63744,9 +63738,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "mPV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -64404,6 +64395,13 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
+/area/science/xenobiology)
+"ooo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/science/xenobiology)
 "ooy" = (
 /obj/machinery/vending/dinnerware{
@@ -65347,14 +65345,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/office)
 "pOS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/festive/sidewalk,
-/area/edina/street/primary/princess)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "pPk" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	color = "#FFFFFE";
@@ -66541,6 +66537,15 @@
 	},
 /turf/open/floor/festive/sidewalk,
 /area/security)
+"rOf" = (
+/obj/structure/sign/departments/xenobio,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/festive/whitebrick{
+	color = "#555555"
+	},
+/area/science/xenobiology)
 "rOA" = (
 /obj/machinery/button/door{
 	id = "Kitchen garage door";
@@ -67290,9 +67295,7 @@
 /area/cargo/warehouse)
 "tqy" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "tqJ" = (
@@ -68572,13 +68575,11 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "vMa" = (
@@ -68637,6 +68638,15 @@
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/primary/perimeter)
+"vSH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vTP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68670,11 +68680,11 @@
 /area/security/office)
 "wax" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "wcq" = (
@@ -69556,7 +69566,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "xxk" = (
@@ -96425,7 +96437,7 @@ aCn
 aCn
 aCn
 aIR
-aCn
+hUg
 aCn
 aCn
 aCn
@@ -96682,7 +96694,7 @@ aws
 aws
 aCn
 aIS
-aCn
+hUg
 aws
 aws
 aws
@@ -96939,7 +96951,7 @@ aCn
 aCn
 aCn
 aIT
-aCn
+hUg
 aCn
 awo
 awo
@@ -97453,7 +97465,7 @@ aGI
 ilm
 eTG
 gNp
-aCY
+vSH
 aGR
 aKI
 aKI
@@ -98221,8 +98233,8 @@ fyZ
 aDV
 aFn
 aGK
-kbq
-fdo
+pOS
+mkb
 aIX
 aCY
 aKq
@@ -99249,7 +99261,7 @@ fyZ
 aDV
 aFu
 aGM
-kbq
+pOS
 iFP
 aIX
 aCY
@@ -100277,7 +100289,7 @@ fyZ
 aDV
 aFx
 aGN
-kbq
+pOS
 fyK
 aIZ
 aCn
@@ -101305,7 +101317,7 @@ fyZ
 aDV
 aFA
 aGO
-kbq
+pOS
 vLV
 aIZ
 aJJ
@@ -102333,7 +102345,7 @@ fyZ
 aDV
 aFE
 aGP
-kbq
+pOS
 aIq
 aJg
 aJN
@@ -103618,7 +103630,7 @@ aDX
 eXD
 aSA
 aCn
-aCm
+rOf
 aIv
 aJl
 aCZ
@@ -103876,7 +103888,7 @@ rTx
 aSC
 wlK
 iVZ
-iVZ
+gUj
 lVC
 aJS
 aDW
@@ -104133,7 +104145,7 @@ lYy
 aTk
 got
 tAb
-tAb
+ooo
 aJm
 aCV
 aDW
@@ -104647,7 +104659,7 @@ aEI
 aCp
 aCn
 aCn
-aCp
+icB
 aJo
 aCp
 aCs
@@ -104904,7 +104916,7 @@ bbT
 aEO
 aEO
 aEO
-aEO
+ckF
 bxs
 aEO
 bxI
@@ -105161,8 +105173,8 @@ aEA
 aEA
 aEA
 aEW
-aEA
-pOS
+ckG
+aGj
 aEA
 aEA
 aEA
@@ -105418,8 +105430,8 @@ aEa
 aEa
 aEa
 aEa
-aEa
 aFd
+aEa
 aEa
 aEa
 aEa

--- a/_maps/map_files/FestiveBall/FestiveStation.dmm
+++ b/_maps/map_files/FestiveBall/FestiveStation.dmm
@@ -12500,9 +12500,6 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name{
 	pixel_y = -30
 	},
@@ -12556,15 +12553,14 @@
 /turf/closed/wall/mineral/iron,
 /area/maintenance/starboard/fore)
 "aCV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/turbine{
-	dir = 1;
-	pixel_y = -30
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/turf/open/floor/carpet/red,
+/area/science/xenobiology)
 "aCW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -13276,6 +13272,8 @@
 	id = "xeno6";
 	name = "Creature Cell #6"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFm" = (
@@ -13317,6 +13315,8 @@
 	id = "xeno5";
 	name = "Creature Cell #5"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFp" = (
@@ -13389,6 +13389,8 @@
 	id = "xeno4";
 	name = "Creature Cell #4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFw" = (
@@ -13430,6 +13432,8 @@
 	id = "xeno3";
 	name = "Creature Cell #3"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFz" = (
@@ -13471,6 +13475,8 @@
 	id = "xeno2";
 	name = "Creature Cell #2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFC" = (
@@ -13516,6 +13522,8 @@
 	id = "xeno1";
 	name = "Creature Cell #1"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aFG" = (
@@ -13894,9 +13902,15 @@
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/primary/perimeter)
 "aGG" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
 	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGH" = (
@@ -13922,6 +13936,8 @@
 	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aGJ" = (
@@ -14241,12 +14257,6 @@
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
 "aHy" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/festive/whitebrick{
-	color = "#555555"
-	},
-/area/science/xenobiology)
-"aHz" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
@@ -14255,21 +14265,45 @@
 	id = "xenosecure";
 	name = "Secure Pen Shutters"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"aHA" = (
+"aHz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
 	dir = 4;
 	network = list("xeno")
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"aHA" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aHB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aHC" = (
@@ -14278,10 +14312,17 @@
 	pixel_x = -5;
 	pixel_y = 27
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aHD" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14300,6 +14341,9 @@
 	dir = 4;
 	pixel_x = -5;
 	pixel_y = 27
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -14326,6 +14370,10 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aHJ" = (
@@ -14540,11 +14588,9 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIj" = (
@@ -14574,6 +14620,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIm" = (
@@ -14583,6 +14630,13 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/requests_console{
+	department = "Xenobiology Lab";
+	name = "Xenobiology RC";
+	receive_ore_updates = 1;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14598,6 +14652,9 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIp" = (
@@ -14607,6 +14664,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIq" = (
@@ -14615,6 +14673,9 @@
 /obj/item/slime_extract/grey,
 /obj/item/slime_extract/grey,
 /obj/item/slime_extract/grey,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIr" = (
@@ -14622,11 +14683,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14637,6 +14702,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aIu" = (
@@ -14645,6 +14713,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aIv" = (
@@ -14814,14 +14885,21 @@
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/primary/perimeter)
 "aIP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14829,6 +14907,12 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14842,6 +14926,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -14859,6 +14949,12 @@
 	dir = 1;
 	light_color = "#ffc1c1"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aIT" = (
@@ -14871,6 +14967,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -15103,6 +15205,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/carpet/red,
 /area/science/xenobiology)
 "aJn" = (
@@ -15116,6 +15224,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/science/xenobiology)
 "aJo" = (
@@ -15126,6 +15240,12 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aJp" = (
@@ -15200,23 +15320,13 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "aJA" = (
-/obj/structure/disposaloutlet{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aJB" = (
 /obj/structure/cable/white,
@@ -15262,6 +15372,10 @@
 /obj/machinery/light,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -15320,6 +15434,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/monkey_recycler,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "aJM" = (
@@ -15496,18 +15611,20 @@
 /turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "aKm" = (
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenosecure";
-	name = "Secure Pen Shutters"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
-"aKn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"aKn" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aKo" = (
@@ -15680,17 +15797,22 @@
 /area/science/xenobiology)
 "aKG" = (
 /obj/structure/cable/white{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
 	},
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aKH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -15909,6 +16031,9 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/festive/alleyway,
 /area/science)
 "aLp" = (
@@ -15923,8 +16048,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/snow/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/festive/alleyway,
 /area/science)
@@ -19068,6 +19193,12 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/science/xenobiology)
 "aSl" = (
@@ -19198,6 +19329,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/science/xenobiology)
 "aSB" = (
@@ -19210,6 +19347,12 @@
 "aSC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/science/xenobiology)
@@ -19456,6 +19599,9 @@
 "aTk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/wood,
 /area/science/xenobiology)
@@ -19731,6 +19877,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aTS" = (
@@ -19920,7 +20071,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/festive/sidewalk,
 /area/edina/street/primary/progress)
@@ -32114,6 +32265,12 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/festive/sidewalk,
 /area/edina/street/primary/princess)
@@ -58193,6 +58350,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/bar/cafe)
+"cZG" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "cZK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -58245,6 +58408,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/edina)
+"dgP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"dhg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "dhz" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/decal/festive/christmas_reef,
@@ -58288,6 +58465,19 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"dmx" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "dnm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -58590,6 +58780,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "dSm" = (
@@ -58850,6 +59046,26 @@
 /obj/structure/sign/departments/examroom,
 /turf/closed/festive/whitebrick,
 /area/medical/exam_room)
+"ekL" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"elG" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "elX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59211,6 +59427,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"eTG" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "eWm" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	color = "#FFFFFF";
@@ -59280,8 +59506,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "fdo" = (
-/turf/open/floor/grass/snow/edina,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "feR" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 4;
@@ -59321,6 +59550,18 @@
 	},
 /turf/open/floor/festive/alleyway,
 /area/science)
+"fjC" = (
+/obj/structure/cable/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenosecure";
+	name = "Secure Pen Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "fkQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59354,6 +59595,12 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop/private)
+"fms" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "fnz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59507,20 +59754,31 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/command/heads_quarters/ce)
+"fyK" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"fyZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "fBZ" = (
 /mob/living/simple_animal/crab,
 /turf/open/floor/holofloor/beach,
 /area/edina/crew_quarters/store/pet)
 "fCo" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Arrivals";
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fCF" = (
@@ -59602,6 +59860,12 @@
 	},
 /turf/open/floor/wood,
 /area/engineering/main)
+"fLj" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "fNL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -59729,6 +59993,20 @@
 	},
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/primary/perimeter)
+"gdU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "gey" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/structure/cable/yellow{
@@ -59835,6 +60113,10 @@
 	},
 /turf/open/floor/plating/dirt/space,
 /area/edina)
+"got" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/science/xenobiology)
 "gph" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59985,6 +60267,23 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/cmo)
+"gCp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "gCq" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -60088,11 +60387,20 @@
 /turf/open/floor/wood,
 /area/edina/crew_quarters/store/clothes)
 "gNp" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engineering/atmos)
+/area/science/xenobiology)
 "gNY" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
@@ -60168,6 +60476,12 @@
 	},
 /turf/open/floor/festive/cobblestone,
 /area/security)
+"haz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "haP" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -60449,6 +60763,18 @@
 /obj/effect/landmark/start/chief_engineer,
 /turf/open/floor/carpet/orange,
 /area/command/heads_quarters/ce)
+"hDA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "hER" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -60536,9 +60862,6 @@
 /obj/machinery/power/smes{
 	capacity = 9e+006;
 	charge = 10000
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -60841,6 +61164,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"ihV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "iir" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	color = "#FFFFFF";
@@ -60898,6 +61229,16 @@
 /obj/item/toy/fluff/tennis_poly,
 /turf/open/floor/carpet/royalblue,
 /area/edina/crew_quarters/store/pet)
+"ilm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "ilI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -61141,6 +61482,9 @@
 /area/medical/genetics)
 "iFP" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "iGc" = (
@@ -61309,6 +61653,22 @@
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/festive/alleyway,
 /area/edina/backstreet/med)
+"iSK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "iUy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61321,6 +61681,10 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/maintenance/bar/cafe)
+"iVZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet/red,
+/area/science/xenobiology)
 "iXm" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/robotics/mechbay";
@@ -61435,6 +61799,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/corporate_showroom)
+"jme" = (
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jmu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61702,6 +62079,12 @@
 /obj/effect/turf_decal/vg_decals/atmos/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"jNY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "jQg" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -61721,6 +62104,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
+"jSo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "jSN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -61795,6 +62194,12 @@
 /obj/structure/chair/pew,
 /turf/open/floor/carpet/green,
 /area/medical/surgery)
+"kbq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "kbA" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
@@ -62043,6 +62448,15 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"kwy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/festive/sidewalk,
+/area/edina/street/primary/progress)
 "kwB" = (
 /obj/effect/turf_decal/stripes/white/corner,
 /obj/effect/turf_decal/stripes/white/line{
@@ -62095,6 +62509,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"kzF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "kAo" = (
 /obj/structure/statue/gold/hop{
 	anchored = 1
@@ -62243,6 +62673,13 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/grass/snow/edina,
 /area/edina)
+"kVk" = (
+/obj/structure/sign/warning/electricshock,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "kWd" = (
 /obj/structure/sign/directions/cells{
 	dir = 8
@@ -62386,6 +62823,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -62667,12 +63107,35 @@
 /mob/living/simple_animal/mouse/white,
 /turf/open/floor/grass,
 /area/edina)
+"lNd" = (
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "lNo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"lNI" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "lNU" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag,
@@ -62757,6 +63220,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/festive/alleyway/safe,
 /area/service/bar/atrium)
+"lVC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
+/area/science/xenobiology)
 "lVR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -62898,6 +63373,12 @@
 /obj/item/clothing/gloves/mittens/random,
 /turf/open/floor/wood,
 /area/edina/crew_quarters/store/clothes)
+"miy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "miR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -62918,6 +63399,22 @@
 	color = "#967832"
 	},
 /area/cargo)
+"mkb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"mkf" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/festive/sidewalk,
+/area/edina/street/primary/progress)
 "mkI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -63259,6 +63756,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"mPV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green,
+/area/science/xenobiology)
 "mQs" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/green,
@@ -63317,6 +63823,13 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"mWL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "mWS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/machinery/power/apc{
@@ -63401,6 +63914,13 @@
 	},
 /turf/open/floor/wood,
 /area/security/office)
+"nfs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "nij" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -63759,6 +64279,16 @@
 	},
 /turf/open/floor/festive/sidewalk,
 /area/edina/street/secondary/command)
+"nWz" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "nXa" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	color = "#FFFFFF";
@@ -63919,6 +64449,9 @@
 "oqc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -64128,6 +64661,12 @@
 	color = "#ffbb4d"
 	},
 /area/commons/storage/tools)
+"oDx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass/snow/edina,
+/area/science)
 "oFL" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -64269,6 +64808,22 @@
 	},
 /turf/open/floor/festive/cobblestone,
 /area/security)
+"oTc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "oTd" = (
 /obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating,
@@ -64702,6 +65257,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
+"pKG" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology - Port";
+	name = "xenobiology camera";
+	network = list("ss13","xeno","rd")
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "pLo" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -64790,8 +65363,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/office)
 "pOS" = (
-/turf/closed/mineral/snowmountain,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/festive/sidewalk,
+/area/edina/street/primary/princess)
 "pPk" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	color = "#FFFFFE";
@@ -65046,6 +65625,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/primary/perimeter)
+"qrY" = (
+/obj/structure/fence,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass/snow/edina,
+/area/science)
 "qsC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65234,6 +65820,21 @@
 	},
 /turf/open/floor/festive/cobblestone,
 /area/edina/street/primary/progress)
+"qJm" = (
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "qKU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -65345,6 +65946,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"qSC" = (
+/obj/structure/sign/warning/electricshock,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "qTR" = (
 /obj/effect/festive/street/streetliftedtile2,
 /obj/structure/disposalpipe/segment,
@@ -65683,6 +66292,22 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"rvm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "rvH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -65758,6 +66383,13 @@
 "ryV" = (
 /turf/closed/wall/rust,
 /area/edina)
+"rzl" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "rzP" = (
 /obj/effect/festive/street/streetlineeast,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65844,6 +66476,15 @@
 "rGH" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/ce)
+"rHH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/festive/sidewalk,
+/area/edina/street/primary/progress)
 "rHL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65952,6 +66593,13 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/festive/greybrick,
 /area/maintenance/bar)
+"rTx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/carpet/red,
+/area/science/xenobiology)
 "rTL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -66245,6 +66893,12 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"sEU" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "sFE" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -66279,6 +66933,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/bar/cafe)
+"sGE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "sIy" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -66338,6 +67001,12 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"sQN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/grass/snow/edina,
+/area/science)
 "sRp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/weather/snow/corner,
@@ -66635,6 +67304,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse)
+"tqy" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "tqJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	name = "output gas connector port"
@@ -66756,6 +67432,10 @@
 	},
 /turf/open/floor/wood,
 /area/cargo/qm)
+"tAb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/red,
+/area/science/xenobiology)
 "tAe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -67257,6 +67937,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
+"utf" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = 26
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "utz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -67331,6 +68026,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"uAC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "uAY" = (
 /turf/closed/festive/redbrick/redbrickcornersw,
 /area/commons/dorms)
@@ -67529,6 +68234,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
+"uZv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/sign/xenobio_guide{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "uZJ" = (
 /turf/open/floor/plating,
 /area/edina)
@@ -67719,9 +68433,6 @@
 /area/engineering/atmos)
 "vtE" = (
 /obj/structure/disposalpipe/trunk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -67770,6 +68481,22 @@
 /obj/structure/fluff/lightpost/light,
 /turf/open/floor/plating/dirt/space,
 /area/edina)
+"vBB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vBV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -67857,6 +68584,19 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"vLV" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "vMa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -67944,6 +68684,15 @@
 /obj/structure/sign/departments/security,
 /turf/closed/wall/mineral/iron,
 /area/security/office)
+"wax" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "wcq" = (
 /obj/effect/festive/street/streetlineeast,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -68066,6 +68815,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/electronic_marketing_den)
+"wlK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/science/xenobiology)
 "wmo" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/structure/cable/yellow{
@@ -68082,6 +68835,18 @@
 	},
 /turf/open/floor/festive/alleyway,
 /area/science)
+"wmr" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "wmV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -68182,10 +68947,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "wuG" = (
 /obj/structure/chair/pew/left{
@@ -68558,6 +69320,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
+"xaZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/science/xenobiology)
 "xbi" = (
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/open/floor/wood,
@@ -68602,6 +69371,20 @@
 	color = "#555555"
 	},
 /area/science/robotics/mechbay)
+"xhZ" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xiY" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -68785,6 +69568,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
+"xwW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xxk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
@@ -68824,6 +69614,13 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"xBp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xBO" = (
 /obj/effect/turf_decal/vg_decals/atmos/mix,
 /turf/open/floor/engine/vacuum,
@@ -68935,6 +69732,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"xKw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "xLs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80977,8 +81783,8 @@ ghx
 aBf
 aBf
 aBL
-aBf
 olA
+rxZ
 rxZ
 aDP
 sgh
@@ -81491,7 +82297,7 @@ itf
 cVh
 kWp
 aoQ
-aoQ
+miy
 aCN
 rxZ
 aoQ
@@ -81748,7 +82554,7 @@ rjx
 biE
 aCe
 aEx
-xBR
+rzl
 aCO
 iIx
 baU
@@ -82005,8 +82811,8 @@ aFj
 aOh
 rqT
 aoQ
-aoQ
-aCV
+jNY
+awE
 akI
 akI
 akI
@@ -82258,19 +83064,19 @@ wuX
 ajK
 akI
 wuC
-gNp
+aFj
 qRx
 aEx
 aEx
 xBR
 izv
 akI
-fdo
-fdo
-fdo
-fdo
-fdo
-fdo
+aal
+aal
+aal
+aal
+aal
+aal
 aal
 aal
 aal
@@ -82515,19 +83321,19 @@ aAz
 ajK
 rxZ
 vtE
-wIj
+mWL
 wIj
 tbY
 aoQ
 aoQ
 aWm
 akI
-fdo
-fdo
-fdo
-fdo
-fdo
-fdo
+aal
+aal
+aal
+aal
+aal
+aal
 aal
 aal
 aad
@@ -82779,12 +83585,12 @@ cpX
 xDk
 vXS
 akI
-fdo
-fdo
-fdo
-fdo
-fdo
-fdo
+aal
+aal
+aal
+aal
+aal
+aal
 aal
 aad
 aad
@@ -83036,10 +83842,10 @@ akI
 akI
 akI
 akI
-pOS
-pOS
-pOS
-pOS
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -92544,19 +93350,19 @@ bdS
 bgm
 cnB
 aRa
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-bdO
-aOj
+aOi
+awo
+awo
+awo
+awo
+awo
+awo
+awo
+awo
+awo
+awo
+awo
+aOi
 aMt
 aMb
 aNR
@@ -92801,19 +93607,19 @@ bdS
 bgl
 cnB
 cnB
-aOi
-awo
-awo
-awo
-awo
-awo
-awo
-awo
-awo
-awo
-awo
-awo
-aOi
+aOj
+aws
+aws
+aws
+aws
+aws
+aws
+aws
+aws
+aws
+aws
+aws
+aOj
 aMu
 aNf
 aNS
@@ -93060,15 +93866,15 @@ cnB
 cnB
 aOj
 aws
-aws
-aws
-aws
-aws
-aws
-aws
-aws
-aws
-aws
+aCn
+aCn
+aCn
+aCn
+aCn
+aCn
+aCn
+aCn
+aCn
 aws
 aOj
 aMv
@@ -93318,13 +94124,13 @@ aRa
 aOj
 aws
 aCn
-aCn
-aCn
-aCn
-aCn
-aCn
-aCn
-aCn
+aGA
+aGA
+aGA
+aIL
+aGA
+aGA
+aGA
 aCn
 aws
 aOj
@@ -93575,13 +94381,13 @@ cnB
 aOj
 aws
 aCn
-aGA
-aGA
-aGA
-aIL
-aGA
-aGA
-aGA
+aGB
+aHx
+aDU
+aDU
+aDU
+aDU
+aKF
 aCn
 aws
 aOj
@@ -93832,13 +94638,13 @@ cnB
 aOj
 aws
 aCn
-aGB
-aHx
-aDU
-aDU
-aDU
-aDU
-aKF
+aGA
+jSo
+oTc
+iSK
+gdU
+kzF
+aGA
 aCn
 aws
 aOj
@@ -94089,13 +94895,13 @@ aRa
 aOj
 aws
 aCn
+lNd
+kVk
 aGA
-aGA
-aGA
-aGA
-aGA
-aGA
-aGA
+rvm
+lNI
+qSC
+cZG
 aCn
 aws
 aOj
@@ -94346,13 +95152,13 @@ cnB
 aOj
 aws
 aCn
-aCn
+aGC
 aHy
-aGA
-aGA
-aJA
-aHy
-aCn
+aIg
+aIM
+aJB
+fjC
+jme
 aCn
 aws
 aOj
@@ -94603,11 +95409,11 @@ cnB
 aOj
 aws
 aCn
-aGC
+aGD
 aHz
-aIg
-aIM
-aJB
+aIh
+aIN
+aJC
 aKm
 aKG
 aCn
@@ -94860,13 +95666,13 @@ aRa
 aOj
 aws
 aCn
-aGD
+pKG
 aHA
-aIh
-aIN
-aJC
+wmr
+qJm
+nWz
 aKn
-aGD
+xhZ
 aCn
 aws
 aOj
@@ -95118,11 +95924,11 @@ aOj
 aws
 aCn
 aGG
-aHB
+gCp
 aHB
 aIP
-aHB
-aHB
+ekL
+vBB
 aKH
 aCn
 aws
@@ -95374,15 +96180,15 @@ aCl
 aDS
 aEz
 aCo
-aDT
-aDT
+utf
+wax
 aIi
-aIQ
+elG
 fCo
-aDT
-aDT
+fLj
+dmx
 aKP
-aws
+sQN
 aOj
 aLp
 aNh
@@ -95639,7 +96445,7 @@ aCn
 aCn
 aCn
 aCn
-aws
+oDx
 aOj
 aLp
 aNh
@@ -95896,7 +96702,7 @@ aCn
 aws
 aws
 aws
-aws
+oDx
 aOj
 aMx
 aNi
@@ -96153,7 +96959,7 @@ aCn
 aCn
 awo
 awo
-awo
+qrY
 aLU
 aLU
 aLU
@@ -96399,7 +97205,7 @@ bdT
 bgm
 aCm
 aCW
-aDT
+tqy
 aDT
 aFk
 aGH
@@ -96410,7 +97216,7 @@ aJD
 aCm
 aws
 aws
-aws
+oDx
 aLU
 aMy
 aNj
@@ -96656,13 +97462,13 @@ bdS
 bgm
 aCn
 aCX
-aDU
-aDV
+mPV
+dgP
 aFl
 aGI
-aHB
-aHB
-aIV
+ilm
+eTG
+gNp
 aCY
 aGR
 aKI
@@ -96913,18 +97719,18 @@ bdS
 bgm
 aCn
 aCY
-aDV
+haz
 aEB
 aFm
 aGJ
-aDV
-aDV
-aIX
+kbq
+sEU
+dhg
 aCY
 aKq
 aws
 aMa
-aLp
+aLr
 aLU
 aMz
 aNk
@@ -97175,13 +97981,13 @@ aCn
 aCn
 aCn
 aHC
-aDV
+mkb
 aIX
 aCY
 aKq
 aws
 aws
-aLp
+aLr
 aLU
 aMA
 aNl
@@ -97427,18 +98233,18 @@ bdS
 bgm
 aCn
 aCY
-aDV
+fyZ
 aDV
 aFn
 aGK
-aDV
-aDV
+kbq
+fdo
 aIX
 aCY
 aKq
 aws
 aws
-aLp
+aLr
 aLU
 aMz
 aNm
@@ -97684,12 +98490,12 @@ bdS
 bgm
 aCn
 aCX
-aDU
-aDV
+mPV
+dgP
 aFo
 aGI
-aHB
-aHB
+ihV
+xwW
 aIV
 aCY
 aKq
@@ -97941,12 +98747,12 @@ bdS
 bgl
 aCn
 aCY
-aDV
+haz
 aEB
 aFp
 aGJ
-aDV
-aDV
+kbq
+nfs
 wTq
 aJE
 qKU
@@ -98202,8 +99008,8 @@ aCn
 aCn
 aCn
 aGL
-aDV
-aDV
+fms
+xKw
 aIX
 aCY
 aKq
@@ -98455,11 +99261,11 @@ bdS
 bgl
 aCn
 aCY
-aDV
+fyZ
 aDV
 aFu
 aGM
-aDV
+kbq
 iFP
 aIX
 aCY
@@ -98712,12 +99518,12 @@ bdS
 bgl
 aCn
 aCX
-aDU
-aDV
+mPV
+dgP
 aFv
 aGI
-aHB
-aHB
+ihV
+xwW
 aIV
 aCY
 aKq
@@ -98969,12 +99775,12 @@ bdT
 bgm
 aCn
 aCY
-aDV
+haz
 aEB
 aFw
 aGJ
-aDV
-aDV
+kbq
+fdo
 aIX
 aCY
 aKq
@@ -99230,8 +100036,8 @@ aCn
 aCn
 aCn
 aCn
-aDV
-aCW
+uAC
+aJA
 aIY
 aJG
 aCn
@@ -99483,12 +100289,12 @@ bdS
 bgm
 aCn
 aCY
-aDV
+fyZ
 aDV
 aFx
 aGN
-aDV
-aCY
+kbq
+fyK
 aIZ
 aCn
 aCn
@@ -99740,11 +100546,11 @@ beA
 bgS
 aCo
 aDa
-aDU
-aDV
+mPV
+dgP
 aFy
 aGI
-aHB
+ihV
 aIl
 aJa
 aJH
@@ -99997,12 +100803,12 @@ bdS
 bgm
 aCn
 aCY
-aDV
+haz
 aEB
 aFz
 aGJ
-aDV
-aCY
+kbq
+sGE
 aJb
 aJI
 aKs
@@ -100258,8 +101064,8 @@ aCn
 aCn
 aCn
 aCn
-aDV
-aCY
+uZv
+hDA
 aJc
 aJI
 aKt
@@ -100511,12 +101317,12 @@ bdS
 bgl
 aCn
 aCY
-aDV
+fyZ
 aDV
 aFA
 aGO
-aDV
-aCY
+kbq
+vLV
 aIZ
 aJJ
 aKu
@@ -100768,11 +101574,11 @@ bdS
 bgl
 aCn
 aCX
-aDU
-aDV
+mPV
+dgP
 aFB
 aGI
-aHB
+ihV
 aIm
 aJd
 aJK
@@ -101025,11 +101831,11 @@ bdS
 bgl
 aCn
 aCY
-aDV
+haz
 aEB
 aFD
 aGJ
-aDV
+kbq
 aIo
 aJe
 aJL
@@ -101286,7 +102092,7 @@ aCn
 aCn
 aCn
 aGL
-aDV
+xBp
 aIp
 aJf
 aJM
@@ -101539,11 +102345,11 @@ bdT
 bgl
 aCn
 aCY
-aDV
+fyZ
 aDV
 aFE
 aGP
-aDV
+kbq
 aIq
 aJg
 aJN
@@ -101796,11 +102602,11 @@ bdS
 bgl
 aCn
 aCX
-aDU
-aDV
+mPV
+dgP
 aFF
 aGI
-aHB
+ihV
 aIr
 aJh
 aJO
@@ -102053,7 +102859,7 @@ bdS
 bgm
 aCn
 aCY
-aDV
+haz
 aEB
 aFG
 aGQ
@@ -102828,7 +103634,7 @@ aDX
 eXD
 aSA
 aCn
-aCn
+aCm
 aIv
 aJl
 aCZ
@@ -103082,12 +103888,12 @@ bgl
 aCn
 aDd
 aDX
-eXD
+rTx
 aSC
-aDW
-aDX
-aDX
-aJm
+wlK
+iVZ
+iVZ
+lVC
 aJS
 aDW
 aCn
@@ -103341,11 +104147,11 @@ aFI
 aRH
 lYy
 aTk
-aDW
-aDX
-aDX
+got
+tAb
+tAb
 aJm
-aJS
+aCV
 aDW
 aCr
 aKT
@@ -103599,7 +104405,7 @@ aDY
 eqF
 aDY
 fTC
-aDY
+xaZ
 aIw
 aJn
 aJT
@@ -104372,7 +105178,7 @@ aEA
 aEA
 aEW
 aEA
-aEA
+pOS
 aEA
 aEA
 aEA
@@ -104628,8 +105434,8 @@ aEa
 aEa
 aEa
 aEa
-aFd
 aEa
+aFd
 aEa
 aEa
 aEa
@@ -106699,8 +107505,8 @@ bmw
 bmw
 bmw
 vhL
-bGv
-ccu
+mkf
+kwy
 cpY
 bAF
 caZ
@@ -106957,7 +107763,7 @@ bnM
 boR
 bmw
 aUv
-ccu
+rHH
 byp
 bAF
 bWE


### PR DESCRIPTION
Основываясь на запросе с последней игры от игроков, ксенобиология была изменена под современные нужды.
Были добавлены:
Скруберы в камерах и ксенобиология была подключена к основной системе трубопровода.
Дробилка мартышек.
БЗ канистра и соответствующие трубы для неё, всё по современым технологиям
Скриншот изменения:
![Desktop Screenshot 2024 10 10 - 08 50 00 28](https://github.com/user-attachments/assets/60df15e4-fca0-49de-987f-261f9b94a514)

:cl:
add: Скруберы в камеры и ксенобио, дробилка мартышек, БЗ канистра и стандартная мелочёмка как "air alarm" на стены
/:cl: