### PR TITLE
Карта синдиката из лодаута:

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/infested_frigate.dmm
@@ -873,7 +873,7 @@
 /obj/item/pickaxe/emergency,
 /obj/item/storage/toolbox/inteq,
 /obj/item/bedsheet/inteq,
-/obj/effect/spawner/lootdrop/trader/illigal{
+/obj/effect/spawner/lootdrop/trader/illegal{
 	lootcount = 2
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/bluemoon/ftu_tradeship.dmm
+++ b/_maps/shuttles/bluemoon/ftu_tradeship.dmm
@@ -32,7 +32,7 @@
 	req_access_txt = "208";
 	name = "Не показывать"
 	},
-/obj/effect/spawner/lootdrop/trader/illigal,
+/obj/effect/spawner/lootdrop/trader/illegal,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/ftu_trade)
 "bz" = (

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -788,7 +788,7 @@
 		/obj/item/clothing/head/maid/syndicate/civil = 5,
 		/obj/item/clothing/head/helmet/swat/ds/civil = 5,
 		/obj/item/clothing/head/hats/warden/syndicate/civil = 5,
-		/obj/item/card/id/syndicate/one_access_copy = 5
+		/obj/item/card/id/syndicate/civilian/vending = 5
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/syndie_wardrobe/civil
 	light_color = COLOR_MOSTLY_PURE_RED

--- a/modular_bluemoon/Ren/Code/FTU/loot.dm
+++ b/modular_bluemoon/Ren/Code/FTU/loot.dm
@@ -182,8 +182,8 @@
 			/obj/item/ammo_box/magazine/smgm9mm
 	)
 
-/obj/effect/spawner/lootdrop/trader/illigal
-	name = "illigal product"
+/obj/effect/spawner/lootdrop/trader/illegal
+	name = "illegal product"
 	lootcount = 12
 	loot = list(
 			/obj/item/grenade/clusterbuster/smoke,

--- a/modular_bluemoon/fingerprinter/fingerprinter.dm
+++ b/modular_bluemoon/fingerprinter/fingerprinter.dm
@@ -34,7 +34,7 @@
 	. += span_info("Toggle modes by using the fingerprinter in hand.<br>\
 		While on <b>\"Read\"</b> mode, use the tool on someone or something that has prints on it to add all the prints to the tool's print database.<br>\
 		While on <b>\"Plant\"</b> mode, use the tool on anything to add any prints from the database on it.")
-	. += span_warning("The device is forbidden and illigal to use in almost all nations and private organizations, including the Pact.")
+	. += span_warning("The device is forbidden and illegal to use in almost all nations and private organizations, including the Pact.")
 
 /obj/item/device/fingerprinter/attack_self(mob/user)
 	. = ..()

--- a/modular_bluemoon/station_agents_cards/cards_id.dm
+++ b/modular_bluemoon/station_agents_cards/cards_id.dm
@@ -4,12 +4,12 @@
 /obj/item/card/id/syndicate/civilian
 	name = "civilian agent card"
 	desc = "A card used to provide ID and determine access across the station. It has a small graved in label, marking it as \"One-Use Electromagnetic Access Copier Device\". \
-	<span class='danger'>The technology is well known and illigal to use in almost all nations and private organizations, but seems like the Pact solds them as souvenirs at its territory.</span>"
+	<span class='danger'>The technology is well known and illegal to use in almost all nations and private organizations, but seems like the Pact solds them as souvenirs at its territory.</span>"
 	uses = 1
 
 /obj/item/card/id/syndicate/civilian/vending // для раздатчиков
 	desc = "A card used to provide ID and determine access across the station. It has a small graved in label, marking it as \"Appearence Changing ID\". \
-	<span class='danger'>The technology is well known and illigal to use in almost all nations and private organizations, but seems like the Pact solds them as souvenirs at its territory.</span>"
+	<span class='danger'>The technology is well known and illegal to use in almost all nations and private organizations, but seems like the Pact solds them as souvenirs at its territory.</span>"
 	uses = 0
 
 /obj/item/card/id/syndicate/civilian/vending/loadout // для лодаута, сохраняем описание карты из автомата

--- a/modular_bluemoon/station_agents_cards/cards_id.dm
+++ b/modular_bluemoon/station_agents_cards/cards_id.dm
@@ -1,6 +1,46 @@
 /obj/item/card/id/syndicate
 	var/uses = 10 // Даём гражданской Синди-Карте одно использование вместо десяти.
 
-/obj/item/card/id/syndicate/one_access_copy
-	name = "Civilian Agent Card"
+/obj/item/card/id/syndicate/civilian
+	name = "civilian agent card"
+	desc = "A card used to provide ID and determine access across the station. It has a small graved in label, marking it as \"One-Use Electromagnetic Access Copier Device\". \
+	<span class='danger'>The technology is well known and illigal to use in almost all nations and private organizations, but seems like the Pact solds them as souvenirs at its territory.</span>"
 	uses = 1
+
+/obj/item/card/id/syndicate/civilian/vending // для раздатчиков
+	desc = "A card used to provide ID and determine access across the station. It has a small graved in label, marking it as \"Appearence Changing ID\". \
+	<span class='danger'>The technology is well known and illigal to use in almost all nations and private organizations, but seems like the Pact solds them as souvenirs at its territory.</span>"
+	uses = 0
+
+/obj/item/card/id/syndicate/civilian/vending/loadout // для лодаута, сохраняем описание карты из автомата
+	var/registred = FALSE
+
+// Используется именно такая функция, т.к. при выдаче через лодаут карта помещается в рюкзак
+/obj/item/card/id/syndicate/civilian/vending/loadout/on_enter_storage()
+	if(!registred)
+		var/mob/living/carbon/human/my_owner = null
+
+		if(ishuman(loc.loc)) // Если карта появляется в сумке
+			my_owner = loc.loc
+		if(ishuman(loc)) // Если карта в кармане или где угодно, но на персонаже
+			my_owner = loc
+
+		if(my_owner) // копирование свойств старой карты и её замена
+			var/obj/item/card/id/id_card = my_owner.get_item_by_slot(ITEM_SLOT_ID)
+			if(id_card?.access.len)
+				access |= id_card.access
+				assignment = id_card.assignment
+				registered_account = id_card.registered_account
+				rank = id_card.rank
+				registered_name = id_card.registered_name
+				name = id_card.name
+				update_icon()
+
+				qdel(id_card)
+				my_owner.equip_to_slot_if_possible(src, ITEM_SLOT_ID, disable_warning = TRUE, bypass_equip_delay_self = TRUE)
+
+		registred = TRUE
+
+		if(src != my_owner.get_item_by_slot(ITEM_SLOT_ID)) // Если в будущем что-то переделают и карта будет спавниться в отдельной коробке или вроде того
+			visible_message(span_warning("ID карта из лодаута не нашла цель для копирования доступа, сообщите разработчикам."))
+	. = ..()

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -86,7 +86,7 @@
 /datum/gear/donator/agent_card
 	name = "Agent Card (without microscanners)" //BLUEMOON CHANGES
 	slot = ITEM_SLOT_BACKPACK
-	path = /obj/item/card/id/syndicate/one_access_copy //BLUEMOON CHANGES
+	path = /obj/item/card/id/syndicate/civilian/vending/loadout  //BLUEMOON CHANGES
 	ckeywhitelist = list()
 	donator_group_id = DONATOR_GROUP_TIER_1
 


### PR DESCRIPTION
# Уберите эти глупые пиццы и ASCI арты

# Суть
Карта синдиката из лодаута:
- заменяет старую карту.
- копирует свойства предыдущей карты.

Карта синдиката из раздатчика больше не может копировать доступ.

Расширен лор карт синдиката.

# Зачем?
- Меньше абуза карт на уровне "ГСБ раздаёт свой доступ всему отделу из донатеров", плюс оставляет только одну карту персонажу, убирая "запаску", которую можно кому-нибудь отдать.

![dreamseeker_A80dug3hLP](https://github.com/user-attachments/assets/6c0f2060-9353-498e-bdf6-d56f3906baea)
![KPh2urhz3u](https://github.com/user-attachments/assets/c24eec5a-441e-4568-9352-ef8008790bfb)
