### PR TITLE
Ремап парка на Мете

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36558,13 +36558,8 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "cIw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "cIG" = (
 /turf/open/floor/plasteel/white,
@@ -38197,12 +38192,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dpq" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "dpQ" = (
 /obj/structure/grille/broken,
 /obj/structure/sign/poster/contraband/random{
@@ -38285,13 +38274,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/cells)
-"dsP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/commons/dorms)
 "dtn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -39757,11 +39739,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ecN" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -40040,14 +40021,11 @@
 	},
 /area/service/theater)
 "ekD" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 32
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/turf/open/floor/grass,
-/area/service/park)
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "ekP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43734,18 +43712,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"gic" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "giT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51738,13 +51704,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/storage)
-"kzF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/commons/fitness)
 "kzR" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
@@ -52986,7 +52945,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -57633,7 +57592,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -58318,6 +58277,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
+"obP" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "oce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -62601,11 +62572,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/floor/wood/wood_diagonal,
-/area/commons/fitness)
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "qBI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -63159,7 +63130,7 @@
 	name = "Park Area"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "qQV" = (
 /obj/structure/cable{
@@ -68929,9 +68900,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/office)
-"ucE" = (
+"ucs" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
+"ucE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness)
@@ -69834,9 +69816,12 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "uEq" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/commons/dorms)
 "uEG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -72824,6 +72809,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/teleporter)
+"wjC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "wjQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73231,7 +73222,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "wuO" = (
 /obj/effect/spawner/lootdrop/maintenance{
@@ -73312,6 +73303,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
+"wxy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/commons/fitness)
 "wyA" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery,
@@ -74282,7 +74277,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/commons/fitness)
 "xdh" = (
 /obj/item/radio/intercom{
@@ -74621,7 +74616,9 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "xoY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood/wood_diagonal,
 /area/commons/fitness)
 "xoZ" = (
@@ -75649,11 +75646,14 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/dorms)
 "xXg" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/obj/structure/flora/tree/jungle/small,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/commons/fitness)
+/turf/open/floor/grass,
+/area/service/park)
 "xXh" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -112311,7 +112311,7 @@ gXs
 aaa
 aaa
 lXr
-ekD
+xXg
 nUT
 mMI
 uHB
@@ -112321,9 +112321,9 @@ vys
 egM
 oyc
 oQA
-qBx
-ucE
-xXg
+xoY
+wjC
+ekD
 fHG
 vWh
 ghD
@@ -112579,8 +112579,8 @@ fLM
 lkr
 xde
 gGX
-xoY
-kzF
+wxy
+ucE
 ghD
 euw
 ltW
@@ -113104,7 +113104,7 @@ arf
 arf
 arf
 arf
-dsP
+uEq
 eSR
 asd
 dtn
@@ -113348,8 +113348,8 @@ nfW
 duP
 cFY
 pgT
-lig
-cIw
+ucs
+nHQ
 sWo
 eOJ
 fha
@@ -113862,9 +113862,9 @@ bBw
 sad
 xkq
 pgT
-uEq
+cIw
 omM
-ecN
+lig
 sYW
 fHG
 ahm
@@ -114376,9 +114376,9 @@ eUU
 sad
 eDt
 pgT
-uEq
+cIw
 omM
-gic
+obP
 sYW
 fHG
 ahm
@@ -114635,7 +114635,7 @@ sad
 qQS
 sad
 kwp
-dpq
+qBx
 wlc
 fHG
 ahm
@@ -114891,7 +114891,7 @@ hoG
 hoG
 pgT
 vDt
-nHQ
+ecN
 uab
 sYW
 fHG

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36558,9 +36558,13 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "cIw" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood/wood_diagonal,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "cIG" = (
 /turf/open/floor/plasteel/white,
@@ -38193,6 +38197,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dpq" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "dpQ" = (
 /obj/structure/grille/broken,
 /obj/structure/sign/poster/contraband/random{
@@ -38275,6 +38285,13 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/cells)
+"dsP" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/commons/dorms)
 "dtn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -39740,13 +39757,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ecN" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 10
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "ecZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40022,8 +40040,13 @@
 	},
 /area/service/theater)
 "ekD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
+/obj/structure/flora/tree/jungle/small,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "ekP" = (
 /obj/effect/turf_decal/tile/red{
@@ -40984,7 +41007,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/service/park)
 "eOL" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
@@ -43711,6 +43734,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"gic" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "giT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -44644,7 +44679,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood/wood_diagonal,
 /area/commons/fitness)
 "gHl" = (
 /obj/structure/disposalpipe/segment,
@@ -44987,6 +45022,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "gNv" = (
@@ -48553,6 +48591,10 @@
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "iWE" = (
@@ -48863,6 +48905,11 @@
 "jdh" = (
 /obj/structure/chair/pew/left{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 0;
+	pixel_x = 32
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -50147,6 +50194,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "jJC" = (
@@ -50324,6 +50374,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness)
@@ -51622,6 +51675,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "kxn" = (
@@ -51682,6 +51738,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/medical/storage)
+"kzF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "kzR" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
@@ -52920,6 +52983,9 @@
 "lig" = (
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -57566,6 +57632,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "nIt" = (
@@ -58225,6 +58294,7 @@
 	name = "Park Area"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/service/park)
 "oay" = (
@@ -58613,7 +58683,6 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "omM" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -58721,6 +58790,10 @@
 "orh" = (
 /obj/structure/flora/grass/jungle/b{
 	icon_state = "grassa5"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -62528,11 +62601,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood/wood_diagonal,
-/area/service/park)
+/area/commons/fitness)
 "qBI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -63085,6 +63158,7 @@
 /obj/machinery/door/airlock{
 	name = "Park Area"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "qQV" = (
@@ -68857,11 +68931,10 @@
 /area/cargo/office)
 "ucE" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 10
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "udC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -69762,9 +69835,6 @@
 /area/service/hydroponics)
 "uEq" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
 /turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "uEG" = (
@@ -70461,6 +70531,11 @@
 /obj/structure/flora/rock/pile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 0;
+	pixel_x = 32
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -71427,6 +71502,9 @@
 	},
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -72826,6 +72904,7 @@
 /obj/machinery/door/airlock{
 	name = "Park Area"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/service/park)
 "wlg" = (
@@ -73151,6 +73230,7 @@
 	name = "Park Area"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "wuO" = (
@@ -73294,6 +73374,9 @@
 /obj/machinery/gear_painter,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness)
@@ -73663,6 +73746,9 @@
 /area/medical/morgue)
 "wMD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "wNp" = (
@@ -74195,7 +74281,8 @@
 	name = "Park Area"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/wood_diagonal,
 /area/commons/fitness)
 "xdh" = (
 /obj/item/radio/intercom{
@@ -74534,12 +74621,9 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "xoY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall,
-/area/service/park)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/commons/fitness)
 "xoZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75565,14 +75649,11 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/dorms)
 "xXg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "xXh" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -112230,7 +112311,7 @@ gXs
 aaa
 aaa
 lXr
-eTS
+ekD
 nUT
 mMI
 uHB
@@ -112240,9 +112321,9 @@ vys
 egM
 oyc
 oQA
-vHm
-fHG
-fHG
+qBx
+ucE
+xXg
 fHG
 vWh
 ghD
@@ -112498,8 +112579,8 @@ fLM
 lkr
 xde
 gGX
-ghD
-ghD
+xoY
+kzF
 ghD
 euw
 ltW
@@ -113013,7 +113094,7 @@ lXr
 prj
 jlZ
 gRo
-ekD
+pgT
 gGW
 ahm
 dvU
@@ -113023,7 +113104,7 @@ arf
 arf
 arf
 arf
-oHB
+dsP
 eSR
 asd
 dtn
@@ -113268,7 +113349,7 @@ duP
 cFY
 pgT
 lig
-nHQ
+cIw
 sWo
 eOJ
 fha
@@ -113524,7 +113605,7 @@ oBp
 oBp
 oBp
 wtR
-ucE
+oBp
 gNt
 wMD
 oaa
@@ -113782,8 +113863,8 @@ sad
 xkq
 pgT
 uEq
+omM
 ecN
-lig
 sYW
 fHG
 ahm
@@ -114295,9 +114376,9 @@ eUU
 sad
 eDt
 pgT
-cIw
-xXg
-vDt
+uEq
+omM
+gic
 sYW
 fHG
 ahm
@@ -114552,9 +114633,9 @@ sad
 sad
 sad
 qQS
-qBx
+sad
 kwp
-uab
+dpq
 wlc
 fHG
 ahm
@@ -114812,7 +114893,7 @@ pgT
 vDt
 nHQ
 uab
-xoY
+sYW
 fHG
 uOy
 arj
@@ -115069,7 +115150,7 @@ lXr
 jOV
 meT
 wtI
-xoY
+sYW
 fHG
 ahm
 qNs

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -32928,12 +32928,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/factory)
-"cqh" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/commons/fitness)
 "cqn" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -36564,16 +36558,8 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "cIw" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "cIG" = (
 /turf/open/floor/plasteel/white,
@@ -39753,12 +39739,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ecN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/commons/fitness)
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "ecZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40033,12 +40018,11 @@
 	},
 /area/service/theater)
 "ekD" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/commons/dorms)
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "ekP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -46504,12 +46488,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/detectives_office/private_investigators_office/investigators_room)
-"hHJ" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "hHM" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -50688,6 +50666,12 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"jWP" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "jWW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/warning/pods{
@@ -51926,6 +51910,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"kGH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "kGJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52725,6 +52718,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/machinery/airalarm{
+	pixel_x = 0;
+	pixel_y = 28
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "kZJ" = (
@@ -52964,7 +52961,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -54179,6 +54176,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lVL" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "lVN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57611,7 +57618,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -58661,11 +58668,9 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "omM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood/wood_diagonal,
-/area/service/park)
+/area/commons/fitness)
 "omQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
@@ -62579,12 +62584,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBx" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/dark_green{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -67391,6 +67398,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
+"tjG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/commons/fitness)
 "tjV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -68912,8 +68925,9 @@
 /turf/open/floor/plasteel,
 /area/cargo/office)
 "ucE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness)
@@ -69816,8 +69830,13 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "uEq" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/wood_diagonal,
+/obj/structure/flora/tree/jungle/small,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "uEG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -72065,15 +72084,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
-"vQc" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "vQf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -72170,15 +72180,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
-"vTw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "vTP" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -74621,11 +74622,12 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "xoY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/turf/open/floor/wood/wood_diagonal,
-/area/commons/fitness)
+/turf/open/floor/plasteel/dark,
+/area/commons/dorms)
 "xoZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75651,8 +75653,10 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/dorms)
 "xXg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood/wood_diagonal,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
 /area/commons/fitness)
 "xXh" = (
 /obj/machinery/holopad,
@@ -112311,7 +112315,7 @@ gXs
 aaa
 aaa
 lXr
-vQc
+uEq
 nUT
 mMI
 uHB
@@ -112321,9 +112325,9 @@ vys
 egM
 oyc
 oQA
-xoY
-ucE
-cqh
+tjG
+xXg
+ekD
 fHG
 vWh
 ghD
@@ -112579,8 +112583,8 @@ fLM
 lkr
 xde
 gGX
-xXg
-ecN
+omM
+ucE
 ghD
 euw
 ltW
@@ -113104,7 +113108,7 @@ arf
 arf
 arf
 arf
-ekD
+xoY
 eSR
 asd
 dtn
@@ -113348,8 +113352,8 @@ nfW
 duP
 cFY
 pgT
-qBx
-nHQ
+lig
+kGH
 sWo
 eOJ
 fha
@@ -113862,9 +113866,9 @@ bBw
 sad
 xkq
 pgT
-uEq
-omM
-lig
+cIw
+ecN
+lVL
 sYW
 fHG
 ahm
@@ -114120,7 +114124,7 @@ sad
 jPj
 pgT
 dvL
-omM
+ecN
 jJt
 sYW
 fHG
@@ -114376,9 +114380,9 @@ eUU
 sad
 eDt
 pgT
-uEq
-omM
 cIw
+ecN
+qBx
 sYW
 fHG
 ahm
@@ -114635,7 +114639,7 @@ sad
 qQS
 sad
 kwp
-hHJ
+jWP
 wlc
 fHG
 ahm
@@ -114891,7 +114895,7 @@ hoG
 hoG
 pgT
 vDt
-vTw
+nHQ
 uab
 sYW
 fHG

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -32928,6 +32928,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/factory)
+"cqh" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "cqn" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -36558,8 +36564,16 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "cIw" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/wood_diagonal,
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "cIG" = (
 /turf/open/floor/plasteel/white,
@@ -39739,14 +39753,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ecN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
+/turf/open/floor/plasteel,
+/area/commons/fitness)
 "ecZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40021,11 +40033,12 @@
 	},
 /area/service/theater)
 "ekD" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/commons/fitness)
+/turf/open/floor/plasteel/dark,
+/area/commons/dorms)
 "ekP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40567,10 +40580,10 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "eBv" = (
-/obj/structure/flora/tree/jungle/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/service/park)
 "eBX" = (
@@ -46491,6 +46504,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/detectives_office/private_investigators_office/investigators_room)
+"hHJ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "hHM" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -47052,13 +47071,13 @@
 /turf/open/floor/wood,
 /area/service/library)
 "iaw" = (
-/obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
 /area/service/park)
 "iaB" = (
@@ -58277,18 +58296,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"obP" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "oce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -62572,8 +62579,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBx" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -68900,20 +68911,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/office)
-"ucs" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "ucE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness)
@@ -69816,12 +69816,9 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "uEq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/commons/dorms)
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "uEG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -72068,6 +72065,15 @@
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
+"vQc" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "vQf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -72164,6 +72170,15 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
+"vTw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "vTP" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -72809,12 +72824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/teleporter)
-"wjC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/commons/fitness)
 "wjQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73303,10 +73312,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
-"wxy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood/wood_diagonal,
-/area/commons/fitness)
 "wyA" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery,
@@ -75646,14 +75651,9 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/dorms)
 "xXg" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/grass,
-/area/service/park)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/commons/fitness)
 "xXh" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -112311,7 +112311,7 @@ gXs
 aaa
 aaa
 lXr
-xXg
+vQc
 nUT
 mMI
 uHB
@@ -112322,8 +112322,8 @@ egM
 oyc
 oQA
 xoY
-wjC
-ekD
+ucE
+cqh
 fHG
 vWh
 ghD
@@ -112579,8 +112579,8 @@ fLM
 lkr
 xde
 gGX
-wxy
-ucE
+xXg
+ecN
 ghD
 euw
 ltW
@@ -113104,7 +113104,7 @@ arf
 arf
 arf
 arf
-uEq
+ekD
 eSR
 asd
 dtn
@@ -113348,7 +113348,7 @@ nfW
 duP
 cFY
 pgT
-ucs
+qBx
 nHQ
 sWo
 eOJ
@@ -113862,7 +113862,7 @@ bBw
 sad
 xkq
 pgT
-cIw
+uEq
 omM
 lig
 sYW
@@ -114376,9 +114376,9 @@ eUU
 sad
 eDt
 pgT
-cIw
+uEq
 omM
-obP
+cIw
 sYW
 fHG
 ahm
@@ -114635,7 +114635,7 @@ sad
 qQS
 sad
 kwp
-qBx
+hHJ
 wlc
 fHG
 ahm
@@ -114891,7 +114891,7 @@ hoG
 hoG
 pgT
 vDt
-ecN
+vTw
 uab
 sYW
 fHG

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1964,8 +1964,9 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "agA" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "agB" = (
@@ -2043,12 +2044,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ahi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "ahp" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
@@ -4395,7 +4390,7 @@
 /area/maintenance/starboard/fore)
 "api" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/service/park)
@@ -10552,13 +10547,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aTd" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "aTi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -12532,19 +12520,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aZu" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4;
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "aZv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13792,23 +13767,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bft" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/trash/plate{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "bfE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
@@ -19994,10 +19952,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bGU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/commons/cryopod)
 "bGV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -26874,6 +26828,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cip" = (
+/obj/machinery/airalarm{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "ciq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -27230,6 +27191,19 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"cjn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "cjp" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
@@ -46414,8 +46388,14 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "dpg" = (
-/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -34;
+	pixel_y = 4
+	},
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "dpk" = (
@@ -48034,6 +48014,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dIB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "dIE" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -48052,15 +48039,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
-"dJy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "dJE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -48546,14 +48524,6 @@
 	dir = 1
 	},
 /area/engineering/atmos)
-"dWb" = (
-/obj/structure/flora/tree/jungle{
-	pixel_x = -47;
-	pixel_y = -13
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/service/park)
 "dWm" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/light{
@@ -49090,11 +49060,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
 "ejb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/clothing/head/hardhat/pumpkinhead,
 /turf/open/floor/grass,
 /area/service/park)
 "ejd" = (
@@ -49205,6 +49170,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/cargo/warehouse)
+"ekD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "ekH" = (
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/turf_decal/bot_white,
@@ -49298,17 +49272,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
-"enT" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "eof" = (
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
@@ -49354,12 +49317,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
-"erm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "erD" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
@@ -49647,6 +49604,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
+"ezJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/grass,
+/area/service/park)
 "ezL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
@@ -50247,15 +50214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eMF" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "eMV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -50537,6 +50495,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/service/hydroponics/garden)
+"eSt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "eSC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51075,17 +51040,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/service/janitor)
-"feH" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -34;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "feJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51948,10 +51902,14 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fCC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/flora/grass/jungle/b{
+	icon_state = "grassa1"
 	},
-/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/firealarm{
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "fCR" = (
@@ -52869,11 +52827,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gaR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+"gaM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/grass,
 /area/service/park)
 "gaV" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -53269,6 +53227,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"gjt" = (
+/obj/structure/flora/rock/pile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "gjy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53818,14 +53783,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "gwc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "gwC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54480,6 +54438,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/service/hydroponics)
+"gMK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/grass,
+/area/service/park)
 "gMW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -54816,12 +54787,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"gVn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "gVv" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -55230,16 +55195,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hgV" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "hhA" = (
 /turf/open/floor/plasteel,
@@ -55629,6 +55589,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"hqA" = (
+/obj/machinery/airalarm{
+	pixel_x = -1;
+	pixel_y = 28
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "hqC" = (
 /obj/structure/barricade/wooden,
 /obj/effect/turf_decal/stripes/line{
@@ -55891,6 +55858,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"hwc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/commons/fitness/recreation)
 "hwd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -56210,6 +56186,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
+"hCy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "hCA" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -56437,6 +56419,14 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"hHr" = (
+/obj/structure/flora/tree/jungle{
+	pixel_x = -47;
+	pixel_y = -13
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "hIg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
@@ -57111,11 +57101,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
-"hUP" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "hUT" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
@@ -57189,13 +57174,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
-"hXf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "hXi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -57451,6 +57429,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"ibB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "ibJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -57604,20 +57588,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/service/library)
-"igt" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4;
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "igL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/office/dark{
@@ -58155,12 +58125,8 @@
 /area/service/bar)
 "iuP" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 9
+	dir = 1
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/grass,
 /area/service/park)
 "iuW" = (
@@ -58409,15 +58375,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
-"iAl" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "iAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/kirbyplants/random,
@@ -58562,12 +58519,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/janitor)
+"iES" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "iET" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"iFc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "iFl" = (
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
@@ -58749,19 +58722,6 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
-"iHh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/grass,
-/area/service/park)
 "iHl" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -58902,9 +58862,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
-"iMu" = (
-/turf/open/floor/grass,
-/area/service/park)
 "iMF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -58952,11 +58909,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/office)
-"iNo" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/service/park)
 "iNR" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -59054,14 +59006,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/upper)
-"iRZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/service/park)
 "iSt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59074,13 +59018,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"iSB" = (
-/obj/structure/flora/rock/pile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "iSE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/chem_master/condimaster{
@@ -59819,6 +59756,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
+"jlV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "jmq" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -60014,13 +59955,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jqz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/grass,
-/area/service/park)
 "jra" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60072,15 +60006,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
-"jsI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "jsO" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
@@ -60142,6 +60067,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
+"jtp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/service/park)
 "jtr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60252,7 +60184,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -60361,11 +60293,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"jxL" = (
-/obj/structure/flora/junglebush/large,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "jyd" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable/yellow{
@@ -61457,9 +61384,6 @@
 /obj/structure/flora/junglebush{
 	icon_state = "bushb1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/grass,
 /area/service/park)
 "jYV" = (
@@ -62007,6 +61931,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"klD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "klE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63656,13 +63586,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "kXp" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 0
-	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/grass,
 /area/service/park)
 "kXt" = (
@@ -64197,13 +64122,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/park)
-"lkL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/service/park)
 "lkU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -64542,6 +64460,15 @@
 	dir = 1
 	},
 /area/service/chapel/main)
+"ltL" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "ltR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -64769,18 +64696,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"lyQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "lyU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -65255,6 +65170,14 @@
 	},
 /turf/open/floor/grass/grass3,
 /area/hallway/primary/central)
+"lLO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "lMh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65878,8 +65801,11 @@
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "lYZ" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/wood_diagonal,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "mah" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -66333,12 +66259,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
-"miN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "miS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67332,6 +67252,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"mFT" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "mGK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain{
@@ -67412,6 +67336,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/storage/satellite)
+"mIy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/commons/cryopod)
 "mIE" = (
 /turf/open/floor/plasteel,
 /area/cargo/storage)
@@ -67536,13 +67464,6 @@
 "mMn" = (
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"mMz" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "mMO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/syndicate_present,
@@ -67729,14 +67650,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"mRs" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "mRE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -68170,13 +68083,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/office)
-"ncr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/grass,
-/area/service/park)
 "ncN" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
@@ -68631,16 +68537,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"nok" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -47;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "noG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -68800,6 +68696,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/commons/dorms/second)
+"nsf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "nsg" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -68952,14 +68854,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nyb" = (
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "nye" = (
 /obj/structure/sign/barbershop,
 /turf/closed/wall,
@@ -69249,9 +69143,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
-"nGw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/wood/wood_diagonal,
+"nHc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "nHn" = (
 /obj/structure/cable{
@@ -69267,9 +69169,7 @@
 /area/engineering/main)
 "nHz" = (
 /obj/structure/flora/junglebush/large,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/grass,
 /area/service/park)
 "nHL" = (
@@ -69890,6 +69790,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"nVY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Park Area"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "nWa" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow{
@@ -70244,6 +70152,10 @@
 "obi" = (
 /obj/structure/flora/junglebush{
 	icon_state = "grassa4"
+	},
+/obj/structure/flora/tree/jungle{
+	pixel_x = -44;
+	pixel_y = -18
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -70697,7 +70609,7 @@
 /area/commons/cryopod)
 "okd" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_diagonal,
@@ -70779,15 +70691,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"ome" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/flora/grass/jungle/b{
-	icon_state = "grassa1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "omQ" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -70807,11 +70710,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
-"onb" = (
-/obj/structure/flora/tree/jungle,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "oni" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70993,15 +70891,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/medical/psychology)
-"opS" = (
-/obj/machinery/door/airlock{
-	name = "Park Area"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "oqC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -71181,14 +71070,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/chapel_floor,
 /area/service/bar)
-"ouK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Park Area"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "ovd" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -71269,6 +71150,23 @@
 	},
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
+"oyd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/trash/plate{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "oyi" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -72239,10 +72137,12 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "oWo" = (
+/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood/wood_diagonal,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
 /area/service/park)
 "oWt" = (
 /obj/machinery/door/firedoor,
@@ -72573,16 +72473,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"pcC" = (
-/obj/structure/flora/junglebush{
-	icon_state = "grassa4"
-	},
-/obj/structure/flora/tree/jungle{
-	pixel_x = -44;
-	pixel_y = -18
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "pcD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -72613,12 +72503,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/commons/toilet/restrooms)
-"pdS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "pdZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -72875,12 +72759,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"pjp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "pjr" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
@@ -73159,6 +73037,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
+"ppy" = (
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pqa" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -73578,6 +73469,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/art)
+"pyI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/grass,
+/area/service/park)
 "pyU" = (
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
@@ -73852,6 +73750,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"pEZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
+"pFw" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pGf" = (
 /obj/structure/chair{
 	dir = 4
@@ -74025,21 +73943,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar)
-"pIY" = (
-/obj/effect/turf_decal/tile/red{
+"pIQ" = (
+/obj/structure/flora/junglebush/large,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/storage/bag/easterbasket{
-	name = "picnic basket";
-	pixel_y = 11;
-	pixel_x = -8
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -74252,6 +74159,13 @@
 "pNW" = (
 /turf/closed/wall,
 /area/science/research/abandoned)
+"pOE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
+/area/service/park)
 "pOP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -74363,6 +74277,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
+"pRI" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "pRX" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -74394,6 +74313,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"pSv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pSz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -74415,16 +74343,6 @@
 /obj/item/coin/silver,
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
-"pSN" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -74534,15 +74452,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"pVD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/commons/fitness/recreation)
 "pVL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -76144,15 +76053,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/cells)
-"qEY" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "qFr" = (
 /obj/structure/toilet/secret/low_loot{
 	pixel_y = 13
@@ -76268,12 +76168,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
-"qIl" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "qIn" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -76409,6 +76303,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
+"qKD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "qLt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -77132,6 +77033,13 @@
 /obj/effect/spawner/lootdrop/syndicate_present,
 /turf/open/floor/wood/wood_parquet,
 /area/service/shop)
+"rbR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/junglebush,
+/turf/open/floor/grass,
+/area/service/park)
 "rbX" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -77605,6 +77513,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
+"rlV" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rma" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table,
@@ -77649,6 +77569,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"rnn" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/service/park)
 "rns" = (
 /obj/structure/chair{
 	dir = 1
@@ -77695,10 +77619,6 @@
 "roz" = (
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
-"roC" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
-/area/service/park)
 "rpa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -78146,6 +78066,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rAd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rAe" = (
 /obj/machinery/button/door{
 	id = "dorm9";
@@ -78165,6 +78091,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"rAG" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rAS" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Air";
@@ -78371,15 +78304,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
-"rGM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "rGV" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
@@ -78785,6 +78709,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/teleporter)
+"rRe" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/storage/bag/easterbasket{
+	name = "picnic basket";
+	pixel_y = 11;
+	pixel_x = -8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rRz" = (
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -78952,6 +78894,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"rTy" = (
+/obj/structure/flora/junglebush{
+	icon_state = "grassa4"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rTM" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
@@ -79460,13 +79408,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
-"sfJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/service/park)
 "sfM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -79588,6 +79529,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/command/blueshielquarters)
+"siR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "siX" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/airalarm{
@@ -79610,7 +79561,13 @@
 /turf/closed/wall,
 /area/command/bridge)
 "sjM" = (
-/turf/open/floor/wood/wood_diagonal,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "sjN" = (
 /obj/machinery/light/small,
@@ -81462,12 +81419,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/commons/dorms)
-"tdc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "tde" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -81591,12 +81542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"tfq" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "tfs" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/binary/valve{
@@ -81810,10 +81755,13 @@
 /turf/open/floor/grass/grass2,
 /area/hallway/primary/central)
 "tjO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/turf/open/floor/wood/wood_diagonal,
+/obj/structure/flora/grass/jungle/b{
+	icon_state = "grassa1"
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "tjW" = (
 /turf/closed/wall,
@@ -81948,6 +81896,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
+"tmO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "tnh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82084,6 +82038,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"tqF" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "tqG" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -83545,6 +83504,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
+"tYb" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "tYf" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -83890,12 +83858,7 @@
 /obj/structure/streetdecor/lamp{
 	light_color = "#ffd6aa";
 	light_power = 1;
-	light_range = 4;
-	pixel_x = -2;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+	light_range = 4
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -84164,6 +84127,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"umy" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "umz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84187,13 +84155,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
-"ung" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "unm" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable/yellow{
@@ -84444,6 +84405,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"usj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/head/hardhat/pumpkinhead,
+/turf/open/floor/grass,
+/area/service/park)
 "usx" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -84842,6 +84811,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"uBT" = (
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -47;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "uBW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -85216,13 +85195,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"uNK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "uOc" = (
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85413,6 +85385,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
+"uUG" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "uUJ" = (
 /obj/effect/turf_decal/tile/dark_green,
 /turf/open/floor/plasteel,
@@ -86540,6 +86522,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"vxj" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "vxw" = (
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table,
@@ -87713,6 +87702,11 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"wbt" = (
+/obj/structure/flora/tree/jungle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "wbv" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -87752,6 +87746,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"wch" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "wcj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -87778,6 +87778,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"wcU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/grass,
+/area/service/park)
 "wcY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -89072,17 +89079,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"wFW" = (
-/obj/structure/flora/grass/jungle/b{
-	icon_state = "grassa1"
-	},
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "wFX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -89166,6 +89162,15 @@
 	},
 /turf/open/floor/grass/grass0,
 /area/service/hydroponics/garden)
+"wHh" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "wHw" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "visitation";
@@ -89775,12 +89780,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/locker)
-"wUG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "wUI" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral,
@@ -90186,6 +90185,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"xby" = (
+/obj/machinery/door/airlock{
+	name = "Park Area"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "xbz" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -90394,6 +90402,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xlk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "xlv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -90566,6 +90583,13 @@
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
+"xok" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "xos" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -92153,13 +92177,6 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
-"xVO" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "xVP" = (
 /obj/machinery/light,
 /obj/structure/sign/poster/official/random{
@@ -92170,13 +92187,6 @@
 "xVW" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
-"xWb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/grass,
-/area/service/park)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -92348,13 +92358,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
-"xZf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/flora/junglebush,
-/turf/open/floor/grass,
-/area/service/park)
 "xZj" = (
 /obj/machinery/gibber,
 /obj/machinery/camera{
@@ -92778,6 +92781,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"ygB" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "yhn" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/computer";
@@ -126158,12 +126172,12 @@ aaa
 wKI
 wKI
 uQN
-jYS
-jxL
+ltL
+nHz
 kwk
 jQb
 rUL
-bGU
+mIy
 fxf
 jQb
 qNE
@@ -126414,10 +126428,10 @@ aaa
 aaa
 wKI
 ckv
-wFW
-dJy
+fCC
+sjM
 mWf
-rGM
+pSv
 edG
 lbv
 jit
@@ -126670,11 +126684,11 @@ rpQ
 lMJ
 xwj
 uQN
-iMu
-dpg
-mMz
-sjM
-sjM
+cip
+tqF
+okd
+gwc
+gwc
 fTp
 dYf
 okb
@@ -126928,9 +126942,9 @@ aaa
 aaa
 wKI
 cud
-aTd
-ahi
-ome
+lYZ
+ibB
+tjO
 xuR
 pMV
 dar
@@ -127185,9 +127199,9 @@ aaa
 aaa
 wKI
 ecx
-hUP
-sjM
-fCC
+kXp
+gwc
+qKD
 lCq
 pMV
 nHL
@@ -127442,8 +127456,8 @@ aaa
 aaa
 uQN
 nWd
-mRs
-api
+lLO
+iES
 kCg
 uQN
 edG
@@ -127701,7 +127715,7 @@ uQN
 wKI
 pGm
 gMh
-sfJ
+jtp
 uQN
 unz
 eCw
@@ -127953,14 +127967,14 @@ aaa
 aag
 aaa
 uQN
-iMu
+ejb
 fbk
-pcC
-xVO
-tjO
+obi
+vxj
+api
 jOd
 wKI
-pSN
+jvD
 dXo
 kGc
 wKI
@@ -128210,15 +128224,15 @@ aaa
 wdu
 aaa
 wKI
-pIY
-iHh
-iMu
-iRZ
-tjO
-tdc
-ouK
+rRe
+gMK
+ejb
+oWo
+api
+hCy
+nVY
 iFR
-jvD
+uUG
 itz
 wKI
 tqs
@@ -128467,15 +128481,15 @@ lMJ
 aag
 aaa
 wKI
-bft
-iHh
-pjp
-igt
-okd
-xWb
+oyd
+gMK
+pEZ
+pFw
+xok
+pyI
 wKI
 uIe
-sjM
+gwc
 wjI
 vDH
 rap
@@ -128726,13 +128740,13 @@ aaa
 wKI
 lfF
 lUM
-miN
+gaM
 nxs
-tjO
-lkL
+api
+eSt
 wKI
 uIe
-sjM
+gwc
 srd
 wKI
 gXt
@@ -128981,12 +128995,12 @@ aaa
 aag
 aaa
 wKI
-iMu
+ejb
 eyW
-gwc
-qIl
-tjO
-ncr
+iFc
+nsf
+api
+wcU
 wKI
 yaX
 bAg
@@ -129238,13 +129252,13 @@ aaa
 aag
 lMJ
 uQN
-nyb
-feH
-uNK
+ufx
+dpg
+dIB
 uRI
 iaF
-hXf
-opS
+hgV
+xby
 lNk
 chN
 uzH
@@ -129496,11 +129510,11 @@ aai
 aaa
 wKI
 utN
-ung
-oWo
-iuP
-ejb
-lyQ
+rAG
+wch
+ezJ
+usj
+nHc
 wKI
 mtf
 vEx
@@ -129753,11 +129767,11 @@ aaf
 aaa
 wKI
 nhK
-agA
-nGw
-pdS
+pRI
+jlV
+iuP
 vLE
-xZf
+rbR
 uQN
 nCh
 vMt
@@ -130011,9 +130025,9 @@ aaa
 wKI
 wLB
 oGY
-oWo
-pdS
-roC
+wch
+iuP
+rnn
 hOL
 uQN
 uQN
@@ -130266,14 +130280,14 @@ aaa
 aaf
 ake
 wKI
-nyb
-iNo
-oWo
-erm
-nok
-hgV
 ufx
-kXp
+umy
+wch
+tmO
+uBT
+rlV
+ppy
+siR
 uqz
 lCq
 wKI
@@ -130523,19 +130537,19 @@ aaa
 aaf
 aaa
 uQN
-iMu
-dWb
-oWo
-sjM
+hqA
+hHr
+wch
+gwc
 nah
-tjO
-sjM
-sjM
-gaR
-lYZ
+api
+gwc
+gwc
+klD
+mFT
 jiP
 wsx
-pVD
+hwc
 kiI
 weB
 oRx
@@ -130780,13 +130794,13 @@ aaa
 aaf
 aaa
 wKI
-iMu
-eMF
-qEY
-sjM
-aZu
-jsI
-wUG
+ejb
+wHh
+ekD
+gwc
+cjn
+xlk
+rAd
 uDM
 lKQ
 xuR
@@ -131039,12 +131053,12 @@ lMJ
 uQN
 uQN
 uQN
-enT
-sjM
-pdS
-jqz
-tfq
-obi
+ygB
+gwc
+iuP
+pOE
+jYS
+rTy
 uQN
 uQN
 uQN
@@ -131296,12 +131310,12 @@ aaa
 aaa
 aaa
 uQN
-iAl
-wUG
-nHz
+tYb
+rAd
+pIQ
 vaG
-iSB
-iMu
+gjt
+ejb
 wKI
 aaa
 wKI
@@ -131553,8 +131567,8 @@ aaa
 aaa
 aaa
 uQN
-gVn
-onb
+agA
+wbt
 kwk
 ljP
 iWb
@@ -131810,7 +131824,7 @@ aaa
 aaa
 aaa
 uQN
-iMu
+ejb
 fbk
 ckv
 uQN

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1964,7 +1964,7 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "agA" = (
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "agB" = (
 /obj/machinery/power/solar_control{
@@ -4386,7 +4386,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "api" = (
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "apm" = (
 /turf/closed/wall,
@@ -9093,6 +9096,15 @@
 "aHE" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
+"aHL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "aHQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -10602,6 +10614,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"aTw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
+/area/service/park)
 "aTC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -16578,7 +16597,10 @@
 "bro" = (
 /obj/structure/flora/rock/pile,
 /obj/machinery/vending/cola/buzz_fuzz,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/service/park)
 "brp" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -18477,13 +18499,11 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
 "bAg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "bAh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -21710,6 +21730,24 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bUh" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/grass,
+/area/service/park)
+"bUn" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "bUs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -26732,6 +26770,10 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "chZ" = (
@@ -27686,7 +27728,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "ckw" = (
 /obj/structure/table,
@@ -31774,7 +31816,7 @@
 	icon_state = "grassa1"
 	},
 /obj/structure/chair/pew/left,
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "cuf" = (
 /obj/structure/closet,
@@ -41801,6 +41843,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cPr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/flora/grass/jungle/b{
+	icon_state = "grassa1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "cPs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -46357,8 +46408,14 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "dpg" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/misc/grass,
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -47;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "dpk" = (
 /obj/item/cigbutt,
@@ -46745,6 +46802,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"dub" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Park Area"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "duo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -47281,6 +47346,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dAH" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "dAU" = (
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
@@ -48042,6 +48119,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"dKU" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "dKV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48425,6 +48511,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"dVv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "dVE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48547,6 +48639,9 @@
 /area/engineering/main)
 "dXo" = (
 /obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48743,7 +48838,8 @@
 	icon_state = "bushb1"
 	},
 /obj/structure/chair/pew,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/grass,
 /area/service/park)
 "edc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49012,7 +49108,8 @@
 /area/security/prison/upper)
 "ejb" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
 /area/service/park)
 "ejd" = (
 /obj/structure/bookcase{
@@ -49510,7 +49607,8 @@
 /area/engineering/supermatter)
 "eyW" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/grass,
 /area/service/park)
 "ezp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -49871,6 +49969,16 @@
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"eFM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "eFQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -50820,7 +50928,10 @@
 /area/space/nearstation)
 "fbk" = (
 /obj/structure/flora/rock/pile,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "fbn" = (
 /obj/structure/cable/yellow{
@@ -51668,7 +51779,9 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "fxf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "fxX" = (
@@ -51825,10 +51938,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fCC" = (
-/obj/structure/flora/grass/jungle/b{
-	icon_state = "grassa1"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/misc/grass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/service/park)
 "fCR" = (
 /obj/machinery/shower{
@@ -52474,7 +52588,7 @@
 	name = "Cryogenics"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_diagonal,
 /area/commons/cryopod)
 "fTr" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -52778,6 +52892,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"gby" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "gbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
@@ -53688,8 +53816,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "gwc" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/spooktime/cobble/roadmid,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "gwC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -53951,6 +54078,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
+"gBi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "gBn" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "24"
@@ -54335,7 +54469,10 @@
 	name = "Park Area"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "gMz" = (
 /obj/effect/spawner/structure/window,
@@ -54500,6 +54637,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
@@ -55081,11 +55222,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hgV" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
 /obj/machinery/vending/snack/random,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/service/park)
 "hhA" = (
 /turf/open/floor/plasteel,
@@ -56158,6 +56299,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "hEr" = (
@@ -56351,6 +56493,24 @@
 	},
 /turf/open/floor/plasteel/chapel_floor,
 /area/service/bar)
+"hJL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/storage/bag/easterbasket{
+	name = "picnic basket";
+	pixel_y = 11;
+	pixel_x = -8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "hJU" = (
 /obj/structure/closet{
 	name = "swimming closet"
@@ -56407,6 +56567,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
+"hKJ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "hKR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56635,7 +56802,10 @@
 	c_tag = "Park Area";
 	dir = 1
 	},
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "hOX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57249,9 +57419,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "iaF" = (
-/obj/item/clothing/head/hardhat/pumpkinhead,
-/obj/structure/table/wood,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "iaH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57874,6 +58046,9 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "itH" = (
@@ -57965,7 +58140,14 @@
 /turf/open/floor/plasteel,
 /area/service/bar)
 "iuP" = (
-/turf/open/floor/spooktime/cobble/roadsideS,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/grass,
 /area/service/park)
 "iuW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -58303,6 +58485,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"iDs" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "iDz" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58420,10 +58607,10 @@
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
 "iFR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/spooktime/cobble/roadmid,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "iGh" = (
 /obj/effect/mapping_helpers/airlock/locked,
@@ -58637,6 +58824,12 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
+"iKN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "iKQ" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2";
@@ -58974,7 +59167,10 @@
 /obj/structure/chair/pew{
 	dir = 8
 	},
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "iWy" = (
 /obj/machinery/door/window{
@@ -59476,7 +59672,9 @@
 /obj/machinery/door/airlock{
 	name = "Park Area"
 	},
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "jiU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59987,6 +60185,9 @@
 "jvD" = (
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -60759,7 +60960,13 @@
 	icon_state = "grassa4"
 	},
 /obj/machinery/vending/coffee,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/service/park)
 "jOk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60860,7 +61067,6 @@
 "jQb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/commons/cryopod)
 "jQR" = (
@@ -61165,10 +61371,40 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/service/chapel/main)
+"jXR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "jXV" = (
 /obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"jYJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/trash/plate{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "jYM" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61182,7 +61418,7 @@
 /obj/structure/flora/junglebush{
 	icon_state = "bushb1"
 	},
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "jYV" = (
 /obj/structure/window/reinforced{
@@ -61202,6 +61438,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -61282,7 +61522,11 @@
 /obj/structure/flora/grass/jungle/b{
 	icon_state = "busha2"
 	},
-/turf/open/misc/grass,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "kbP" = (
 /obj/structure/table/wood/poker,
@@ -61359,6 +61603,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"kdE" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "kdR" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -61418,6 +61667,9 @@
 	pixel_x = -24
 	},
 /obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "kff" = (
@@ -61490,6 +61742,11 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
+"kga" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "kgv" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -62138,7 +62395,8 @@
 	icon_state = "grassa4"
 	},
 /obj/item/kirbyplants/random,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
 /area/service/park)
 "kwq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -62484,10 +62742,14 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "kCg" = (
-/obj/structure/closet/crate/bin{
-	pixel_x = 6
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/spooktime/cobble/roadsideW,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/grass,
 /area/service/park)
 "kCp" = (
 /turf/closed/wall/r_wall,
@@ -62775,6 +63037,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/commons/locker)
+"kJv" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "kJB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -63363,7 +63632,10 @@
 /area/engineering/main)
 "kXp" = (
 /obj/machinery/vending/cola/random,
-/turf/open/floor/spooktime/cobble/roadsideE,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
 /area/service/park)
 "kXt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -63740,7 +64012,7 @@
 /area/engineering/atmos)
 "lfF" = (
 /obj/structure/flora/bush,
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "lgF" = (
 /obj/machinery/door/firedoor,
@@ -63878,6 +64150,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
+"ljt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "ljM" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -63892,7 +64174,10 @@
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "lkU" = (
 /obj/machinery/disposal/bin,
@@ -64101,6 +64386,14 @@
 	luminosity = 2
 	},
 /area/maintenance/aft)
+"lqi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/head/hardhat/pumpkinhead,
+/turf/open/floor/grass,
+/area/service/park)
 "lqj" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -64621,8 +64914,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "lCq" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/spooktime/cobble/roadsideN,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
 /area/service/park)
 "lCt" = (
 /obj/machinery/light/small{
@@ -64897,8 +65190,14 @@
 /turf/open/floor/plating/airless,
 /area/construction/mining/aux_base)
 "lKQ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/grass,
 /area/service/park)
 "lLr" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -64964,10 +65263,11 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "lNk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/spooktime/cobble/roadmid,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "lNK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -65324,7 +65624,7 @@
 /area/engineering/main)
 "lUM" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "lUO" = (
 /obj/structure/table/wood,
@@ -65546,10 +65846,16 @@
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "lYZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/commons/cryopod)
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "mah" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -65626,6 +65932,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"mbT" = (
+/obj/structure/flora/junglebush{
+	icon_state = "grassa4"
+	},
+/obj/structure/flora/tree/jungle{
+	pixel_x = -44;
+	pixel_y = -18
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "mcu" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -66390,6 +66706,9 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "mtv" = (
@@ -66507,6 +66826,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
+"mvM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/commons/cryopod)
 "mvN" = (
 /turf/closed/wall,
 /area/construction/storage_wing)
@@ -67286,6 +67609,12 @@
 /obj/effect/turf_decal/tile/dark_green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mNN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "mNP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
@@ -67358,6 +67687,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"mPZ" = (
+/obj/structure/flora/tree/jungle{
+	pixel_x = -47;
+	pixel_y = -13
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "mQt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -67579,7 +67916,10 @@
 	light_power = 1;
 	light_range = 4
 	},
-/turf/open/floor/spooktime/cobble/roadsideW,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "mWg" = (
 /obj/structure/girder,
@@ -67683,7 +68023,7 @@
 /obj/structure/chair/pew/right{
 	dir = 8
 	},
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "mYT" = (
 /obj/machinery/power/apc{
@@ -67781,7 +68121,7 @@
 /area/security/checkpoint/engineering)
 "nah" = (
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/spooktime/cobble/roadsideW,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "nas" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -67966,7 +68306,8 @@
 /obj/structure/chair/pew{
 	dir = 1
 	},
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/grass,
 /area/service/park)
 "nhL" = (
 /obj/machinery/airalarm{
@@ -68545,12 +68886,9 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nxs" = (
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4
-	},
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
 /area/service/park)
 "nxA" = (
 /obj/machinery/computer/security/telescreen/interrogation{
@@ -68614,6 +68952,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"nzM" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/grass,
+/area/service/park)
 "nzZ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -68881,8 +69223,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nHz" = (
-/obj/structure/flora/junglebush/large,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "nHL" = (
 /obj/machinery/light{
@@ -69528,7 +69873,8 @@
 	pixel_y = 32
 	},
 /obj/structure/chair/pew/right,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/grass,
 /area/service/park)
 "nWu" = (
 /obj/structure/chair,
@@ -69856,7 +70202,7 @@
 /obj/structure/flora/junglebush{
 	icon_state = "grassa4"
 	},
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "obm" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -70308,7 +70654,10 @@
 /area/commons/cryopod)
 "okd" = (
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "okm" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -70846,6 +71195,19 @@
 	},
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
+"oxY" = (
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "oyi" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -71185,7 +71547,15 @@
 /obj/structure/flora/grass/jungle/b{
 	icon_state = "grassa5"
 	},
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
+"oHI" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "oHW" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -71209,6 +71579,11 @@
 	dir = 5
 	},
 /area/engineering/break_room)
+"oJi" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "oJk" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
@@ -71815,7 +72190,10 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "oWo" = (
-/turf/open/floor/spooktime/cobble/roadsideN,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "oWt" = (
 /obj/machinery/door/firedoor,
@@ -72858,6 +73236,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
+"psF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/service/park)
 "psM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73446,7 +73831,11 @@
 	name = "Park Area"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/spooktime/cobble/roadsideN,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "pGD" = (
 /obj/structure/cable{
@@ -74213,6 +74602,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
+"pZm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pZP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -76159,6 +76557,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
+"qTm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "qTn" = (
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/cyborgrecharger,
@@ -77204,6 +77608,13 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rqi" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rqn" = (
 /obj/machinery/vr_sleeper{
 	dir = 4
@@ -77804,6 +78215,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
+"rEB" = (
+/obj/structure/flora/grass/jungle/b{
+	icon_state = "grassa1"
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/firealarm{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/grass,
+/area/service/park)
+"rES" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "rGp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78492,6 +78918,7 @@
 /area/command/bridge)
 "rUL" = (
 /obj/machinery/cryopod,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "rVf" = (
@@ -78539,6 +78966,15 @@
 /obj/machinery/light_switch/directional/south,
 /turf/closed/wall,
 /area/service/theater)
+"rXf" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rXs" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -79084,7 +79520,13 @@
 /turf/closed/wall,
 /area/command/bridge)
 "sjM" = (
-/turf/open/floor/spooktime/cobble/roadsideW,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "sjN" = (
 /obj/machinery/light/small,
@@ -79123,6 +79565,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"skd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "skf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -79343,6 +79789,12 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/ntr)
+"son" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "sos" = (
 /obj/structure/mirror,
 /turf/closed/wall,
@@ -79350,12 +79802,26 @@
 "soy" = (
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"soC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/junglebush,
+/turf/open/floor/grass,
+/area/service/park)
 "spx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"spE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/grass,
+/area/service/park)
 "spG" = (
 /obj/structure/closet/crate/rcd{
 	pixel_y = 4
@@ -79429,6 +79895,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "ssp" = (
@@ -79784,6 +80253,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
+"sAt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/commons/fitness/recreation)
 "sAy" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -80426,6 +80904,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"sPY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "sQb" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -81269,7 +81753,10 @@
 /turf/open/floor/grass/grass2,
 /area/hallway/primary/central)
 "tjO" = (
-/turf/open/floor/spooktime/cobble/roadsideE,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "tjW" = (
 /turf/closed/wall,
@@ -81434,6 +81921,11 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
+"toA" = (
+/obj/structure/flora/junglebush/large,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "toC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -81867,6 +82359,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics/garden)
+"tBG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "tBW" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -82140,11 +82638,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
@@ -83348,7 +83846,7 @@
 	light_power = 1;
 	light_range = 4
 	},
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "ufE" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -83805,7 +84303,10 @@
 "uqz" = (
 /obj/structure/flora/junglebush/c,
 /obj/item/kirbyplants/random,
-/turf/open/misc/grass,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "uqB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -83969,7 +84470,8 @@
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/grass,
 /area/service/park)
 "utQ" = (
 /obj/structure/chair/stool{
@@ -84173,8 +84675,11 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -84335,7 +84840,10 @@
 /area/engineering/atmos)
 "uDM" = (
 /obj/structure/flora/bush,
-/turf/open/floor/spooktime/cobble/roadsideE,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "uDX" = (
 /obj/structure/table/wood,
@@ -84503,10 +85011,10 @@
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
 "uIe" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/spooktime/cobble/roadmid,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "uIA" = (
 /obj/effect/turf_decal/delivery,
@@ -84750,8 +85258,11 @@
 /turf/open/floor/plasteel/white,
 /area/command/gateway)
 "uRI" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/spooktime/cobble/roadsideS,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "uRL" = (
 /obj/structure/window/reinforced{
@@ -85089,7 +85600,10 @@
 /area/engineering/supermatter)
 "vaG" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/misc/grass,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "vaQ" = (
 /obj/effect/turf_decal/bot{
@@ -85740,6 +86254,14 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms/second)
+"vpH" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "vpQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -85927,6 +86449,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"vwv" = (
+/obj/structure/flora/junglebush/large,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "vwK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -85947,6 +86476,15 @@
 	dir = 1
 	},
 /area/medical/surgery)
+"vxd" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "vxf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -86050,6 +86588,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"vzI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "vAp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -86242,6 +86786,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -86443,6 +86990,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
+"vJZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/grass,
+/area/service/park)
 "vKw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -86477,8 +87031,8 @@
 /turf/open/space/basic,
 /area/space)
 "vLE" = (
-/obj/structure/flora/junglebush,
-/turf/open/misc/grass,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
 /area/service/park)
 "vLV" = (
 /obj/effect/turf_decal/tile/blue{
@@ -87490,6 +88044,9 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "wjR" = (
@@ -87910,8 +88467,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"wsG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "wsV" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -88725,6 +89292,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
+"wLm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/grass,
+/area/service/park)
 "wLu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
@@ -88743,7 +89323,7 @@
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
-/turf/open/misc/grass,
+/turf/open/floor/grass,
 /area/service/park)
 "wLX" = (
 /obj/structure/table/wood,
@@ -90022,7 +90602,6 @@
 "xpD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/commons/cryopod)
 "xpY" = (
@@ -90272,8 +90851,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "xuR" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/spooktime/cobble/roadsideN,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "xvf" = (
 /obj/structure/rack,
@@ -90541,6 +91122,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xBk" = (
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -34;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "xBK" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/light{
@@ -90967,6 +91559,15 @@
 /obj/effect/landmark/navigate_destination/dorms,
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"xKh" = (
+/obj/machinery/door/airlock{
+	name = "Park Area"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "xKw" = (
 /obj/structure/chair/stool/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -91167,6 +91768,13 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"xNN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "xNY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -91328,6 +91936,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
+"xQS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "xQZ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -91476,6 +92096,7 @@
 /obj/effect/turf_decal/tile/dark_green/opposingcorners{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/service/park)
 "xUs" = (
@@ -91801,9 +92422,9 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "yaX" = (
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/spooktime/cobble/roadmid,
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "ybi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -92204,6 +92825,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
+"yix" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "yiZ" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office - Backroom";
@@ -125281,7 +125908,7 @@ pMV
 jwh
 tDZ
 kfb
-lYZ
+pMV
 pDO
 hwn
 aey
@@ -125531,12 +126158,12 @@ aaa
 wKI
 wKI
 uQN
-jYS
-nHz
+rXf
+toA
 kwk
-pMV
+jQb
 rUL
-dYf
+mvM
 fxf
 jQb
 qNE
@@ -125787,10 +126414,10 @@ aaa
 aaa
 wKI
 ckv
-fCC
+rEB
 sjM
 mWf
-sjM
+pZm
 edG
 lbv
 jit
@@ -126044,10 +126671,10 @@ lMJ
 xwj
 uQN
 agA
-dpg
+kga
 okd
-api
-api
+gwc
+gwc
 fTp
 dYf
 okb
@@ -126301,15 +126928,15 @@ aaa
 aaa
 wKI
 cud
-oWo
+kJv
 api
-tjO
+cPr
 kXp
 pMV
 dar
 okb
 dYf
-lYZ
+pMV
 txt
 gFl
 agq
@@ -126558,8 +127185,8 @@ aaa
 aaa
 wKI
 ecx
-oWo
-api
+oJi
+gwc
 fCC
 hgV
 pMV
@@ -126815,8 +127442,8 @@ aaa
 aaa
 uQN
 nWd
-oWo
-api
+bUh
+qTm
 kCg
 uQN
 edG
@@ -127074,7 +127701,7 @@ uQN
 wKI
 pGm
 gMh
-wKI
+psF
 uQN
 unz
 eCw
@@ -127327,10 +127954,10 @@ aag
 aaa
 uQN
 agA
-fbk
-obi
-oWo
-api
+nzM
+mbT
+rqi
+tBG
 jOd
 wKI
 jvD
@@ -127583,15 +128210,15 @@ aaa
 wdu
 aaa
 wKI
+hJL
+wLm
 agA
-agA
-ejb
-oWo
-api
-vaG
-wKI
+vpH
+tBG
+dVv
+dub
 iFR
-jvD
+bUn
 itz
 wKI
 tqs
@@ -127840,15 +128467,15 @@ lMJ
 aag
 aaa
 wKI
-agA
-agA
-oWo
-api
-okd
-sjM
-gMh
+jYJ
+wLm
+vzI
+gby
+oHI
+spE
+wKI
 uIe
-iFR
+gwc
 wjI
 vDH
 rap
@@ -128099,12 +128726,12 @@ aaa
 wKI
 lfF
 lUM
-oWo
+sPY
 nxs
-api
-api
+tBG
+xNN
 wKI
-api
+uIe
 gwc
 srd
 wKI
@@ -128356,11 +128983,11 @@ aaa
 wKI
 agA
 eyW
-oWo
-api
-tjO
-tjO
-gMh
+ljt
+mNN
+tBG
+vJZ
+wKI
 yaX
 bAg
 jZh
@@ -128612,12 +129239,12 @@ aag
 lMJ
 uQN
 ufx
-dpg
-oWo
+xBk
+gBi
 uRI
 iaF
 nHz
-wKI
+xKh
 lNk
 chN
 uzH
@@ -128869,11 +129496,11 @@ aai
 aaa
 wKI
 utN
-agA
+hKJ
 oWo
 iuP
-ejb
-agA
+lqi
+xQS
 wKI
 mtf
 vEx
@@ -129126,11 +129753,11 @@ aaf
 aaa
 wKI
 nhK
-agA
-oWo
-iuP
+iDs
+skd
+iKN
 vLE
-jYS
+soC
 uQN
 nCh
 vMt
@@ -129385,8 +130012,8 @@ wKI
 wLB
 oGY
 oWo
-iuP
-eyW
+iKN
+lCq
 hOL
 uQN
 uQN
@@ -129640,15 +130267,15 @@ aaf
 ake
 wKI
 ufx
-eyW
+kdE
 oWo
-iuP
+yix
 dpg
-jYS
-ufx
-agA
+dAH
+oxY
+eFM
 uqz
-lCq
+hgV
 wKI
 kAI
 xSl
@@ -129897,18 +130524,18 @@ aaf
 aaa
 uQN
 agA
-ejb
+mPZ
 oWo
-api
+gwc
 nah
-sjM
-sjM
-sjM
-sjM
-api
+tBG
+gwc
+gwc
+xuR
+rES
 jiP
 wsx
-htT
+sAt
 kiI
 weB
 oRx
@@ -130154,15 +130781,15 @@ aaf
 aaa
 wKI
 agA
-jYS
-oWo
-api
-tjO
-tjO
+dKU
+wsG
+gwc
+jXR
+aHL
 tjO
 uDM
 lKQ
-xuR
+kXp
 wKI
 xvD
 htT
@@ -130412,10 +131039,10 @@ lMJ
 uQN
 uQN
 uQN
-agA
-agA
-agA
-ejb
+lYZ
+gwc
+iKN
+aTw
 jYS
 obi
 uQN
@@ -130669,9 +131296,9 @@ aaa
 aaa
 aaa
 uQN
-agA
-agA
-nHz
+vxd
+tjO
+vwv
 vaG
 fbk
 agA
@@ -130926,7 +131553,7 @@ aaa
 aaa
 aaa
 uQN
-agA
+son
 ejb
 kwk
 ljP
@@ -131184,7 +131811,7 @@ aaa
 aaa
 uQN
 agA
-fbk
+nzM
 ckv
 uQN
 wKI

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1964,6 +1964,8 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "agA" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/grass,
 /area/service/park)
 "agB" = (
@@ -2041,6 +2043,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ahi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "ahp" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
@@ -4386,8 +4394,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "api" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/service/park)
@@ -9096,15 +9104,6 @@
 "aHE" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
-"aHL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "aHQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -10553,6 +10552,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"aTd" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "aTi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -10614,13 +10620,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"aTw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/grass,
-/area/service/park)
 "aTC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -12533,6 +12532,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aZu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "aZv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13780,6 +13792,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"bft" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/trash/plate{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "bfE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
@@ -19965,6 +19994,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bGU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/commons/cryopod)
 "bGV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -21730,24 +21763,6 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bUh" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/grass,
-/area/service/park)
-"bUn" = (
-/obj/effect/turf_decal/tile/dark_green/opposingcorners,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/service/park)
 "bUs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -41843,15 +41858,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cPr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/flora/grass/jungle/b{
-	icon_state = "grassa1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "cPs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -46408,13 +46414,8 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "dpg" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -47;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/service/park)
 "dpk" = (
@@ -46802,14 +46803,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"dub" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Park Area"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "duo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -47346,18 +47339,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dAH" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "dAU" = (
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
@@ -48071,6 +48052,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
+"dJy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "dJE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -48119,15 +48109,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
-"dKU" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "dKV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48511,12 +48492,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"dVv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "dVE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48571,6 +48546,14 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"dWb" = (
+/obj/structure/flora/tree/jungle{
+	pixel_x = -47;
+	pixel_y = -13
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "dWm" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/light{
@@ -49107,8 +49090,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
 "ejb" = (
-/obj/structure/flora/tree/jungle,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/head/hardhat/pumpkinhead,
 /turf/open/floor/grass,
 /area/service/park)
 "ejd" = (
@@ -49312,6 +49298,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
+"enT" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "eof" = (
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
@@ -49357,6 +49354,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"erm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "erD" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
@@ -49969,16 +49972,6 @@
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
-"eFM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "eFQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -50254,6 +50247,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eMF" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "eMV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -50928,9 +50930,6 @@
 /area/space/nearstation)
 "fbk" = (
 /obj/structure/flora/rock/pile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/grass,
 /area/service/park)
 "fbn" = (
@@ -51076,6 +51075,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/service/janitor)
+"feH" = (
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -34;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "feJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52588,7 +52598,7 @@
 	name = "Cryogenics"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "fTr" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -52859,6 +52869,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gaR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "gaV" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel,
@@ -52892,20 +52908,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
-"gby" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4;
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "gbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
@@ -53816,7 +53818,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "gwc" = (
-/turf/open/floor/wood/wood_diagonal,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
 /area/service/park)
 "gwC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54078,13 +54087,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
-"gBi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "gBn" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "24"
@@ -54472,7 +54474,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "gMz" = (
 /obj/effect/spawner/structure/window,
@@ -54814,6 +54816,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"gVn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "gVv" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -55222,11 +55230,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hgV" = (
-/obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/siding/thinplating/dark/end{
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "hhA" = (
 /turf/open/floor/plasteel,
@@ -56493,24 +56506,6 @@
 	},
 /turf/open/floor/plasteel/chapel_floor,
 /area/service/bar)
-"hJL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/storage/bag/easterbasket{
-	name = "picnic basket";
-	pixel_y = 11;
-	pixel_x = -8
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "hJU" = (
 /obj/structure/closet{
 	name = "swimming closet"
@@ -56567,13 +56562,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
-"hKJ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "hKR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57123,6 +57111,11 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"hUP" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "hUT" = (
 /obj/structure/loot_pile/maint,
 /turf/open/floor/plating,
@@ -57196,6 +57189,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"hXf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "hXi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -57604,6 +57604,20 @@
 /obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/service/library)
+"igt" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4;
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "igL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/office/dark{
@@ -58395,6 +58409,15 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
+"iAl" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "iAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/kirbyplants/random,
@@ -58485,11 +58508,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"iDs" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "iDz" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58731,6 +58749,19 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"iHh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/grass,
+/area/service/park)
 "iHl" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -58824,12 +58855,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
-"iKN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "iKQ" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2";
@@ -58877,6 +58902,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
+"iMu" = (
+/turf/open/floor/grass,
+/area/service/park)
 "iMF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -58924,6 +58952,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/office)
+"iNo" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/service/park)
 "iNR" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -59021,6 +59054,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/upper)
+"iRZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/service/park)
 "iSt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59033,6 +59074,13 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"iSB" = (
+/obj/structure/flora/rock/pile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "iSE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/chem_master/condimaster{
@@ -59674,7 +59722,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "jiU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59966,6 +60014,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jqz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
+/area/service/park)
 "jra" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60017,6 +60072,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
+"jsI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "jsO" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bowl,
@@ -60188,7 +60252,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/park)
@@ -60297,6 +60361,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"jxL" = (
+/obj/structure/flora/junglebush/large,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "jyd" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable/yellow{
@@ -61371,40 +61440,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/service/chapel/main)
-"jXR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4;
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "jXV" = (
 /obj/machinery/computer/security/labor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"jYJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/trash/plate{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "jYM" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61417,6 +61456,9 @@
 "jYS" = (
 /obj/structure/flora/junglebush{
 	icon_state = "bushb1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -61603,11 +61645,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"kdE" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/service/park)
 "kdR" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -61742,11 +61779,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
-"kga" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/service/park)
 "kgv" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -63037,13 +63069,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/commons/locker)
-"kJv" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "kJB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -63631,11 +63656,14 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "kXp" = (
-/obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/siding/thinplating/dark/end{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth,
+/obj/machinery/firealarm{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/grass,
 /area/service/park)
 "kXt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -64150,16 +64178,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
-"ljt" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/service/park)
 "ljM" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -64177,6 +64195,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/turf/open/floor/grass,
+/area/service/park)
+"lkL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/service/park)
 "lkU" = (
@@ -64386,14 +64411,6 @@
 	luminosity = 2
 	},
 /area/maintenance/aft)
-"lqi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/clothing/head/hardhat/pumpkinhead,
-/turf/open/floor/grass,
-/area/service/park)
 "lqj" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -64752,6 +64769,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"lyQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "lyU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -64914,8 +64943,11 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "lCq" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/grass,
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/service/park)
 "lCt" = (
 /obj/machinery/light/small{
@@ -65846,15 +65878,8 @@
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "lYZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/grass,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "mah" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -65932,16 +65957,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
-"mbT" = (
-/obj/structure/flora/junglebush{
-	icon_state = "grassa4"
-	},
-/obj/structure/flora/tree/jungle{
-	pixel_x = -44;
-	pixel_y = -18
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "mcu" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -66318,6 +66333,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"miN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "miS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66826,10 +66847,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
-"mvM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/commons/cryopod)
 "mvN" = (
 /turf/closed/wall,
 /area/construction/storage_wing)
@@ -67519,6 +67536,13 @@
 "mMn" = (
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"mMz" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "mMO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/syndicate_present,
@@ -67609,12 +67633,6 @@
 /obj/effect/turf_decal/tile/dark_green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mNN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "mNP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
@@ -67687,14 +67705,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"mPZ" = (
-/obj/structure/flora/tree/jungle{
-	pixel_x = -47;
-	pixel_y = -13
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/service/park)
 "mQt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -67719,6 +67729,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"mRs" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "mRE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -68152,6 +68170,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/office)
+"ncr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/grass,
+/area/service/park)
 "ncN" = (
 /obj/vehicle/ridden/secway,
 /obj/item/key/security,
@@ -68606,6 +68631,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"nok" = (
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -47;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "noG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -68917,6 +68952,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nyb" = (
+/obj/structure/streetdecor/lamp{
+	light_color = "#ffd6aa";
+	light_power = 1;
+	light_range = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "nye" = (
 /obj/structure/sign/barbershop,
 /turf/closed/wall,
@@ -68952,10 +68995,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
-"nzM" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/grass,
-/area/service/park)
 "nzZ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -69210,6 +69249,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
+"nGw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "nHn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69223,11 +69266,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "nHz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/flora/junglebush/large,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/grass,
 /area/service/park)
 "nHL" = (
 /obj/machinery/light{
@@ -70654,7 +70697,7 @@
 /area/commons/cryopod)
 "okd" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_diagonal,
@@ -70736,6 +70779,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"ome" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/flora/grass/jungle/b{
+	icon_state = "grassa1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "omQ" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -70755,6 +70807,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
+"onb" = (
+/obj/structure/flora/tree/jungle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/grass,
+/area/service/park)
 "oni" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70936,6 +70993,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/medical/psychology)
+"opS" = (
+/obj/machinery/door/airlock{
+	name = "Park Area"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "oqC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -71115,6 +71181,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/chapel_floor,
 /area/service/bar)
+"ouK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Park Area"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "ovd" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -71195,19 +71269,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
-"oxY" = (
-/obj/structure/streetdecor/lamp{
-	light_color = "#ffd6aa";
-	light_power = 1;
-	light_range = 4;
-	pixel_x = -2;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "oyi" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -71550,13 +71611,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/service/park)
-"oHI" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "oHW" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera{
@@ -71579,11 +71633,6 @@
 	dir = 5
 	},
 /area/engineering/break_room)
-"oJi" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "oJk" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
@@ -72524,6 +72573,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"pcC" = (
+/obj/structure/flora/junglebush{
+	icon_state = "grassa4"
+	},
+/obj/structure/flora/tree/jungle{
+	pixel_x = -44;
+	pixel_y = -18
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pcD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -72554,6 +72613,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
 /area/commons/toilet/restrooms)
+"pdS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pdZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -72810,6 +72875,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"pjp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pjr" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
@@ -73236,13 +73307,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
-"psF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/service/park)
 "psM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -73835,7 +73899,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/dark,
 /area/service/park)
 "pGD" = (
 /obj/structure/cable{
@@ -73961,6 +74025,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar)
+"pIY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/storage/bag/easterbasket{
+	name = "picnic basket";
+	pixel_y = 11;
+	pixel_x = -8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "pJd" = (
 /obj/structure/window/reinforced,
 /obj/machinery/holopad/secure,
@@ -74333,6 +74415,16 @@
 /obj/item/coin/silver,
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
+"pSN" = (
+/obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/park)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -74442,6 +74534,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"pVD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/commons/fitness/recreation)
 "pVL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -74602,15 +74703,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
-"pZm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "pZP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -76052,6 +76144,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/cells)
+"qEY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "qFr" = (
 /obj/structure/toilet/secret/low_loot{
 	pixel_y = 13
@@ -76167,6 +76268,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"qIl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "qIn" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -76557,12 +76664,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
-"qTm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "qTn" = (
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/cyborgrecharger,
@@ -77594,6 +77695,10 @@
 "roz" = (
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"roC" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/grass,
+/area/service/park)
 "rpa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -77608,13 +77713,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"rqi" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "rqn" = (
 /obj/machinery/vr_sleeper{
 	dir = 4
@@ -78215,21 +78313,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
-"rEB" = (
-/obj/structure/flora/grass/jungle/b{
-	icon_state = "grassa1"
-	},
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/grass,
-/area/service/park)
-"rES" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "rGp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78288,6 +78371,15 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
+"rGM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "rGV" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
@@ -78966,15 +79058,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/closed/wall,
 /area/service/theater)
-"rXf" = (
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "rXs" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -79377,6 +79460,13 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
+"sfJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/service/park)
 "sfM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -79520,13 +79610,7 @@
 /turf/closed/wall,
 /area/command/bridge)
 "sjM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "sjN" = (
 /obj/machinery/light/small,
@@ -79565,10 +79649,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"skd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "skf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -79789,12 +79869,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/ntr)
-"son" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "sos" = (
 /obj/structure/mirror,
 /turf/closed/wall,
@@ -79802,26 +79876,12 @@
 "soy" = (
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"soC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/flora/junglebush,
-/turf/open/floor/grass,
-/area/service/park)
 "spx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
-"spE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/grass,
-/area/service/park)
 "spG" = (
 /obj/structure/closet/crate/rcd{
 	pixel_y = 4
@@ -80253,15 +80313,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
-"sAt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/commons/fitness/recreation)
 "sAy" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -80904,12 +80955,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"sPY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "sQb" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -81417,6 +81462,12 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/commons/dorms)
+"tdc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "tde" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -81540,6 +81591,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"tfq" = (
+/obj/structure/flora/junglebush{
+	icon_state = "bushb1"
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "tfs" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/binary/valve{
@@ -81753,10 +81810,10 @@
 /turf/open/floor/grass/grass2,
 /area/hallway/primary/central)
 "tjO" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/floor/wood/wood_diagonal,
 /area/service/park)
 "tjW" = (
 /turf/closed/wall,
@@ -81921,11 +81978,6 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
-"toA" = (
-/obj/structure/flora/junglebush/large,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/grass,
-/area/service/park)
 "toC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -82359,12 +82411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics/garden)
-"tBG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "tBW" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -83844,7 +83890,12 @@
 /obj/structure/streetdecor/lamp{
 	light_color = "#ffd6aa";
 	light_power = 1;
-	light_range = 4
+	light_range = 4;
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -84136,6 +84187,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"ung" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "unm" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/cable/yellow{
@@ -85158,6 +85216,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"uNK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_diagonal,
+/area/service/park)
 "uOc" = (
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -86254,14 +86319,6 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms/second)
-"vpH" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/service/park)
 "vpQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -86449,13 +86506,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
-"vwv" = (
-/obj/structure/flora/junglebush/large,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "vwK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -86476,15 +86526,6 @@
 	dir = 1
 	},
 /area/medical/surgery)
-"vxd" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "vxf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
@@ -86588,12 +86629,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"vzI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "vAp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -86990,13 +87025,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
-"vJZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/flora/junglebush/large,
-/turf/open/floor/grass,
-/area/service/park)
 "vKw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -88470,15 +88498,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"wsG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "wsV" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -89053,6 +89072,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wFW" = (
+/obj/structure/flora/grass/jungle/b{
+	icon_state = "grassa1"
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/firealarm{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "wFX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -89292,19 +89322,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
-"wLm" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/grass,
-/area/service/park)
 "wLu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
@@ -89758,6 +89775,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/locker)
+"wUG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "wUI" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral,
@@ -90851,10 +90874,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "xuR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
 	},
-/turf/open/floor/wood/wood_diagonal,
+/turf/open/floor/iron/smooth,
 /area/service/park)
 "xvf" = (
 /obj/structure/rack,
@@ -91122,17 +91146,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xBk" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -34;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "xBK" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/light{
@@ -91559,15 +91572,6 @@
 /obj/effect/landmark/navigate_destination/dorms,
 /turf/open/floor/plasteel,
 /area/commons/dorms)
-"xKh" = (
-/obj/machinery/door/airlock{
-	name = "Park Area"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood/wood_diagonal,
-/area/service/park)
 "xKw" = (
 /obj/structure/chair/stool/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -91768,13 +91772,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
-"xNN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/service/park)
 "xNY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -91936,18 +91933,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
-"xQS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/flora/junglebush{
-	icon_state = "bushb1"
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "xQZ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -92168,6 +92153,13 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
+"xVO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/service/park)
 "xVP" = (
 /obj/machinery/light,
 /obj/structure/sign/poster/official/random{
@@ -92178,6 +92170,13 @@
 "xVW" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
+"xWb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/grass,
+/area/service/park)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -92349,6 +92348,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"xZf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/flora/junglebush,
+/turf/open/floor/grass,
+/area/service/park)
 "xZj" = (
 /obj/machinery/gibber,
 /obj/machinery/camera{
@@ -92825,12 +92831,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
-"yix" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/service/park)
 "yiZ" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office - Backroom";
@@ -126158,12 +126158,12 @@ aaa
 wKI
 wKI
 uQN
-rXf
-toA
+jYS
+jxL
 kwk
 jQb
 rUL
-mvM
+bGU
 fxf
 jQb
 qNE
@@ -126414,10 +126414,10 @@ aaa
 aaa
 wKI
 ckv
-rEB
-sjM
+wFW
+dJy
 mWf
-pZm
+rGM
 edG
 lbv
 jit
@@ -126670,11 +126670,11 @@ rpQ
 lMJ
 xwj
 uQN
-agA
-kga
-okd
-gwc
-gwc
+iMu
+dpg
+mMz
+sjM
+sjM
 fTp
 dYf
 okb
@@ -126928,10 +126928,10 @@ aaa
 aaa
 wKI
 cud
-kJv
-api
-cPr
-kXp
+aTd
+ahi
+ome
+xuR
 pMV
 dar
 okb
@@ -127185,10 +127185,10 @@ aaa
 aaa
 wKI
 ecx
-oJi
-gwc
+hUP
+sjM
 fCC
-hgV
+lCq
 pMV
 nHL
 pHr
@@ -127442,8 +127442,8 @@ aaa
 aaa
 uQN
 nWd
-bUh
-qTm
+mRs
+api
 kCg
 uQN
 edG
@@ -127701,7 +127701,7 @@ uQN
 wKI
 pGm
 gMh
-psF
+sfJ
 uQN
 unz
 eCw
@@ -127953,14 +127953,14 @@ aaa
 aag
 aaa
 uQN
-agA
-nzM
-mbT
-rqi
-tBG
+iMu
+fbk
+pcC
+xVO
+tjO
 jOd
 wKI
-jvD
+pSN
 dXo
 kGc
 wKI
@@ -128210,15 +128210,15 @@ aaa
 wdu
 aaa
 wKI
-hJL
-wLm
-agA
-vpH
-tBG
-dVv
-dub
+pIY
+iHh
+iMu
+iRZ
+tjO
+tdc
+ouK
 iFR
-bUn
+jvD
 itz
 wKI
 tqs
@@ -128467,15 +128467,15 @@ lMJ
 aag
 aaa
 wKI
-jYJ
-wLm
-vzI
-gby
-oHI
-spE
+bft
+iHh
+pjp
+igt
+okd
+xWb
 wKI
 uIe
-gwc
+sjM
 wjI
 vDH
 rap
@@ -128726,13 +128726,13 @@ aaa
 wKI
 lfF
 lUM
-sPY
+miN
 nxs
-tBG
-xNN
+tjO
+lkL
 wKI
 uIe
-gwc
+sjM
 srd
 wKI
 gXt
@@ -128981,12 +128981,12 @@ aaa
 aag
 aaa
 wKI
-agA
+iMu
 eyW
-ljt
-mNN
-tBG
-vJZ
+gwc
+qIl
+tjO
+ncr
 wKI
 yaX
 bAg
@@ -129238,13 +129238,13 @@ aaa
 aag
 lMJ
 uQN
-ufx
-xBk
-gBi
+nyb
+feH
+uNK
 uRI
 iaF
-nHz
-xKh
+hXf
+opS
 lNk
 chN
 uzH
@@ -129496,11 +129496,11 @@ aai
 aaa
 wKI
 utN
-hKJ
+ung
 oWo
 iuP
-lqi
-xQS
+ejb
+lyQ
 wKI
 mtf
 vEx
@@ -129753,11 +129753,11 @@ aaf
 aaa
 wKI
 nhK
-iDs
-skd
-iKN
+agA
+nGw
+pdS
 vLE
-soC
+xZf
 uQN
 nCh
 vMt
@@ -130012,8 +130012,8 @@ wKI
 wLB
 oGY
 oWo
-iKN
-lCq
+pdS
+roC
 hOL
 uQN
 uQN
@@ -130266,16 +130266,16 @@ aaa
 aaf
 ake
 wKI
-ufx
-kdE
+nyb
+iNo
 oWo
-yix
-dpg
-dAH
-oxY
-eFM
-uqz
+erm
+nok
 hgV
+ufx
+kXp
+uqz
+lCq
 wKI
 kAI
 xSl
@@ -130523,19 +130523,19 @@ aaa
 aaf
 aaa
 uQN
-agA
-mPZ
+iMu
+dWb
 oWo
-gwc
+sjM
 nah
-tBG
-gwc
-gwc
-xuR
-rES
+tjO
+sjM
+sjM
+gaR
+lYZ
 jiP
 wsx
-sAt
+pVD
 kiI
 weB
 oRx
@@ -130780,16 +130780,16 @@ aaa
 aaf
 aaa
 wKI
-agA
-dKU
-wsG
-gwc
-jXR
-aHL
-tjO
+iMu
+eMF
+qEY
+sjM
+aZu
+jsI
+wUG
 uDM
 lKQ
-kXp
+xuR
 wKI
 xvD
 htT
@@ -131039,11 +131039,11 @@ lMJ
 uQN
 uQN
 uQN
-lYZ
-gwc
-iKN
-aTw
-jYS
+enT
+sjM
+pdS
+jqz
+tfq
 obi
 uQN
 uQN
@@ -131296,12 +131296,12 @@ aaa
 aaa
 aaa
 uQN
-vxd
-tjO
-vwv
+iAl
+wUG
+nHz
 vaG
-fbk
-agA
+iSB
+iMu
 wKI
 aaa
 wKI
@@ -131553,8 +131553,8 @@ aaa
 aaa
 aaa
 uQN
-son
-ejb
+gVn
+onb
 kwk
 ljP
 iWb
@@ -131810,8 +131810,8 @@ aaa
 aaa
 aaa
 uQN
-agA
-nzM
+iMu
+fbk
 ckv
 uQN
 wKI


### PR DESCRIPTION
# Описание
1) переработка пола в парке Меты во избежание неразбираемого пола
2) Добавление вентиляции в парке
3) замена мусорок на мусорные баки с мусоропроводом
4) огнетушители с пожарной тревогой в парке Меты и Бокса
5) Добавление пожарных створок на двери в парке Меты и Бокса
## Причина изменений
Интеграция парка в экосистему станции и мапфиксы
## Демонстрация изменений
![image](https://github.com/user-attachments/assets/6198d03f-b690-4ab5-8890-31f217fa5e18)
