### PR TITLE
Добавляем тряпочку для чистки микроволновки в капсулу шахтёров

### DIFF
--- a/_maps/templates/shelter_6.dmm
+++ b/_maps/templates/shelter_6.dmm
@@ -208,6 +208,10 @@
 "Gc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
+/obj/item/reagent_containers/rag{
+	pixel_y = 15;
+	pixel_x = 10
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/survivalpod/nonpowered)
 "Gn" = (


### PR DESCRIPTION
# Описание
Тряпочка чтобы чистить микроволновку в капсуле с гидропоникой и кухней
## Причина изменений
Чтобы всё работало из коробки (капсулы)
