### PR TITLE
rifles.dm

### DIFF
--- a/modular_bluemoon/phenyamomota/code/modules/guns/rifles.dm
+++ b/modular_bluemoon/phenyamomota/code/modules/guns/rifles.dm
@@ -53,8 +53,8 @@
 	name = "\improper tactical M16A4 rifle"
 	desc = "An american automatic rifle chambered for the 5.56 round, designed for use by Special Ops."
 	icon_state = "m16_tactical"
-	burst_size = 5
-	fire_delay = 3
+	burst_size = 3 // BLUEMOON EDIT - was "burst_size = 5"
+	fire_delay = 2 // BLUEMOON EDIT - was "fire_delay = 3"
 
 /obj/item/gun/ballistic/automatic/m16a4/tactical/update_icon_state()
 	if(magazine)


### PR DESCRIPTION
I changed fire delay and burst size so M16A4 - Tac. would be useful ^^

# Описание
Изменил барст режим тактической M16A4 на 3 выстрела заместо бесполезных 5 и снизил задержку выстрелов на 2 как у обычной версии M16A4
Предложка по изменению:
https://discord.com/channels/875735187449847830/1330520447753785354
- [ x] Изменения были проверены на локальном сервере
- [ x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений
В связи с предложкой:
ДС-2 получит нормальное оружие (Экспедиторы которые могут выбить это оружие будут иметь не с кусок  кала калибра 5.56) В целом данная вариация М16 теперь будет адекватно вести себя среди её аналогов.

