### PR TITLE
Вариация карт forced руин

### DIFF
--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -11,6 +11,7 @@
 	var/placement_weight = 1 //How often should this ruin appear
 	var/cost = 0 //Cost in ruin budget placement system
 	var/allow_duplicates = TRUE
+	var/list/variants = null //list of variants of a map suffixes, only one of them will be chosen and loaded
 	var/list/always_spawn_with = null //These ruin types will be spawned along with it (where dependent on the flag) eg list(/datum/map_template/ruin/space/teleporter_space = SPACERUIN_Z)
 	var/list/never_spawn_with = null //If this ruin is spawned these will not eg list(/datum/map_template/ruin/base_alternate)
 

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -21,7 +21,7 @@
 
 			if(!valid)
 				break
-			
+
 
 		if(!valid)
 			continue
@@ -94,6 +94,11 @@
 		if(forced_ruins.len) //We have something we need to load right now, so just pick it
 			for(var/ruin in forced_ruins)
 				current_pick = ruin
+				if(current_pick.variants)
+					var/list/pool = current_pick.variants + current_pick.suffix
+					var/picked_variant = pickweight(pool)
+					current_pick.suffix = picked_variant
+					current_pick.mappath = current_pick.prefix + picked_variant
 				if(isturf(forced_ruins[ruin]))
 					var/turf/T = forced_ruins[ruin]
 					forced_z = T.z //In case of chained ruins

--- a/modular_splurt/code/datums/ruins/space.dm
+++ b/modular_splurt/code/datums/ruins/space.dm
@@ -24,3 +24,4 @@
 	name = "Twin Spires Hotel and Club"
 	description = "A Nanotrasen-partnered interstellar hotel and stripclub"
 	always_place = TRUE
+	//variants = list("map_variant1.dmm", "map_variant2.dmm") should be in the same prefix directory as parent map


### PR DESCRIPTION
# Описание

К map_templates/ruin было добавлено свойство variants
variants - список названий файлов возможных вариантов карты
При генерации forced руин, если список вариантов определен, выбирается один из них или сама изначальная карта.
<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений
Части карт обычных руин могут выбираться динамически при генерации, forced руины же в процессе выбора не участвуют, а иногда хотелось бы.
<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
