### PR TITLE
Альтнейм: AC детектив

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_splurt/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -387,6 +387,7 @@
 		"Slutective",
 		"Studective",
 		"Van Dorn Agent",
+		"AC Recon Agent",
 		"Forensic Investigator",
 		"Cinder Dick",
 		"Cooperate Auditor"


### PR DESCRIPTION
Новый альт нейм для детектива, AC Recon Agent - "Агент АС по разведке" (У всего состава брига, кроме детектива, были альтнеймы тематики АС).

Оговорено с Они, как автором этой кеткринской ЧВК.