### PR TITLE
Убираем сомнительные механики

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -146,7 +146,10 @@
 			damage = affecting.brute_dam
 			affecting.update_threshhold_state(burn = FALSE)
 			if(affecting.threshhold_brute_passed)
-				heal_amount = min(heal_amount, damage - affecting.threshhold_passed_mindamage)
+				// BLUEMOON ADD - только сложные в обслуживании синтетики зависят от минимальных порогов
+				if(HAS_TRAIT(H, TRAIT_BLUEMOON_COMPLEX_MAINTENANCE)) // только роботехники, РД и борги могут ремонтировать таких роботов
+				// BLUEMOON ADD END
+					heal_amount = min(heal_amount, damage - affecting.threshhold_passed_mindamage)
 
 				if(!heal_amount)
 //					to_chat(user, "<span class='notice'>[user == H ? "Your" : "[H]'s"] [affecting.name] appears to have suffered severe internal damage and requires surgery to repair further.</span>") - BLUEMOON REMOVAL

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -799,11 +799,11 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Йоу, а что, если мы 
 
 
 /mob/living/carbon/proc/get_environment_cooling_efficiency()
-/* BLUEMOON REMOVAL START - для защиты от космоса, у синтетиков теперь есть portable cooling unit. Скафандры не должны работать
+///* BLUEMOON REMOVAL START - для защиты от космоса, у синтетиков теперь есть portable cooling unit. Скафандры не должны работать
 	var/suitlink = check_suitlinking()
 	if(suitlink)
 		return suitlink //If you are wearing full EVA or lavaland hazard gear (on lavaland), assume it has been made to accomodate your cooling needs.
-BLUEMOON REMOVAL END */
+//BLUEMOON REMOVAL END */
 	var/datum/gas_mixture/environment = loc.return_air()
 	if(!environment)
 		return FALSE

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -166,9 +166,11 @@
 			owner.DefaultCombatKnockdown(80)
 			deaf = max(deaf, 30)
 
+	/* убрано в связи с жалобами на невозможность адекватного противодействия в бою
 	// BLUEMOON ADD START - шанс на перманентный выход из строя
 	if(prob(10)) //Chance of permanent effects
 		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replace soon
 		if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))
 			to_chat(owner, span_userdanger("Fatal failure detected in \the [src] - Seek for replace immediately."))
 	// BLUEMOON ADD END
+	*/

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -439,6 +439,7 @@
 	to_chat(owner, "<span class='warning'>Alert: Perception visuals overload!</span>")
 	owner.flash_act(intensity = 0, visual = TRUE)
 
+	/* убрано в связи с жалобами на невозможность адекватного противодействия в бою
 	// BLUEMOON ADD START - шанс на перманентный выход из строя
 	owner.blur_eyes(rand(5,10))
 	if(prob(10)) //Chance of permanent effects
@@ -446,6 +447,7 @@
 		if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))
 			to_chat(owner, span_userdanger("Fatal failure detected in \the [src] - Seek for replace immediately."))
 	// BLUEMOON ADD END
+	*/
 
 /obj/item/organ/eyes/night_vision/arachnid
 	name = "arachnid eyes"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -303,10 +303,12 @@
 		owner.Dizzy(10)
 		owner.losebreath += 10
 		COOLDOWN_START(src, severe_cooldown, 20 SECONDS)
+	/* убрано в связи с жалобами на невозможность адекватного противодействия в бою
 	if(prob(10)) //Chance of permanent effects
 		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
 		if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))
 			to_chat(owner, span_userdanger("Fatal failure detected in \the [src] - Emergency mod activated for next 4 minutes - Seek for replace immediately."))
+	*/
 // BLUEMOON ADD END
 
 /obj/item/organ/heart/freedom

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -108,10 +108,12 @@
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
 		owner.adjustToxLoss(10) // Урон только для людей
 		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
+	/* убрано в связи с жалобами на невозможность адекватного противодействия в бою
 	if(prob(10)) //Chance of permanent effects
 		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
 		if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))
 			to_chat(owner, span_userdanger("Fatal failure detected in [src] - Seek for replace immediately."))
+	*/
 // BLUEMOON ADD END
 
 /obj/item/organ/liver/cybernetic

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -450,12 +450,14 @@
 		if(50 to INFINITY)
 			owner.adjust_bodytemperature(100*TEMPERATURE_DAMAGE_COEFFICIENT)
 
+	/* убрано в связи с жалобами на невозможность адекватного противодействия в бою
 	// BLUEMOON ADD START - шанс на перманентный выход из строя
 	if(prob(10)) //Chance of permanent effects
 		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
 		if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))
 			to_chat(owner, span_userdanger("Fatal failure detected in the cooling system - Seek for replace immediately."))
 	// BLUEMOON ADD END
+	*/
 
 /obj/item/organ/lungs/ipc/ui_action_click(mob/user, actiontype)
 	if(!owner)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -147,6 +147,7 @@
 	if(HAS_TRAIT(target, TRAIT_BLUEMOON_HEAVY_SUPER))
 		propability = 0.8
 
+	/* Вырезано из-за жалоб на переусложнение операции
 	// Шансы на операции в зависимости от состояния пациента
 	var/check_for_painkillers = FALSE
 	var/check_for_pain = FALSE
@@ -267,8 +268,8 @@
 							patient.emote("cry")
 				else if(prob(40))
 					patient.emote(pick("realagony", "scream", "cry"))
-
 	propability += pain_propability_debuff + surgeon_requirments_debuff
+	*/
 	// BLUEMOON ADDITION END
 	return propability + success_multiplier
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -93,6 +93,7 @@
 				if(!HAS_TRAIT(user.mind, QUALIFIED_ROBOTIC_MAINTER) && !user.mind.antag_datums) // гост роли и обученный персонал могут оперировать таких синтов
 					to_chat(user, span_warning("Этот протез выглядит слишком сложно... Здесь необходим специалист!"))
 					prob_chance = 0
+		/* вырезано из-за жалоб на невозможность самооперирования (снижение динамики игры)
 		if(target == user)
 			if(HAS_TRAIT(target, CAN_BE_OPERATED_WITHOUT_PAIN)) // Роботам и некоторым другим расам даётся проще. Они не чувствуют боли
 				display_results(target, self_message = "<span class='notice'>Вы пытаетесь [HAS_TRAIT(target, TRAIT_ROBOTIC_ORGANISM) ? "отремонтироваться" : "вылечитья"] самостоятельно. Это не так сложно, как было бы [HAS_TRAIT(target, TRAIT_ROBOTIC_ORGANISM) ? "органикам" : "другим расам"], но неудобно.</span>")
@@ -102,6 +103,7 @@
 				prob_chance = 0
 			else
 				prob_chance = min(prob_chance, 20)
+		*/
 		if(prob_chance <= 0 && !try_to_fail)
 			to_chat(user, span_warning("Условия операции слишком ужасны, ничего не выйдет!"))
 		// BLUEMOON ADD END


### PR DESCRIPTION
- Убрано получение корозии синтетиками в космосе, если они надели скафандр. На лаваленде достаточно костюма эксплорера (как и было).
- Если у конечности кап по урону, для его действия нужно обладать квирком "дорогое техобслуживание". Т.е. обычный синтетик может починить себя до 100% мотком провода или сваркой.
- Убраны добавленные перманентные отказы у некоторых органов. Те, которые были изначально, оставлены.
- Вырезана боль из операций.
- Самохирургия снова работает для всех.

## Зачем?

- Более казуальный и ориентированный на динамику геймплей.
- Синтетики теперь более робастные. Кап на урон был изначально. Здесь он убран.
- )