### PR TITLE
Double fix

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -111,8 +111,8 @@
 #define FREQ_TARKOFF 1243
 
 #define RADIO_CHANNEL_DS1 "DS-1"
-#define RADIO_KEY_DS1 "q"
-#define RADIO_TOKEN_DS1 ":q"
+#define RADIO_KEY_DS1 "a"
+#define RADIO_TOKEN_DS1 ":a"
 #define FREQ_DS1 1210
 
 #define RADIO_CHANNEL_DS2 "DS-2"

--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -111,8 +111,8 @@
 #define FREQ_TARKOFF 1243
 
 #define RADIO_CHANNEL_DS1 "DS-1"
-#define RADIO_KEY_DS1 "a"
-#define RADIO_TOKEN_DS1 ":a"
+#define RADIO_KEY_DS1 "q"
+#define RADIO_TOKEN_DS1 ":q"
 #define FREQ_DS1 1210
 
 #define RADIO_CHANNEL_DS2 "DS-2"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -57,6 +57,10 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Faction
 	"е" = RADIO_CHANNEL_SYNDICATE,
 	"н" = RADIO_CHANNEL_CENTCOM,
+	// Ghostrole
+	"ф" = RADIO_CHANNEL_DS1,
+	"ц" = RADIO_CHANNEL_DS2,
+	"й" = RADIO_CHANNEL_HOTEL,
 
 	// Admin
 	"з" = MODE_ADMIN,

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -59,8 +59,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	"н" = RADIO_CHANNEL_CENTCOM,
 	// Ghostrole
 	"ф" = RADIO_CHANNEL_DS1,
-	"ц" = RADIO_CHANNEL_DS2,
-	"й" = RADIO_CHANNEL_HOTEL,
+	"й" = RADIO_CHANNEL_DS2,
 
 	// Admin
 	"з" = MODE_ADMIN,

--- a/modular_bluemoon/SmiLeY/inteq_ghostrole/forgottenship.dm
+++ b/modular_bluemoon/SmiLeY/inteq_ghostrole/forgottenship.dm
@@ -464,6 +464,9 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 	desc = "Стандартный наушник InteQ."
 	icon_state = "inteq_headset"
 	item_state = "inteq_headset"
+	icon = 'modular_bluemoon/kovac_shitcode/icons/solfed/obj_sol_head.dmi'
+	mob_overlay_icon = 'modular_bluemoon/kovac_shitcode/icons/solfed/mob_sol_head.dmi'
+	radiosound = 'modular_bluemoon/kovac_shitcode/sound/radio.ogg'
 
 /obj/item/radio/headset/ghost_inteq/leader
 	name = "InteQ Headset"
@@ -471,6 +474,3 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 	icon_state = "inteq_headset_alt"
 	item_state = "inteq_headset_alt"
 	bowman = TRUE
-	icon = 'modular_bluemoon/kovac_shitcode/icons/solfed/obj_sol_head.dmi'
-	mob_overlay_icon = 'modular_bluemoon/kovac_shitcode/icons/solfed/mob_sol_head.dmi'
-	radiosound = 'modular_bluemoon/kovac_shitcode/sound/radio.ogg'


### PR DESCRIPTION
### Мелкие фиксы

- Исправлены спрайты наушника/headset гост-интекью. Раньше он не отображался в руке, на земле и на кукле, не имел уникального звукового эффекта рации. Подробнее смотреть по изменению в файле.
- Добавлены хоткеи :й и :ц для ДС-1 и ДС-2 соответственно. Теперь работает :w хоткей для ДС-2 канала.

К сожалению, я не смог заставить воспринимать хоткей для ДС-1 в английской раскладке (:q не работает). 
Более того, оно не работало даже при смене клавиши q (Занятой Каарен в файле `\code\__DEFINES\say.dm` и отелем в `\code\__DEFINES\radio.dm`) на другую (:a в моём случае).

Работает русский аналог, что я, считаю, тоже хорошо.
