### PR TITLE
Layer machinery fix

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -590,7 +590,7 @@
 	has_panel_overlay = FALSE
 	amount = 10
 	pixel_y = 6
-	layer = WALL_OBJ_LAYER
+	layer = BELOW_OBJ_LAYER
 	circuit = /obj/item/circuitboard/machine/chem_dispenser/drinks
 	working_state = null
 	nopower_state = null


### PR DESCRIPTION
Выставил `chem_dispenser/drinks` слой-layer как у, например, автолата, чтобы прислоняющиеся к столику бармены не стояли с ними "на плечах".