### PR TITLE
Фикс невозможности за борга разобрать рнд оборудование

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -274,7 +274,7 @@
 
 /obj/machinery/autolathe/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(user.a_intent == INTENT_DISARM)
+	if(user.a_intent == INTENT_DISARM || HAS_TRAIT(I, TRAIT_NODROP))
 		if(busy)
 			balloon_alert(user, "Занято!")
 			return STOP_ATTACK_PROC_CHAIN

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -31,8 +31,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 	linked_console.linked_destroy = null
 	..()
 
-/obj/machinery/rnd/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
-	if(user.a_intent == INTENT_DISARM)
+/obj/machinery/rnd/destructive_analyzer/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
+	if(user.a_intent == INTENT_DISARM || HAS_TRAIT(I, TRAIT_NODROP))
 		return ..()
 
 /obj/machinery/rnd/destructive_analyzer/Insert_Item(obj/item/O, mob/user)


### PR DESCRIPTION
# Описание
1) пофикшен баг невозможности за борга (из-за отсутствия интента дизарм) разобрать аутолат и анализатор
2) требование выборать дизарм нужно только для анализатора из всех научных штук (протолат, принтер плат и тд)

## Причина изменений
Багфиксы