### PR TITLE
Персонажи с Naga (coiled) телом, могут использовать способность coiling

### DIFF
--- a/code/modules/mob/living/carbon/human/innate_abilities/coiling.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/coiling.dm
@@ -7,6 +7,7 @@
 	background_icon_state = "bg_alien"
 	required_mobility_flags = MOBILITY_STAND
 	var/currently_coiling = FALSE
+	var/originally_coiled_body = FALSE
 	var/mob/living/carbon/human/currently_coiled
 	var/mutable_appearance/tracked_overlay
 
@@ -47,7 +48,7 @@
 						"<span class='userdanger'>[owner] coils you with their tail!</span>")
 	currently_coiling = TRUE
 	currently_coiled = H
-
+	
 	H.layer -= 0.1 // LISTEN I HATE TOUCHING MOB LAYERS TOO BUT THIS IS JUST SO THEY RENDER UNDER THE OTHER PLAYER SDFHSDFHDSFHDSH
 	var/prev_grab_state = owner.grab_state
 	// move user to same tile
@@ -66,10 +67,15 @@
 	update_coil_offset(null, null, owner.dir)
 
 	// set our overlay to new image
+	
 	var/mob/living/carbon/human/user = owner
-	user.dna.species.mutant_bodyparts["taur"] = "Naga (coiled)"
-	user.dna.features["taur"] = "Naga (coiled)"
-	user.update_mutant_bodyparts()
+
+	originally_coiled_body = user.dna.features["taur"] == "Naga (coiled)"
+
+	if(!originally_coiled_body)
+		user.dna.species.mutant_bodyparts["taur"] = "Naga (coiled)"
+		user.dna.features["taur"] = "Naga (coiled)"
+		user.update_mutant_bodyparts()
 
 /datum/action/innate/ability/coiling/proc/cancel_coil()
 	if (!currently_coiled)
@@ -91,9 +97,10 @@
 	UnregisterSignal(owner, COMSIG_ATOM_DIR_CHANGE)
 
 	// change overlay back to original image
-	H.dna.species.mutant_bodyparts["taur"] = "Naga"
-	H.dna.features["taur"] = "Naga"
-	H.update_mutant_bodyparts()
+	if(!originally_coiled_body)
+		H.dna.species.mutant_bodyparts["taur"] = "Naga"
+		H.dna.features["taur"] = "Naga"
+		H.update_mutant_bodyparts()
 
 	H.update_body()
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -962,7 +962,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	if(found_action && (!tauric || (H.dna.features["taur"] != "Naga" && H.dna.features["taur"] != "Naga (coiled)")))
 		found_action.Remove(H)
 
-	if(!found_action && tauric && H.dna.features["taur"] == "Naga")
+	if(!found_action && tauric && (H.dna.features["taur"] == "Naga" || H.dna.features["taur"] == "Naga (coiled)"))
 		found_action = new /datum/action/innate/ability/coiling()
 		found_action.Grant(H)
 


### PR DESCRIPTION
# Описание

<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
Дает персонажам с taur body == Naga (coiled), способность обвивать других, которая есть у обычного Naga варианта.
Для Naga туловища, ничего не поменяется, оно все так-же будет скручиваться при активации и раскручиваться, при отпускании.
Для Naga (coiled) туловище меняться не будет.
https://discord.com/channels/875735187449847830/1343580064989843577/1343580064989843577
- [x] Изменения были проверены на локальном сервере, включая квирк полиморфа
- [x] Готово к мерджу

## Причина изменений
Не очень логично, что выбор альтернативного скина хвоста наги, отнимает эту способность
<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

