### PR TITLE
Фикс взрывоопасной мыши

### DIFF
--- a/modular_splurt/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -9,6 +9,8 @@
 	maxHealth = 7
 	health = 7
 	chew_probability = 0
+	gold_core_spawnable = HOSTILE_SPAWN
+
 
 /mob/living/simple_animal/mouse/boommouse/Initialize()
 	. = ..()


### PR DESCRIPTION


# Описание

Перенёс взрывомышь в спавн АГРЕССИВНЫХ мобов (Ибо мирные мобы уж точно не должны взрываться С ПЛАЗМОЙ тем самым нанося огромный вред отделу)


## Причина изменений

Это не логично? Сплюрты опять натворили откровенной дичи? Мобы которые появляются из жёлтого экстракта при использовании воды в априори не может являться опасными или агрессивными 

## Демонстрация изменений

---

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
