### PR TITLE
Вещи с лодаута заменяют вещи на персонаже и фикс потеряшек

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -528,8 +528,8 @@ SUBSYSTEM_DEF(job)
 			equip_loadout(N, H) // CIT CHANGE - allows players to spawn with loadout items
 	//BLUEMOON ADD проходимся по всем вещам потеряшкам если такие есть, закидываем НАСИЛЬНО в рюкзак невзирая на размеры оного
 		else if(items_to_add_later.len)
-			if(iscarbon(M))
-				var/mob/living/carbon/C = M
+			if(iscarbon(H))
+				var/mob/living/carbon/C = H
 				var/obj/item/storage/backpack/B = C.back
 				if(B)
 					for(var/obj/item/I in items_to_add_later)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -91,7 +91,7 @@
 	var/exclusive_mail_goodies = FALSE
 
 	//If a job complies with dresscodes, loadout items will not be equipped instead of the job's outfit, instead placing the items into the player's backpack.
-	var/dresscodecompliant = TRUE
+	var/dresscodecompliant = FALSE //BLUEMOON CHANGE ну кмон все и так потом выбрасывают стартовые вещи оставляя свои из лодаута
 	// How much threat this job is worth in dynamic. Is subtracted if the player's not an antag, added if they are.
 	var/threat = 0
 
@@ -245,7 +245,7 @@
 /datum/job/proc/radio_help_message(mob/M)
 	to_chat(M, "<b>Prefix your message with :h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>")
 
-// BLUEMOON ADD 
+// BLUEMOON ADD
 /datum/job/proc/jobname_to_ru(mob/M, jobname)
 	var/static/list/joblist = list()
 // BLUEMOON ADD END


### PR DESCRIPTION
# Описание
1) Вещи с лодаута заменяют вещи на персонаже при спавне (вы и так всеравно это снимали и выкидывали)
2) Пофикшен баг когда при выборе большого количества предметов в лодауте те выпадали на главный экран

## Причина изменений
Багфиксы и упрощение жизни игры для всех