### PR TITLE
попытка оптимизировать нагрузку на сервер

### DIFF
--- a/modular_bluemoon/SmiLeY/code/space.dm
+++ b/modular_bluemoon/SmiLeY/code/space.dm
@@ -4,6 +4,7 @@
 	prefix = "_maps/RandomRuins/SpaceRuins/BlueMoon/"
 	allow_duplicates = FALSE
 	id = "tarkoff-base"
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/tarkoff/New()
 	var/num = rand(0, 3)
@@ -24,8 +25,9 @@
 	prefix = "_maps/RandomRuins/SpaceRuins/BlueMoon/"
 	suffix = "space_syndicate_base.dmm"
 	allow_duplicates = FALSE
-	always_place = TRUE
+	always_place = FALSE
 	id = "ds2-base"
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/forgottenship
 	name = "SCSBC-12"
@@ -33,8 +35,9 @@
 	prefix = "_maps/RandomRuins/SpaceRuins/BlueMoon/"
 	suffix = "forgotten_ship.dmm"
 	allow_duplicates = FALSE
-	always_place = TRUE
+	always_place = FALSE
 	id = "forgottenship"
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/forgottenship/New()
 	if(GLOB.master_mode == "Extended")


### PR DESCRIPTION
remove: удалены из ротации большинство крупных руин и космических объектов: Порт Тарков, DS-2 и прослушка.

По результатам тестов: 
Удаление руин снижает (при тесте на локальном сервере без игроков) пиковую нагрузку на ЦПУ (именно она вызывает фризы, так как в моменты максимальной нагрузки процессор не успевает обрабатывать все запросы и откладывает их в очередь из-за чего происходит замедление) на ~23%. Производительность процессора на ядро (важно заметить, что BYOND работает в основном на одном потоке), на котором проводился тест в 1.12 раза выше чем у серверного. Следовательно, удаление руин должно снизить пик нагрузки на ЦПУ сервера минимум на 25%, что, учитывая деятельность игроков на этих руинах, должно снизить нагрузку ещё сильнее. В итоге можно заключить, что удаление руин с высокой долей вероятности должно решить проблему фризов на сервере.

Конспект логов по нагрузке при тестах (обычная сборка/сборка с отключёнными руинами):

Master(без изменений):
CPU: 16-64%
Atmos: 39ms, 74-83%
Machines: 112ms, 224-239%
Mobs: 37ms, 74%
NPC Pool: 15ms, 28-32%
Obkects: 12ms, 24%

Without major ruins:
CPU: 16-41%
Atmos: 38-41ms, 81-83%
Machines: 99-112ms; 199-224%
Mobs: 34ms, 68%
NPC Pool: 14ms, 27%
Objects: 12ms, 24%

//OUTDATED
Гипотеза заключается в том, что данные структуры имеют количество машинерии, атмосферы и мобов сопоставимое с основной станцией из-за чего при высокой нагрузке из-за онлайна сервер может не справляться, тем самым поднимая задержку (пинг) и понижая качество игры для всех игроков.