### PR TITLE
Нёрф странного реагента

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1012,7 +1012,7 @@
 		if(M.suiciding || M.hellbound) //they are never coming back
 			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
 			return ..()
-		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || HAS_TRAIT(M, TRAIT_HUSK)) //body is too damaged to be revived
+		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || M.getToxLoss() >= 10 || HAS_TRAIT(M, TRAIT_HUSK)) //body is too damaged to be revived
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			M.do_jitter_animation(10)
 			return ..()
@@ -1037,6 +1037,11 @@
 
 				M.adjustOxyLoss(-20, 0)
 				M.adjustToxLoss(-20, 0)
+
+				M.adjustCloneLoss(rand(15, 80), 0)
+				M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 60)
+				M.adjustOrganLoss(ORGAN_SLOT_LIVER, rand(10, 60))
+
 				M.updatehealth()
 				if(iscarbon(M))
 					var/mob/living/carbon/C = M

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -219,13 +219,13 @@
 /datum/chemical_reaction/strange_reagent
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
-	results = list(/datum/reagent/medicine/strange_reagent = 3)
+	results = list(/datum/reagent/medicine/strange_reagent = 1)
 	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/strange_reagent/alt
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
-	results = list(/datum/reagent/medicine/strange_reagent = 2)
+	results = list(/datum/reagent/medicine/strange_reagent = 1)
 	required_reagents = list(/datum/reagent/medicine/omnizine/protozine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/mannitol


### PR DESCRIPTION
В связи со слишком частым абузом странного в последнее время(как по случаю так и нет) а так же доставания разных СМО я принял решение, не смотря на то что моя предложка набрала больше дизлайков чем лайков немного отредактировать этот реагент.

Коротко описание работы странного учитывая моя изменения:

Странный не работает если количество брута/бёрна выше 100 или количество токсинов выше 10 или имеется хаск

После поднятия странным, тушка получает  случайное количество генетического(от 15 до 80),
Урон по мозгу в размере 60 единиц и случайный урон по печени от 10 до 60.

+ изменения в приготовлении реагента. Теперь, вне зависимости от способа изготовления будет даваться только 1 часть реагента по причине: я не знаю зачем давать 3 части реагента когда для его действия нужно меньше 0.1 юнитов.
