### PR TITLE
Фикс абуза секс стола в гост кафе

### DIFF
--- a/_maps/templates/apartment_prison.dmm
+++ b/_maps/templates/apartment_prison.dmm
@@ -1515,8 +1515,8 @@
 	},
 /area/hilbertshotel)
 "Vz" = (
-/obj/machinery/research_table/slaver,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/research_table,
 /turf/open/floor/iron/grimy,
 /area/hilbertshotel)
 "VI" = (

--- a/modular_splurt/code/game/machinery/research_table.dm
+++ b/modular_splurt/code/game/machinery/research_table.dm
@@ -122,6 +122,8 @@
 	tier /= parts
 
 /obj/machinery/research_table/proc/on_cum(mob/living/carbon/buckled_mob, obj/item/organ/genital/target_orifice, mob/living/partner)
+	if(is_centcom_level(src.z) && !slaver_mode) //BLUEMOON ADD защита от абузов и набивания очков через гост кафе
+		return
 	if(!configured)
 		say("Failed to get any data, the table is not configured!")
 		return


### PR DESCRIPTION
# Описание
1) Секс стол в инф дормах (тип: тюрьма) заменён со слейверского на обычный
2) Секс стол находясь на цк слое (гост кафе) не даёт очки при оргазме (если не слейверский)

## Причина изменений
Фикс абузов