### PR TITLE
Карты с позывным вместо гражданских кард агентов

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -23,7 +23,12 @@
 		var/obj/item/clothing/neck/petcollar/collar = wear_neck
 		if(collar.tagname)
 			collar_tagname = " \[[collar.tagname]\]"
-	. = list("<span class='info'>Это - <EM>[!obscure_name ? name : "Неизвестный"][collar_tagname]</EM>!")
+	var/id_card_callsign_name = ""
+	if(istype(wear_id?.GetID(), /obj/item/card/id/callsign))
+		var/obj/item/card/id/callsign/callsign_id = wear_id?.GetID()
+		if(callsign_id.callsign)
+			id_card_callsign_name = " \[[callsign_id.callsign]\]"
+	. = list("<span class='info'>Это - <EM>[!obscure_name ? name : "Неизвестный"][collar_tagname][id_card_callsign_name]</EM>!")
 	if(skipface || get_visible_name() == "Unknown")
 		. += "Вы не можете разобрать, к какому виду относится находящееся перед вами существо."
 	else

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -789,7 +789,7 @@
 		/obj/item/clothing/head/maid/syndicate/civil = 5,
 		/obj/item/clothing/head/helmet/swat/ds/civil = 5,
 		/obj/item/clothing/head/hats/warden/syndicate/civil = 5,
-		/obj/item/card/id/syndicate/civilian/vending = 5
+		/obj/item/card/id/callsign = 5
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/syndie_wardrobe/civil
 	light_color = COLOR_MOSTLY_PURE_RED

--- a/modular_bluemoon/phoenix404/modules/vending/wardrobes.dm
+++ b/modular_bluemoon/phoenix404/modules/vending/wardrobes.dm
@@ -922,7 +922,7 @@
 		/obj/item/clothing/head/maid/syndicate/civil = 5,
 		/obj/item/clothing/head/helmet/swat/ds/civil = 5,
 		/obj/item/clothing/head/hats/warden/syndicate/civil = 5,
-		/obj/item/card/id/syndicate/civilian/vending = 5
+		/obj/item/card/id/callsign = 5
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/syndie_wardrobe/civil
 	light_color = COLOR_MOSTLY_PURE_RED

--- a/modular_bluemoon/station_agents_cards/cards_id.dm
+++ b/modular_bluemoon/station_agents_cards/cards_id.dm
@@ -1,23 +1,64 @@
 /obj/item/card/id/syndicate
 	var/uses = 10 // Даём гражданской Синди-Карте одно использование вместо десяти.
 
-/obj/item/card/id/syndicate/civilian
-	name = "civilian agent card"
-	desc = "A card used to provide ID and determine access across the station. It has a small graved in label, marking it as \"One-Use Electromagnetic Access Copier Device\". \
-	<span class='danger'>The technology is well known and illegal to use in almost all nations and private organizations, but seems like the Pact sells them as souvenirs at its territory.</span>"
-	uses = 1
-	anyone = TRUE // все могут изменять характеристики
+/obj/item/card/id/callsign
+	name = "сallsign id card"
+	desc = "A card used to provide ID and determine access across various facilities. This one belongs to NanoTrasen and has a small graved in label, marking it as \"Callsing Changing ID\"."
+	icon_state = "card_black"
+	assignment = "All-Callsigns-Check-In"
+	var/forged = FALSE //have we set a custom name and job assignment, or will we use what we're given when we chameleon change?
+	var/callsign = ""
 
-/obj/item/card/id/syndicate/civilian/vending // для раздатчиков
-	desc = "A card used to provide ID and determine access across the station. It has a small graved in label, marking it as \"Appearence Changing ID\". \
-	<span class='danger'>The technology is well known and illegal to use in almost all nations and private organizations, but seems like the Pact sells them as souvenirs at its territory.</span>"
-	uses = 0
+/obj/item/card/id/callsign/Initialize(mapload)
+	. = ..()
+	var/datum/action/item_action/chameleon/change/chameleon_action = new(src)
+	chameleon_action.chameleon_type = /obj/item/card/id
+	chameleon_action.chameleon_name = "ID Card"
+	chameleon_action.initialize_disguises()
 
-/obj/item/card/id/syndicate/civilian/vending/loadout // для лодаута, сохраняем описание карты из автомата
+/obj/item/card/id/callsign/attack_self(mob/user)
+	if(isliving(user) && user.mind)
+
+		var/popup_input
+		popup_input = alert(user, "Choose Action", "Callsign ID", "Show", "Forge/Reset")
+		if(!user.canUseTopic(src, BE_CLOSE, FALSE))
+			return
+		if(popup_input == "Forge/Reset" && !forged)
+			var/desired_callsign = stripped_input(user, "What callsign would you like to put on this card? Leave blank to remove.", "Callsign card", callsign, MAX_NAME_LEN)
+			desired_callsign = reject_bad_name(desired_callsign)
+			if(!desired_callsign)
+				desired_callsign = ""
+
+			callsign = desired_callsign
+
+			update_label()
+			forged = TRUE
+			to_chat(user, "<span class='notice'>You successfully forge the ID card.</span>")
+			return
+		else if (popup_input == "Forge/Reset" && forged)
+			callsign = ""
+
+			update_label()
+			forged = FALSE
+			to_chat(user, "<span class='notice'>You successfully reset the ID card.</span>")
+			return
+	return ..()
+
+/obj/item/card/id/callsign/update_label(newname, newjob)
+	if(newname || newjob)
+		name = "[(!newname)	? "identification card"	: "[newname] - ID Card"][(!newjob) ? "" : " ([newjob])"]"
+		update_icon()
+		return
+
+	name = "[(!registered_name)	? "identification card"	: "[registered_name] [callsign ? "'[callsign]'" : ""] - ID Card"][(!assignment) ? "" : " ([assignment])"]"
+
+	update_icon()
+
+/obj/item/card/id/callsign/loadout
 	var/registred = FALSE
 
 // Используется именно такая функция, т.к. при выдаче через лодаут карта помещается в рюкзак
-/obj/item/card/id/syndicate/civilian/vending/loadout/on_enter_storage()
+/obj/item/card/id/callsign/loadout/on_enter_storage()
 	if(!registred)
 		var/mob/living/carbon/human/my_owner = null
 
@@ -29,8 +70,15 @@
 		if(my_owner) // копирование свойств старой карты и её замена
 			var/obj/item/card/id/id_card = my_owner.get_item_by_slot(ITEM_SLOT_ID)
 
-			if(istype(id_card, /obj/item/card/id/inteq) || istype(id_card, /obj/item/card/id/syndicate) || istype(id_card, /obj/item/card/id/prisoner))
-				to_chat(my_owner, span_warning("Ваша карта уже обладает свойствами, доступными гражданской карте синдиката или принадлежит заключенному! Лишняя была удалена."))
+			// Если взять эту карту из лодаута и зайти на авейку, она может удалить старую карту у персонажа, что приведёт к нежелательным последствиям
+			if(istype(id_card, /obj/item/card/id/inteq) || istype(id_card, /obj/item/card/id/syndicate))
+				to_chat(my_owner, span_warning("Ваша карта уже обладает свойствами, доступными гражданской карте синдиката! Лишняя была удалена."))
+				qdel(src)
+				return
+
+			// Зэкам эта карта не положена
+			if(istype(id_card, /obj/item/card/id/prisoner))
+				to_chat(my_owner, span_warning("Ваша основная карта принадлежит заключенному! Лишняя была удалена."))
 				qdel(src)
 				return
 

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -84,9 +84,9 @@
 	donator_group_id = DONATOR_GROUP_TIER_1
 
 /datum/gear/donator/agent_card
-	name = "Agent Card (without microscanners)" //BLUEMOON CHANGES
+	name = "Callsign ID Card" //BLUEMOON CHANGES
 	slot = ITEM_SLOT_BACKPACK
-	path = /obj/item/card/id/syndicate/civilian/vending/loadout  //BLUEMOON CHANGES
+	path = /obj/item/card/id/callsign/loadout  //BLUEMOON CHANGES
 	ckeywhitelist = list()
 	donator_group_id = DONATOR_GROUP_TIER_1
 


### PR DESCRIPTION
# Описание
Замена кард агентов из лоадута и автомата на карты с позывным.

От кард агентов отличаются тем, что имеют отличительный путь, не имеют доступа синдиката, не могут копировать доступ.

Могут изменять свой позывной (НЕ ИМЯ) и внешний вид.


- [X] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу. - ДЛЯ ТАКГО ЕСТЬ СТЕЙТ ДРАФТА
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

https://discord.com/channels/875735187449847830/1310986350668939274

## Демонстрация изменений

![dreamseeker_Qa3EUgnMAT](https://github.com/user-attachments/assets/011be4db-4ee1-43e6-8e3d-a59b52a1abed)
![dreamseeker_IF7qGZ6pce](https://github.com/user-attachments/assets/de93066e-79f6-4fd7-b7ac-725248cffff5)
![dreamseeker_ksddiPbsFi](https://github.com/user-attachments/assets/69fdac9d-16e7-4c47-8269-3ae35df77167)
![dreamseeker_QpHWtzqyvC](https://github.com/user-attachments/assets/ae228423-039f-4033-8a44-ecee2ac326be)

