### PR TITLE
Фикс проклятого и energized топора

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -36,7 +36,7 @@
 
 /datum/component/omen/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(check_accident))
-	RegisterSignal(parent, COMSIG_LIVING_STATUS_KNOCKDOWN, PROC_REF(check_slip))
+	RegisterSignal(parent, COMSIG_ON_CARBON_SLIP, PROC_REF(check_slip))
 	RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT, PROC_REF(check_bless))
 	RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT, PROC_REF(check_death))
 

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -80,6 +80,7 @@
 /obj/item/fireaxe/energized
 	desc = "Someone with a love for fire axes decided to turn this one into a high-powered energy weapon. Seems excessive."
 	armour_penetration = 50
+	icon_state = "fireaxe_old0"
 	icon = 'modular_bluemoon/icons/obj/items_and_weapons.dmi'
 	var/charge = 90
 	var/max_charge = 90


### PR DESCRIPTION
# Описание
1) У проклятых прок их проклятья был каждое изменение кнока (очень часто особенно когда в теле медецина его меняющая), баг вызванный мёржом с апстримом (место с удалением сигнала было как-раз на подскальзывание)
2) У energized топора не было спрайта до взятия в обе руки

## Причина изменений
Багфиксы и играбельный проклятый