### PR TITLE
Экспедиторы имели неправильное написание для рд

### DIFF
--- a/code/modules/jobs/job_types/research/expeditor.dm
+++ b/code/modules/jobs/job_types/research/expeditor.dm
@@ -1,7 +1,7 @@
 /datum/job/expeditor
 	title = "Expeditor"
 	flag = EXPEDITOR
-	department_head = list("Captain", "RD")
+	department_head = list("Captain", "Research Director")
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 4


### PR DESCRIPTION
# Описание
1) Именование главы было неправильным, вызывало баги у кровососателей на цели из рнд

## Причина изменений
багфикс