### PR TITLE
Поставил на посту прослушки правильные слиперы

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1088,7 +1088,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "gC" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms,
+/obj/effect/mob_spawn/human/ds2/syndicate_command/comms,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "gU" = (


### PR DESCRIPTION
Мапер залепил на прослушку в космосе слипер офкома с Дюны. Не круто. Вообще не круто.

Поставил прослушников которые должны быть