### PR TITLE
Фикс хирургии для ромерольных зомби и мазохистов

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2442,7 +2442,8 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 				if(BP.receive_damage(damage_amount, 0, wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness))
 					H.update_damage_overlays()
 					if(HAS_TRAIT(H, TRAIT_MASO) && prob(damage_amount))
-						H.mob_climax(forced_climax=TRUE, cause = "masochism")
+						if(!(patient.IsSleeping() || patient.stat >= 2 || patient.IsUnconscious())) // BLUEMOON ADD - персонаж не спит, не без сознания и не мертв
+							H.mob_climax(forced_climax=TRUE, cause = "masochism")
 
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage_amount)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2442,7 +2442,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 				if(BP.receive_damage(damage_amount, 0, wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness))
 					H.update_damage_overlays()
 					if(HAS_TRAIT(H, TRAIT_MASO) && prob(damage_amount))
-						if(!(patient.IsSleeping() || patient.stat >= 2 || patient.IsUnconscious())) // BLUEMOON ADD - персонаж не спит, не без сознания и не мертв
+						if(!(H.IsSleeping() || H.stat >= 2 || H.IsUnconscious())) // BLUEMOON ADD - персонаж не спит, не без сознания и не мертв
 							H.mob_climax(forced_climax=TRUE, cause = "masochism")
 
 			else//no bodypart, we deal damage with a more general method.

--- a/modular_sand/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/modular_sand/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -3,4 +3,14 @@
 	. = ..()
 	var/modular_inherent_traits = list(CAN_BE_OPERATED_WITHOUT_PAIN)
 	LAZYADD(inherent_traits, modular_inherent_traits)
+
+/datum/species/zombies/notspaceproof/New()
+	. = ..()
+	var/modular_inherent_traits = list(CAN_BE_OPERATED_WITHOUT_PAIN)
+	LAZYADD(inherent_traits, modular_inherent_traits)
+
+/datum/species/zombies/infectious/New()
+	. = ..()
+	var/modular_inherent_traits = list(CAN_BE_OPERATED_WITHOUT_PAIN)
+	LAZYADD(inherent_traits, modular_inherent_traits)
 // BLUEMOON ADD END


### PR DESCRIPTION
- У обычных зомби нет необходимости использовать обезболивающее при хирургии. Но ромерольные зомби берут обычных зомби, переписывают их трейты и теряют часть данных свойств. Этот ПР фиксит это.
- Мазохисты больше не должны ОКАНЧИВАТЬ, когда они без сознания (например, присмерти при получении дамага или на хирургическом столе).