### PR TITLE
Ограничение contractor kit в динамик лайт

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_bundles.dm
+++ b/code/modules/uplink/uplink_items/uplink_bundles.dm
@@ -38,7 +38,7 @@
 			specialised contractor baton, and three randomly selected low cost items. Can include otherwise unobtainable items."
 	item = /obj/item/storage/box/syndie_kit/contract_kit
 	cost = 30
-	player_minimum = 25
+	player_minimum = 50
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	restricted = TRUE
 


### PR DESCRIPTION
# Описание
Теперь контрактор кит требует 50 игроков (Что дозволит режиму быть или лайтом с большим количеством игроков, или медиумом с околоминимальным для него) для появления в аплинке, вместо 25.

## Причина изменений
Соответствующая [предложка](https://discord.com/channels/875735187449847830/1329888659922751568/1329888659922751568) по ограничению кита в лайт (Собрала 10 лайков и 0 дизлайков за почти сутки).
Лично обжёгся о то, что при полтора инвалидах на СБ, те не смогли отреагировать и спасти меня от контрактора в лайт, которому по контракту надо заниматься той или иной резнёй, для лайта недопустимой. Игроку админы пояснили, что так не надо, но ПР будет профилактикой подобного в целом.