### PR TITLE
Банкаккаунты для гостролей

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -1034,6 +1034,7 @@
 	can_load_appearance = TRUE
 	loadout_enabled = TRUE
 	computer_area = /area/ruin/space/has_grav/bluemoon/port_tarkon/centerhall
+	make_bank_account = TRUE
 
 	give_cooler_to_mob_if_synth = TRUE
 
@@ -1063,7 +1064,6 @@
 	target_radio.set_frequency(FREQ_TARKOFF)
 	target_radio.recalculateChannels()
 
-	handlebank(tarkoff)
 	return ..()
 
 /obj/effect/mob_spawn/human/tarkon/sci
@@ -1137,14 +1137,6 @@
 	gloves = /obj/item/clothing/gloves/combat
 	l_pocket = /obj/item/melee/classic_baton/telescopic
 	r_pocket = /obj/item/grenade/barrier
-
-/datum/outfit/proc/handlebank(mob/living/carbon/human/owner)
-	var/datum/bank_account/offstation_bank_account = new(owner.real_name)
-	owner.account_id = offstation_bank_account.account_id
-	if(owner.wear_id)
-		var/obj/item/card/id/id_card = owner.wear_id
-		id_card.registered_account = offstation_bank_account
-	return
 
 /obj/item/radio/headset/tarkoff
 	name = "Tarkov Headset"
@@ -1331,6 +1323,7 @@
 	use_outfit_name = TRUE
 	computer_area = /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms
 	antagonist_type = /datum/antagonist/ghost_role/ds2
+	make_bank_account = TRUE // BLUEMOON ADD
 
 /obj/effect/mob_spawn/human/ds2/prisoner
 	name = "Syndicate Prisoner"
@@ -1434,7 +1427,6 @@
 		id_card.update_label()
 		id_card.update_icon()
 
-	handlebank(syndicate)
 	return ..()
 
 //DS-2 Hostage

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -34,6 +34,8 @@
 	var/skip_reentry_check = FALSE //Skips the ghost role blacklist time for people who ghost/suicide/cryo
 	var/loadout_enabled = FALSE
 	var/can_load_appearance = FALSE
+	var/make_bank_account = FALSE // BLUEMOON ADD
+	var/starting_money = 0 // BLUEMOON ADD работает только при make_bank_account = TRUE
 
 ///override this to add special spawn conditions to a ghost role
 /obj/effect/mob_spawn/proc/allow_spawn(mob/user, silent = FALSE)
@@ -172,6 +174,8 @@
 			M.mind.assigned_role = assignedrole
 		special(M, name)
 		MM.name = M.real_name
+		if(make_bank_account)
+			handlebank(M, starting_money)
 		special_post_appearance(M, name) // BLUEMOON ADD
 	if(uses > 0)
 		uses--
@@ -247,6 +251,21 @@
 				to_chat(H, span_reallybig("Не забудьте забрать космический охладитель под собой.")) // чтобы не упустили из виду при резком спавне
 				new /obj/item/device/cooler/charged(H.loc)
 	. = ..()
+
+// Создаём банк аккаунт и всё такое
+/obj/effect/mob_spawn/proc/handlebank(mob/living/carbon/human/owner, starting_money = 0)
+	return
+
+/obj/effect/mob_spawn/human/handlebank(mob/living/carbon/human/owner, starting_money = 0)
+	var/datum/bank_account/offstation_bank_account = new(owner.real_name)
+	owner.account_id = offstation_bank_account.account_id
+	owner.add_memory("Номер вашего банковского аккаунта - [owner.account_id].")
+	if(owner.wear_id)
+		var/obj/item/card/id/id_card = owner.wear_id
+		id_card.registered_account = offstation_bank_account
+	if(starting_money > 0)
+		offstation_bank_account.account_balance = starting_money
+
 // BLUEMOON ADD END
 
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H, load_character)

--- a/modular_splurt/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_splurt/code/game/objects/structures/ghost_role_spawners.dm
@@ -124,6 +124,7 @@
 	ears = /obj/item/radio/headset/headset_srv/hotel
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
 						/obj/item/storage/ifak=1)
+	make_bank_account = TRUE
 
 /obj/effect/mob_spawn/human/hotel_staff/splurt/security
 	name = "Hotel Security Sleeper"
@@ -174,7 +175,8 @@
 	head = /obj/item/clothing/head/beret/black
 	r_pocket = /obj/item/pda
 	back = /obj/item/storage/backpack
-	r_hand = /obj/item/storage/secure/briefcase/syndie
+	make_bank_account = TRUE // BLUEMOON ADD
+	starting_money = 10000 // BLUEMOON ADD
 
 //Forgotten syndicate ship
 


### PR DESCRIPTION
# Описание
1) Переработана система выдачи банк аккаунта гост роли, прок выдачи банкаккунта переехал из униформы в сам спавнер и у спавнера появилось 2 новые переменные позволяющие быстро создать аккаунт и количество на нём денег (при желании можно оставить гост роли кучу денег на банк аккаунте, но не выдать карту)
2) В память гостролей имеющий банк аккаунт добавлен номер их аккаунта
3) Гостроли имеющие карту со своим банковским аккаунтом получают аккаунт на своё имя, а не на случайное имя
4) Посетители отеля лишаются кейса с деньгами и их деньги сразу переезжают на карточку 
## Причина изменений
Багфиксы, упрощение создание гостролей и выполнение [запроса](https://discord.com/channels/875735187449847830/1296558261650063381) 
## Демонстрация изменений
![image](https://github.com/user-attachments/assets/f28192ee-ba12-47ff-b878-7d98b21b99ad)
![image](https://github.com/user-attachments/assets/6c85251c-453c-46f1-953a-dc8295bf2938)
