### PR TITLE
Фиксы Дельта Станции

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18517,6 +18517,11 @@
 /obj/item/storage/backpack/duffelbag/med/surgery{
 	pixel_y = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Surgery 1";
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "bSm" = (
@@ -72975,7 +72980,8 @@
 	},
 /obj/machinery/door/window{
 	dir = 8;
-	name = "Library Desk"
+	name = "Library Desk";
+	req_access_txt = "37"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/service/library)
@@ -93061,7 +93067,7 @@
 	height = 5;
 	shuttle_id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/delta;
 	width = 9
 	},
 /turf/open/space/basic,
@@ -93589,7 +93595,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay - Surgery";
+	c_tag = "Medbay - Surgery 2";
 	dir = 1;
 	name = "medbay camera";
 	network = list("ss13","medbay")
@@ -119520,10 +119526,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/fax{
-	fax_name = "General Fax";
-	name = "General Fax"
-	},
 /turf/open/floor/plasteel/grimy,
 /area/service/library)
 "uyf" = (
@@ -123667,6 +123669,10 @@
 /obj/structure/table/wood,
 /obj/machinery/light_switch{
 	pixel_y = 26
+	},
+/obj/machinery/fax{
+	fax_name = "General Fax";
+	name = "General Fax"
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -18,7 +18,8 @@
 
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer, /area/commons/toilet, /area/security/prison, /area/security/brig,
-	/area/ai_monitored/turret_protected/ai, /area/commons/storage/emergency/starboard, /area/commons/storage/emergency/port, /area/shuttle, /area/ruin/lavaland, /area/commons/dorms)
+	/area/ai_monitored/turret_protected/ai, /area/commons/storage/emergency/starboard, /area/commons/storage/emergency/port, /area/shuttle, /area/ruin/lavaland, /area/commons/dorms,
+	/area/service/electronic_marketing_den, /area/service/hydroponics/garden/abandoned, /area/service/abandoned_gambling_den)
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = TRAIT_RADSTORM_IMMUNE


### PR DESCRIPTION
# Описание
1) Общественный принтер теперь на столе в библиотеке в открытом месте, а стеклянная дверь ведущая до него до этого теперь на доступе библиотекаря (теперь его "рубка" вновь закрыта со всех сторон)
2) Камера во второй операционной теперь есть (ваши грязные делишки теперь видно.
3) В техах комнаты (см 1) теперь имеют защиту от радшторма
4) Just in case перепроверена работа шатлла на лаваленд у сб, теперь оно точно не врезается в комнаты заключённых

## Причина изменений
Багфиксы и добавление непродуманных моментов
## Демонстрация изменений
![image](https://github.com/user-attachments/assets/6040377a-bb8f-4409-93d6-4edc237ac0a7)
