### PR TITLE
Фикс возможности бесконечно менять положение при помощи пиксельшифта

### DIFF
--- a/modular_sand/code/modules/pixel_shift/pixel_shift.dm
+++ b/modular_sand/code/modules/pixel_shift/pixel_shift.dm
@@ -59,26 +59,26 @@
 	if(CHECK_BITFIELD(direction, NORTH))
 		if(pixel_y <= PIXEL_SHIFT_MAXIMUM + base_pixel_y)
 			pixel_y++
-			if(client?.prefs.view_pixelshift) //SPLURT Edit
-				client?.pixel_y++
+			if(client && client.prefs.view_pixelshift && client.pixel_y <= PIXEL_SHIFT_MAXIMUM) //SPLURT Edit
+				client.pixel_y++
 			is_shifted = TRUE
 	if(CHECK_BITFIELD(direction, EAST))
 		if(pixel_x <= PIXEL_SHIFT_MAXIMUM + base_pixel_x)
 			pixel_x++
-			if(client?.prefs.view_pixelshift) //SPLURT Edit
-				client?.pixel_x++
+			if(client && client.prefs.view_pixelshift && client.pixel_x <= PIXEL_SHIFT_MAXIMUM) //SPLURT Edit
+				client.pixel_x++
 			is_shifted = TRUE
 	if(CHECK_BITFIELD(direction, SOUTH))
 		if(pixel_y >= -PIXEL_SHIFT_MAXIMUM + base_pixel_y)
 			pixel_y--
-			if(client?.prefs.view_pixelshift) //SPLURT Edit
-				client?.pixel_y--
+			if(client && client.prefs.view_pixelshift && client.pixel_y >= -PIXEL_SHIFT_MAXIMUM) //SPLURT Edit
+				client.pixel_y--
 			is_shifted = TRUE
 	if(CHECK_BITFIELD(direction, WEST))
 		if(pixel_x >= -PIXEL_SHIFT_MAXIMUM + base_pixel_x)
 			pixel_x--
-			if(client?.prefs.view_pixelshift) //SPLURT Edit
-				client?.pixel_x--
+			if(client && client.prefs.view_pixelshift && client.pixel_x >= -PIXEL_SHIFT_MAXIMUM) //SPLURT Edit
+				client.pixel_x--
 			is_shifted = TRUE
 
 	// Yes, I know this sets it to true for everything if more than one is matched.


### PR DESCRIPTION
# Описание
Баг с остаточным пиксельшифтом, конечно, из-за ограничений, сохраняется, но теперь нельзя подвинуть камеру при пиксельшифте больше допустимого

## Причина изменений
Костыли против багоюзеров