### PR TITLE
Удаление мобов сумасшедшего учёного и тёмного мага при убийстве

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
@@ -11,6 +11,7 @@
 	ranged_message = "earth bolts"
 	ranged_cooldown_time = 20
 	maxHealth = 50
+	del_on_death = 1
 	health = 50
 	harm_intent_damage = 5
 	obj_damage = 20

--- a/modular_splurt/code/modules/mob/living/simple_animal/hostile/crazysci.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/hostile/crazysci.dm
@@ -11,6 +11,7 @@
 	turns_per_move = 1
 	maxHealth = 120
 	health = 120
+	del_on_death = 1
 	see_in_dark = 7
 	response_help_continuous  = "pets"
 	response_disarm_continuous = "pushes aside"


### PR DESCRIPTION
Теперь мобы удаляются, не давая экспедиторам дюпать себе по 20+ сабель и свитков

# Описание

Теперь мобы удаляются, не давая экспедиторам дюпать себе по 20+ сабель и свитков (при помощи лазаруса)

## Причина изменений

Эти два предмета довольно имбовые и могут знатно подпортить людям динаму/эксту 

## Демонстрация изменений

Нету

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
