### PR TITLE
Фикс реврайта капкана кристальным капканом с AGRComplex

### DIFF
--- a/modular_splurt/code/modules/awaymissions/mission_code/AGRComplex.dm
+++ b/modular_splurt/code/modules/awaymissions/mission_code/AGRComplex.dm
@@ -1091,7 +1091,7 @@
 	armed = FALSE
 	trap_damage = 40
 
-/obj/item/restraints/legcuffs/beartrap/Crossed(AM as mob|obj)
+/obj/item/restraints/legcuffs/beartrap/crystalwire/Crossed(AM as mob|obj)
 	if(armed && isturf(src.loc))
 		if(isliving(AM))
 			var/mob/living/L = AM


### PR DESCRIPTION
# Описание
Капкан переписывался капканами с агр комплекса (они работают не как адекватный капкан и наносили слишком много урона и не по ногам (ломая даже череп)

## Причина изменений
Багфиксы