### PR TITLE
Ренейм вип комнат для заключённых у слейверов

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -13115,7 +13115,7 @@
 /area/centcom/control)
 "eqf" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Medical Bay";
+	name = "VIP cell 1";
 	req_access_txt = "154"
 	},
 /turf/open/floor/plasteel/dark/side{
@@ -18263,7 +18263,7 @@
 /area/syndicate_mothership/control)
 "iNE" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Medical Bay";
+	name = "VIP cell 3";
 	req_access_txt = "154"
 	},
 /turf/open/floor/plating,
@@ -27490,7 +27490,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	name = "Medical Bay";
+	name = "VIP cells";
 	req_access_txt = "154"
 	},
 /turf/open/floor/plasteel,


### PR DESCRIPTION
# Описание
Из-за ленивого копипаста они назывались медбеем

## Причина изменений
Вип камеры теперь вип камеры