### PR TITLE
Фикс света у парамедиков на дельте

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -117882,12 +117882,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
-/obj/item/wallframe/light_fixture/small{
-	pixel_y = -15
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
 "uhb" = (


### PR DESCRIPTION
# Описание
Даже тут попилили бюджет и вместо цокола с лампой дали просто корпус без проводов и лампы

## Причина изменений
Да будет свет у парамедиков