### PR TITLE
Замена камней для заточке в инф дормах на использование

### DIFF
--- a/_maps/templates/apartment_3.dmm
+++ b/_maps/templates/apartment_3.dmm
@@ -55,7 +55,10 @@
 	pixel_y = 9
 	},
 /obj/item/sharpener{
-	pixel_x = 10
+	pixel_x = 10;
+	used = 1;
+	desc = "A block that makes things sharp. At least, it used to.";
+	name = "worn out whetstone"
 	},
 /turf/open/floor/plasteel/white,
 /area/hilbertshotel)

--- a/_maps/templates/apartment_beach.dmm
+++ b/_maps/templates/apartment_beach.dmm
@@ -48,7 +48,10 @@
 	},
 /obj/item/sharpener{
 	pixel_x = -10;
-	pixel_y = -8
+	pixel_y = -8;
+	used = 1;
+	desc = "A block that makes things sharp. At least, it used to.";
+	name = "worn out whetstone"
 	},
 /turf/open/floor/plasteel/white,
 /area/hilbertshotel)

--- a/_maps/templates/apartment_jungle.dmm
+++ b/_maps/templates/apartment_jungle.dmm
@@ -374,7 +374,11 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/sharpener,
+/obj/item/sharpener{
+	used = 1;
+	desc = "A block that makes things sharp. At least, it used to.";
+	name = "worn out whetstone"
+	},
 /turf/open/floor/plasteel/kitchen,
 /area/hilbertshotel)
 "zJ" = (

--- a/_maps/templates/apartment_winter.dmm
+++ b/_maps/templates/apartment_winter.dmm
@@ -670,7 +670,10 @@
 	pixel_x = 10
 	},
 /obj/item/sharpener{
-	pixel_x = -5
+	pixel_x = -5;
+	used = 1;
+	desc = "A block that makes things sharp. At least, it used to.";
+	name = "worn out whetstone"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hilbertshotel)


### PR DESCRIPTION
# Описание
1) Камни для заточки в инф дормах заменены на сточенные
## Причина изменений
Использование инф дорм ради бесплатного лута который должен быть ограничен в доступе