### PR TITLE
Фикс питья крови и фикс рантайма

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -52,7 +52,7 @@
 			C.adjust_integration_blood(round(reac_volume, 0.1))
 			// we don't care about bloodtype here, we're just refilling the mob
 
-	if(reac_volume >= 10 && istype(L) && method != INJECT)
+	if(reac_volume >= 10 && istype(L) && (method != INJECT && method != INGEST))
 		L.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
 
 /datum/reagent/blood/on_mob_life(mob/living/carbon/C)	//Because lethals are preferred over stamina. damnifino.

--- a/modular_splurt/code/datums/traits/positive_quirks/bloodfledge.dm
+++ b/modular_splurt/code/datums/traits/positive_quirks/bloodfledge.dm
@@ -137,8 +137,10 @@
 	// Remove quirk ability action datums
 	var/datum/action/cooldown/bloodfledge/bite/act_bite = locate() in quirk_mob.actions
 	var/datum/action/cooldown/bloodfledge/revive/act_revive = locate() in quirk_mob.actions
-	act_bite.Remove(quirk_mob)
-	act_revive.Remove(quirk_mob)
+	if(act_bite)
+		act_bite.Remove(quirk_mob)
+	if(act_revive)
+		act_revive.Remove(quirk_mob)
 
 	// Remove quirk language
 	quirk_mob.remove_language(/datum/language/vampiric, TRUE, TRUE, LANGUAGE_BLOODSUCKER)


### PR DESCRIPTION
# Описание
1) Во время питья крови из человека или чаггинга из кружки (когда выпивается много), персонаж более не измазывается с ног до головы в крови
2) фикс рантайма с попыткой удалить то, чего нету

## Причина изменений
Багфиксы и уменьшение странного поведения игры