### PR TITLE
Пачки сигарет мне в tailbag!

### DIFF
--- a/modular_splurt/code/game/objects/items/storage/wallets.dm
+++ b/modular_splurt/code/game/objects/items/storage/wallets.dm
@@ -39,7 +39,8 @@
 	/obj/item/assembly/flash,
 	/obj/item/laser_pointer,
 	/obj/item/pda,
-	/obj/item/paicard
+	/obj/item/paicard,
+	/obj/item/storage/fancy/cigarettes
 	))
 
 /obj/item/storage/wallet/tailbag/xtralg


### PR DESCRIPTION
Теперь пачки сигарет (любых) можно засунуть в tailbag. 
В xl tailbag тоже. 
Коробки сигар нельзя.


