### PR TITLE
Фикс рантайма при выпадении вещей из двух рук если это двуручное оружие

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -242,7 +242,8 @@
 	// Remove the object in the offhand
 	if(offhand_item)
 		UnregisterSignal(offhand_item, COMSIG_ITEM_DROPPED)
-		qdel(offhand_item)
+		if(!QDELETED(offhand_item))
+			qdel(offhand_item)
 	// Clear any old refrence to an item that should be gone now
 	offhand_item = null
 


### PR DESCRIPTION
# Описание
Фикс безвредного рантайма завязанного на двойном выкидывании оффэнхда двуручного оружия при уходе в крит

## Причина изменений
Фикс рантайма