### PR TITLE
Фикс реквест консолей на чекпоинтах сб

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6622,7 +6622,7 @@
 "aDf" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -13829,7 +13829,7 @@
 	c_tag = "Security Post - Medbay"
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -19450,7 +19450,7 @@
 /area/hallway/primary/central)
 "byO" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -20565,7 +20565,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Science Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -26847,7 +26847,7 @@
 /area/security/checkpoint/engineering)
 "bXP" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -4708,7 +4708,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	name = "Security RC";
 	pixel_y = -32
@@ -6698,8 +6698,11 @@
 /turf/closed/wall,
 /area/security/brig)
 "asM" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
+/obj/machinery/requests_console{
+	department = "Public Router";
+	name = "Public Router RC";
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/commons/fitness/cogpool)
@@ -60188,7 +60191,7 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	name = "Security RC";
 	pixel_x = 32
@@ -67921,13 +67924,13 @@
 /area/security/prison/work)
 "rDB" = (
 /obj/machinery/requests_console{
-	department = "Public Router";
-	name = "Public Router RC";
+	department = "Engineering Router";
+	name = "Engineering Router RC";
+	pixel_y = 0;
 	pixel_x = -32
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/engineering/main)
 "rEG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
@@ -68601,11 +68604,6 @@
 /area/security/prison/mess)
 "sRZ" = (
 /obj/machinery/light/small,
-/obj/machinery/requests_console{
-	department = "Engineering Router";
-	name = "Engineering Router RC";
-	pixel_y = -32
-	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "sSg" = (
@@ -69292,6 +69290,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"uqr" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/commons/fitness/cogpool)
 "uqO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/easel,
@@ -106053,7 +106061,7 @@ asx
 asM
 auN
 auN
-arN
+uqr
 aAy
 aGH
 aKj
@@ -106564,7 +106572,7 @@ aHO
 xQe
 vuq
 aHt
-rDB
+aaU
 aaU
 dQE
 aaU
@@ -107629,7 +107637,7 @@ aaa
 aaa
 aaU
 aQC
-cnK
+rDB
 bqS
 bqS
 bqS

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -41034,12 +41034,6 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dir" = (
-/obj/machinery/requests_console{
-	department = "Chemistry Lab";
-	name = "Chemistry RC";
-	pixel_y = -64;
-	receive_ore_updates = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -41963,6 +41957,13 @@
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry Lab";
+	name = "Chemistry RC";
+	pixel_y = -32;
+	receive_ore_updates = 1;
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
@@ -67209,14 +67210,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"fMG" = (
-/obj/machinery/requests_console{
-	department = "Chapel Office";
-	name = "Chapel RC";
-	pixel_y = -32
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "fMJ" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -70323,6 +70316,12 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/engineer,
 /obj/effect/turf_decal/bot,
+/obj/machinery/requests_console{
+	department = "Chapel Office";
+	name = "Chapel RC";
+	pixel_y = 0;
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "gHQ" = (
@@ -72502,6 +72501,12 @@
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "hnV" = (
+/obj/machinery/requests_console{
+	department = "Detective's Office";
+	name = "Detective RC";
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hnW" = (
@@ -83154,6 +83159,14 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/stamp/hop,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	name = "Head of Personnel RC";
+	pixel_x = 0;
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "kdz" = (
@@ -90659,14 +90672,6 @@
 "mqf" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/machinery/light_switch{
 	pixel_x = -38;
 	pixel_y = 7
@@ -100467,11 +100472,6 @@
 /area/ai_monitored/aisat/exterior)
 "pdX" = (
 /obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Law Office";
-	name = "'Law Office RC";
-	pixel_y = -64
-	},
 /obj/item/folder/blue{
 	pixel_x = 3;
 	pixel_y = 3
@@ -115673,6 +115673,12 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
+/obj/machinery/requests_console{
+	department = "Law Office";
+	name = "'Law Office RC";
+	pixel_y = -32;
+	pixel_x = 0
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "tug" = (
@@ -130828,14 +130834,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
-"xNs" = (
-/obj/machinery/requests_console{
-	department = "Detective's Office";
-	name = "Detective RC";
-	pixel_x = 30
-	},
-/turf/closed/wall,
-/area/security/detectives_office)
 "xOe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -157338,7 +157336,7 @@ lNk
 kYh
 kue
 xkp
-fMG
+qjg
 qjg
 wGe
 qjg
@@ -178400,7 +178398,7 @@ bKX
 bMW
 bJn
 qdI
-xNs
+bMW
 bUX
 bXr
 bZw

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1299,14 +1299,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science RC";
-	pixel_x = -30;
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5801,6 +5793,14 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science RC";
+	pixel_x = -32;
+	pixel_y = 0;
+	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
@@ -12989,7 +12989,7 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	name = "Engineering Checkpoint RC";
 	pixel_x = -30
@@ -20986,7 +20986,7 @@
 	dir = 8
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	name = "Medbay Checkpoint RC";
 	pixel_y = 30
@@ -34146,7 +34146,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Science Checkpoint";
 	departmentType = 5;
 	name = "Science Checkpoint RC";
 	pixel_y = -30
@@ -37376,7 +37376,7 @@
 /obj/machinery/computer/security/labor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	name = "Cargo Checkpoint RC";
 	pixel_y = 30
@@ -56752,7 +56752,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	name = "Security RC";
 	pixel_x = 30

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -15461,7 +15461,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Science Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -42330,7 +42330,7 @@
 "bNC" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -45877,7 +45877,7 @@
 "bXE" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	pixel_x = -30
 	},
@@ -51949,7 +51949,7 @@
 	dir = 8
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10689,7 +10689,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -13375,7 +13375,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -23127,7 +23127,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -24159,16 +24159,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"cbP" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
 	departmentType = 1;
-	name = "Medbay RC"
+	name = "Medbay RC";
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/turf/closed/wall,
-/area/security/checkpoint/medical)
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "cbQ" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -32100,7 +32099,7 @@
 	dir = 9
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Science Checkpoint";
 	departmentType = 5;
 	name = "Science Checkpoint RC";
 	pixel_y = -30
@@ -55755,14 +55754,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"hwv" = (
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 4;
-	name = "Engineering RC"
-	},
-/turf/closed/wall,
-/area/engineering/main)
 "hwM" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -58632,6 +58623,13 @@
 "iJM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 4;
+	name = "Engineering RC";
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "iKH" = (
@@ -80416,7 +80414,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	pixel_x = 30
 	},
@@ -115862,7 +115860,7 @@ bWm
 bXL
 bXL
 cad
-cbP
+bXL
 cdv
 cez
 cfP
@@ -132787,7 +132785,7 @@ urs
 iGQ
 dYF
 iJM
-hwv
+eDX
 nmz
 nmz
 nmz

--- a/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
+++ b/_maps/map_files/PeaceSyndicateStation/PeaceSyndicateBoxStation.dmm
@@ -11515,7 +11515,7 @@
 "aDf" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -22488,7 +22488,7 @@
 	c_tag = "Security Post - Medbay"
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -29896,7 +29896,7 @@
 /area/hallway/primary/central)
 "byO" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -31256,7 +31256,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Science Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -39832,7 +39832,7 @@
 /area/security/checkpoint/engineering)
 "bXP" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -14689,7 +14689,7 @@
 /area/hallway/primary/central)
 "aMd" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	pixel_x = -32
 	},
@@ -19965,7 +19965,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -24529,7 +24529,7 @@
 "bjX" = (
 /obj/structure/filingcabinet,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -41271,7 +41271,7 @@
 	dir = 8
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	pixel_x = -32
 	},

--- a/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
+++ b/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
@@ -11479,7 +11479,7 @@
 "aDf" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Arrival Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -22415,7 +22415,7 @@
 	c_tag = "Security Post - Medbay"
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Medbay Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},
@@ -29783,7 +29783,7 @@
 /area/hallway/primary/central)
 "byO" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Cargo Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -31162,7 +31162,7 @@
 	dir = 1
 	},
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Science Checkpoint";
 	departmentType = 5;
 	pixel_y = -30
 	},
@@ -39711,7 +39711,7 @@
 /area/security/checkpoint/engineering)
 "bXP" = (
 /obj/machinery/requests_console{
-	department = "Security";
+	department = "Engineering Checkpoint";
 	departmentType = 5;
 	pixel_y = 30
 	},


### PR DESCRIPTION
# Описание
1) Теперь реквест консоли в чекпоинтах сб отсылают к отделу для которого они чекпойт, а не просто Security
2) на части карт были пофикшены совсем конченные расстановки реквест консолей (не с той стороны стены, внутри стены, за 2 тайла от стены) 

## Причина изменений
Багфиксы и упрощение восприятия игры