### PR TITLE
Частичный ремап ДС2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1009,6 +1009,9 @@
 	},
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "dr" = (
@@ -1376,8 +1379,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "eU" = (
 /obj/machinery/light/dim/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
@@ -4046,7 +4049,9 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "pt" = (
 /obj/machinery/light/dim/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "pu" = (
@@ -4173,6 +4178,9 @@
 	},
 /obj/item/bedsheet/brown/double{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
@@ -4519,7 +4527,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "rk" = (
@@ -4707,6 +4714,9 @@
 	pixel_x = 24
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "se" = (
@@ -6649,6 +6659,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "AS" = (
@@ -7002,20 +7015,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
-"Cz" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "CC" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -7224,8 +7223,8 @@
 	dir = 6;
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
@@ -7303,7 +7302,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DK" = (
@@ -8356,7 +8357,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
@@ -9584,6 +9585,9 @@
 	color = "#596479";
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "No" = (
@@ -10028,6 +10032,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"Pc" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Pe" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -10477,6 +10495,9 @@
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "QK" = (
@@ -11873,7 +11894,6 @@
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "VE" = (
@@ -12634,6 +12654,9 @@
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
@@ -14981,7 +15004,7 @@ at
 Hz
 QM
 pu
-Cz
+Pc
 fA
 cz
 WC

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1087,6 +1087,9 @@
 /obj/item/kirbyplants/hedge{
 	anchored = 1
 	},
+/obj/item/toy/plush/laska{
+	desc = " Мягкая игрушка в форме кошки легко утолит вашу жажду объятий и ласки, от неё вы можете почувствовать легкий аромат пепла и сладковато ягодного вкуса. Кажется именно она была серым кардиналом всё это время"
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "dI" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1681,7 +1681,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "gk" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4054,9 +4054,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "pu" = (
 /obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4990,10 +4987,10 @@
 "tm" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron/dark/side{
-	dir = 1
+	dir = 9
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "tn" = (
@@ -5546,7 +5543,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "vD" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -6442,9 +6444,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "zU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
 /obj/machinery/light/dim/directional/west,
 /obj/structure/chair/office/light,
 /obj/machinery/turretid{
@@ -6456,7 +6455,13 @@
 	pixel_x = -29;
 	pixel_y = -3
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "zV" = (
 /obj/item/kirbyplants/hedge{
@@ -8850,7 +8855,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Kz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -8963,12 +8973,12 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "KT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
 /obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/side{
-	dir = 1
+	dir = 5
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "KV" = (
@@ -9309,7 +9319,7 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Mk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -9443,7 +9453,7 @@
 "MP" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "MT" = (
 /obj/machinery/computer/shuttle/ds_syndicate,
@@ -10709,7 +10719,6 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "RH" = (
-/obj/effect/turf_decal/siding/dark,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10721,7 +10730,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "RK" = (
 /obj/machinery/jukebox{
@@ -10982,11 +10996,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "SB" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark/corner{
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -11075,7 +11089,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/textured,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "SR" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/top/right,
@@ -12125,7 +12139,10 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "WE" = (
 /obj/effect/spawner/structure/window/plastitanium,
@@ -12696,9 +12713,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "YR" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
 /obj/machinery/camera/xray/directional/west{
 	c_tag = "DS-2 Research";
 	network = list("ds2")
@@ -12708,6 +12722,9 @@
 	id = "DS2lab";
 	name = "Research shutters control";
 	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -12754,6 +12771,20 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"Zl" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Zo" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
@@ -14951,7 +14982,7 @@ at
 Hz
 QM
 pu
-fA
+Zl
 fA
 cz
 WC

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1997,14 +1997,11 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 6
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/effect/turf_decal/siding/thinplating/end,
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "hs" = (
@@ -5081,9 +5078,7 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/dark_blue/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
+/obj/effect/turf_decal/siding/white/end,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "tN" = (
@@ -6515,8 +6510,8 @@
 /obj/structure/sink/directional/east{
 	pixel_x = -11
 	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 5
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 1
 	},
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
@@ -7007,6 +7002,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"Cz" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "CC" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -9372,7 +9381,9 @@
 	amount = 10
 	},
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "MC" = (
 /obj/structure/chair/sofa/corner{
@@ -9407,10 +9418,8 @@
 /obj/machinery/shower/directional/east{
 	pixel_x = -13
 	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 6
-	},
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/effect/turf_decal/siding/thinplating/end,
 /turf/open/floor/plasteel/showroomfloor/shower,
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
@@ -11611,6 +11620,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "UO" = (
@@ -12771,20 +12783,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
-"Zl" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Zo" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
@@ -12931,6 +12929,7 @@
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "ZP" = (
@@ -14982,7 +14981,7 @@ at
 Hz
 QM
 pu
-Zl
+Cz
 fA
 cz
 WC

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -38,6 +38,13 @@
 	pixel_x = 4
 	},
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/kirbyplants/hedge,
+/obj/item/kirbyplants/hedge,
+/obj/item/kirbyplants/hedge,
+/obj/item/kirbyplants/hedge,
+/obj/item/kirbyplants/hedge,
+/obj/item/kirbyplants/hedge,
+/obj/item/kirbyplants/hedge,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "ag" = (
@@ -453,17 +460,11 @@
 	dir = 1;
 	name = "station admiral's bedsheet"
 	},
-/obj/machinery/turretid{
-	ailock = 1;
-	dir = 1;
-	icon_state = "control_kill";
-	lethal = 1;
-	name = "Base turret controls";
-	pixel_x = -30;
-	req_access = null;
-	req_access_txt = "151"
+/obj/effect/mob_spawn/human/ds2/syndicate_command/admiral{
+	dir = 4;
+	layer = 4.1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "bu" = (
 /obj/structure/curtain,
@@ -624,12 +625,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "ch" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/camera/xray/directional/north{
 	c_tag = "DS-2 Diner";
 	network = list("ds2")
@@ -637,7 +632,11 @@
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/comfy{
+	dir = 8;
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "cj" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/middle/middle,
@@ -854,6 +853,10 @@
 	name = "corporate liaison's bedsheet"
 	},
 /obj/structure/bed/double,
+/obj/effect/mob_spawn/human/ds2/syndicate_command/corporateliaison{
+	dir = 8;
+	layer = 4.1
+	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "cI" = (
@@ -1056,19 +1059,11 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "dD" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/dark_red/end,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 4
+/obj/structure/chair/comfy/shuttle{
+	dir = 1;
+	name = "tactical chair"
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 8
-	},
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "dF" = (
 /obj/machinery/button/door/directional/north{
@@ -1084,9 +1079,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/structure/bed/dogbed,
-/obj/effect/decal/cleanable/oil,
-/mob/living/simple_animal/pet/syndifox,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "dI" = (
@@ -1225,11 +1220,9 @@
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "ep" = (
-/obj/structure/closet/secure_closet/freezer/meat{
-	req_access_txt = "150"
-	},
 /obj/effect/turf_decal/bot_blue,
 /obj/machinery/light/dim/directional/west,
+/obj/machinery/icecream_vat,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "ez" = (
@@ -1295,6 +1288,16 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
+"eG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/sofa/middle{
+	dir = 4;
+	color = "#800000"
+	},
+/turf/open/floor/wood/wood_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "eH" = (
 /obj/effect/turf_decal/box/red/corners,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -1424,16 +1427,17 @@
 "fa" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4;
+	level = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "fc" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 8
@@ -1494,9 +1498,6 @@
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -1934,11 +1935,11 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
 "hh" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	color = "#4D4D4D"
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "hi" = (
@@ -2135,9 +2136,6 @@
 	anchored = 1
 	},
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
@@ -2428,14 +2426,12 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
 "iY" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/comfy{
+	dir = 4;
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "iZ" = (
 /obj/machinery/light/dim/directional/south,
@@ -2492,9 +2488,6 @@
 /obj/structure/closet/emcloset,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -2573,7 +2566,7 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "jt" = (
 /obj/effect/turf_decal/siding/wood,
@@ -2593,9 +2586,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "jB" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479"
-	},
 /obj/machinery/button/door{
 	desc = "Keep out the paperwork.";
 	id = "ds2admiral";
@@ -2604,6 +2594,15 @@
 	pixel_y = 24;
 	req_access_txt = "151"
 	},
+/obj/item/camera{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/paper{
+	default_raw_text = "<h1>Командный Отчёт DS2</h1><p>Передовая оперативная база 'Благословлённый' под кодовым названием Deep Space 2 успешно разместилась вблизи активных объектов NanoTrasen. Идет перезагрузка двигателей шаттла...</p><p>Синдикат рад видеть вас на поле боя, адмирал. Nanotrasen находится в опасном секторе и, как таковой, является прямой целью оперативников из других Пластов Вселенной. Управляйте своим экипажем хорошо и с уважением, а весь свой гнев оставьте для достойной битвы с Аномалиями. Помните о том, что DS1 находятся под вашей ответственностью и их проблемы - ваши проблемы. Не советуем вашему экипажу выставлять напоказ свою групповую принадлежность, если только вы не являетесь представителем Кайберсанов или Горлексов.</p><p>Не болейте и оставайтесь в выигрыше.</p>";
+	name = "paper- 'Командный Отчёт DS2'"
+	},
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "jC" = (
@@ -2617,9 +2616,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "jD" = (
-/obj/item/storage/secure/briefcase/permits{
-	pixel_y = 13
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
 	},
+/obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "jJ" = (
@@ -2761,14 +2761,14 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "kc" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 10;
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -2778,9 +2778,6 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /obj/machinery/button/door/incinerator_vent_syndicatelava_aux{
 	name = "Combustion Chamber Blast Door Control";
 	pixel_x = -24;
@@ -2855,13 +2852,18 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "kG" = (
-/obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 6;
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -3042,7 +3044,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "lu" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+	dir = 5
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -3054,23 +3056,16 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/light/dim/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/photocopier,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "lD" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/obj/structure/chair/office{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/turf/open/floor/iron/dark/textured_half,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1;
+	name = "tactical chair"
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "lF" = (
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
@@ -3407,19 +3402,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "mY" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
+	},
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -3480,9 +3467,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "nG" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -3603,14 +3587,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "nV" = (
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/storage/fancy/egg_box,
 /obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null;
-	req_access_txt = "150"
-	},
+/obj/machinery/gibber,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "ob" = (
@@ -3631,9 +3609,6 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -3653,7 +3628,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "of" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+	dir = 9
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -3664,6 +3639,9 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/light/dim/directional/south,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "og" = (
@@ -3733,10 +3711,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "ou" = (
-/obj/effect/turf_decal/trimline/dark_red/corner,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
 /obj/item/paper{
 	default_raw_text = "<h1>Отчёт о Пополнении Состава DS2</h1><p>Передовая оперативная база 'Благословлённый' под кодовым названием Deep Space 2 успешно переместилась вблизи активных объектов NanoTrasen. Идет перезагрузка двигателей шаттла...</p><p>Активные оперативники Синдиката были переведены на DS2 для слежки за Кордоном и не должны взаимодействовать с Космической Станцией Тринадцатого Сектора, если только командование Синдиката это не разрешит или не появится особо серьёзная для этого причина. Разрешение на наблюдение за их деятельностью получено и настоятельно рекомендуется.</p><p>Не болейте и оставайтесь в выигрыше.</p>";
 	name = "paper- 'Отчёт о Пополнении Состава DS2'"
@@ -3751,14 +3725,17 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ox" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/obj/machinery/jukebox/disco{
-	anchored = 1;
-	req_one_access = null
+/obj/effect/turf_decal/siding/thinplating/end{
+	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "oz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -3832,8 +3809,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "oT" = (
-/obj/machinery/icecream_vat,
-/turf/open/floor/iron/white,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "oV" = (
 /obj/machinery/door/firedoor,
@@ -3984,9 +3963,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -4057,15 +4033,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "pz" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -4077,25 +4044,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/sofa/left{
+	dir = 4;
+	color = "#800000"
+	},
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "pI" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
 /obj/structure/window/reinforced/survival_pod,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/siding/thinplating/end{
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/small,
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "pL" = (
 /obj/structure/table/reinforced,
@@ -4154,10 +4120,6 @@
 "qa" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5;
-	pixel_y = 6
-	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -4256,9 +4218,6 @@
 	dir = 4
 	},
 /obj/structure/railing/corner,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -4336,20 +4295,17 @@
 "qH" = (
 /obj/structure/table,
 /obj/machinery/light/dim/directional/east,
-/obj/item/rsf{
-	pixel_y = 14
-	},
-/obj/item/rcd_ammo{
-	pixel_y = 11
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/item/storage/box/beakers/variety,
+/obj/item/storage/belt/military/snack,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "qI" = (
-/obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/computer/crew/syndie,
 /turf/open/floor/iron/dark/textured_large,
@@ -4357,6 +4313,9 @@
 "qK" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
+	},
+/mob/living/simple_animal/pet/penguin/emperor/shamebrero{
+	name = "Alberto Diego San Francisco Diaz Mias Buritos"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
@@ -4631,13 +4590,11 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "rM" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "rN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4657,6 +4614,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"rR" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "rU" = (
 /obj/structure/sink/directional/east{
 	pixel_y = -6
@@ -4708,6 +4669,14 @@
 /obj/item/storage/fancy/egg_box,
 /obj/effect/turf_decal/bot_blue,
 /obj/machinery/light/dim/directional/south,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/sugar,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "sh" = (
@@ -4869,6 +4838,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/end,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/item/export/bottle/tequila{
+	pixel_x = 11;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "sV" = (
@@ -5342,19 +5315,11 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "uZ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "va" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -5674,9 +5639,6 @@
 	anchored = 1
 	},
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "wj" = (
@@ -5838,10 +5800,13 @@
 "xk" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 8;
-	pixel_y = 0;
-	flags_1 = 2
+	flags_1 = 2;
+	pixel_x = 3;
+	pixel_y = 0
 	},
-/obj/structure/table/wood,
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "xp" = (
@@ -5910,6 +5875,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "DS2lab"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "xH" = (
@@ -6083,13 +6051,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "yy" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "yA" = (
 /obj/docking_port/stationary{
@@ -6115,19 +6077,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "yI" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "yL" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/closet/secure_closet{
@@ -6199,9 +6153,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "zb" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/iron/dark,
@@ -6351,7 +6302,10 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "zD" = (
-/obj/machinery/photocopier,
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	color = "#4D4D4D"
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "zH" = (
@@ -6395,15 +6349,16 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
+"zR" = (
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "zS" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -6435,11 +6390,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "zV" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
+/obj/structure/chair/sofa/left{
+	color = "#800000"
 	},
-/obj/structure/chair,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "zX" = (
 /obj/structure/window/reinforced/tinted{
@@ -6502,7 +6456,7 @@
 	pixel_x = -4;
 	pixel_y = 15
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Au" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -6521,7 +6475,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Av" = (
-/obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/computer/message_monitor{
@@ -6553,17 +6506,18 @@
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "AC" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/siding/thinplating/end{
+/obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 4
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 10
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/computer/station_alert{
 	dir = 1
 	},
-/turf/open/floor/iron/small,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "AG" = (
 /obj/structure/closet/secure_closet{
@@ -6894,19 +6848,15 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Ch" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/window/survival_pod{
 	name = "Diner";
 	req_access_txt = "150"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Cj" = (
 /obj/machinery/light/dim/directional/west,
@@ -6919,7 +6869,10 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
 "Cm" = (
-/obj/effect/mob_spawn/human/ds2/syndicate_command/corporateliaison,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/fox{
+	name = "Rhials"
+	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "Cn" = (
@@ -6999,7 +6952,7 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "CH" = (
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "CJ" = (
 /obj/structure/window/reinforced/tinted{
@@ -7199,25 +7152,14 @@
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DF" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/dark_red/corner,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/item/paper_bin/carbon{
-	pixel_y = 3
-	},
+/obj/item/paper_bin/carbon,
 /obj/item/pen/fountain/captain{
-	name = "admiral's fountain pen";
-	pixel_y = 5
+	name = "admiral's fountain pen"
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "DH" = (
 /obj/effect/turf_decal/siding/dark{
@@ -7485,14 +7427,12 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "EU" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa/right{
+	dir = 1;
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "EV" = (
 /obj/structure/weightmachine/stacklifter,
@@ -7559,6 +7499,13 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+"Fc" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "DS2lab"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Fe" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -7567,9 +7514,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Ff" = (
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plastitanium,
 /obj/item/stack/sheet/plastitaniumglass,
@@ -7589,15 +7533,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Fi" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Fj" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -7709,9 +7649,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "FD" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/machinery/button/door/directional/north{
 	desc = "Keep out the paperwork.";
 	id = "scorpliaison";
@@ -7721,6 +7658,9 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/dim/directional/west,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "FG" = (
@@ -7787,13 +7727,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "FY" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -7801,7 +7735,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "FZ" = (
 /turf/open/floor/iron/dark,
@@ -7885,24 +7822,15 @@
 /obj/structure/window/reinforced/survival_pod,
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/table,
-/obj/item/choice_beacon/ingredients{
-	pixel_y = 11
-	},
-/obj/item/choice_beacon/ingredients{
-	pixel_x = -5;
-	pixel_y = 2
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/item/clothing/accessory/armband/hydro{
 	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
-	name = "service armband";
-	pixel_x = 15
+	name = "service armband"
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 17;
-	pixel_y = 8
+	pixel_x = 9;
+	pixel_y = 15
 	},
-/obj/item/storage/belt/military/snack,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -8035,14 +7963,9 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "GV" = (
-/obj/structure/table/wood,
-/obj/item/camera{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/paper{
-	default_raw_text = "<h1>Командный Отчёт DS2</h1><p>Передовая оперативная база 'Благословлённый' под кодовым названием Deep Space 2 успешно разместилась вблизи активных объектов NanoTrasen. Идет перезагрузка двигателей шаттла...</p><p>Синдикат рад видеть вас на поле боя, адмирал. Nanotrasen находится в опасном секторе и, как таковой, является прямой целью оперативников из других Пластов Вселенной. Управляйте своим экипажем хорошо и с уважением, а весь свой гнев оставьте для достойной битвы с Аномалиями. Помните о том, что DS1 находятся под вашей ответственностью и их проблемы - ваши проблемы. Не советуем вашему экипажу выставлять напоказ свою групповую принадлежность, если только вы не являетесь представителем Кайберсанов или Горлексов.</p><p>Не болейте и оставайтесь в выигрыше.</p>";
-	name = "paper- 'Командный Отчёт DS2'"
+/obj/structure/chair/sofa/middle{
+	dir = 8;
+	color = "#4D4D4D"
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
@@ -8095,12 +8018,17 @@
 "Hh" = (
 /obj/structure/table,
 /obj/machinery/light/dim/directional/east,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/spawner/lootdrop/pizzaparty{
+	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
+	pixel_y = 9
+	},
+/obj/effect/spawner/lootdrop/pizzaparty{
+	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
+	pixel_y = 9
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -8134,9 +8062,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
@@ -8146,7 +8071,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Ht" = (
-/obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/computer/shuttle{
 	desc = "A shuttle terminal which allows a connection to the DS-2 forward base's supply shuttle.";
@@ -8189,7 +8113,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Hz" = (
@@ -8221,19 +8147,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "HE" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	color = "#800000"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "HF" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -8449,7 +8368,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "IN" = (
-/obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -8458,6 +8376,7 @@
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "IQ" = (
@@ -8482,9 +8401,6 @@
 	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
 	},
 /obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/dark/smooth_large,
@@ -8594,9 +8510,6 @@
 /obj/item/clothing/head/HoS/beret/syndicate,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -8977,6 +8890,17 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+"La" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_tiled,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Lb" = (
 /obj/effect/turf_decal/tile/dark_red/half,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
@@ -8988,7 +8912,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Lf" = (
 /obj/effect/turf_decal/siding/wood,
@@ -9208,9 +9132,6 @@
 /obj/structure/sign/flag/syndicate/directional/south,
 /obj/machinery/light/dim/directional/south,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -9236,19 +9157,10 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "LQ" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
-/obj/item/poster/random_contraband{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband{
-	pixel_x = 2;
-	pixel_y = 5
+/obj/structure/chair/sofa/right{
+	dir = 1;
+	color = "#4D4D4D"
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -9310,7 +9222,15 @@
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Mk" = (
-/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
+	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Mn" = (
@@ -9331,13 +9251,12 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "Mw" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
 /obj/machinery/light/dim/directional/west,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/comfy{
+	dir = 4;
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "MB" = (
 /obj/structure/cable,
@@ -9356,10 +9275,9 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "MC" = (
-/obj/structure/table/wood,
-/obj/machinery/fax{
-	fax_name = "DS-2 Syndicate Fax";
-	name = "DS-2 Fax Machine"
+/obj/structure/chair/sofa/corner{
+	dir = 8;
+	color = "#4D4D4D"
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
@@ -9375,8 +9293,14 @@
 "MF" = (
 /obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/freezer/meat{
-	req_access_txt = "150"
+	req_access_txt = "150";
+	pixel_x = 0;
+	pixel_y = 0
 	},
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
+/obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "MG" = (
@@ -9571,7 +9495,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Nr" = (
-/obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -9582,6 +9505,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -9772,10 +9701,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "NX" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479"
-	},
 /obj/machinery/light/dim/directional/north,
+/obj/structure/chair/sofa/right{
+	dir = 8;
+	color = "#4D4D4D"
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "NY" = (
@@ -9783,14 +9713,18 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Ob" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured_corner,
+/obj/machinery/light/dim/directional/north,
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/item/paper/fluff/ruins/listeningstation/receipt,
+/obj/item/paper/fluff/ruins/listeningstation/reports/october,
+/obj/item/paper/fluff/ruins/listeningstation/reports/september,
+/obj/item/paper/fluff/ruins/listeningstation/reports/august,
+/obj/item/paper/fluff/ruins/listeningstation/reports/july,
+/obj/item/paper/fluff/ruins/listeningstation/reports/june,
+/obj/item/paper/fluff/ruins/listeningstation/reports/may,
+/obj/item/paper/fluff/ruins/listeningstation/reports/april,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Oc" = (
 /obj/effect/turf_decal/siding/dark{
@@ -9807,14 +9741,17 @@
 "Od" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 8;
-	pixel_y = 4;
-	flags_1 = 2
+	pixel_y = 0;
+	flags_1 = 2;
+	pixel_x = 3
 	},
-/obj/structure/table/wood,
 /obj/machinery/firealarm/directional/east,
 /obj/item/reagent_containers/food/drinks/shaker{
 	pixel_x = -6;
 	pixel_y = -7
+	},
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -9827,9 +9764,6 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "Ok" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
@@ -9842,10 +9776,6 @@
 	},
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/vending/snack,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10;
-	pixel_y = -7
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Ov" = (
@@ -9892,9 +9822,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
@@ -10091,20 +10018,14 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Pt" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
+/turf/open/floor/iron/kitchen{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_half,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Px" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/window/reinforced/survival_pod,
@@ -10210,7 +10131,16 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/grill,
+/obj/structure/rack,
+/obj/item/rsf{
+	pixel_y = 10;
+	pixel_x = 3
+	},
+/obj/item/rcd_ammo{
+	pixel_y = -3;
+	pixel_x = 10
+	},
+/obj/item/storage/box/beakers/variety,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -10242,10 +10172,10 @@
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "Qa" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
+/obj/machinery/jukebox{
+	req_one_access = null
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Qb" = (
 /turf/open/floor/engine,
@@ -10322,15 +10252,21 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/bed/dogbed,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
+/obj/structure/rack,
+/obj/item/storage/secure/briefcase/permits{
+	pixel_y = 13
 	},
-/mob/living/simple_animal/pet/fox{
-	name = "Rhials"
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/poster/random_contraband{
+	pixel_x = 2;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -10385,12 +10321,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "QB" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/button/door/directional/east{
 	desc = "To keep your food away from the carp.";
 	id = "diner-view";
@@ -10398,7 +10328,7 @@
 	pixel_y = -24;
 	req_access_txt = "150"
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "QC" = (
 /obj/effect/turf_decal/trimline/dark_green/corner,
@@ -10509,8 +10439,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "QW" = (
-/obj/structure/chair/office/light{
-	dir = 8
+/obj/structure/chair/sofa/left{
+	dir = 4;
+	color = "#4D4D4D"
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
@@ -10619,16 +10550,14 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Rr" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/chair/stool/bar{
-	dir = 4
+/obj/structure/chair/sofa/right{
+	dir = 4;
+	color = "#800000"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Rt" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -10659,13 +10588,12 @@
 	req_access = null;
 	req_access_txt = "150"
 	},
-/obj/effect/spawner/lootdrop/pizzaparty{
-	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
-	pixel_y = 9
+/obj/item/choice_beacon/ingredients{
+	pixel_x = -5;
+	pixel_y = 2
 	},
-/obj/effect/spawner/lootdrop/pizzaparty{
-	loot = list(/obj/item/pizzabox/margherita=2,/obj/item/pizzabox/meat=2,/obj/item/pizzabox/mushroom=2,/obj/item/pizzabox/pineapple=2,/obj/item/pizzabox/vegetable=2);
-	pixel_y = 9
+/obj/item/choice_beacon/ingredients{
+	pixel_y = 11
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
@@ -10732,7 +10660,6 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "RQ" = (
-/obj/structure/table/wood,
 /obj/item/stamp{
 	pixel_x = -7;
 	pixel_y = 6
@@ -10759,6 +10686,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
+/obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RT" = (
@@ -10792,10 +10720,10 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RY" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RZ" = (
@@ -10824,9 +10752,6 @@
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/survival_pod,
 /obj/item/paper_bin,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /obj/item/pen,
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/wood,
@@ -10934,7 +10859,6 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Sx" = (
-/obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/computer/camera_advanced/syndie,
@@ -11059,7 +10983,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "SY" = (
-/obj/structure/table/wood,
 /obj/item/storage/photo_album/syndicate{
 	pixel_x = -5;
 	pixel_y = -3
@@ -11079,6 +11002,7 @@
 	pixel_x = -7;
 	pixel_y = 6
 	},
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "SZ" = (
@@ -11404,9 +11328,6 @@
 	},
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/item/flashlight/lamp/green{
 	pixel_x = -10
 	},
@@ -11417,11 +11338,21 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Ui" = (
-/obj/structure/table/wood,
 /obj/item/reagent_containers/rag,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
 	pixel_x = 3;
 	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 11;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -11429,9 +11360,6 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/command{
 	hackProof = 1;
 	name = "Bridge";
@@ -11459,14 +11387,13 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Un" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
 /obj/machinery/light/dim/directional/east,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/comfy{
+	dir = 8;
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Up" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -11712,22 +11639,20 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Vn" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4;
+	level = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8;
+	name = "disposal pipe"
 	},
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 8
-	},
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Vo" = (
 /obj/machinery/light/dim/directional/west,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -11761,8 +11686,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Vw" = (
-/obj/machinery/gibber,
 /obj/machinery/light/dim/directional/south,
+/obj/machinery/grill,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -12082,11 +12007,10 @@
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "WA" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "WC" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -12142,28 +12066,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "WN" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark/textured_half,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "WS" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -12465,21 +12373,15 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "XN" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/obj/machinery/computer/monitor{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
 	req_access_txt = "150"
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/fax{
+	fax_name = "DS-2 Syndicate Fax";
+	name = "DS-2 Fax Machine"
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -12498,17 +12400,17 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/west,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "XV" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa/right{
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "XX" = (
 /obj/structure/railing{
@@ -12526,16 +12428,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Ya" = (
-/obj/structure/filingcabinet,
-/obj/item/paper/fluff/ruins/listeningstation/reports/april,
-/obj/item/paper/fluff/ruins/listeningstation/reports/may,
-/obj/item/paper/fluff/ruins/listeningstation/reports/june,
-/obj/item/paper/fluff/ruins/listeningstation/reports/july,
-/obj/item/paper/fluff/ruins/listeningstation/reports/august,
-/obj/item/paper/fluff/ruins/listeningstation/reports/september,
-/obj/item/paper/fluff/ruins/listeningstation/reports/october,
-/obj/item/paper/fluff/ruins/listeningstation/receipt,
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -12544,6 +12436,9 @@
 	pixel_x = -16
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/machinery/computer/monitor{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_half,
@@ -12604,10 +12499,6 @@
 "Yz" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/vending/games,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6;
-	pixel_y = -7
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "YC" = (
@@ -12629,8 +12520,10 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison/shower)
 "YG" = (
-/obj/effect/mob_spawn/human/ds2/syndicate_command/admiral,
-/turf/open/floor/carpet/red,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/syndifox,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "YH" = (
 /obj/machinery/door/airlock/silver{
@@ -12680,6 +12573,11 @@
 	network = list("ds2")
 	},
 /obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/button/door/directional/west{
+	id = "DS2lab";
+	name = "Research shutters control";
+	req_access_txt = "150"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "YT" = (
@@ -12753,19 +12651,15 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "Zt" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/three_course_meal{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/effect/spawner/lootdrop/three_course_meal{
-	pixel_y = 3
-	},
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_y = 7;
+	pixel_x = 0
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Zz" = (
 /obj/machinery/door/firedoor,
@@ -13752,8 +13646,8 @@ on
 yP
 sO
 NW
-HE
-Lz
+Fj
+on
 XR
 Lz
 Lz
@@ -14026,8 +13920,8 @@ wg
 wg
 aT
 Bk
-VM
-fa
+Ob
+Ke
 dO
 ak
 hi
@@ -14082,7 +13976,7 @@ Bk
 Bk
 XN
 AV
-uZ
+BT
 lu
 RX
 RX
@@ -14137,8 +14031,8 @@ UB
 qI
 lD
 AV
-yI
-Vn
+BT
+AV
 AC
 RX
 Cm
@@ -14168,7 +14062,7 @@ Io
 OK
 OD
 Cn
-Qb
+zR
 YC
 Tt
 Tt
@@ -14355,10 +14249,10 @@ iE
 wg
 UB
 Ht
-Pt
+dD
 AV
 BT
-Ob
+AV
 ZA
 EY
 YG
@@ -14811,9 +14705,9 @@ Hz
 Fm
 Hz
 Hz
-Fz
-Fz
-Fz
+Fc
+Fc
+Fc
 xG
 Hz
 my
@@ -15125,9 +15019,9 @@ LT
 Vm
 bw
 Zt
-FY
-Qa
-Qa
+Vn
+rR
+uZ
 Iw
 uf
 DH
@@ -15180,9 +15074,9 @@ bw
 bw
 bw
 ch
-FY
-Qa
-Qa
+fa
+yy
+yy
 lO
 No
 kD
@@ -15231,12 +15125,12 @@ wg
 xr
 NB
 bw
-zV
+oT
 Mw
 yy
 WA
 pz
-Rr
+eG
 Rr
 tZ
 jT
@@ -15244,7 +15138,7 @@ WL
 Ws
 Rz
 ep
-oT
+Kg
 nV
 Hz
 YK
@@ -15287,8 +15181,8 @@ wg
 xr
 bw
 XV
-Qa
-Qa
+yI
+HE
 Fi
 Nr
 Mk
@@ -15347,7 +15241,7 @@ EU
 Ch
 kc
 Hw
-Hw
+La
 ro
 eP
 zq
@@ -15396,7 +15290,7 @@ EJ
 kx
 Mt
 bw
-zV
+oT
 Un
 QB
 pI
@@ -15461,7 +15355,7 @@ bw
 bw
 qa
 qH
-jj
+Pt
 aC
 Cf
 Cf
@@ -15516,7 +15410,7 @@ wg
 gv
 bw
 bw
-jj
+Pt
 Bt
 Hh
 Bj

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -2866,7 +2866,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -4605,7 +4605,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "rM" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/carpet/blackred,
@@ -4914,7 +4914,7 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
 "tj" = (
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/carpet/blackred,
@@ -5833,7 +5833,7 @@
 	pixel_x = 3;
 	pixel_y = 0
 	},
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -9251,7 +9251,7 @@
 /obj/effect/spawner/lootdrop/three_course_meal{
 	pixel_y = 3
 	},
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -9532,7 +9532,7 @@
 /obj/effect/spawner/lootdrop/three_course_meal{
 	pixel_y = 3
 	},
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -9766,7 +9766,7 @@
 	pixel_x = -6;
 	pixel_y = -7
 	},
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -11382,7 +11382,7 @@
 	pixel_x = 12;
 	pixel_y = 6
 	},
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -12685,7 +12685,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "Zt" = (
 /obj/machinery/light/dim/directional/north,
-/obj/structure/table/reinforced/plastitaniumglass{
+/obj/structure/table/reinforced{
 	color = "#777777"
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large{

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -85,7 +85,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "ak" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -1144,7 +1146,9 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "dQ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3069,7 +3073,9 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "lD" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -3432,7 +3438,9 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "nd" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -3665,7 +3673,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/dark_red/corner,
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 2
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "og" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -3748,7 +3758,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "ov" = (
 /obj/structure/disposalpipe/segment{
@@ -4355,7 +4365,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "qK" = (
 /obj/effect/turf_decal/siding/dark{
@@ -4871,7 +4881,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_corner{
+/turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -6191,7 +6201,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_corner{
+/turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -6548,7 +6558,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Aw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -8134,8 +8144,8 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Ht" = (
@@ -8159,7 +8169,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Hu" = (
 /obj/structure/closet/crate,
@@ -10873,21 +10883,19 @@
 	anchorable = 0;
 	anchored = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/corner,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
 /obj/machinery/camera/xray/directional/south{
 	c_tag = "DS-2 Bridge";
 	network = list("ds2")
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Sj" = (
@@ -10964,7 +10972,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Sy" = (
 /obj/effect/turf_decal/siding/dark,
@@ -11516,8 +11524,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_red/corner,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Us" = (
@@ -12497,7 +12505,9 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "XP" = (
 /obj/structure/window/reinforced/tinted{
@@ -12821,7 +12831,7 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
+/turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -65,10 +65,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ah" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/wood/wood_parquet,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "aj" = (
 /obj/structure/frame/machine{
@@ -5081,9 +5081,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "tH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
 	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/item/clothing/under/syndicate/baseball,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tJ" = (
@@ -7387,14 +7391,10 @@
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "DV" = (
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/item/clothing/under/syndicate/baseball,
-/turf/open/floor/carpet/blackred,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DZ" = (
 /obj/machinery/airalarm/syndicate{
@@ -9118,6 +9118,10 @@
 "KY" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/camera/xray/directional/south{
+	c_tag = "DS-2 Dormitories 2";
+	network = list("ds2")
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Lb" = (
@@ -13230,7 +13234,7 @@ wg
 nO
 Kf
 Kf
-DV
+tH
 EP
 mX
 Fq
@@ -13451,7 +13455,7 @@ Az
 Kf
 qc
 qc
-ah
+DV
 kF
 pX
 uS
@@ -13780,7 +13784,7 @@ nn
 Pe
 Kf
 qs
-tH
+ah
 QO
 uV
 xy

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -326,6 +326,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
+"ba" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "bd" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -464,7 +468,7 @@
 	dir = 4;
 	layer = 4.1
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "bu" = (
 /obj/structure/curtain,
@@ -790,6 +794,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
+"cw" = (
+/obj/structure/chair/sofa/left{
+	color = "#800000"
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "cy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -848,15 +858,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "cG" = (
-/obj/item/bedsheet/qm/double{
-	desc = "It is decorated with the Donk Co. logo.";
-	name = "corporate liaison's bedsheet"
-	},
 /obj/structure/bed/double,
 /obj/effect/mob_spawn/human/ds2/syndicate_command/corporateliaison{
 	dir = 8;
 	layer = 4.1
 	},
+/obj/item/bedsheet/syndie/double,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "cI" = (
@@ -895,7 +902,10 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/cell_charger_multi,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	req_access_txt = "150";
+	req_access = null
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "cP" = (
@@ -966,7 +976,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	req_access_txt = "150";
+	req_access = null
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
@@ -1272,7 +1285,10 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "eE" = (
 /obj/structure/filingcabinet,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
@@ -1288,16 +1304,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
-"eG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/chair/sofa/middle{
-	dir = 4;
-	color = "#800000"
-	},
-/turf/open/floor/wood/wood_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "eH" = (
 /obj/effect/turf_decal/box/red/corners,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -1425,18 +1431,13 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "fa" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
+/turf/open/floor/iron/kitchen{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "fc" = (
 /obj/effect/turf_decal/box/red/corners{
@@ -1594,7 +1595,10 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -2566,7 +2570,7 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "jt" = (
 /obj/effect/turf_decal/siding/wood,
@@ -3809,10 +3813,17 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "oT" = (
-/obj/item/kirbyplants/hedge{
-	anchored = 1
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/turf/open/floor/carpet/blackred,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "oV" = (
 /obj/machinery/door/firedoor,
@@ -4378,7 +4389,10 @@
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -4614,10 +4628,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
-"rR" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "rU" = (
 /obj/structure/sink/directional/east{
 	pixel_y = -6
@@ -4749,7 +4759,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	req_access_txt = "150";
+	req_access = null
+	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
@@ -4900,6 +4913,12 @@
 /turf/open/floor/plasteel/showroomfloor/shower,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
+"tj" = (
+/obj/structure/table/reinforced/plastitaniumglass{
+	color = "#777777"
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "tk" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -5168,7 +5187,10 @@
 	},
 /obj/structure/closet/crate/goldcrate,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	req_access_txt = "150";
+	req_access = null
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 9;
 	level = 1
@@ -5315,10 +5337,14 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "uZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/carpet/blackred,
+/obj/structure/chair/sofa/middle{
+	dir = 4;
+	color = "#800000"
+	},
+/turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "va" = (
 /obj/effect/spawner/structure/window/plastitanium,
@@ -5422,7 +5448,10 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -6077,11 +6106,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "yI" = (
-/obj/structure/table/reinforced/plastitaniumglass{
-	color = "#777777"
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/engine,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "yL" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/closet/secure_closet{
@@ -6355,10 +6382,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
-"zR" = (
-/mob/living/simple_animal/cockroach,
-/turf/open/floor/engine,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "zS" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
@@ -6390,8 +6413,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "zV" = (
-/obj/structure/chair/sofa/left{
-	color = "#800000"
+/obj/item/kirbyplants/hedge{
+	anchored = 1
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -6456,7 +6479,7 @@
 	pixel_x = -4;
 	pixel_y = 15
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Au" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -6693,7 +6716,10 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	req_access_txt = "150";
+	req_access = null
+	},
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
@@ -6952,7 +6978,7 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "CH" = (
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "CJ" = (
 /obj/structure/window/reinforced/tinted{
@@ -7499,13 +7525,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
-"Fc" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "DS2lab"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Fe" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -7735,8 +7754,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8;
+	name = "disposal pipe"
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -8110,10 +8130,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -8147,9 +8165,16 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "HE" = (
-/obj/structure/chair/sofa/left{
-	dir = 1;
-	color = "#800000"
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -8311,7 +8336,10 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
@@ -8405,6 +8433,12 @@
 /obj/machinery/suit_storage_unit/syndicate/chameleon,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
+"Jc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Jd" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
@@ -8890,17 +8924,6 @@
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
-"La" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Lb" = (
 /obj/effect/turf_decal/tile/dark_red/half,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
@@ -8912,7 +8935,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Lf" = (
 /obj/effect/turf_decal/siding/wood,
@@ -9713,19 +9736,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Ob" = (
-/obj/machinery/light/dim/directional/north,
-/obj/structure/filingcabinet,
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
-/obj/item/paper/fluff/ruins/listeningstation/receipt,
-/obj/item/paper/fluff/ruins/listeningstation/reports/october,
-/obj/item/paper/fluff/ruins/listeningstation/reports/september,
-/obj/item/paper/fluff/ruins/listeningstation/reports/august,
-/obj/item/paper/fluff/ruins/listeningstation/reports/july,
-/obj/item/paper/fluff/ruins/listeningstation/reports/june,
-/obj/item/paper/fluff/ruins/listeningstation/reports/may,
-/obj/item/paper/fluff/ruins/listeningstation/reports/april,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "DS2lab"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Oc" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -9931,7 +9947,10 @@
 	dir = 9
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /obj/structure/chair/sofa/corp/right{
 	color = "#DE3A3A";
 	dir = 4
@@ -10018,14 +10037,19 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Pt" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/kitchen{
-	dir = 4
-	},
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+/obj/machinery/light/dim/directional/north,
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/item/paper/fluff/ruins/listeningstation/receipt,
+/obj/item/paper/fluff/ruins/listeningstation/reports/october,
+/obj/item/paper/fluff/ruins/listeningstation/reports/september,
+/obj/item/paper/fluff/ruins/listeningstation/reports/august,
+/obj/item/paper/fluff/ruins/listeningstation/reports/july,
+/obj/item/paper/fluff/ruins/listeningstation/reports/june,
+/obj/item/paper/fluff/ruins/listeningstation/reports/may,
+/obj/item/paper/fluff/ruins/listeningstation/reports/april,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Px" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/window/reinforced/survival_pod,
@@ -10172,8 +10196,9 @@
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "Qa" = (
-/obj/machinery/jukebox{
-	req_one_access = null
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	color = "#800000"
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -10631,6 +10656,12 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
+"RK" = (
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "RL" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -11640,16 +11671,15 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Vn" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8;
-	name = "disposal pipe"
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -12365,7 +12395,10 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	req_access = null;
+	req_access_txt = "150"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -12523,7 +12556,7 @@
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/syndifox,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "YH" = (
 /obj/machinery/door/airlock/silver{
@@ -13920,7 +13953,7 @@ wg
 wg
 aT
 Bk
-Ob
+Pt
 Ke
 dO
 ak
@@ -14062,7 +14095,7 @@ Io
 OK
 OD
 Cn
-zR
+yI
 YC
 Tt
 Tt
@@ -14705,9 +14738,9 @@ Hz
 Fm
 Hz
 Hz
-Fc
-Fc
-Fc
+Ob
+Ob
+Ob
 xG
 Hz
 my
@@ -14964,8 +14997,8 @@ rU
 me
 bw
 iY
-FY
-Qa
+HE
+RK
 ox
 Iw
 gs
@@ -15019,9 +15052,9 @@ LT
 Vm
 bw
 Zt
-Vn
-rR
-uZ
+FY
+ba
+Jc
 Iw
 uf
 DH
@@ -15074,7 +15107,7 @@ bw
 bw
 bw
 ch
-fa
+Vn
 yy
 yy
 lO
@@ -15125,12 +15158,12 @@ wg
 xr
 NB
 bw
-oT
+zV
 Mw
 yy
 WA
 pz
-eG
+uZ
 Rr
 tZ
 jT
@@ -15181,8 +15214,8 @@ wg
 xr
 bw
 XV
-yI
-HE
+tj
+Qa
 Fi
 Nr
 Mk
@@ -15235,13 +15268,13 @@ wg
 wg
 wg
 bw
-zV
+cw
 rM
 EU
 Ch
 kc
+oT
 Hw
-La
 ro
 eP
 zq
@@ -15290,7 +15323,7 @@ EJ
 kx
 Mt
 bw
-oT
+zV
 Un
 QB
 pI
@@ -15355,7 +15388,7 @@ bw
 bw
 qa
 qH
-Pt
+fa
 aC
 Cf
 Cf
@@ -15410,7 +15443,7 @@ wg
 gv
 bw
 bw
-Pt
+fa
 Bt
 Hh
 Bj

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -285,12 +285,6 @@
 "aT" = (
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
-"aU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "aW" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 6
@@ -524,19 +518,20 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "bP" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
+/obj/machinery/button/door{
+	id = "TESBattlespire";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 5;
+	pixel_y = 34;
+	specialfunctions = 4
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/obj/machinery/light/dim/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "bR" = (
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/tile/dark_blue/full,
@@ -955,13 +950,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
-"cX" = (
-/obj/structure/bookcase/random/adult,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
@@ -995,18 +983,11 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "dh" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
-/obj/machinery/airalarm/syndicate{
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "dn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -1210,6 +1191,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
+"dW" = (
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "dZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -1516,13 +1503,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
-"fq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+"fv" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "fw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -1861,10 +1855,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
-"gL" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "gN" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -2180,10 +2170,6 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
-"hN" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "hP" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -2244,6 +2230,10 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
+"ic" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ie" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos{
@@ -2392,15 +2382,27 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "iK" = (
-/turf/open/floor/iron/dark/side{
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
-"iM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light/dim/directional/east,
-/turf/open/floor/wood/wood_parquet,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+"iM" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/trimline/dark/line,
+/obj/effect/turf_decal/trimline/dark/line,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/washing_machine,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "iO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -2415,10 +2417,8 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "iR" = (
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
-/turf/open/floor/wood/wood_parquet,
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "iS" = (
 /obj/machinery/meter,
@@ -2428,11 +2428,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "iV" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/structure/sink/kitchen/directional/east,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "iX" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -2603,6 +2603,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"jA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "jB" = (
 /obj/machinery/button/door{
 	desc = "Keep out the paperwork.";
@@ -2663,16 +2667,9 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
-"jL" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
+"jM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "jN" = (
@@ -2843,6 +2840,9 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"ki" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "km" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/light/dim/directional/north,
@@ -2864,12 +2864,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"kC" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/structure/sink/kitchen/directional/east,
-/turf/open/floor/iron/white/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "kD" = (
 /obj/machinery/smartfridge/food,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -3093,6 +3087,12 @@
 	dir = 8
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+"lz" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "lD" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
@@ -3334,6 +3334,10 @@
 	dir = 8
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"mE" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "mF" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -3392,13 +3396,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
-"mN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "mO" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -4399,6 +4396,13 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"qR" = (
+/obj/structure/bookcase/random/adult,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "qS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -4505,7 +4509,14 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "rj" = (
-/obj/structure/table/wood/fancy/black,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESBattlespire";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "rk" = (
@@ -4652,6 +4663,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"rQ" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "rU" = (
 /obj/structure/sink/directional/east{
 	pixel_y = -6
@@ -4685,13 +4705,16 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "sc" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/trimline/dark/line,
-/obj/effect/turf_decal/trimline/dark/line,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/washing_machine,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESRedguard";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "se" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	req_access = null;
@@ -4778,10 +4801,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
-"sz" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "sB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -4915,10 +4934,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
-"sY" = (
-/obj/structure/sign/flag/syndicate/directional/north,
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "sZ" = (
 /obj/machinery/vending/dinnerware{
 	onstation = 0
@@ -5003,11 +5018,18 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "tt" = (
-/obj/structure/dresser,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
 	},
-/turf/open/floor/carpet/blackred,
+/obj/machinery/airalarm/syndicate{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tA" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -5057,29 +5079,19 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"tH" = (
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tJ" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/machinery/light/dim/directional/west,
-/obj/structure/table,
-/obj/item/coin/iron{
-	pixel_x = -10
-	},
-/obj/item/toy/cards/deck,
-/obj/item/storage/dice{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tL" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/survival_pod{
@@ -5129,14 +5141,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "tR" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESArena";
-	name = "Dormitory"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tS" = (
@@ -5283,9 +5290,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "ui" = (
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/dark/textured_large,
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "um" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -5308,35 +5314,6 @@
 "uu" = (
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
-"uw" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
-"uy" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/light/dim/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
-"uz" = (
-/obj/structure/dresser,
-/obj/machinery/button/door{
-	id = "TESArena";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 5;
-	pixel_y = -34;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "uA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -5868,6 +5845,15 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
+"wR" = (
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "wS" = (
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine,
@@ -5907,6 +5893,15 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
+"xh" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "xj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
@@ -5977,6 +5972,20 @@
 /obj/machinery/atmospherics/pipe/simple/dark,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
+"xD" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "xE" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 3
@@ -6150,9 +6159,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
-"yw" = (
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "yy" = (
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -6609,13 +6615,12 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "Az" = (
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet/blackred,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "AC" = (
 /obj/effect/turf_decal/trimline/dark_red/corner{
@@ -6697,6 +6702,10 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
+"AU" = (
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "AV" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -6785,11 +6794,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
-"Bn" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Bs" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube{
@@ -7089,30 +7093,24 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "CT" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/prison_loot_toilet,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -5;
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/item/toy/crayon/spraycan{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
-"CU" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESBattlespire";
-	name = "Dormitory"
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "CX" = (
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -7194,8 +7192,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Du" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Dv" = (
@@ -7217,6 +7217,12 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"Dx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Dy" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -7372,6 +7378,16 @@
 	},
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+"DV" = (
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/item/clothing/under/syndicate/baseball,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DZ" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
@@ -7405,11 +7421,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
-"Eh" = (
-/obj/effect/turf_decal/box/white,
-/obj/structure/punching_bag,
-/turf/open/floor/carpet/blue,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Ej" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/thinplating/end{
@@ -7473,6 +7484,10 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+"Et" = (
+/obj/structure/sign/flag/syndicate/directional/north,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Ew" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/dark/end{
@@ -7481,12 +7496,6 @@
 /obj/item/reagent_containers/rag/towel/syndicate,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
-"Ex" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Ey" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -7494,19 +7503,6 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
-"Ez" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "EA" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
 /obj/effect/turf_decal/siding/white,
@@ -7555,12 +7551,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "EP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/iron/dark,
+/obj/structure/dresser,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "EQ" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -7745,6 +7737,11 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+"Fq" = (
+/obj/effect/turf_decal/box/white,
+/obj/structure/punching_bag,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Fw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -7876,16 +7873,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
-"FW" = (
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
-	},
-/obj/item/clothing/under/syndicate/baseball,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "FY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
@@ -7996,15 +7983,6 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
-"Gs" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Gt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8077,11 +8055,28 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "GL" = (
-/obj/structure/sign/flag/syndicate/directional/north,
-/obj/structure/table/wood/fancy/black,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/wood/wood_parquet,
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/item/clothing/under/costume/jabroni{
+	has_sensor = 0
+	},
+/obj/item/storage/wallet/random,
+/obj/machinery/button/door{
+	id = "TESRedguard";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 5;
+	pixel_y = 34;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "GO" = (
 /obj/effect/turf_decal/stripes/red/corner,
@@ -8195,6 +8190,19 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+"Hj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Hn" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/window/reinforced/survival_pod{
@@ -8255,12 +8263,16 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Hu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/dark,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Hw" = (
 /obj/structure/disposalpipe/segment{
@@ -8364,6 +8376,11 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
+"HU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "HV" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -8440,16 +8457,10 @@
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Ir" = (
-/obj/item/kirbyplants/hedge{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north{
-	req_access = null;
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
@@ -8547,13 +8558,7 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "IQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -8627,6 +8632,9 @@
 /obj/item/tank/internals/emergency_nitrogen,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+"Jp" = (
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Jv" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/disposalpipe/segment{
@@ -8711,14 +8719,49 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "JE" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
-"JF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/item/radio{
+	desc = "An old handheld radio. You could use it, if you really wanted to.";
+	icon_state = "radio";
+	name = "old radio";
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/item/reagent_containers/rag/towel/syndicate{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
+"JF" = (
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/obj/machinery/power/apc/auto_name/north{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
@@ -8773,23 +8816,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
-"JP" = (
-/obj/structure/bed/double{
-	dir = 1
-	},
-/obj/item/bedsheet/brown/double{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
-"JQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "JR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -8806,6 +8832,13 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+"JX" = (
+/obj/structure/sign/flag/syndicate/directional/north,
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "JZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -8939,12 +8972,6 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
-"Kv" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Kz" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/end,
@@ -8963,10 +8990,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
-"KF" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "KG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -9038,6 +9061,11 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
+"KO" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "KQ" = (
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 4
@@ -9440,9 +9468,6 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
-"Mr" = (
-/turf/closed/wall/r_wall/syndicate,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Mt" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 5
@@ -9457,6 +9482,19 @@
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+"MA" = (
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/item/bedsheet/brown/double{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "MB" = (
 /obj/structure/cable,
 /obj/structure/table/glass,
@@ -9558,30 +9596,6 @@
 /obj/machinery/computer/shuttle/ds_syndicate,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
-"MW" = (
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
-	},
-/obj/item/clothing/under/costume/jabroni{
-	has_sensor = 0
-	},
-/obj/item/storage/wallet/random,
-/obj/machinery/button/door{
-	id = "TESRedguard";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 5;
-	pixel_y = 34;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/blackred,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "MZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -9639,15 +9653,28 @@
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Ni" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 4
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/west,
+/obj/structure/table,
+/obj/item/coin/iron{
+	pixel_x = -10
+	},
+/obj/item/toy/cards/deck,
+/obj/item/storage/dice{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Nk" = (
 /obj/machinery/door/airlock/command{
 	hackProof = 1;
@@ -9764,6 +9791,12 @@
 "NC" = (
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
+"NE" = (
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "NG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -9889,6 +9922,10 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"NU" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "NW" = (
 /obj/structure/chair{
 	dir = 1
@@ -10066,6 +10103,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"OH" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "OK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10123,9 +10170,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Pe" = (
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Pf" = (
@@ -10466,6 +10511,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
+"Qu" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Qw" = (
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
@@ -10565,6 +10615,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/item/taperecorder{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/tape{
+	pixel_x = 8;
+	pixel_y = -10
+	},
+/obj/item/tape{
+	pixel_x = 9;
+	pixel_y = -6
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "QK" = (
@@ -10631,10 +10693,12 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "QV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/carpet/blackred,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "QW" = (
 /obj/structure/chair/sofa/left{
@@ -10860,9 +10924,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "RP" = (
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "RQ" = (
 /obj/item/stamp{
 	pixel_x = -7;
@@ -10932,10 +10998,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Sb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/corner{
@@ -10975,8 +11042,12 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Se" = (
-/turf/open/floor/iron/white/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Sf" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -11239,21 +11310,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
-"Tc" = (
-/obj/machinery/button/door{
-	id = "TESBattlespire";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 5;
-	pixel_y = 34;
-	specialfunctions = 4
-	},
-/obj/machinery/light/dim/directional/north,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Td" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -11265,16 +11321,16 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "Tf" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESRedguard";
-	name = "Dormitory"
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/mob_spawn/human/ds2/prisoner{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/machinery/vr_sleeper{
+	dir = 4;
+	state_open = 0
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Tm" = (
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11299,6 +11355,19 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
+"Tr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Tt" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
@@ -11524,15 +11593,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
 "Ua" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/mob_spawn/human/ds2/prisoner{
-	dir = 4
-	},
-/obj/machinery/vr_sleeper{
-	dir = 4;
-	state_open = 0
-	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Uc" = (
 /obj/machinery/light/dim/directional/west,
@@ -11682,6 +11743,17 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+"UD" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESArena";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "UE" = (
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 4
@@ -11776,15 +11848,13 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "UT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "UX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/survival_pod{
@@ -11859,13 +11929,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
-"Vh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Vm" = (
 /obj/machinery/light/dim/directional/east,
 /obj/effect/turf_decal/siding/dark{
@@ -11979,15 +12042,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
-"VD" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
-/turf/open/floor/wood/wood_parquet,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "VE" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 4
@@ -12593,19 +12647,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "XG" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "XI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -12658,39 +12704,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
-"XQ" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/item/radio{
-	desc = "An old handheld radio. You could use it, if you really wanted to.";
-	icon_state = "radio";
-	name = "old radio";
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/south{
-	req_access = null;
-	req_access_txt = "150"
-	},
-/obj/item/reagent_containers/rag/towel/syndicate{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "XR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -12858,11 +12871,22 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "YN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
+/obj/structure/dresser,
+/obj/machinery/button/door{
+	id = "TESArena";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 5;
+	pixel_y = -34;
+	specialfunctions = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "YQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -12967,25 +12991,6 @@
 /obj/item/ashtray,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
-"Zw" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/prison_loot_toilet,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/toy/crayon/spraycan{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/toy/crayon/spraycan{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Zz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -13093,13 +13098,10 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "ZP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ZQ" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 8
@@ -13132,6 +13134,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
+"ZZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 
 (1,1,1) = {"
 wg
@@ -13204,10 +13216,10 @@ wg
 nO
 Kf
 Kf
-Kv
-rj
+lz
+AU
 mX
-Eh
+Fq
 rH
 kF
 kF
@@ -13221,15 +13233,15 @@ uN
 uN
 jZ
 xx
-Ua
-Ua
-Ua
-tJ
+Tf
+Tf
+Tf
+Ni
 ve
 fe
 uc
 KM
-kC
+iV
 BL
 kF
 wg
@@ -13248,7 +13260,7 @@ wg
 wg
 wg
 wg
-Mr
+ki
 Kf
 Kf
 Kf
@@ -13260,11 +13272,11 @@ Kf
 Kf
 qc
 qc
-iV
+tR
 kF
 Ew
 gA
-Zw
+CT
 nS
 fy
 UR
@@ -13275,16 +13287,16 @@ kM
 Vp
 Vp
 Vp
-Gs
+xh
 rc
 rc
 rc
 yh
-Se
-Se
+Ua
+Ua
 Al
 ah
-Se
+Ua
 Jf
 NB
 NB
@@ -13304,23 +13316,23 @@ EJ
 kx
 nO
 Kf
-iR
-Az
+dW
+wR
 gb
 iZ
 Kf
-Ni
-XG
-cX
+OH
+iK
+qR
 Kf
-Tc
-jL
-VD
+bP
+Hu
+rQ
 kF
 Oe
 So
 yZ
-UT
+ZZ
 wE
 Dh
 bs
@@ -13338,7 +13350,7 @@ kM
 Vp
 Vp
 JA
-Se
+Ua
 Ve
 kF
 zX
@@ -13359,18 +13371,18 @@ wg
 wg
 wg
 Kf
-GL
-aU
+JX
+tJ
 DE
-uz
-Kf
-uy
 YN
-ZP
-CU
-fq
-JP
-CT
+Kf
+Se
+IQ
+QV
+rj
+dh
+MA
+xD
 kF
 Qx
 Po
@@ -13414,18 +13426,18 @@ wg
 wg
 xr
 Kf
+jM
+RZ
+HU
 Du
-mN
-iM
-Vh
-tR
-EP
-JF
-Hu
+UD
+UT
+Ir
+Az
 Kf
-sY
-QV
-yw
+Et
+RP
+Jp
 kF
 pX
 uS
@@ -13449,7 +13461,7 @@ GD
 Ar
 sC
 yR
-ui
+ZP
 kF
 zX
 Oi
@@ -13474,13 +13486,13 @@ Kf
 Kf
 Kf
 Kf
-Ir
+JF
 ok
-Bn
+Qu
 Kf
 Kf
-FW
-hN
+DV
+EP
 kF
 Dz
 Gh
@@ -13501,10 +13513,10 @@ kF
 Kc
 kF
 kF
-KF
+ic
 LP
 Oy
-ui
+ZP
 kF
 zX
 Oi
@@ -13528,10 +13540,10 @@ tg
 Cj
 rs
 Kf
-gL
+iR
 eo
 ok
-JE
+Pe
 Ne
 Kf
 Kf
@@ -13556,7 +13568,7 @@ BN
 PP
 lJ
 kF
-uw
+ui
 dI
 ct
 lb
@@ -13639,13 +13651,13 @@ YH
 wj
 Kf
 Kf
-dh
-Ez
+tt
+Tr
 xH
 Kf
-MW
+GL
 DE
-tt
+tH
 uV
 it
 QH
@@ -13688,19 +13700,19 @@ wg
 IC
 Oi
 qh
-RP
+NU
 ZF
 DK
-iK
+KO
 PY
 wj
-sz
-IQ
+mE
+Hj
 NG
-Tf
-fq
-JQ
-Ex
+sc
+dh
+jA
+Dx
 uV
 kb
 Ye
@@ -13751,7 +13763,7 @@ ny
 wj
 do
 nn
-JE
+Pe
 Kf
 qs
 qc
@@ -13802,7 +13814,7 @@ wj
 EV
 il
 AX
-sc
+iM
 wj
 Nm
 DB
@@ -13810,7 +13822,7 @@ Lf
 Kf
 km
 eU
-iR
+dW
 uV
 VC
 Ii
@@ -13857,7 +13869,7 @@ wj
 rI
 vD
 qY
-XQ
+JE
 wj
 cU
 DJ
@@ -13914,9 +13926,9 @@ NO
 EL
 wj
 wj
-Pe
+NE
 ok
-Pe
+NE
 Kf
 GG
 ps
@@ -14021,10 +14033,10 @@ qh
 NB
 jf
 sE
-RZ
+XG
 yU
-RZ
-RZ
+XG
+XG
 zb
 yU
 Lr
@@ -15138,7 +15150,7 @@ Hz
 QM
 pu
 fA
-bP
+fv
 cz
 WC
 gj

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1281,6 +1281,13 @@
 	pixel_y = 16
 	},
 /obj/item/toy/figure/syndie,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "eE" = (
@@ -3050,17 +3057,18 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/light/dim/directional/south,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "lD" = (
@@ -3405,11 +3413,23 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "mY" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
 /obj/machinery/computer/camera_advanced/syndie{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_half,
@@ -3634,18 +3654,17 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/light/dim/directional/south,
 /obj/item/kirbyplants/hedge{
 	anchored = 1
 	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "og" = (
@@ -3720,6 +3739,15 @@
 	name = "paper- 'Отчёт о Пополнении Состава DS2'"
 	},
 /obj/machinery/computer/communications/syndicate,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "ov" = (
@@ -4319,6 +4347,14 @@
 "qI" = (
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/machinery/computer/crew/syndie,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "qK" = (
@@ -6504,6 +6540,14 @@
 	dir = 2
 	},
 /obj/item/paper/monitorkey,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Aw" = (
@@ -6538,6 +6582,10 @@
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
@@ -8070,13 +8118,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 4
@@ -8086,6 +8128,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -8102,6 +8150,15 @@
 	req_access_txt = "150";
 	shuttleId = "syndie_cargo"
 	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Hu" = (
@@ -10825,6 +10882,12 @@
 	network = list("ds2")
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Sj" = (
@@ -10890,9 +10953,17 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Sx" = (
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/computer/camera_advanced/syndie,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Sy" = (
@@ -11432,21 +11503,19 @@
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -12405,7 +12474,9 @@
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "XN" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
@@ -12415,6 +12486,16 @@
 /obj/machinery/fax{
 	fax_name = "DS-2 Syndicate Fax";
 	name = "DS-2 Fax Machine"
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
@@ -12474,6 +12555,13 @@
 /obj/machinery/computer/monitor{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Yb" = (
@@ -12713,9 +12801,6 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 6
 	},
 /obj/item/toy/mecha/mauler{
@@ -12725,6 +12810,16 @@
 /obj/item/toy/mecha/deathripley{
 	pixel_x = -16;
 	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -10,8 +10,8 @@
 	req_access = null;
 	req_access_txt = "150"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/item/restraints/handcuffs,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ac" = (
@@ -51,7 +51,6 @@
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
@@ -62,14 +61,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ah" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "aj" = (
 /obj/structure/frame/machine{
@@ -97,12 +96,12 @@
 	req_access_txt = "151"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "ao" = (
@@ -195,11 +194,11 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "aC" = (
@@ -214,12 +213,12 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "aH" = (
@@ -270,7 +269,6 @@
 /obj/effect/turf_decal/trimline/dark_green/warning{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -281,11 +279,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "aT" = (
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+"aU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "aW" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 6
@@ -353,13 +358,13 @@
 /turf/open/space/basic,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "bf" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "bj" = (
@@ -519,19 +524,19 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "bP" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria{
-	pixel_y = 3
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
-/obj/item/storage/bag/tray/cafeteria{
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "bR" = (
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/tile/dark_blue/full,
@@ -569,7 +574,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "bW" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/structure/window/reinforced/survival_pod{
@@ -588,6 +592,7 @@
 	dir = 6;
 	level = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "bX" = (
@@ -620,7 +625,6 @@
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "ca" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -628,6 +632,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "ch" = (
@@ -646,7 +651,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "cj" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/middle/middle,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/bluemoon_decals/ds2/middle,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -656,6 +660,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "cl" = (
@@ -716,14 +721,13 @@
 /obj/structure/transit_tube{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/poddoor/preopen{
 	id = "ds2bridge"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "cn" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -734,6 +738,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "cq" = (
@@ -773,15 +778,12 @@
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "ct" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24;
-	req_access = list(151)
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
 	},
-/turf/open/floor/iron/white/textured_large,
+/obj/structure/table,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "cu" = (
 /obj/machinery/door/firedoor,
@@ -821,11 +823,11 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "cA" = (
@@ -844,11 +846,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
 "cD" = (
 /obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "cE" = (
@@ -887,7 +889,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -895,6 +896,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "cO" = (
@@ -902,12 +904,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/cell_charger_multi,
 /obj/machinery/power/apc/auto_name/east{
 	req_access_txt = "150";
 	req_access = null
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "cP" = (
@@ -953,6 +955,13 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"cX" = (
+/obj/structure/bookcase/random/adult,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
@@ -971,7 +980,6 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "dg" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
@@ -983,17 +991,22 @@
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "dh" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/airalarm/syndicate{
+	pixel_x = 0;
+	pixel_y = 28
 	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "dn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -1003,19 +1016,11 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "do" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_large,
+/obj/machinery/vending/wardrobe/syndie_wardrobe,
+/obj/structure/sign/flag/syndicate/directional/north,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "dr" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/west,
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -1031,6 +1036,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "ds" = (
@@ -1057,7 +1063,6 @@
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "dz" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -1066,6 +1071,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "dC" = (
@@ -1103,11 +1109,11 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "dI" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/sink/kitchen/directional/west{
-	pixel_x = 13
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
-/turf/open/floor/iron/white/textured_large,
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "dN" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -1144,11 +1150,11 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -1166,16 +1172,15 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "dR" = (
-/obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
@@ -1183,7 +1188,8 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/structure/curtain,
+/obj/machinery/shower/directional/north,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
 "dS" = (
@@ -1205,13 +1211,13 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "dZ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ek" = (
@@ -1231,13 +1237,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "eo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "ep" = (
 /obj/effect/turf_decal/bot_blue,
@@ -1331,11 +1338,11 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "eL" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "eO" = (
@@ -1351,12 +1358,12 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "eP" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -1378,11 +1385,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "eU" = (
-/obj/machinery/light/dim/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "eV" = (
 /obj/effect/turf_decal/tile/dark_blue{
@@ -1405,19 +1411,13 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "eW" = (
-/obj/machinery/button/door{
-	id = "TESRedguard";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -24;
-	specialfunctions = 4
+/obj/structure/table/wood/fancy/black,
+/obj/item/toy/cards/deck,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "eX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -1435,13 +1435,13 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "fa" = (
@@ -1476,7 +1476,6 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ff" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1485,6 +1484,7 @@
 	dir = 4;
 	level = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "fh" = (
@@ -1516,6 +1516,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"fq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "fw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -1545,14 +1552,14 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "fB" = (
@@ -1605,7 +1612,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "fS" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
@@ -1620,6 +1626,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "fW" = (
@@ -1633,13 +1640,13 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "gb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
+/obj/structure/bed/double{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+/obj/item/bedsheet/brown/double{
+	dir = 1
 	},
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "gf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -1656,13 +1663,13 @@
 	dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external/glass{
 	name = "External Access";
 	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "gi" = (
@@ -1679,11 +1686,11 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "gj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "gk" = (
@@ -1709,13 +1716,13 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "gv" = (
@@ -1740,7 +1747,6 @@
 	name = "Engineering";
 	req_access_txt = "150"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1754,6 +1760,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "gy" = (
@@ -1780,17 +1787,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "gB" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/airalarm/syndicate{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "gF" = (
@@ -1806,7 +1816,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery/red,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1821,10 +1830,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "gG" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
@@ -1839,6 +1848,7 @@
 	network = list("ds2")
 	},
 /obj/structure/sign/flag/syndicate/directional/north,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "gK" = (
@@ -1851,6 +1861,10 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
+"gL" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "gN" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -1864,7 +1878,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -1875,6 +1888,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "gW" = (
@@ -1891,11 +1905,11 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "gY" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ha" = (
@@ -1930,7 +1944,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "hf" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
 	},
@@ -1942,6 +1955,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "hg" = (
@@ -1962,7 +1976,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "hi" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
 	pixel_x = 24
@@ -1971,6 +1984,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "hn" = (
@@ -2018,7 +2032,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "hu" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -2026,6 +2039,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -2056,13 +2070,13 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "hz" = (
@@ -2084,9 +2098,6 @@
 /obj/machinery/light/dim/directional/east,
 /obj/effect/spawner/lootdrop/prison_loot_toilet,
 /obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/grille_or_trash{
-	pixel_y = -5
-	},
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -2169,6 +2180,10 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
+"hN" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "hP" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -2211,8 +2226,8 @@
 /obj/effect/turf_decal/siding/dark/end{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "ib" = (
@@ -2251,7 +2266,6 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2259,6 +2273,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/light/dim/directional/north,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "ij" = (
@@ -2274,12 +2289,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "il" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
@@ -2341,11 +2355,11 @@
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "iB" = (
@@ -2365,7 +2379,6 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "iJ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2375,34 +2388,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "iK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESArena";
-	name = "Dormitory"
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood/wood_tiled,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "iM" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "iO" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
@@ -2416,8 +2415,10 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "iR" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/wood_tiled,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "iS" = (
 /obj/machinery/meter,
@@ -2427,13 +2428,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "iV" = (
-/obj/item/chair{
-	dir = 8;
-	pixel_x = 5;
-	pixel_y = -3
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "iX" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -2449,8 +2448,12 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "iZ" = (
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/wood/wood_tiled,
+/obj/structure/table/wood/fancy/black,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "jb" = (
 /obj/machinery/iv_drip,
@@ -2461,12 +2464,12 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "jd" = (
@@ -2492,11 +2495,11 @@
 	req_access = null;
 	req_access_txt = "150"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/camera/xray/directional/west{
 	c_tag = "DS-2 Brig Storage";
 	network = list("ds2")
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "jf" = (
@@ -2622,12 +2625,12 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "jC" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/middle/right,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/bluemoon_decals/ds2/right,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "jD" = (
@@ -2653,13 +2656,25 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "jK" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
+"jL" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "jN" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2673,7 +2688,6 @@
 "jO" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -2682,17 +2696,18 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "jP" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "jR" = (
@@ -2706,7 +2721,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "jT" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -2714,6 +2728,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -2775,7 +2790,6 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "kc" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 10;
 	level = 1
@@ -2786,6 +2800,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "kd" = (
@@ -2806,10 +2821,10 @@
 /obj/machinery/button/ignition/incinerator/syndicatelava{
 	pixel_x = -36
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "ke" = (
@@ -2829,19 +2844,9 @@
 /turf/template_noop,
 /area/template_noop)
 "km" = (
-/obj/machinery/button/door{
-	id = "TESBattlespire";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 24;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood/wood_tiled,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "kt" = (
 /obj/effect/turf_decal/stripes/end{
@@ -2859,6 +2864,12 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"kC" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/structure/sink/kitchen/directional/east,
+/turf/open/floor/iron/white/textured_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "kD" = (
 /obj/machinery/smartfridge/food,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -2868,17 +2879,22 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "kG" = (
 /obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 6;
-	pixel_y = 4
+	pixel_x = 11;
+	pixel_y = -7
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 2
+	pixel_y = -7;
+	pixel_x = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /obj/structure/table/reinforced{
 	color = "#777777"
+	},
+/obj/item/ashtray{
+	pixel_x = -5;
+	pixel_y = -7
 	},
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -2937,33 +2953,33 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "kT" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "kZ" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "lb" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 8
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
 	},
-/turf/open/floor/iron/white/textured_large,
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ld" = (
 /obj/effect/turf_decal/bot,
@@ -3028,7 +3044,6 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "lo" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -3042,6 +3057,7 @@
 	req_access_txt = "151";
 	specialfunctions = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "lt" = (
@@ -3078,11 +3094,11 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "lD" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1;
 	name = "tactical chair"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "lF" = (
@@ -3122,13 +3138,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "lM" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "lO" = (
@@ -3138,7 +3154,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 5;
 	level = 1
@@ -3146,6 +3161,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "lW" = (
@@ -3179,7 +3195,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "md" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/airlock/cmo/glass{
 	name = "Medical Bay";
 	req_access = null;
@@ -3190,6 +3205,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "me" = (
@@ -3243,11 +3259,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/airlock/external/glass{
 	name = "External Access";
 	req_access_txt = "150"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "mr" = (
@@ -3274,11 +3290,11 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "my" = (
@@ -3288,13 +3304,13 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "mD" = (
@@ -3376,6 +3392,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
+"mN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "mO" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -3456,12 +3479,12 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/west,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "nj" = (
@@ -3477,15 +3500,17 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "nn" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "ny" = (
 /obj/machinery/light/dim/directional/south,
@@ -3518,7 +3543,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -3529,11 +3553,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "nI" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -3544,6 +3568,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "nK" = (
@@ -3611,11 +3636,11 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "nV" = (
@@ -3639,8 +3664,8 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 6
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/window/reinforced/survival_pod,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -3678,7 +3703,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "og" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
@@ -3687,6 +3711,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "oi" = (
@@ -3697,20 +3722,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "ok" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Dormitories"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "on" = (
 /turf/open/floor/iron/dark,
@@ -3732,8 +3751,8 @@
 	pixel_y = 6
 	},
 /obj/structure/table/glass,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "ot" = (
@@ -3795,7 +3814,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -3807,6 +3825,7 @@
 	dir = 4;
 	level = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
 "oG" = (
@@ -3851,7 +3870,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "oT" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -3861,6 +3879,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "oV" = (
@@ -3946,7 +3965,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/red/corner,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -3957,6 +3975,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "pi" = (
@@ -4011,7 +4030,6 @@
 /obj/effect/turf_decal/bluemoon_decals/departments/bridge{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -4019,6 +4037,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -4048,15 +4067,11 @@
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "pt" = (
-/obj/machinery/light/dim/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/wood/wood_tiled,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "pu" = (
 /obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4066,6 +4081,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "py" = (
@@ -4081,7 +4097,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "pz" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -4099,6 +4114,7 @@
 	dir = 4;
 	color = "#800000"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "pI" = (
@@ -4173,20 +4189,10 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "qc" = (
-/obj/structure/bed/double{
-	dir = 1
-	},
-/obj/item/bedsheet/brown/double{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "qg" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4194,6 +4200,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "qh" = (
@@ -4240,20 +4247,16 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "qs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
 	},
-/obj/item/storage/wallet/random,
-/obj/item/clothing/under/costume/jabroni{
-	has_sensor = 0
-	},
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
-	},
-/turf/open/floor/wood/wood_tiled,
+/obj/structure/table/wood/fancy/black,
+/obj/structure/sign/flag/syndicate/directional/north,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "qt" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/brown/warning,
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -4262,6 +4265,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "qu" = (
@@ -4269,10 +4273,10 @@
 	dir = 4
 	},
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "qv" = (
@@ -4309,7 +4313,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -4317,6 +4320,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "qE" = (
@@ -4329,7 +4333,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
 	req_access_txt = "150"
@@ -4341,6 +4344,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
 "qH" = (
@@ -4417,30 +4421,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "qY" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/item/radio{
-	desc = "An old handheld radio. You could use it, if you really wanted to.";
-	icon_state = "radio";
-	name = "old radio";
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/south{
-	req_access = null;
-	req_access_txt = "150"
-	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -4482,11 +4464,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "rc" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/mob_spawn/human/ds2/prisoner{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "rd" = (
 /obj/effect/turf_decal/arrows{
@@ -4521,13 +4505,8 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "rj" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood/wood_large,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "rk" = (
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -4545,7 +4524,6 @@
 "ro" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -4557,22 +4535,24 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "rr" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "rs" = (
-/obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/machinery/shower/directional/east,
+/obj/structure/curtain,
+/obj/machinery/shower/directional/north,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
 "rx" = (
@@ -4586,11 +4566,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "rz" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "rB" = (
@@ -4630,10 +4610,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/structure/bookcase/random{
-	books_to_load = 10
-	},
-/turf/open/floor/iron/dark/small,
+/turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "rI" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -4651,10 +4628,10 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "rM" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/table/reinforced{
 	color = "#777777"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "rN" = (
@@ -4708,17 +4685,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "sc" = (
-/obj/structure/table/wood,
-/obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_tiled,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/trimline/dark/line,
+/obj/effect/turf_decal/trimline/dark/line,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/washing_machine,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "se" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	req_access = null;
@@ -4797,14 +4770,18 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "sy" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/middle/left,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/bluemoon_decals/ds2/left,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
+"sz" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "sB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -4813,31 +4790,34 @@
 	req_access_txt = "150";
 	req_access = null
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "sC" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "sD" = (
 /obj/machinery/vending/sustenance,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "sE" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 10;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -4925,7 +4905,6 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 9;
 	level = 1
@@ -4933,8 +4912,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"sY" = (
+/obj/structure/sign/flag/syndicate/directional/north,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "sZ" = (
 /obj/machinery/vending/dinnerware{
 	onstation = 0
@@ -4955,18 +4939,19 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "tg" = (
-/obj/machinery/shower/directional/south,
 /obj/item/soap/syndie,
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/structure/curtain,
+/obj/machinery/shower/directional/south,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
 "tj" = (
 /obj/structure/table/reinforced{
 	color = "#777777"
 	},
+/obj/item/ashtray,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "tk" = (
@@ -5018,9 +5003,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "tt" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/brown/double,
-/turf/open/floor/wood/wood_tiled,
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tA" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -5071,12 +5058,28 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "tJ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/west,
+/obj/structure/table,
+/obj/item/coin/iron{
+	pixel_x = -10
+	},
+/obj/item/toy/cards/deck,
+/obj/item/storage/dice{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "tL" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/survival_pod{
@@ -5113,12 +5116,12 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "tQ" = (
@@ -5126,14 +5129,16 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "tR" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESArena";
+	name = "Dormitory"
 	},
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "tS" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -5216,8 +5221,22 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "uc" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/dark/textured_large,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/prison_loot_toilet,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/obj/item/storage/box/drinkingglasses,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ue" = (
 /obj/effect/turf_decal/tile/dark_blue{
@@ -5234,7 +5253,6 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/goldcrate,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/south{
 	req_access_txt = "150";
 	req_access = null
@@ -5243,13 +5261,13 @@
 	dir = 9;
 	level = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "uf" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -5257,6 +5275,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "uh" = (
@@ -5264,18 +5283,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "ui" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESBattlespire";
-	name = "Dormitory"
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood/wood_tiled,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "um" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
@@ -5297,6 +5308,35 @@
 "uu" = (
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
+"uw" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+"uy" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+"uz" = (
+/obj/structure/dresser,
+/obj/machinery/button/door{
+	id = "TESArena";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 5;
+	pixel_y = -34;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "uA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -5396,10 +5436,10 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "va" = (
 /obj/effect/spawner/structure/window/plastitanium,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/poddoor/preopen{
 	id = "ds2bridge"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "vc" = (
@@ -5422,8 +5462,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "ve" = (
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/processor,
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "vg" = (
 /obj/structure/table/optable,
@@ -5459,13 +5499,13 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "vq" = (
@@ -5473,7 +5513,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
@@ -5484,6 +5523,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
 "vr" = (
@@ -5495,7 +5535,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/south{
 	req_access = null;
 	req_access_txt = "150"
@@ -5503,6 +5542,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "vx" = (
@@ -5556,13 +5596,13 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "vD" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -5604,11 +5644,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "vM" = (
 /obj/effect/turf_decal/trimline/yellow/corner,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "vN" = (
@@ -5631,7 +5671,6 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "vQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -5639,6 +5678,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "vR" = (
@@ -5724,9 +5764,8 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "wj" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/iron/dark/smooth_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "wk" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -5767,7 +5806,6 @@
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "wp" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -5775,6 +5813,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "wt" = (
@@ -5813,12 +5852,12 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "wH" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "wJ" = (
@@ -5843,17 +5882,16 @@
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "xc" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 1
 	},
@@ -5866,10 +5904,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "xj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -5877,6 +5915,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "xk" = (
@@ -5906,7 +5945,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "xu" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5917,6 +5955,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "xx" = (
@@ -5963,18 +6002,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "xH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "xQ" = (
 /obj/effect/turf_decal/stripes/red/full,
@@ -6031,8 +6061,8 @@
 	desc = "What appears to be a single-celled organism with a pronounced low-level intelligence.";
 	name = "Murder-Mittens"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/bed/dogbed,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "yd" = (
@@ -6061,29 +6091,16 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "yh" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/machinery/light/dim/directional/west,
-/obj/structure/table,
-/obj/item/coin/iron{
-	pixel_x = -10
-	},
-/obj/item/toy/cards/deck,
-/obj/item/storage/dice{
-	pixel_x = 8;
-	pixel_y = 3
-	},
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "yi" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
@@ -6095,6 +6112,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "yn" = (
@@ -6107,7 +6125,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "yu" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
@@ -6119,10 +6136,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "yv" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -6130,8 +6147,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"yw" = (
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "yy" = (
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
@@ -6181,7 +6202,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "yR" = (
-/turf/open/floor/iron/white/small,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "yS" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -6213,11 +6237,11 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "yU" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "yX" = (
@@ -6232,9 +6256,9 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "zb" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "zc" = (
@@ -6317,13 +6341,13 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "zq" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -6398,7 +6422,6 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "zK" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
@@ -6406,6 +6429,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "zL" = (
@@ -6496,8 +6520,10 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Al" = (
-/obj/structure/table,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "An" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6526,8 +6552,8 @@
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "Ar" = (
-/obj/machinery/smartfridge/food,
-/turf/open/floor/iron/white/textured_large,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "At" = (
 /obj/structure/dresser,
@@ -6555,7 +6581,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Av" = (
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/computer/message_monitor{
 	dir = 2
 	},
@@ -6568,6 +6593,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Aw" = (
@@ -6583,14 +6609,13 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "Az" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/item/clothing/under/syndicate/baseball,
 /obj/structure/closet/secure_closet/personal{
 	icon_state = "cabinet"
 	},
-/turf/open/floor/wood/wood_tiled,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "AC" = (
 /obj/effect/turf_decal/trimline/dark_red/corner{
@@ -6645,7 +6670,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "AI" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 4
 	},
@@ -6653,6 +6677,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "AK" = (
@@ -6689,9 +6714,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "AX" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/trimline/dark/line,
-/obj/effect/turf_decal/trimline/dark/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "AZ" = (
@@ -6705,7 +6727,6 @@
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Be" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -6714,6 +6735,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Bi" = (
@@ -6763,6 +6785,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
+"Bn" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Bs" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube{
@@ -6783,7 +6810,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Bu" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
@@ -6792,6 +6818,7 @@
 	req_access = null
 	},
 /obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "Bv" = (
@@ -6838,7 +6865,6 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "BN" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 1
 	},
@@ -6849,13 +6875,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "BO" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6866,6 +6892,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "BS" = (
@@ -6875,7 +6902,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "BT" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -6883,10 +6909,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "BV" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -6894,6 +6920,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "Cb" = (
@@ -6931,7 +6958,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Cg" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
@@ -6942,10 +6968,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Ch" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -6953,6 +6979,7 @@
 	name = "Diner";
 	req_access_txt = "150"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Cj" = (
@@ -6990,7 +7017,6 @@
 /obj/effect/turf_decal/bluemoon_decals/departments/bridge{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -6998,6 +7024,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
@@ -7020,7 +7047,6 @@
 	dir = 1
 	},
 /obj/machinery/light/dim/directional/west,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
@@ -7028,6 +7054,7 @@
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "CE" = (
@@ -7062,12 +7089,30 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "CT" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
+/obj/structure/table/wood/fancy/black,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+"CU" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESBattlespire";
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "CX" = (
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -7117,11 +7162,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Dn" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Dr" = (
@@ -7149,14 +7194,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Du" = (
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Dv" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/structure/disposalpipe/segment{
@@ -7166,7 +7207,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Dw" = (
 /obj/structure/closet/emcloset,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
 	},
@@ -7174,6 +7214,7 @@
 	dir = 1
 	},
 /obj/machinery/light/dim/directional/south,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Dy" = (
@@ -7218,44 +7259,32 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "DB" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 6;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DE" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "TESArena";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -8;
-	pixel_y = 24;
-	specialfunctions = 4
-	},
-/obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DF" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/item/paper_bin/carbon,
 /obj/item/pen/fountain/captain{
 	name = "admiral's fountain pen"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "DH" = (
@@ -7281,7 +7310,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
@@ -7292,27 +7320,34 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
 "DJ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitories"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -7366,10 +7401,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Ed" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
+"Eh" = (
+/obj/effect/turf_decal/box/white,
+/obj/structure/punching_bag,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Ej" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/thinplating/end{
@@ -7424,9 +7464,6 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "En" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 5;
 	level = 1
@@ -7434,16 +7471,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Ew" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/iron/dark/textured_large,
+/obj/structure/table,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
+/obj/item/reagent_containers/rag/towel/syndicate,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+"Ex" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Ey" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -7451,6 +7494,19 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
+"Ez" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "EA" = (
 /obj/effect/turf_decal/tile/dark_blue/full,
 /obj/effect/turf_decal/siding/white,
@@ -7499,9 +7555,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "EP" = (
-/obj/machinery/light/dim/directional/north,
-/obj/machinery/vending/clothing,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "EQ" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -7526,11 +7585,11 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "EU" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/chair/sofa/right{
 	dir = 1;
 	color = "#800000"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "EV" = (
@@ -7632,13 +7691,12 @@
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Fj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
@@ -7662,7 +7720,6 @@
 	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7673,6 +7730,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Fo" = (
@@ -7688,11 +7746,11 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Fw" = (
-/obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
-/turf/open/floor/plasteel/showroomfloor/shower,
+/obj/machinery/shower/directional/south,
+/obj/structure/curtain,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
 "Fx" = (
@@ -7818,8 +7876,17 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
+"FW" = (
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/item/clothing/under/syndicate/baseball,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "FY" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -7831,6 +7898,7 @@
 	dir = 8;
 	name = "disposal pipe"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "FZ" = (
@@ -7845,18 +7913,17 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Ge" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Gg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -7867,6 +7934,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Gh" = (
@@ -7915,7 +7983,6 @@
 /obj/structure/window/reinforced/survival_pod,
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/table,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/item/clothing/accessory/armband/hydro{
 	desc = "An armband, worn by the FOB's operatives to display which department they're assigned to.";
 	name = "service armband"
@@ -7924,20 +7991,30 @@
 	pixel_x = 9;
 	pixel_y = 15
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+"Gs" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Gt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Gx" = (
@@ -8000,28 +8077,19 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "GL" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/prison_loot_toilet,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/toy/crayon/spraycan{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/toy/crayon/spraycan{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/structure/sign/flag/syndicate/directional/north,
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "GO" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "GR" = (
@@ -8038,11 +8106,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "GU" = (
@@ -8148,7 +8216,6 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
@@ -8159,6 +8226,7 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -8187,28 +8255,14 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Hu" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/prison_loot_toilet,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/turf/open/floor/iron/white/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Hw" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -8216,6 +8270,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Hz" = (
@@ -8247,7 +8302,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "HE" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -8258,6 +8312,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "HF" = (
@@ -8344,11 +8399,11 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Ii" = (
@@ -8362,7 +8417,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "Im" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
@@ -8372,6 +8426,7 @@
 /obj/machinery/light/dim/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Io" = (
@@ -8385,17 +8440,19 @@
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Ir" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/item/kirbyplants/hedge{
+	anchored = 1
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/obj/machinery/power/apc/auto_name/north{
+	req_access = null;
+	req_access_txt = "150"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Iw" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/plating,
@@ -8417,12 +8474,12 @@
 	icon_state = "plant-18"
 	},
 /obj/machinery/light/dim/directional/south,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/south{
 	req_access = null;
 	req_access_txt = "150"
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "IC" = (
@@ -8490,8 +8547,18 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "IQ" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "IV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/iron/dark,
@@ -8591,14 +8658,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "JA" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 4;
+	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "JC" = (
 /turf/open/floor/catwalk_floor,
@@ -8644,34 +8711,17 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "JE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "JF" = (
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/light/dim/directional/north,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "JI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -8701,17 +8751,16 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "JL" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "JN" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
 	},
@@ -8721,8 +8770,26 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
+"JP" = (
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/item/bedsheet/brown/double{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+"JQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "JR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -8744,12 +8811,12 @@
 	dir = 2
 	},
 /obj/machinery/light/small/directional/east,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/camera/xray/directional/east{
 	c_tag = "DS-2 Engineering Airlock";
 	network = list("ds2")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Kb" = (
@@ -8804,13 +8871,13 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Ke" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Kf" = (
@@ -8845,13 +8912,13 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Ku" = (
@@ -8872,12 +8939,18 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
+"Kv" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Kz" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/turf_decal/siding/dark/end,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "KC" = (
@@ -8890,6 +8963,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"KF" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "KG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -8922,9 +8999,18 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/eva)
 "KM" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/turf_decal/bot_white,
+/obj/structure/table,
+/obj/machinery/airalarm/syndicate{
+	dir = 4;
+	pixel_x = -25;
+	req_access = list(151);
+	pixel_y = 0
+	},
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "KN" = (
 /obj/machinery/door/airlock/security/glass{
@@ -8937,7 +9023,6 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/delivery/red,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -8950,6 +9035,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "KQ" = (
@@ -8972,7 +9058,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "KS" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -8980,6 +9065,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "KT" = (
@@ -9001,15 +9087,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "KY" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_large,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Lb" = (
 /obj/effect/turf_decal/tile/dark_red/half,
@@ -9025,15 +9105,17 @@
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Lf" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
 	},
-/turf/open/floor/wood/wood_large,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Lg" = (
 /obj/machinery/atmospherics/miner/toxins,
@@ -9054,11 +9136,11 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Lq" = (
@@ -9066,7 +9148,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "Lr" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9076,6 +9157,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Ls" = (
@@ -9225,7 +9307,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "LG" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
 	pixel_x = -24
@@ -9236,15 +9317,16 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "LK" = (
 /obj/structure/sign/flag/syndicate/directional/south,
 /obj/machinery/light/dim/directional/south,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "LM" = (
@@ -9261,10 +9343,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "LP" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "LQ" = (
 /obj/machinery/firealarm/directional/south,
@@ -9306,7 +9392,6 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "LY" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/camera/xray/directional/south{
 	c_tag = "DS-2 Armory";
 	network = list("ds2")
@@ -9323,6 +9408,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/armory)
 "Mg" = (
@@ -9354,6 +9440,9 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
+"Mr" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Mt" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 5
@@ -9447,7 +9536,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -9458,17 +9546,42 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "MP" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "MT" = (
 /obj/machinery/computer/shuttle/ds_syndicate,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
+"MW" = (
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/item/clothing/under/costume/jabroni{
+	has_sensor = 0
+	},
+/obj/item/storage/wallet/random,
+/obj/machinery/button/door{
+	id = "TESRedguard";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 5;
+	pixel_y = 34;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "MZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -9516,22 +9629,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "Ne" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/button/door/directional/south{
-	id = "dorms-view";
-	name = "Dorms Blast Door Control";
-	req_access_txt = "150"
-	},
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_large,
+/obj/machinery/vending/kink,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Ng" = (
 /obj/effect/turf_decal/vg_decals/atmos/plasma{
@@ -9540,12 +9639,15 @@
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Ni" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Nk" = (
 /obj/machinery/door/airlock/command{
 	hackProof = 1;
@@ -9553,7 +9655,6 @@
 	req_access_txt = "151"
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
@@ -9565,6 +9666,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Nl" = (
@@ -9578,22 +9680,13 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Nm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/turf/open/floor/wood/wood_large,
+/obj/machinery/vending/clothing,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "No" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/airlock/silver/glass{
 	name = "Kitchen";
 	req_access_txt = "150"
@@ -9605,10 +9698,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Nr" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -9625,6 +9718,7 @@
 /obj/structure/table/reinforced{
 	color = "#777777"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Ns" = (
@@ -9644,7 +9738,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -9662,6 +9755,7 @@
 	dir = 8;
 	req_access_txt = "150"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "NB" = (
@@ -9671,23 +9765,12 @@
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "NG" = (
-/obj/machinery/airalarm/syndicate{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "NL" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -9703,10 +9786,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "NN" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -9714,23 +9797,22 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "NO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Fitness"
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Fitness Room"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "NP" = (
 /obj/structure/window/reinforced/survival_pod{
@@ -9752,7 +9834,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -9762,6 +9843,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "NR" = (
@@ -9862,8 +9944,8 @@
 /turf/open/floor/wood/wood_tiled,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Oe" = (
-/obj/structure/punching_bag,
 /obj/effect/turf_decal/box/white,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Oi" = (
@@ -9913,10 +9995,18 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "Oy" = (
+/obj/structure/table,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_y = 3
+	},
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_y = 6
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "OC" = (
 /obj/item/storage/belt/security/full,
@@ -9992,8 +10082,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "OP" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/top/left,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "OT" = (
@@ -10020,7 +10110,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "OX" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
@@ -10030,39 +10119,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
-"Pc" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "Pe" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/item/kirbyplants/hedge{
+	anchored = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
-/obj/machinery/power/apc/auto_name/north{
-	req_access = null;
-	req_access_txt = "150"
-	},
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Pf" = (
 /obj/structure/chair{
@@ -10093,8 +10157,8 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Pn" = (
@@ -10119,6 +10183,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -10190,7 +10257,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "PM" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 1
 	},
@@ -10200,6 +10266,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "PO" = (
@@ -10227,7 +10294,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10239,13 +10305,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "PS" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -10253,6 +10319,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "PU" = (
@@ -10352,7 +10419,6 @@
 	dir = 1
 	},
 /obj/structure/sink/directional/south,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -10360,6 +10426,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Qp" = (
@@ -10400,7 +10467,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "Qw" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
 	req_access_txt = "150"
@@ -10421,6 +10487,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Qx" = (
@@ -10501,7 +10568,6 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
 "QK" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 4
 	},
@@ -10515,6 +10581,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -10541,19 +10608,18 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "QO" = (
-/obj/structure/table/wood,
-/obj/machinery/airalarm/syndicate{
-	dir = 4;
-	pixel_x = -24
+/obj/item/kirbyplants/hedge{
+	anchored = 1
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
-/turf/open/floor/wood/wood_tiled,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "QQ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4;
 	level = 1
@@ -10561,15 +10627,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "QV" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/turf_decal/stripes/red/line{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "QW" = (
 /obj/structure/chair/sofa/left{
 	dir = 4;
@@ -10603,11 +10669,11 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Rc" = (
@@ -10665,7 +10731,6 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Rm" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -10675,6 +10740,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Rp" = (
@@ -10715,7 +10781,6 @@
 /obj/structure/window/reinforced/survival_pod,
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/table,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
 	req_access_txt = "150"
@@ -10727,6 +10792,7 @@
 /obj/item/choice_beacon/ingredients{
 	pixel_y = 11
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -10749,7 +10815,6 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "RH" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10763,6 +10828,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -10774,33 +10840,29 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "RL" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "RM" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "RP" = (
-/obj/effect/turf_decal/siding/dark,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "RQ" = (
 /obj/item/stamp{
 	pixel_x = -7;
@@ -10861,22 +10923,21 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RY" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Sb" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 1
 	},
@@ -10885,6 +10946,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Sc" = (
@@ -10902,7 +10964,6 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 6;
 	level = 1
@@ -10910,13 +10971,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "Se" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Sf" = (
@@ -10946,7 +11004,6 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
@@ -10954,6 +11011,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "So" = (
@@ -10961,6 +11019,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/small,
@@ -11005,7 +11066,6 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "Sx" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/computer/camera_advanced/syndie,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
@@ -11016,6 +11076,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Sy" = (
@@ -11123,8 +11184,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "SR" = (
 /obj/effect/turf_decal/bluemoon_decals/syndicate/top/right,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "SX" = (
@@ -11178,6 +11239,21 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
+"Tc" = (
+/obj/machinery/button/door{
+	id = "TESBattlespire";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 5;
+	pixel_y = 34;
+	specialfunctions = 4
+	},
+/obj/machinery/light/dim/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Td" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -11189,22 +11265,22 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "Tf" = (
-/obj/effect/turf_decal/stripes/red/corner,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESRedguard";
+	name = "Dormitory"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Tm" = (
 /obj/structure/window/reinforced/survival_pod,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "To" = (
@@ -11227,7 +11303,6 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Tu" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 8
 	},
@@ -11237,6 +11312,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Tw" = (
@@ -11400,7 +11476,6 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "TS" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/machinery/door/airlock/vault{
 	id_tag = "syndie_ds2_vault";
@@ -11420,6 +11495,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "TT" = (
@@ -11437,10 +11513,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "TW" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "TX" = (
@@ -11448,14 +11524,15 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
 "Ua" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/mob_spawn/human/ds2/prisoner{
+	dir = 4
 	},
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
+/obj/machinery/vr_sleeper{
+	dir = 4;
+	state_open = 0
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Uc" = (
 /obj/machinery/light/dim/directional/west,
@@ -11512,7 +11589,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Uj" = (
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	hackProof = 1;
@@ -11529,6 +11605,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Um" = (
@@ -11542,18 +11619,17 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Un" = (
 /obj/machinery/light/dim/directional/east,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/chair/comfy{
 	dir = 8;
 	color = "#800000"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Up" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
@@ -11568,16 +11644,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Us" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Uv" = (
@@ -11588,25 +11665,24 @@
 /turf/template_noop,
 /area/template_noop)
 "Uz" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/light/dim/directional/east,
 /obj/effect/turf_decal/trimline/dark_blue/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "UB" = (
 /obj/effect/spawner/structure/window/plastitanium,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/door/poddoor/preopen{
 	id = "ds2bridge"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "UE" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 4
 	},
@@ -11618,6 +11694,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "UM" = (
@@ -11699,13 +11776,15 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "UT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/obj/machinery/light/dim/directional/east,
-/obj/machinery/vending/kink,
-/turf/open/floor/wood/wood_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "UX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/survival_pod{
@@ -11751,10 +11830,10 @@
 	pixel_x = -6;
 	req_access_txt = "151"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "Vb" = (
@@ -11769,11 +11848,8 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Ve" = (
 /obj/machinery/light/dim/directional/south,
-/obj/machinery/processor,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
+/obj/machinery/smartfridge/food,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Vf" = (
@@ -11783,6 +11859,13 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
+"Vh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Vm" = (
 /obj/machinery/light/dim/directional/east,
 /obj/effect/turf_decal/siding/dark{
@@ -11794,7 +11877,6 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Vn" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -11805,11 +11887,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "Vo" = (
 /obj/machinery/light/dim/directional/west,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/ore_box,
@@ -11819,6 +11901,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Vp" = (
@@ -11896,6 +11979,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/lawyer)
+"VD" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "VE" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 4
@@ -11920,9 +12012,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/vault)
 "VI" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 9;
 	level = 1
@@ -11930,7 +12019,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/turf/open/floor/iron/white/small,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "VJ" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -11985,12 +12077,6 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "VT" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "VX" = (
@@ -12054,7 +12140,6 @@
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "Wm" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
@@ -12065,6 +12150,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Wn" = (
@@ -12166,7 +12252,6 @@
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "WC" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
@@ -12174,6 +12259,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "WE" = (
@@ -12189,13 +12275,13 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/hydroponics)
 "WH" = (
@@ -12222,11 +12308,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "WN" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "WS" = (
@@ -12436,10 +12522,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "Xy" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -12493,7 +12579,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "XF" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -12504,23 +12589,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "XG" = (
-/obj/effect/turf_decal/siding/dark{
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/iron/white/small,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "XI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/south{
 	req_access = null;
 	req_access_txt = "150"
@@ -12528,13 +12617,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "XN" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/power/apc/auto_name/west{
 	req_access = null;
 	req_access_txt = "150"
@@ -12554,6 +12643,7 @@
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
@@ -12568,6 +12658,39 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
+"XQ" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/item/radio{
+	desc = "An old handheld radio. You could use it, if you really wanted to.";
+	icon_state = "radio";
+	name = "old radio";
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/item/reagent_containers/rag/towel/syndicate{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "XR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -12694,9 +12817,9 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay/chem)
 "YE" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "YF" = (
@@ -12714,14 +12837,14 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness/shower)
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms/fitness)
 "YI" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
@@ -12735,15 +12858,18 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "YN" = (
-/obj/machinery/vending/wardrobe/syndie_wardrobe,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "YQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "YR" = (
@@ -12821,10 +12947,10 @@
 "Zq" = (
 /obj/structure/sign/flag/syndicate/directional/south,
 /obj/machinery/light/dim/directional/south,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood/wood_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "Zs" = (
@@ -12838,24 +12964,35 @@
 /obj/structure/table/reinforced{
 	color = "#777777"
 	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_y = 7;
-	pixel_x = 0
-	},
+/obj/item/ashtray,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
+"Zw" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/prison_loot_toilet,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Zz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESRedguard";
-	name = "Dormitory"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood/wood_tiled,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "ZA" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -12888,17 +13025,16 @@
 	},
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "ZB" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 6;
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "ZC" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
@@ -12906,6 +13042,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ZE" = (
@@ -12956,19 +13093,14 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "ZP" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_large,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "ZQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 8
 	},
@@ -12976,6 +13108,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "ZS" = (
@@ -13015,24 +13148,15 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
+Kf
+Kf
+Kf
+kF
 mX
 kF
-kF
-kF
-kF
-kF
-kF
-kF
-kF
-kF
-kF
-kF
-kF
-kF
+nO
+kx
+kx
 kx
 kx
 kx
@@ -13041,9 +13165,18 @@ kF
 kF
 kF
 kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
+kF
 mX
-wg
-wg
+kF
+nO
 wg
 wg
 wg
@@ -13068,37 +13201,37 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
-wg
+nO
+Kf
+Kf
+Kv
+rj
 mX
-kF
+Eh
 rH
-GL
-nS
-fy
-UR
-Xm
-Jl
-iV
+kF
+kF
+kF
+kF
+kF
+kF
+kF
 tS
 uN
 uN
 jZ
-kF
-kF
-kF
-kF
-kF
+xx
+Ua
+Ua
+Ua
+tJ
 ve
-QV
+fe
 uc
 KM
+kC
+BL
 kF
-mX
-wg
 wg
 wg
 wg
@@ -13115,44 +13248,44 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-EJ
-kx
-nO
-NB
+Mr
+Kf
+Kf
+Kf
+Kf
+Kf
+WE
+WE
+Kf
+Kf
+qc
+qc
+iV
 kF
 Ew
 gA
-Vp
-Ni
-Tf
+Zw
+nS
+fy
 UR
-tR
-RZ
+Xm
+Jl
 vc
 kM
 Vp
 Vp
 Vp
-xx
+Gs
 rc
 rc
 rc
 yh
-ve
-bP
+Se
+Se
 Al
 ah
 Se
-kF
+Jf
 NB
 NB
 NB
@@ -13167,27 +13300,27 @@ wg
 "}
 (4,1,1) = {"
 wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-qz
-qh
+EJ
+kx
+nO
+Kf
+iR
+Az
+gb
+iZ
+Kf
+Ni
+XG
+cX
+Kf
+Tc
+jL
+VD
 kF
 Oe
 So
 yZ
-zC
+UT
 wE
 Dh
 bs
@@ -13200,12 +13333,12 @@ kQ
 En
 iO
 VT
-Ir
-Du
-ve
-CT
+vc
+kM
+Vp
+Vp
 JA
-Ua
+Se
 Ve
 kF
 zX
@@ -13225,19 +13358,19 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-IC
-zI
-qh
+Kf
+GL
+aU
+DE
+uz
+Kf
+uy
+YN
+ZP
+CU
+fq
+JP
+CT
 kF
 Qx
 Po
@@ -13257,11 +13390,11 @@ mW
 SK
 Ru
 uL
-RP
-XG
+kQ
+kQ
 VI
-iM
-Hu
+Vp
+Vp
 kF
 zX
 Oi
@@ -13279,20 +13412,20 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-wg
-Nc
-Oi
-qh
+xr
+Kf
+Du
+mN
+iM
+Vh
+tR
+EP
+JF
+Hu
+Kf
+sY
+QV
+yw
 kF
 pX
 uS
@@ -13316,7 +13449,7 @@ GD
 Ar
 sC
 yR
-Jf
+ui
 kF
 zX
 Oi
@@ -13333,21 +13466,21 @@ wg
 (7,1,1) = {"
 wg
 wg
-wg
-wg
 xr
-IQ
-IQ
-IQ
+NB
 Kf
 Kf
 Kf
 Kf
-WE
-WE
 Kf
 Kf
+Ir
+ok
+Bn
 Kf
+Kf
+FW
+hN
 kF
 Dz
 Gh
@@ -13368,10 +13501,10 @@ kF
 Kc
 kF
 kF
-fe
+KF
 LP
 Oy
-BL
+ui
 kF
 zX
 Oi
@@ -13387,22 +13520,22 @@ wg
 "}
 (8,1,1) = {"
 wg
-EJ
-kx
-nO
+wg
+dT
+qh
 NB
 tg
 Cj
 rs
 Kf
-iR
+gL
 eo
-Kf
-Pe
+ok
+JE
 Ne
 Kf
-Az
-iR
+Kf
+Kf
 kF
 yH
 NS
@@ -13423,7 +13556,7 @@ BN
 PP
 lJ
 kF
-fe
+uw
 dI
 ct
 lb
@@ -13443,8 +13576,8 @@ wg
 (9,1,1) = {"
 wg
 wg
-wg
-wg
+cI
+qh
 NB
 Fw
 FH
@@ -13454,8 +13587,8 @@ pt
 eW
 Zz
 KY
-dh
-iK
+Kf
+Kf
 gb
 iZ
 uV
@@ -13497,20 +13630,20 @@ wg
 "}
 (10,1,1) = {"
 wg
-wg
-wg
-xr
-NB
-IQ
+Nc
+zI
+qh
+wj
+wj
 YH
-IQ
+wj
 Kf
-sc
-tt
 Kf
+dh
+Ez
 xH
-UT
 Kf
+MW
 DE
 tt
 uV
@@ -13552,22 +13685,22 @@ wg
 "}
 (11,1,1) = {"
 wg
-wg
-xr
-NB
-NB
+IC
+Oi
+qh
+RP
 ZF
 DK
+iK
 PY
-Kf
-Kf
-Kf
-Kf
+wj
+sz
+IQ
 NG
-Kf
-Kf
-Kf
-Kf
+Tf
+fq
+JQ
+Ex
 uV
 kb
 Ye
@@ -13589,8 +13722,8 @@ vp
 ni
 tP
 mA
-tJ
-tJ
+uo
+uo
 uo
 LY
 oG
@@ -13607,14 +13740,14 @@ wg
 "}
 (12,1,1) = {"
 wg
-wg
-dT
+Nc
+zI
 qh
-NB
+wj
 VO
 il
+AX
 ny
-Kf
 wj
 do
 nn
@@ -13662,19 +13795,19 @@ wg
 "}
 (13,1,1) = {"
 wg
-wg
-cI
+IC
+Oi
 qh
-NB
+wj
 EV
 il
 AX
-Kf
-EP
+sc
+wj
 Nm
 DB
 Lf
-ui
+Kf
 km
 eU
 iR
@@ -13720,15 +13853,15 @@ wg
 nO
 NB
 NB
-NB
+wj
 rI
 vD
 qY
-Kf
-YN
-rj
+XQ
+wj
+cU
 DJ
-ZP
+cU
 Kf
 Kf
 Kf
@@ -13775,15 +13908,15 @@ wg
 Nc
 zI
 qh
-NB
+wj
 EL
 NO
 EL
-Kf
-cU
-cU
+wj
+wj
+Pe
 ok
-cU
+Pe
 Kf
 GG
 ps
@@ -13888,10 +14021,10 @@ qh
 NB
 jf
 sE
-YQ
+RZ
 yU
-YQ
-YQ
+RZ
+RZ
 zb
 yU
 Lr
@@ -13964,7 +14097,7 @@ Rt
 oC
 oC
 Rt
-JF
+yi
 xp
 ms
 Ha
@@ -15004,8 +15137,8 @@ at
 Hz
 QM
 pu
-Pc
 fA
+bP
 cz
 WC
 gj

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1372,10 +1372,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "eU" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_parquet,
+/obj/structure/bed/double,
+/obj/item/bedsheet/brown/double,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "eV" = (
 /obj/effect/turf_decal/tile/dark_blue{
@@ -2448,11 +2447,11 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "iZ" = (
-/obj/structure/table/wood/fancy/black,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -4;
 	pixel_y = 2
 	},
+/obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "jb" = (
@@ -2844,9 +2843,14 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "km" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/light/dim/directional/north,
-/turf/open/floor/wood/wood_parquet,
+/obj/structure/closet/secure_closet/personal{
+	icon_state = "cabinet"
+	},
+/obj/item/clothing/under/costume/jabroni{
+	has_sensor = 0
+	},
+/obj/item/storage/wallet/random,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "kt" = (
 /obj/effect/turf_decal/stripes/end{
@@ -4244,14 +4248,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/research)
 "qs" = (
-/obj/structure/window/reinforced/survival_pod{
+/obj/structure/sign/flag/syndicate/directional/north,
+/obj/machinery/light/dim/directional/north,
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/table/wood/fancy/black,
-/obj/structure/sign/flag/syndicate/directional/north,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/wood/wood_parquet,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "qt" = (
 /obj/effect/turf_decal/trimline/brown/warning,
@@ -5080,9 +5082,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "tH" = (
-/obj/structure/dresser,
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
@@ -5973,7 +5974,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "xD" = (
-/obj/structure/table/wood/fancy/black,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -4;
 	pixel_y = 2
@@ -5984,6 +5984,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/table/wood/fancy/blackred,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "xE" = (
@@ -7221,6 +7222,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Dy" = (
@@ -8055,13 +8062,6 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "GL" = (
-/obj/structure/closet/secure_closet/personal{
-	icon_state = "cabinet"
-	},
-/obj/item/clothing/under/costume/jabroni{
-	has_sensor = 0
-	},
-/obj/item/storage/wallet/random,
 /obj/machinery/button/door{
 	id = "TESRedguard";
 	name = "Dorm Bolt Control";
@@ -8073,10 +8073,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/item/kirbyplants/hedge{
+	anchored = 1
 	},
-/turf/open/floor/carpet/blackred,
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "GO" = (
 /obj/effect/turf_decal/stripes/red/corner,
@@ -10111,6 +10111,14 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
+/obj/machinery/button/door/directional/north{
+	req_access_txt = "150";
+	name = "Dorms Blast Door Control";
+	desc = "To keep your sleepy heads away from the carp.";
+	id = "dorms-view";
+	pixel_x = 6;
+	pixel_y = 30
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "OK" = (
@@ -10670,13 +10678,14 @@
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/medbay)
 "QO" = (
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/wood/wood_parquet,
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "QQ" = (
 /obj/effect/turf_decal/siding/dark{
@@ -13601,8 +13610,8 @@ Zz
 KY
 Kf
 Kf
-gb
-iZ
+AU
+lz
 uV
 uV
 uV
@@ -13656,8 +13665,8 @@ Tr
 xH
 Kf
 GL
-DE
-tH
+qc
+tR
 uV
 it
 QH
@@ -13766,7 +13775,7 @@ nn
 Pe
 Kf
 qs
-qc
+tH
 QO
 uV
 xy
@@ -13822,7 +13831,7 @@ Lf
 Kf
 km
 eU
-dW
+iZ
 uV
 VC
 Ii

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -65,11 +65,11 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "ah" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/iron/white/textured_large,
-/area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
+/turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "aj" = (
 /obj/structure/frame/machine{
 	anchored = 1;
@@ -1777,11 +1777,11 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -2171,11 +2171,11 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo/hangar)
 "hP" = (
 /obj/machinery/light/dim/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
@@ -3489,11 +3489,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security)
 "nj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	level = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -4511,14 +4511,14 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/lounge)
 "rj" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "TESBattlespire";
-	name = "Dormitory"
-	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/grunge{
+	id_tag = "TESBattlespire";
+	name = "Dormitory"
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "rk" = (
@@ -4620,9 +4620,6 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "rH" = (
 /obj/machinery/light/dim/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "rI" = (
@@ -4666,13 +4663,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/cargo)
 "rQ" = (
-/obj/structure/window/reinforced/survival_pod{
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
-/turf/open/floor/wood/wood_parquet,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "rU" = (
 /obj/structure/sink/directional/east{
@@ -5244,6 +5243,9 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/storage/box/drinkingglasses,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "ue" = (
@@ -5974,18 +5976,16 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/engineering)
 "xD" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -4;
-	pixel_y = 2
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/obj/structure/table/wood/fancy/blackred,
-/turf/open/floor/carpet/blackred,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "xE" = (
 /obj/effect/turf_decal/box/red/corners{
@@ -6528,7 +6528,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/halls)
 "Al" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
@@ -7348,7 +7348,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Dormitories"
+	name = "Dormitories";
+	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -7389,10 +7390,10 @@
 /obj/structure/closet/secure_closet/personal{
 	icon_state = "cabinet"
 	},
-/obj/item/clothing/under/syndicate/baseball,
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+	dir = 4
 	},
+/obj/item/clothing/under/syndicate/baseball,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "DZ" = (
@@ -7501,6 +7502,7 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/rag/towel/syndicate,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/security/prison)
 "Ey" = (
@@ -8263,16 +8265,15 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge)
 "Hu" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/wood/wood_parquet,
+/obj/structure/bed/double,
+/obj/item/bedsheet/brown/double,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Hw" = (
 /obj/structure/disposalpipe/segment{
@@ -9483,17 +9484,14 @@
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "MA" = (
-/obj/structure/bed/double{
-	dir = 1
-	},
-/obj/item/bedsheet/brown/double{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
 	},
-/turf/open/floor/carpet/blackred,
+/obj/item/kirbyplants/hedge{
+	anchored = 1
+	},
+/turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "MB" = (
 /obj/structure/cable,
@@ -9643,7 +9641,14 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo)
 "Ne" = (
-/obj/machinery/vending/kink,
+/obj/machinery/vending/kink{
+	shut_up = 1
+	},
+/obj/structure/curtain{
+	open = 1;
+	color = "#555555";
+	alpha = 255
+	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/dorms)
 "Ng" = (
@@ -13225,8 +13230,8 @@ wg
 nO
 Kf
 Kf
-lz
-AU
+DV
+EP
 mX
 Fq
 rH
@@ -13279,9 +13284,9 @@ WE
 WE
 Kf
 Kf
-qc
-qc
-tR
+Et
+RP
+Jp
 kF
 Ew
 gA
@@ -13291,7 +13296,7 @@ fy
 UR
 Xm
 Jl
-vc
+VT
 kM
 Vp
 Vp
@@ -13304,7 +13309,7 @@ yh
 Ua
 Ua
 Al
-ah
+Ua
 Ua
 Jf
 NB
@@ -13444,9 +13449,9 @@ UT
 Ir
 Az
 Kf
-Et
-RP
-Jp
+qc
+qc
+ah
 kF
 pX
 uS
@@ -13500,8 +13505,8 @@ ok
 Qu
 Kf
 Kf
-DV
-EP
+lz
+AU
 kF
 Dz
 Gh
@@ -13610,8 +13615,8 @@ Zz
 KY
 Kf
 Kf
-AU
 lz
+AU
 uV
 uV
 uV


### PR DESCRIPTION
# Описание
1) У всех апц доступ переставлен на синдикатский (теперь их не нужно взламывать)
2) Кухня переделана в более удобной компановке и убраны 2 дипфраера (серьёзно 3 дипфраера при 1 микроволновке)
3) В рнд добавлена створка для окон
4) Мостик и офисы адмирала и (второго чувака от него) передизайнены в понимании, что комнаты устроены для удобства
5) Клёвый пингвин в шляпе с текилой, в шляпе и с текилой!!
6) Столовая переделана в бар и диско шар заменён на приогрыватель (ибо диско шар был оверкилом)
7) в карго в одним из ящиков лежит куча кустов которые расставлены на дс-2
8) переработка дорм дс-2
9) добавление под капсулы заключённых вр слиперов
10) добавление диктофона и кассет для неё в допросную

## Причина изменений
Редизайн ДС-2 с целью сделать его более приятным для пребывания не требующим ежераундового перестраивания
## Демонстрация изменений
![image](https://github.com/user-attachments/assets/5611959a-e12a-427f-ab70-60d42c8614f3)
![image](https://github.com/user-attachments/assets/5e8c7607-187a-41d4-b0a8-5318258eaa0b)
![image](https://github.com/user-attachments/assets/170c8383-057b-4aa2-a99e-0921a1f06cb9)
![image](https://github.com/user-attachments/assets/aad6f6bc-f0ed-4778-8154-64369d1a8f21)
