### PR TITLE
Usefull Atmos Firesuit

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -1342,7 +1342,7 @@
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/service/diner)
 "eT" = (
 /obj/structure/table,
-/obj/item/analyzer{
+/obj/item/analyzer/ranged{
 	pixel_y = 10
 	},
 /obj/item/pipe_dispenser{

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -211,3 +211,4 @@
 	new /obj/item/clothing/suit/fire/atmos(src)
 	new /obj/item/clothing/head/hardhat/atmos(src)
 	new /obj/item/tank/internals/oxygen/red(src)
+	new /obj/item/watertank/atmos(src)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -104,7 +104,7 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	cold_protection = HEAD
-	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	mutantrace_variation = STYLE_MUZZLE
 
 /obj/item/clothing/head/hardhat/weldhat

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -54,6 +54,9 @@
 	icon_state = "atmos_firesuit"
 	item_state = "firesuit_atmos"
 	tail_state = "atmos"
+	w_class = WEIGHT_CLASS_NORMAL
+	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAUR
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_SNEK_TAURIC|STYLE_PAW_TAURIC


### PR DESCRIPTION
# Описание

Короче, сделал Атмос Фаерсьюты более полезными. Их можно складывать в сумку и носить с собой. Так же они теперь защищают от космического холода. Надеюсь они перестанут бесконечно и бесполезно лежать в шкафчиках.

Ну и на DS-2 добавил дальномерный газоанализатор и атмос водяной танк в шкаф к энерготопору.

Viva la Atmosia!
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [ ] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Атмос Фаерсьюты никто не носил никогда.

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
