### PR TITLE
Удаление бутылки при выстреле

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -221,6 +221,7 @@
 		if(prob(33))
 			new/obj/item/shard(drop_location())
 		obj_integrity = 1
+		qdel(src)
 	..()
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Описание
После попадания пули (поцелуя или чего-то такого) по бутылке она теперь реально крошится на разбитую бутылку, сколько до этого оно это делало без удаления бутылки

## Причина изменений
Багфикс