### PR TITLE
Фикс невозможности переставить раздатчики на синдибазах

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -5838,7 +5838,8 @@
 "xk" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 8;
-	pixel_y = 0
+	pixel_y = 0;
+	flags_1 = 2
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_tiled,
@@ -9806,7 +9807,8 @@
 "Od" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 8;
-	pixel_y = 4
+	pixel_y = 4;
+	flags_1 = 2
 	},
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/east,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -2126,7 +2126,8 @@
 "Kf" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 4
+	dir = 4;
+	flags_1 = 2
 	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"
@@ -2435,7 +2436,8 @@
 "QP" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 4
+	dir = 4;
+	flags_1 = 2
 	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"

--- a/_maps/map_files/Mining/Lavaland_novaya.dmm
+++ b/_maps/map_files/Mining/Lavaland_novaya.dmm
@@ -9823,7 +9823,8 @@
 "jJb" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 1
+	dir = 1;
+	flags_1 = 2
 	},
 /turf/open/floor/iron,
 /area/ruin/lavaland/unpowered/deepspaceone/dormitories)
@@ -14335,7 +14336,8 @@
 "nyy" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 1
+	dir = 1;
+	flags_1 = 2
 	},
 /obj/machinery/airalarm/directional/south{
 	req_access = list("syndicate")


### PR DESCRIPTION
# Описание
1) Фикс невозможности перетащить раздатчики на ДС-1 ДС-2 и станции прослушки

## Причина изменений
багфиксы