### PR TITLE
Исправил плейсхолдер текст в менеджменте ООС-заметок

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		if("OOC-заметки")
 			if(iscarbon(src))
 				var/mob/living/carbon/our_mob = src
-				var/new_text = tgui_input_text(our_mob, "Введите новые ООС-заметки своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новые ООС-заметки", our_mob.dna.custom_species_lore, MAX_FLAVOR_LEN, TRUE, TRUE)
+				var/new_text = tgui_input_text(our_mob, "Введите новые ООС-заметки своего персонажа (максимум [MAX_FLAVOR_LEN] символов).", "Новые ООС-заметки", our_mob.dna.ooc_notes, MAX_FLAVOR_LEN, TRUE, TRUE)
 				if(new_text)
 					our_mob.dna.ooc_notes = new_text
 			if(issilicon(src))


### PR DESCRIPTION
# Описание

Теперь при выборе изменения ООС-заметок в Manage Flavor Text подставляются старые ООС-заметки, а не лор расы.
- [ ] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Багфикс https://discord.com/channels/875735187449847830/1322946806002221159/1322946806002221159

## Демонстрация изменений
