### PR TITLE
Atmos uniform protection

### DIFF
--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -18,10 +18,11 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 
 /obj/item/clothing/under/rank/engineering/atmospheric_technician
-	desc = "It's a jumpsuit worn by atmospheric technicians."
+	desc = "It's a jumpsuit worn by atmospheric technicians. It provides decent fire protection."
 	name = "atmospheric technician's jumpsuit"
 	icon_state = "atmos"
 	item_state = "atmos_suit"
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 70, ACID = 20, WOUND = 5)
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt


### PR DESCRIPTION
Добавил защиту униформе атмостеха, услышал, что много раз  просили.
Защита от радиации убрана, компенсировано повышенной защитой от огня. В описании это указано, зеркально к описанию рад. защиты униформы инженера. Защита перенесётся и на вариант-юбку.

![atmos](https://github.com/user-attachments/assets/cc635db6-07b2-478e-8aa9-8dcc58293331)
