### PR TITLE
Возможность адекватно призывать персонажей из гост кафе с квирком призываемый

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -961,23 +961,16 @@
 	. = ..()
 	if(new_spawn.client)
 		new_spawn.client.prefs.copy_to(new_spawn)
-		var/area/A = get_area(src)
+		var/datum/antagonist/ghost_role/ghost_cafe/GC = new_spawn.mind?.has_antag_datum(/datum/antagonist/ghost_role/ghost_cafe)
+		GC.adittonal_allowed_area = get_area(src)
+		GC.adittonal_allowed_area = GC.adittonal_allowed_area.type
 		var/datum/outfit/O = new /datum/outfit/ghostcafe()
 		O.equip(new_spawn, FALSE, new_spawn.client)
 		SSjob.equip_loadout(null, new_spawn)
 		SSjob.post_equip_loadout(null, new_spawn)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
-		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
-		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/centcom/holding/exterior,  /area/hilbertshotel)) // BLUEMOON EDIT - добавлена внешняя зона ГК
-		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
-		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
-		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
+		new_spawn.ghost_cafe_traits(TRUE, GC.adittonal_allowed_area)
 		to_chat(new_spawn,"<span class='boldwarning'>Ghosting is free!</span>")
-		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
-		D.Grant(new_spawn)
-		var/datum/action/disguise/disguise_action = new(new_spawn)
-		disguise_action.Grant(new_spawn)
 
 /datum/outfit/ghostcafe
 	name = "ID, jumpsuit and shoes"

--- a/modular_bluemoon/Fink/code/items/summon_chalk.dm
+++ b/modular_bluemoon/Fink/code/items/summon_chalk.dm
@@ -107,12 +107,17 @@
 			REMOVE_TRAIT(target, TRAIT_LEWD_SUMMONED, TRAIT_LEWD_SUMMONED)
 		else
 			ADD_TRAIT(target, TRAIT_LEWD_SUMMONED, TRAIT_LEWD_SUMMONED)
+			if(target.mind?.has_antag_datum(/datum/antagonist/ghost_role/ghost_cafe))
+				target.ghost_cafe_traits(FALSE) // Выдаём и забираем трэйты в разных места для ситуаций ухода госта обратно домой
 
 	playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/spook.ogg", 50, 1)
 	new /obj/effect/temp_visual/yellowsparkles(target.loc)
 	if(nude_target)
 		nuding(target)
 	do_teleport(target, pos_to_teleport, channel = TELEPORT_CHANNEL_MAGIC, forced = TRUE)
+	if(!HAS_TRAIT(target, TRAIT_LEWD_SUMMONED) && switch_summoned && target.mind?.has_antag_datum(/datum/antagonist/ghost_role/ghost_cafe))
+		var/datum/antagonist/ghost_role/ghost_cafe/GC = target.mind?.has_antag_datum(/datum/antagonist/ghost_role/ghost_cafe)
+		target.ghost_cafe_traits(TRUE, GC.adittonal_allowed_area)
 	new /obj/effect/temp_visual/yellowsparkles(src.loc)
 	return TRUE
 

--- a/modular_bluemoon/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_bluemoon/code/game/objects/structures/ghost_role_spawners.dm
@@ -1,0 +1,39 @@
+mob/living/proc/ghost_cafe_traits(switch_on = FALSE, additional_area)
+	if(switch_on)
+		AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
+		AddElement(/datum/element/dusts_on_catatonia)
+		var/list/Not_dust_area = list(/area/centcom/holding/exterior,  /area/hilbertshotel)
+		if(additional_area)
+			Not_dust_area += additional_area
+		AddElement(/datum/element/dusts_on_leaving_area, Not_dust_area)
+
+		ADD_TRAIT(src, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
+		ADD_TRAIT(src, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
+		ADD_TRAIT(src, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
+
+		var/datum/action/toggle_dead_chat_mob/D = new(src)
+		D.Grant(src)
+		var/datum/action/disguise/disguise_action = new(src)
+		disguise_action.Grant(src)
+
+	else
+		RemoveElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
+		RemoveElement(/datum/element/dusts_on_catatonia)
+		var/datum/antagonist/ghost_role/ghost_cafe/GC = mind?.has_antag_datum(/datum/antagonist/ghost_role/ghost_cafe)
+		if(GC)
+			RemoveElement(/datum/element/dusts_on_leaving_area, list(/area/centcom/holding/exterior,  /area/hilbertshotel, GC.adittonal_allowed_area))
+		else
+			RemoveElement(/datum/element/dusts_on_leaving_area, list(/area/centcom/holding/exterior,  /area/hilbertshotel))
+
+		REMOVE_TRAIT(src, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
+		REMOVE_TRAIT(src, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
+		REMOVE_TRAIT(src, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT)
+
+		var/datum/action/toggle_dead_chat_mob/D = locate(/datum/action/toggle_dead_chat_mob) in actions
+		if(D)
+			D.Remove(src)
+		var/datum/action/disguise/disguise_action = locate(/datum/action/disguise) in actions
+		if(disguise_action)
+			if(disguise_action.currently_disguised)
+				remove_alt_appearance("ghost_cafe_disguise")
+			disguise_action.Remove(src)

--- a/modular_bluemoon/vlad0s_staff/code/ghost_role_antag_datums.dm
+++ b/modular_bluemoon/vlad0s_staff/code/ghost_role_antag_datums.dm
@@ -4,6 +4,7 @@
 
 /datum/antagonist/ghost_role/ghost_cafe
 	name = "Ghost Cafe"
+	var/area/adittonal_allowed_area
 
 /datum/antagonist/ghost_role/tarkov
 	name = "Port Tarkov"

--- a/modular_sand/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_sand/code/game/objects/structures/ghost_role_spawners.dm
@@ -31,16 +31,8 @@
 	if(new_spawn.client)
 		new_spawn.updatename(new_spawn.client)
 		new_spawn.gender = NEUTER
-		var/area/A = get_area(src)
-		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
-		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/centcom/holding/exterior,  /area/hilbertshotel)) // BLUEMOON EDIT - добавлена внешняя зона ГК
-		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
-		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
-		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
+		var/datum/antagonist/ghost_role/ghost_cafe/GC = new_spawn.mind?.has_antag_datum(/datum/antagonist/ghost_role/ghost_cafe)
+		GC.adittonal_allowed_area = get_area(src)
+		GC.adittonal_allowed_area = GC.adittonal_allowed_area.type
+		new_spawn.ghost_cafe_traits(TRUE, GC.adittonal_allowed_area)
 		to_chat(new_spawn,"<span class='boldwarning'>Ghosting is free!</span>")
-		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
-		D.Grant(new_spawn)
-		var/datum/action/disguise/disguise_action = new(new_spawn)
-		disguise_action.Grant(new_spawn)
-		new_spawn.mind.add_antag_datum(/datum/antagonist/ghost_role)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5463,6 +5463,7 @@
 #include "modular_splurt\code\game\objects\structures\fence.dm"
 #include "modular_splurt\code\game\objects\structures\flora.dm"
 #include "modular_splurt\code\game\objects\structures\ghost_role_spawners.dm"
+#include "modular_bluemoon\code\game\objects\structures\ghost_role_spawners.dm"
 #include "modular_splurt\code\game\objects\structures\ladder.dm"
 #include "modular_splurt\code\game\objects\structures\micro_bricks.dm"
 #include "modular_splurt\code\game\objects\structures\pole.dm"


### PR DESCRIPTION
# Описание
1) Возможность призвать посетителей гост кафе с квирком призываемый
2) Данное действие отрубает все гост кафешные абилки, убирает  маскировку и так убирает возможность слышать гостов
3) Возвращение на руне возвращает все абилки обратно если они до этого были
4) Теперь возможность дегостокафецировать, убрав у поситителя гост отеля все его абилки от спавна на данной роли (для админов)

## Причина изменений
Призываемый - ерп квирк, призываемый даже из гост кафе с собой вещей иметь не будет и вреда это никому не причинит, особенно в эксту в которую квирк и работает