### PR TITLE
Фикс ночного зрения + цветка на головке

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -608,7 +608,7 @@
 		if(A.update_remote_sight(src)) //returns 1 if we override all other sight updates.
 			return
 
-	if(glasses)
+	if(glasses && istype(glasses, /obj/item/clothing/head))
 		var/obj/item/clothing/glasses/G = glasses
 		sight |= G.vision_flags
 		see_in_dark = max(G.darkness_view, see_in_dark)
@@ -618,10 +618,8 @@
 			see_invisible = min(G.invis_view, see_invisible)
 		if(!isnull(G.lighting_alpha))
 			lighting_alpha = min(lighting_alpha, G.lighting_alpha)
-	if(head)
+	if(head && istype(head, /obj/item/clothing/head))
 		var/obj/item/clothing/head/H = head
-		if(!istype(H, /obj/item/clothing/head))
-			return
 		sight |= H.vision_flags
 		see_in_dark = max(H.darkness_view, see_in_dark)
 


### PR DESCRIPTION
# Описание
Цветок не одежда, но на голове = прок прерывался из-за этого и не шёл дальше. пофиксил чтобы всё работало и теперь  ночное зрение включается когда цветок на голове

## Причина изменений
Багфиксы круто