### PR TITLE
Spear damage updated

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -114,7 +114,7 @@
 			AddComponent(/datum/component/two_handed, force_unwielded=11, force_wielded=19, icon_wielded="[icon_prefix]1")
 		if(/obj/item/shard/titanium)
 			force = 13
-			throwforce = 41
+			throwforce = 43
 			throw_range = 8
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/titaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
@@ -123,7 +123,7 @@
 			AddComponent(/datum/component/two_handed, force_unwielded=13, force_wielded=18, icon_wielded="[icon_prefix]1")
 		if(/obj/item/shard/plastitanium)
 			force = 13
-			throwforce = 42
+			throwforce = 43
 			throw_range = 9
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plastitaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)


### PR DESCRIPTION
### Урон копий повышен на 20 при броске. 

У обычного стеклянного копья throwforce 40 при force 10. 
Копья из других материалов, что имели throwforce 21, 21, 22, уравнены и теперь немного лучше стеклянного, в соответствии с качеством материала. Теперь они не бесполезны при бросках.

Урон стеклянного копья, урон костяного копья остался старым.
