### PR TITLE
Обновление офиса кма для избежание недоступных турфов

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55127,16 +55127,32 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "gZf" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/item/toy/figure/qm,
+/obj/structure/table,
+/obj/item/cartridge/quartermaster{
+	pixel_x = 11;
+	pixel_y = 14
+	},
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/gps{
+	gpstag = "QM0";
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 11;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "gZo" = (
@@ -56463,11 +56479,11 @@
 /area/service/chapel/main)
 "hDb" = (
 /obj/effect/landmark/start/quartermaster,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/chair/office/dark{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
@@ -56895,8 +56911,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/commons/toilet/restrooms)
 "hMN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/holopad/secure,
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "hMQ" = (
@@ -59794,6 +59808,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/holopad/secure{
+	pixel_x = 16;
+	pixel_y = -16
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
@@ -65914,13 +65932,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "lYW" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/toy/figure/qm{
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
@@ -66245,19 +66268,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/commons/toilet/restrooms)
 "mgb" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/pen/red,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
 	pixel_x = 32
 	},
-/obj/item/stamp/qm,
+/obj/machinery/computer/card/minor/qm{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "mgh" = (
@@ -67330,8 +67348,16 @@
 /obj/machinery/status_display/supply{
 	pixel_x = 32
 	},
-/obj/machinery/computer/card/minor/qm{
-	dir = 8
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/stamp/qm{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/pen/red,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
@@ -81797,19 +81823,6 @@
 /turf/closed/wall,
 /area/command/bridge)
 "tmr" = (
-/obj/structure/table,
-/obj/item/cartridge/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/cartridge/quartermaster,
-/obj/item/gps{
-	gpstag = "QM0"
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -81819,7 +81832,10 @@
 /obj/machinery/keycard_auth{
 	pixel_y = 23
 	},
-/obj/item/clipboard,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "tmB" = (
@@ -83421,6 +83437,9 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)


### PR DESCRIPTION
# Описание
Один из столов до этого был закрыт мусоркой и компом, теперь оно так не делает и можно спокойно взять игрушку
## Причина изменений
Уменьшение багов маппинга из-за недоступных для использования столов