### PR TITLE
Фикс попыток посадить сверхтяжа

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -93,6 +93,15 @@
 		return FALSE
 	// BLUEMOON ADD END
 
+	// BLUEMOON ADD START - запрет на усаживание сверхтяжёлого персонажа посторонними
+	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER)) // проверка не раньше, т.к. в post_buckle_mob обратаюыватся объекты-исключения, на которые сверхтяжёлые персонажи садятся с особым эффектом
+		if(istype(src, /obj/structure/bed/roller/heavy)) // простая проверка на предмет, пока не появится необходимость в большем количестве предметов-исключений
+			// Всё в порядке
+		else if(M != usr)
+			to_chat(usr, span_warning("Слишком много весит!"))
+			return FALSE
+	// BLUEMOON ADD END
+
 	// if(!check_loc && M.loc != loc)
 	if(M.loc != loc)
 		M.forceMove(loc)
@@ -104,15 +113,6 @@
 	M.update_mobility()
 	M.throw_alert("buckled", /atom/movable/screen/alert/restrained/buckled)
 	post_buckle_mob(M)
-
-	// BLUEMOON ADDITION AHEAD - запрет на усаживание сверхтяжёлого персонажа посторонними
-	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER)) // проверка не раньше, т.к. в post_buckle_mob обратаюыватся объекты-исключения, на которые сверхтяжёлые персонажи садятся с особым эффектом
-		if(!M.buckled) // чтобы лишний раз не появлялось сообщение о попытке сесть
-			return FALSE
-		if(M != usr)
-			to_chat(usr, span_warning("Слишком много весит!"))
-			return FALSE
-	// BLUEMOON ADDITION END
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUCKLE, M, force)
 	return TRUE

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -103,7 +103,7 @@
 		usr.put_in_hands(B)
 		qdel(src)
 
-// BLUEMOON ADD AHEAD - сверхтяжёлых персонажей нельзя помещать на носилки (предотвращает абуз через толкание + повышает значимость боргов, халков и других сверхтяжёлых персонажей)
+// BLUEMOON ADD AHEAD - сверхтяжёлых персонажей нельзя помещать на обычные носилки (предотвращает абуз через толкание + повышает значимость боргов, халков и других сверхтяжёлых персонажей)
 /obj/structure/bed/roller/pre_buckle_mob(mob/living/M)
 	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER))
 		if(!can_move_superheavy_characters)
@@ -227,6 +227,14 @@
 /obj/structure/bed/dogbed/buckle_mob(mob/living/M, force, check_loc)
 	. = ..()
 	update_owner(M)
+
+// BLUEMOON ADD AHEAD - сверхтяжёлых персонажей нельзя помещать на кроватки для питомцев (потому что эти кроватки можно таскать, прямо как носилки)
+/obj/structure/bed/dogbed/pre_buckle_mob(mob/living/M)
+	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER))
+		usr.visible_message(span_warning("[usr] tried to put [M] on [src], but it is too small!"), span_warning("You try to put [M] on [src], but it is too small!"))
+		return FALSE
+	. = ..()
+// BLUEMOON ADD END
 
 /obj/structure/bed/alien
 	name = "resting contraption"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1256,6 +1256,11 @@
 		buckle_mob(M)
 
 /mob/living/silicon/robot/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
+	// BLUEMOON ADD START - дубликает проверки, т.к. функция переписывает попытку сесть
+	if(!pre_buckle_mob(M))
+		return FALSE
+	// BLUEMOON ADD END
+
 	if(!is_type_in_typecache(M, can_ride_typecache))
 		M.visible_message("<span class='warning'>[M] really can't seem to mount [src]...</span>")
 		return

--- a/code/modules/mob/living/silicon/robot/robot_mobility.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mobility.dm
@@ -16,11 +16,10 @@
 
 // BLUEMOON ADD START - киборги не могут брать сверхтяжёлых персонажей на свой корпус
 /mob/living/silicon/robot/pre_buckle_mob(mob/living/M)
-	. = ..()
 	if(HAS_TRAIT(M, TRAIT_BLUEMOON_HEAVY_SUPER))
 		usr.visible_message(span_warning("<b>[usr]</b> tried to put <b>[M]</b> on its sheel, but [M.p_they()] weight too much!."), \
 							span_warning("You tried to put <b>[M]</b> on yourself, but your system reported about weight overload. Abort!"), target = M,
 							target_message = span_notice("<b>[M]</b> tried to take you on [src]'s shell, but looks like you weight too much for them!"))
-		unbuckle_mob(M, TRUE)
-		return
+		return FALSE
+	. = ..()
 // BLUEMOON ADD END


### PR DESCRIPTION
# УБЕРИТЕ ЭТИ ГЛУПЫЕ ПИЦЦЫ И NSFW СПРАЙТЫ, ЭТО ГИТХАБ

Сверхтяжёлых персонажей снова нельзя укладывать на объекты, которые для них не предназначены