### PR TITLE
Фикс неработающего инжектора

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -44522,7 +44522,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/science/xenobiology)
 "dcG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,


### PR DESCRIPTION
# Описание
1) Инжектор не был рабочим из-за отсутствия энергии сколько он был в зоне космоса
## Причина изменений
Мапфикс