### PR TITLE
Навыки проводки и видимость проводки инженерам и робототехникам

### DIFF
--- a/code/datums/skills/modifiers/job.dm
+++ b/code/datums/skills/modifiers/job.dm
@@ -35,8 +35,14 @@
 /datum/skill_modifier/job/level/wiring/basic
 	level_mod = JOB_SKILL_BASIC
 
+/datum/skill_modifier/job/level/wiring/trained // BLUEMOON ADD
+	level_mod = JOB_SKILL_TRAINED
+
 /datum/skill_modifier/job/level/wiring/expert
 	level_mod = JOB_SKILL_EXPERT
+
+/datum/skill_modifier/job/level/wiring/master //BLUEMOON ADD... Why wasn't it there while we have had master machinery for hacking?
+	level_mod = JOB_SKILL_MASTER
 
 /datum/skill_modifier/job/level/dwarfy/blacksmithing
 	target_skills = /datum/skill/level/dwarfy/blacksmithing

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -34,6 +34,8 @@
 	var/req_skill = JOB_SKILL_BASIC //used in user's cutting/pulsing/mending speed calculations.
 	var/list/current_users //list of untrained people currently interacting with this set of wires.
 
+	var/visibility_trait = null //BLUEMOON ADD use of TRAIT system for /datum/wires/* machinery
+
 /datum/wires/New(atom/holder)
 	..()
 	if(!istype(holder, holder_type))
@@ -263,6 +265,10 @@
 
 	// Admin ghost can see a purpose of each wire.
 	if(IsAdminGhost(user) || user.mind.get_skill_level(/datum/skill/level/job/wiring) >= req_knowledge)
+		reveal_wires = TRUE
+
+	// BLUEMOON ADD engineers, roboticist with required TRAIT can see a purpose of wire for needed machinery
+	if (visibility_trait && HAS_TRAIT(user.mind, visibility_trait))
 		reveal_wires = TRUE
 
 	// Same for anyone with an abductor multitool.

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/airalarm
 	proper_name = "Air Alarm"
 	req_knowledge = JOB_SKILL_MASTER
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 
 /datum/wires/airalarm/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/door/airlock
 	proper_name = "Generic Airlock"
 	req_skill = JOB_SKILL_UNTRAINED //Training wheel, as per request.
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 	var/wiretype
 
 /datum/wires/airlock/secure

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/power/apc
 	proper_name = "APC"
 	req_knowledge = JOB_SKILL_MASTER
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 
 /datum/wires/apc/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/autolathe
 	proper_name = "Autolathe"
 	req_knowledge = JOB_SKILL_EXPERT
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 
 /datum/wires/autolathe/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/emitter.dm
+++ b/code/datums/wires/emitter.dm
@@ -3,6 +3,7 @@
 	holder_type = /obj/machinery/power/emitter
 	req_knowledge = JOB_SKILL_TRAINED
 	req_skill = JOB_SKILL_UNTRAINED
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 
 /datum/wires/emitter/New(atom/holder)
 	wires = list(WIRE_ZAP,WIRE_HACK)

--- a/code/datums/wires/mod.dm
+++ b/code/datums/wires/mod.dm
@@ -3,6 +3,7 @@
 	proper_name = "MOD control unit"
 	req_knowledge = JOB_SKILL_MASTER
 	req_skill = JOB_SKILL_TRAINED
+	visibility_trait = TRAIT_KNOW_CYBORG_WIRES // BLUEMOON ADD
 
 /datum/wires/mod/New(atom/holder)
 	wires = list(WIRE_DISABLE, WIRE_SHOCK, WIRE_INTERFACE)

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -2,6 +2,7 @@
 	holder_type = /mob/living/simple_animal/bot/mulebot
 	randomize = TRUE
 	req_knowledge = JOB_SKILL_MASTER
+	visibility_trait = TRAIT_KNOW_CYBORG_WIRES // BLUEMOON ADD
 
 /datum/wires/mulebot/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -3,6 +3,7 @@
 	proper_name = "Particle Accelerator"
 	req_knowledge = JOB_SKILL_EXPERT
 	req_skill = JOB_SKILL_TRAINED
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 
 /datum/wires/particle_accelerator/control_box/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -3,6 +3,7 @@
 	randomize = TRUE
 	req_knowledge = JOB_SKILL_MASTER
 	req_skill = JOB_SKILL_TRAINED
+	visibility_trait = TRAIT_KNOW_CYBORG_WIRES // BLUEMOON ADD
 
 /datum/wires/robot/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/vending
 	proper_name = "Vending Unit"
 	req_knowledge = JOB_SKILL_EXPERT
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES // BLUEMOON ADD
 
 /datum/wires/vending/New(atom/holder)
 	wires = list(

--- a/code/modules/jobs/job_types/command/chief_engineer.dm
+++ b/code/modules/jobs/job_types/command/chief_engineer.dm
@@ -33,7 +33,9 @@
 	paycheck_department = ACCOUNT_ENG
 	bounty_types = CIV_JOB_ENG
 
-	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring)
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/master, /datum/skill_modifier/job/affinity/wiring) //BLUEMOON CHANGE job/level to master
+
+	mind_traits = list(TRAIT_KNOW_ENGI_WIRES) //BLUEMOON ADD use #define TRAIT system
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_ENGINEER
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/insanity, /datum/quirk/bluemoon_criminal)

--- a/code/modules/jobs/job_types/command/research_director.dm
+++ b/code/modules/jobs/job_types/command/research_director.dm
@@ -37,6 +37,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_RESEARCH_DIRECTOR
 	starting_modifiers = list(/datum/skill_modifier/job/level/wiring)
+	mind_traits = list(TRAIT_KNOW_CYBORG_WIRES) //BLUEMOON ADD use #define TRAIT system
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/insanity, /datum/quirk/bluemoon_criminal)
 	threat = 5
 

--- a/code/modules/jobs/job_types/engineer/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/engineer/atmospheric_technician.dm
@@ -23,7 +23,7 @@
 	bounty_types = CIV_JOB_ENG
 	departments = DEPARTMENT_BITFLAG_ENGINEERING
 
-	starting_modifiers = list(/datum/skill_modifier/job/level/wiring, /datum/skill_modifier/job/affinity/wiring)
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/trained, /datum/skill_modifier/job/affinity/wiring) //BLUEMOON CHANGE job/level to trained
 
 	display_order = JOB_DISPLAY_ORDER_ATMOSPHERIC_TECHNICIAN
 	threat = 0.5

--- a/code/modules/jobs/job_types/engineer/station_engineer.dm
+++ b/code/modules/jobs/job_types/engineer/station_engineer.dm
@@ -23,7 +23,9 @@
 	bounty_types = CIV_JOB_ENG
 	departments = DEPARTMENT_BITFLAG_ENGINEERING
 
-	starting_modifiers = list(/datum/skill_modifier/job/level/wiring, /datum/skill_modifier/job/affinity/wiring)
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring) //BLUEMOON CHANGE job/level to expert
+
+	mind_traits = list(TRAIT_KNOW_ENGI_WIRES) //BLUEMOON ADD use #define TRAIT system
 
 	display_order = JOB_DISPLAY_ORDER_STATION_ENGINEER
 

--- a/code/modules/jobs/job_types/research/roboticist.dm
+++ b/code/modules/jobs/job_types/research/roboticist.dm
@@ -23,6 +23,8 @@
 
 	starting_modifiers = list(/datum/skill_modifier/job/level/wiring, /datum/skill_modifier/job/affinity/wiring)
 
+	mind_traits = list(TRAIT_KNOW_CYBORG_WIRES) //BLUEMOON ADD use #define TRAIT system
+
 	display_order = JOB_DISPLAY_ORDER_ROBOTICIST
 	threat = 1
 

--- a/modular_sand/code/datums/wires/firealarm.dm
+++ b/modular_sand/code/datums/wires/firealarm.dm
@@ -2,6 +2,7 @@
 	holder_type = /obj/machinery/firealarm
 	proper_name = "Fire alarm's"
 	req_knowledge = JOB_SKILL_MASTER
+	visibility_trait = TRAIT_KNOW_ENGI_WIRES //BLUEMOON ADD
 
 /datum/wires/firealarm/New(atom/holder)
 	wires = list(
@@ -37,7 +38,7 @@
 			A.detecting = !A.detecting
 		if(WIRE_FIRE_TRIGGER)
 			A.alarm()
-			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/firealarm, reset), wire), 1000)				
+			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/firealarm, reset), wire), 1000)
 
 /datum/wires/firealarm/on_cut(index, mend)
 	var/obj/machinery/firealarm/A = holder


### PR DESCRIPTION
### Первое
 Трейты `TRAIT_KNOW_ENGI_WIRES` и `TRAIT_KNOW_CYBORG_WIRES` теперь задействованы в коде и позволяют видеть значения цветов проводов раундстарт/прилетевшим инженерам, робототехникам. Теперь **квалифицированные** специалисты действительно обучены.
- Mulebot, MOD, cyborg - для робототехника и РД;
- Airlock и куча машинерии - для инженеров и СЕ.

Для этого этим профессиям добавлен соответствующий трейт через `mind_traits =`. 

![WIRES](https://github.com/user-attachments/assets/7b8ccc1f-fa09-4de6-8e73-74074ef2116d)

### Второе
В `/datum/skill_modifier/job/level/wiring` теперь добавлены градации скилла `trained` и `master`, поскольку есть машины, требующие для видимости проводки таких значений (Микроволновка для trained, например; master для киборга и АПЦ). 
- Теперь атмосферный техник обучен проводке на уровне `trained`, обычный инженер как `expert` и СЕ как `master`. Basic нет ни у кого (Возможно, есть смысл добавить робототехнику, но я лично не увидел);
- Роботех и РД не имеют данной квалификации и должны тренировать этот навык. Ранее код **уже** имел мультипликатор-бонус к этой тренировке для них, fun fact.