### PR TITLE
Фикс рескина тайлов в гриппере боргов

### DIFF
--- a/modular_splurt/code/game/objects/items/stacks/tiles/tile_reskinning.dm
+++ b/modular_splurt/code/game/objects/items/stacks/tiles/tile_reskinning.dm
@@ -2,12 +2,21 @@
 /obj/item/stack/tile/attack_self(mob/user)
 	if(!tile_reskin_types)
 		return ..()
-	var/obj/item/stack/tile/choice = show_radial_menu(user, src, tile_reskin_types, radius = 48, require_near = TRUE)
+	var/anchor = src
+	if(istype(loc, /obj/item/gripper)) // Incase reskin in cyborg gripper
+		anchor = loc
+	var/obj/item/stack/tile/choice = show_radial_menu(user, anchor, tile_reskin_types, radius = 48, require_near = TRUE)
 	if (!choice || choice == type)
+		return
+	if(anchor == loc && !istype(loc, /obj/item/gripper)) // Double check after choice
 		return
 	choice = new choice(user.drop_location(), amount)
 	if (!QDELETED(choice))	// If the tile merged with floor tiles as a borg, you're fucked.
-		if (istype(user, /mob/living/silicon/robot))	// This is where the changes start. Find out if we're a borgo
+		if(istype(loc, /obj/item/gripper))
+			var/obj/item/gripper/GP = loc
+			moveToNullspace()
+			GP.takeitem(choice, TRUE)
+		else if (istype(user, /mob/living/silicon/robot) )	// This is where the changes start. Find out if we're a borgo
 			var/mob/living/silicon/robot/R = user		// I want intellisense, give it to me.
 			var/selected_module = R.get_selected_module()	// Store the selected module
 			R.deselect_module(selected_module)			// Deactivate the selected module so we don't cry about it later


### PR DESCRIPTION
Фикс рескина плитки когда ту держит борг.
1) пофикшено расположение меню (теперь оно всегда на персонаже)
2) пофикшено превращение плитки в сломанный модуль, от чего плитка застревала в модулях борга мёртвым грузом