### PR TITLE
rpg_loot_items "фикс" рантайма связанного с тактичными вещами

### DIFF
--- a/code/datums/components/fantasy/prefixes.dm
+++ b/code/datums/components/fantasy/prefixes.dm
@@ -38,6 +38,8 @@
 	else
 		return "[pick(badPrefixes)] [newName]"
 
+/* BLUEMOON DELETE Оставь надежду, всяк сюда входящий, каким-то неимоверным образом уводить сам объект как элемент в _AddElement(list/arguments)
+//времени попыток решить данную околесицу 4 часа
 /datum/fantasy_affix/tactical
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD
@@ -50,6 +52,7 @@
 	comp.appliedElements += list(dat)
 	return "tactical [newName]"
 
+*/
 /datum/fantasy_affix/pyromantic
 	placement = AFFIX_PREFIX
 	alignment = AFFIX_GOOD

--- a/code/modules/unit_tests/chain_pull_through_space.dm
+++ b/code/modules/unit_tests/chain_pull_through_space.dm
@@ -33,7 +33,7 @@
 	qdel(charlie)
 	return ..()
 
-/datum/unit_test/chain_pull_through_space/Run() ХА-ХА СМЕШНО
+/datum/unit_test/chain_pull_through_space/Run()
 	// Alice pulls Bob, who pulls Charlie
 	// Normally, when Alice moves forward, the rest follow
 	alice.start_pulling(bob)

--- a/code/modules/unit_tests/chain_pull_through_space.dm
+++ b/code/modules/unit_tests/chain_pull_through_space.dm
@@ -33,7 +33,7 @@
 	qdel(charlie)
 	return ..()
 
-/datum/unit_test/chain_pull_through_space/Run()
+/datum/unit_test/chain_pull_through_space/Run() ХА-ХА СМЕШНО
 	// Alice pulls Bob, who pulls Charlie
 	// Normally, when Alice moves forward, the rest follow
 	alice.start_pulling(bob)


### PR DESCRIPTION
# Описание
Данный аффикс вызывает рантаймы, собственно при этом никак не работает. 

## Причина изменений

Не ну былоб круто если-бы получилось это пофиксить, но это проклятая часть кода и навряд-ли кто-то пофиксит
Вызывает рантаймы  на этапе тестов если на тестируемой карте выпадет ивент на рпг систему и собственно в самой игре.
Нет, я не знаю как это пофиксить и да, повторюсь - оно не работает