### PR TITLE
No negative moodlet for kinky restrains

### DIFF
--- a/modular__juicy/code/game/objects/items/weapons/bondage_cuffs.dm
+++ b/modular__juicy/code/game/objects/items/weapons/bondage_cuffs.dm
@@ -5,6 +5,7 @@
 	icon_state = "silk_ribbon"
 	custom_materials = null
 	breakouttime = 450 //Deciseconds = 45s
+	demoralize_criminals = FALSE //Негативный moodlet всех restrains/
 
 /obj/item/restraints/handcuffs/cable/silk_ribbon/attack_self() //Not cable
 	return
@@ -49,6 +50,7 @@
 	icon_state = "cuff_rope"
 	custom_materials = null
 	breakouttime = 450 //Deciseconds = 45s
+	demoralize_criminals = FALSE //Негативный moodlet всех restrains/
 
 /obj/item/restraints/handcuffs/cable/rope/attack_self() //Not cable
 	return
@@ -60,6 +62,7 @@
 	icon_state = "cuff_belts"
 	custom_materials = null
 	breakouttime = 450 //Deciseconds = 45s
+	demoralize_criminals = FALSE //Негативный moodlet всех restrains/
 
 /obj/item/restraints/handcuffs/cable/belts/attack_self() //Not cable
 	return

--- a/modular_splurt/code/game/objects/items/lewd_items/rope.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/rope.dm
@@ -37,6 +37,7 @@ GLOBAL_LIST_INIT(bondage_rope_slowdowns, list(
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 600 //Deciseconds = 60s = 1 minute
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
+	demoralize_criminals = FALSE //Негативный moodlet всех restrains/
 	var/cuffsound = 'modular_splurt/sound/lewd/rope.ogg'
 	var/rope_target = ROPE_TARGET_HANDS_IN_FRONT
 	var/rope_state = ROPE_STATE_UNTIED


### PR DESCRIPTION
Кинковые/фетишные стяжки разного рода и цветов теперь не дают негативный мудлет настроению, по запросу [предложки](https://discord.com/channels/875735187449847830/1288581273987842100/1288581273987842100) с внушительными ~30 апвоутами. А именно:
- Silk ribbon;
- Rope (Кабельная, не был уверен, но решил включить эту тоже);
- Suspending belts;
- Bondage rope.

Обычные наручники и кинковые настоящие наручники работают как раньше. Код откомментировал. Выйдет как приятное дополнение игрокам с квирком любителя бондажа.

![Handcuffs](https://github.com/user-attachments/assets/9bc0fa85-2705-4a77-976b-a34e1103a316)
