### PR TITLE
Фикс проливания из бота масла во время личения

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -11,7 +11,7 @@
 
 /datum/export/material/get_amount(obj/O)
 	if(!material_id)
-		return FALSE
+		return FALSE 1
 	if(!isitem(O))
 		return FALSE
 	var/obj/item/I = O

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -11,7 +11,7 @@
 
 /datum/export/material/get_amount(obj/O)
 	if(!material_id)
-		return FALSE 1
+		return FALSE
 	if(!isitem(O))
 		return FALSE
 	var/obj/item/I = O

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -243,7 +243,7 @@
 
 /mob/living/simple_animal/bot/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
-	if(. && prob(10) && amount > 0)
+	if(. && amount > 0 && prob(10))
 		new oil_spill_type(loc)
 
 /mob/living/simple_animal/bot/updatehealth()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -243,7 +243,7 @@
 
 /mob/living/simple_animal/bot/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
-	if(. && prob(10))
+	if(. && prob(10) && amount > 0)
 		new oil_spill_type(loc)
 
 /mob/living/simple_animal/bot/updatehealth()


### PR DESCRIPTION
# Описание
Боты во время получения лечения имел шанс пролить масла, теперь нет. (Особенно ярко это происходит при лечащей ауре)
## Причина изменений
Багфикс