### PR TITLE
Фикс спавна интековца вместо синди слипера для гостроли

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -599,7 +599,7 @@
 	dir = 4;
 	pixel_y = 5
 	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -1262,7 +1262,7 @@
 /obj/structure/bed/pod{
 	dir = 1
 	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 4
 	},
 /obj/item/bedsheet/syndie{

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -195,11 +195,13 @@
 	outfit = /datum/outfit/lavaland_syndicate/comms
 	can_load_appearance = TRUE
 
+/*
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/Initialize(mapload)
 	. = ..()
 	if(prob(1)) //only has a 99% chance of existing, otherwise it'll just be a NPC syndie.
 		new /mob/living/simple_animal/hostile/syndicate/ranged(get_turf(src))
 		return INITIALIZE_HINT_QDEL
+*/
 
 /datum/outfit/lavaland_syndicate/comms
 	name = "Syndicate Comms Agent"

--- a/modular_bluemoon/Ren/Code/mobs.dm
+++ b/modular_bluemoon/Ren/Code/mobs.dm
@@ -241,7 +241,7 @@
 
 //спавн трупа
 /obj/effect/mob_spawn/human/corpse/inteq_dead
-	name = "InteQ Operative"
+	name = "InteQ Operative
 	id_job = "Operative"
 	hair_style = "Bald"
 	facial_hair_style = "Shaved"

--- a/modular_bluemoon/Ren/Code/mobs.dm
+++ b/modular_bluemoon/Ren/Code/mobs.dm
@@ -241,7 +241,7 @@
 
 //спавн трупа
 /obj/effect/mob_spawn/human/corpse/inteq_dead
-	name = "InteQ Operative
+	name = "InteQ Operative"
 	id_job = "Operative"
 	hair_style = "Bald"
 	facial_hair_style = "Shaved"

--- a/modular_splurt/_maps/RandomRuins/SpaceRuins/syndielistenspace.dmm
+++ b/modular_splurt/_maps/RandomRuins/SpaceRuins/syndielistenspace.dmm
@@ -583,7 +583,7 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	assignedrole = "Space Syndicate";
 	dir = 8;
 	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13. <b>Monitor enemy activity as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"


### PR DESCRIPTION
# Описание
1) имел шанс быть заспавниться интековец вместо слипера агента прослушки синдикека

## Причина изменений
багфиксы