### PR TITLE
Отображение причёски и ушей у каски

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -68,7 +68,7 @@
 	icon_state = "hardhat0_purple"
 	item_state = "hardhat0_purple"
 	dynamic_hair_suffix = ""
-	flags_inv = HIDEHAIR|HIDEEARS
+	flags_inv = 0
 	brightness_on = 5
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	custom_materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/plastic = 3000, /datum/material/silver = 500)


### PR DESCRIPTION
Фиолетовая каска а.к.а. workplace-ready firefighter helmet `/hardhat/red/upgraded` скрывала причёску и уши куклы, спрайт каски при этом выглядит как модифицированная незакрытая hardhat каска. 
Удалил ей изначальные флаги. Дал ей игнорирование флагов от родительской `/hardhat/red` (Шлем пожарного), чтобы отображалось корректно.

![hardhat_purple](https://github.com/user-attachments/assets/66d628d3-332e-4fd0-8d91-6c914dc5ee5e) 

И вот обычная hard hat `/hardhat` каска, для сравнения фиолетовой и обычной версий.
![Hardhat](https://github.com/user-attachments/assets/60da33ce-6cd6-4d5f-8f0d-045b47b0ea12)

