### PR TITLE
Вырезание спавнера на синди станции

### DIFF
--- a/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
+++ b/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
@@ -8339,13 +8339,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/fore)
-"ate" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
 "atf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -97602,7 +97595,7 @@ aod
 aqe
 ctq
 apY
-ate
+ath
 ctq
 apY
 ath

--- a/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
+++ b/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
@@ -8304,13 +8304,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/primary/fore)
-"ate" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/commons/dorms)
 "atf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -97656,7 +97649,7 @@ aod
 aqe
 ctq
 apY
-ate
+ath
 ctq
 apY
 ath


### PR DESCRIPTION
# Описание
Вырезание спавнера угроз из 3 дормы на синди станции (на обычном боксе уже вырезано)
## Причина изменений
Уменьшение кринжовых ситуации с упавшим на голову когтём секса