### PR TITLE
Кольца нормалайзеры теперь можно запихнуть на перчатки и это работает

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -103,7 +103,12 @@
 
 	//gloves
 	if(gloves && !(ITEM_SLOT_GLOVES in obscured))
-		. += "[t_on] одет[t_a] в [gloves.get_examine_string(user)]."
+		var/gloves_accessory_msg
+		var/obj/item/clothing/gloves/G = gloves
+		if(istype(G))
+			if(G.attached_accessories.len == 1)
+				gloves_accessory_msg = " c [G.attached_accessories[1].get_examine_string(user)]"
+		. += "[t_on] одет[t_a] в [gloves.get_examine_string(user)][gloves_accessory_msg]."
 	else if(length(blood_DNA))
 		var/hand_number = get_num_arms(FALSE)
 		if(hand_number)

--- a/modular_splurt/code/modules/clothing/sizeaccessories.dm
+++ b/modular_splurt/code/modules/clothing/sizeaccessories.dm
@@ -12,32 +12,68 @@
 	strip_delay = 40
 	equip_delay_self = 175
 	unequip_delay_self = 175
+	var/list/previous_gloves_data[3] // strip_delay, equip_delay_self, unequip_delay_self
 	//These are already defined under the parent ring, but I wanna leave em here for reference purposes
 
-//For glove slots
-/obj/item/clothing/accessory/ring/syntech/equipped(mob/living/user, slot)
-	if(slot != ITEM_SLOT_GLOVES)
-		return ..()
+/obj/item/clothing/proc/clothing_size_normalize(mob/living/user, slot, slot_to_check)
+	if(slot_to_check && slot != slot_to_check)
+		return FALSE
 
-	// BLUEMOON ADDITION AHEAD - запрет на нормализацию размера существ, у которых есть трейт на невозможность нормализации размера
 	if(HAS_TRAIT(user, TRAIT_BLUEMOON_ANTI_NORMALIZER))
 		to_chat(user, "<span class='warning'>\The [src] buzzes, as nothing changes.</span>")
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-		return . = ..()
-	// BLUEMOON ADDITION END
+		return FALSE
 
 	if(user.GetComponent(/datum/component/size_normalized))
 		to_chat(user, "<span class='warning'>\The [src] buzzes, being overwritten by another accessory.</span>")
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-	else
-		user.AddComponent(/datum/component/size_normalized, wear=src)
-	. = ..()
+		return FALSE
 
-/obj/item/clothing/accessory/ring/syntech/dropped(mob/living/user, slot)
+	user.AddComponent(/datum/component/size_normalized, wear=src)
+
+/obj/item/clothing/proc/clothing_size_un_normalize(mob/living/user)
 	var/datum/component/size_normalized/comp = user.GetComponent(/datum/component/size_normalized)
 	if(comp?.attached_wear == src)
 		qdel(comp)
-	. = ..()
+
+//For glove slots
+/obj/item/clothing/accessory/ring/syntech/equipped(mob/living/user, slot)
+	clothing_size_normalize(user, slot, ITEM_SLOT_GLOVES)
+	..()
+
+/obj/item/clothing/accessory/ring/syntech/dropped(mob/living/user, slot)
+	clothing_size_un_normalize(user)
+	..()
+
+/obj/item/clothing/accessory/ring/syntech/attach(obj/item/clothing/under/U, mob/living/carbon/human/user)
+	if(istype(user) && user.gloves == U)
+		if(!user.dna.species.equip_delay_self_check(src, user))
+			if(!user.put_in_hands(src)) // Из-за специфики работы прока attach_accessory следует проследить, чтобы кольцо не осталось внутри без локации на теле
+				to_chat(user, "<span class='warning'>[src] just slip off your hands!</span>")
+			return FALSE
+
+
+	previous_gloves_data[1] = U.strip_delay
+	U.strip_delay = max(U.strip_delay, strip_delay)
+	previous_gloves_data[2] = U.equip_delay_self
+	U.equip_delay_self = max(U.equip_delay_self, equip_delay_self)
+	previous_gloves_data[3] = U.unequip_delay_self
+	U.unequip_delay_self = max(U.unequip_delay_self, unequip_delay_self)
+	..()
+
+/obj/item/clothing/accessory/ring/syntech/detach(obj/item/clothing/under/U, user)
+	clothing_size_un_normalize(user)
+	U.strip_delay = previous_gloves_data[1]
+	U.equip_delay_self = previous_gloves_data[2]
+	U.unequip_delay_self = previous_gloves_data[3]
+	..()
+
+/obj/item/clothing/accessory/ring/syntech/on_uniform_equip(obj/item/clothing/under/U, mob/living/carbon/human/user)
+	if(istype(user) && user.gloves == U)
+		clothing_size_normalize(user)
+
+/obj/item/clothing/accessory/ring/syntech/on_uniform_dropped(obj/item/clothing/under/U, mob/living/user)
+	clothing_size_un_normalize(user)
 
 //SynTech Wristband
 /obj/item/clothing/wrists/syntech
@@ -51,28 +87,12 @@
 	unequip_delay_self = 175
 
 /obj/item/clothing/wrists/syntech/equipped(mob/user, slot)
-	if(slot != ITEM_SLOT_WRISTS)
-		return ..()
-
-	// BLUEMOON ADDITION AHEAD - запрет на нормализацию размера существ, у которых есть трейт на невозможность нормализации размера
-	if(HAS_TRAIT(user, TRAIT_BLUEMOON_ANTI_NORMALIZER))
-		to_chat(user, "<span class='warning'>\The [src] buzzes, as nothing changes.</span>")
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-		return . = ..()
-	// BLUEMOON ADDITION END
-
-	if(user.GetComponent(/datum/component/size_normalized))
-		to_chat(user, "<span class='warning'>\The [src] buzzes, being overwritten by another accessory.</span>")
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-	else
-		user.AddComponent(/datum/component/size_normalized, wear=src)
-	. = ..()
+	clothing_size_normalize(user, slot, ITEM_SLOT_WRISTS)
+	..()
 
 /obj/item/clothing/wrists/syntech/dropped(mob/living/user, slot)
-	var/datum/component/size_normalized/comp = user.GetComponent(/datum/component/size_normalized)
-	if(comp?.attached_wear == src)
-		qdel(comp)
-	. = ..()
+	clothing_size_un_normalize(user)
+	..()
 
 //NECK SLOT ITEMS...
 //Syntech Pendant
@@ -88,34 +108,17 @@
 
 //For neck items
 /obj/item/clothing/neck/syntech/equipped(mob/living/user, slot)
-	if(slot != ITEM_SLOT_NECK)
-		return ..()
-
-	// BLUEMOON ADDITION AHEAD - запрет на нормализацию размера существ, у которых есть трейт на невозможность нормализации размера
-	if(HAS_TRAIT(user, TRAIT_BLUEMOON_ANTI_NORMALIZER))
-		to_chat(user, "<span class='warning'>\The [src] buzzes, as nothing changes.</span>")
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-		return . = ..()
-	// BLUEMOON ADDITION END
-
-	if(user.GetComponent(/datum/component/size_normalized))
-		to_chat(user, "<span class='warning'>\The [src] buzzes, being overwritten by another accessory.</span>")
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
-	else
-		user.AddComponent(/datum/component/size_normalized, wear=src)
-	. = ..()
+	clothing_size_normalize(user, slot, ITEM_SLOT_NECK)
+	..()
 
 /obj/item/clothing/neck/syntech/dropped(mob/living/user, slot)
-	var/datum/component/size_normalized/comp = user.GetComponent(/datum/component/size_normalized)
-	if(comp?.attached_wear == src)
-		qdel(comp)
+	clothing_size_un_normalize(user)
 	. = ..()
 
 //Syntech Choker
 /obj/item/clothing/neck/syntech/choker
 	name = "normalizer choker"
 	desc = "A sleek, tight-fitting choker embezzled with silver to gold, adorned with vibrant purple studs; combined technology of NanoTrasen and SynTech. It will 'normalize' the size of the user to a specified height for approved work-conditions, as long as it is equipped. There is a small screen buzzing with information."
-	icon = 'modular_splurt/icons/obj/clothing/sizeaccessories.dmi'
 	icon_state = "choker"
 	item_state = "collar"
 
@@ -123,7 +126,5 @@
 /obj/item/clothing/neck/syntech/collar
 	name = "normalizer collar"
 	desc = "A cute pet collar, technologically designed with vibrant purples and smooth silvers. There is a small gem bordered by gold at the front, reading 'SYNTECH' engraved within the metal. It will 'normalize' the size of the user to a specified height for approved work-conditions, as long as it is equipped. The artificial violet gem inside twinkles ominously."
-	icon = 'modular_splurt/icons/obj/clothing/sizeaccessories.dmi'
-	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/neck.dmi'
 	icon_state = "collar"
 	item_state = "collar"


### PR DESCRIPTION
# Описание
Переписал код нормалайзеров и убрал лишние строки
Кольцо нормалайзер можно запихнуть на перчатки (перчатки получают время снятия и надевания как кольцо нормализатор)
Кольцо нацепленное на перчатку теперь отображается при осмотре персонажа

## Причина изменений
Багфиксы
Возможность нормально использовать кольцо нормализатор с любой одеждой
Больше информации при осмотре других персонажей