### PR TITLE
реальное удалением гостов при помощи автокрио

### DIFF
--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -8,6 +8,8 @@
 			SELECT reason FROM [format_table_name("ban")]
 			WHERE ckey = :ckey AND (bantype = 'JOB_PERMABAN' OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned) AND job = :rank
 			"}, list("ckey" = M.ckey, "rank" = rank))
+		if(!query_jobban_check_ban) //BLUEMOON ADD лишние проверки не помешают
+			return
 		if(!query_jobban_check_ban.warn_execute())
 			qdel(query_jobban_check_ban)
 			return

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -2,6 +2,7 @@
 	update_z(null)
 	if (client)
 		client.images -= (GLOB.ghost_images_default+GLOB.ghost_images_simple)
+	lastclienttime = world.time //BLUEMOON ADD фиксируем время выхода игрока
 
 	if(observetarget)
 		if(ismob(observetarget))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -59,6 +59,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/deadchat_name
 	var/datum/orbit_menu/orbit_menu
 	var/datum/spawners_menu/spawners_menu
+	var/lastclienttime = 0 //BLUEMOON ADD фиксируем время выхода игрока
 
 /mob/dead/observer/Initialize(mapload, mob/body)
 	set_invisibility(GLOB.observer_default_invisibility)
@@ -161,6 +162,12 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 10)
 
 /mob/dead/observer/Destroy()
+	//BLUEMOON ADD проверяем клиента на все болячки и ссылаем его в лобби при наличии его в госте или удаляем сикей, чтобы при заходе его отправило в лобби (fix undeleting ghosts)
+	if(client)
+		transfer_to_lobby()
+	if(ckey)
+		ckey = null
+	//BLUEMOON ADD END
 	if(data_huds_on)
 		remove_data_huds()
 	GLOB.ghost_images_default -= ghostimage_default

--- a/config/splurt/autocryo.txt
+++ b/config/splurt/autocryo.txt
@@ -3,3 +3,8 @@
 
 ## Time in ticks before sending SSD users to cryo
 AUTOCRYO_TIME_TRIGGER 24000
+
+# Uncomment to enable automatic disconnected ghost culling
+GHOST_CHECKING
+## Time in ticks before deleting a ghost whose client has disconnected
+GHOST_CHECK_TIME 6000

--- a/modular_splurt/code/controllers/configuration/entries/splurt_autocryo.dm
+++ b/modular_splurt/code/controllers/configuration/entries/splurt_autocryo.dm
@@ -6,3 +6,12 @@
 
 // Should this system be used?
 /datum/config_entry/flag/autocryo_enabled
+
+// Time before deleting a disconnected ghost
+/datum/config_entry/number/ghost_check_time
+	config_entry_value = 10 MINUTES
+	min_val = 600
+	integer = TRUE
+
+// Should the system check for ghosts to delete too?
+/datum/config_entry/flag/ghost_checking

--- a/modular_splurt/code/controllers/subsystem/afk.dm
+++ b/modular_splurt/code/controllers/subsystem/afk.dm
@@ -1,6 +1,8 @@
 // Define config entries for cryo
 #define SUBSYSTEM_CRYO_CAN_RUN CONFIG_GET(flag/autocryo_enabled)
+#define SUBSYSTEM_CRYO_CHECK_GHOSTS CONFIG_GET(flag/ghost_checking)
 #define SUBSYSTEM_CRYO_TIME CONFIG_GET(number/autocryo_time_trigger)
+#define SUBSYSTEM_CRYO_GHOST_PERIOD CONFIG_GET(number/ghost_check_time)
 
 SUBSYSTEM_DEF(auto_cryo)
 	name = "Automated Cryogenics"
@@ -17,6 +19,8 @@ SUBSYSTEM_DEF(auto_cryo)
 /datum/controller/subsystem/auto_cryo/fire()
 	if(SUBSYSTEM_CRYO_CAN_RUN)
 		cryo_mobs()
+	if(SUBSYSTEM_CRYO_CHECK_GHOSTS) //BLUEMOON REWORKED real this time
+		cull_ghosts()
 
 /datum/controller/subsystem/auto_cryo/proc/cryo_mobs()
 	// Check for any targets
@@ -25,11 +29,12 @@ SUBSYSTEM_DEF(auto_cryo)
 		return
 
 	// Check possible targets
+	var/afk_time
 	for(var/mob/living/cryo_mob in GLOB.ssd_mob_list)
 
 		// Get SSD time
 		// This is set when disconnecting
-		var/afk_time = world.time - cryo_mob.lastclienttime
+		afk_time = world.time - cryo_mob.lastclienttime
 
 		// Check if client meets the time requirement
 		if(afk_time < SUBSYSTEM_CRYO_TIME)
@@ -44,6 +49,32 @@ SUBSYSTEM_DEF(auto_cryo)
 		// Log cryo interaction
 		log_game("[cryo_mob] was sent to cryo after being SSD for [afk_time] ticks.")
 
+//BLUEMOON REWORKED теперь реально удаляем гостов
+/datum/controller/subsystem/auto_cryo/proc/cull_ghosts()
+	// Check for any targets
+	if(!LAZYLEN(GLOB.dead_mob_list))
+		return
+
+	// Check possible targets
+	var/afk_time = 0
+	for(var/mob/dead/observer/ghost_mob in GLOB.dead_mob_list)
+		// Get SSD time
+		// This is set when disconnecting
+		afk_time = world.time - ghost_mob.lastclienttime
+
+		// Check if client meets the time requirement
+		if(ghost_mob.client || afk_time < SUBSYSTEM_CRYO_GHOST_PERIOD)
+			continue
+
+		// Log del interaction
+		log_game("[ghost_mob] was deleted after being SSD for [afk_time] ticks.")
+
+		// Send to valhalla
+		qdel(ghost_mob)
+//BLUEMOON REWORKED END
+
 // Remove defines
 #undef SUBSYSTEM_CRYO_CAN_RUN
+#undef SUBSYSTEM_CRYO_CHECK_GHOSTS
 #undef SUBSYSTEM_CRYO_TIME
+#undef SUBSYSTEM_CRYO_GHOST_PERIOD


### PR DESCRIPTION
Фикс пары рантаймов при попытке удалить госта
Удаление госта теперь чистить его клиента и отправляет его в лобби (теперь можно удалять гостов и это реально будет работать)
Автокрио теперь корректно удаляет гостов и они удаляются из любых список (да, боле без мёртвых душ)