### PR TITLE
Квирки медбея + балансное

### DIFF
--- a/code/__BLUEMOONCODE/_DEFINES/surgery.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/surgery.dm
@@ -4,3 +4,9 @@
 #define OPERATION_MUST_BE_PERFORMED_AWAKE	"operation_must_be_performed_awake"
 // требуется полная анестезия (пациент спит)
 #define OPERATION_NEED_FULL_ANESTHETIC		"operation_need_full_anesthetic"
+// знание операций для mind докторов
+#define KNOW_MED_SURGERY_OPERATIONS list( \
+	/datum/surgery/healing/brute/upgraded, \
+	/datum/surgery/healing/burn/upgraded, \
+	/datum/surgery/advanced/toxichealing \
+	)

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -657,6 +657,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_KNOW_VIR_SURGERY_T1 "know_vir_surgery_t1"
 #define TRAIT_SKILLCHIP_ADAPTER "skillchip_adapter"
 
+//BLUEMOON ADD SKILLS START
+#define TRAIT_REAGENT_EXPERT "reagent_expert"
+//BLUEMOON ADD SKILLS END
+
 ///Movement type traits for movables. See elements/movetype_handler.dm
 #define TRAIT_MOVE_GROUND "move_ground"
 #define TRAIT_MOVE_FLYING "move_flying"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -1421,19 +1421,6 @@
 	outfit = /datum/outfit/ds2/syndicate_command/admiral
 	starting_money = 10000 // BLUEMOON ADD
 
-// BLUEMOON ADD wires trait system + */special proc place for future coding
-/obj/effect/mob_spawn/human/ds2/syndicate/enginetech/special(mob/living/carbon/human/new_spawn)
-	. = ..()
-	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_ENGI_WIRES, GHOSTROLE_TRAIT)
-	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring))
-
-/obj/effect/mob_spawn/human/ds2/syndicate/researcher/special(mob/living/carbon/human/new_spawn)
-	. = ..()
-	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_CYBORG_WIRES, GHOSTROLE_TRAIT)
-	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/trained, /datum/skill_modifier/job/affinity/wiring))
-
-// BLUEMOON ADD END
-
 /datum/outfit/ds2
 	name = "default ds2 outfit"
 

--- a/code/modules/jobs/job_types/brig/brigdoc.dm
+++ b/code/modules/jobs/job_types/brig/brigdoc.dm
@@ -25,7 +25,7 @@
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_SEC
 
-	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
+	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM, TRAIT_KNOW_MED_SURGERY_T2) //BLUEMOON EDIT added surgery trait
 
 	display_order = JOB_DISPLAY_ORDER_BRIG_PHYSICIAN
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/blindness, /datum/quirk/monophobia, /datum/quirk/bluemoon_criminal)

--- a/code/modules/jobs/job_types/command/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/command/chief_medical_officer.dm
@@ -31,6 +31,8 @@
 	paycheck_department = ACCOUNT_MED
 	bounty_types = CIV_JOB_MED
 
+	mind_traits = list(TRAIT_REAGENT_EXPERT, TRAIT_QUICK_CARRY) //BLUEMOON ADD use TRAIT system for jobs
+
 	display_order = JOB_DISPLAY_ORDER_CHIEF_MEDICAL_OFFICER
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/insanity, /datum/quirk/bluemoon_criminal)
 	threat = 2

--- a/code/modules/jobs/job_types/medbay/chemist.dm
+++ b/code/modules/jobs/job_types/medbay/chemist.dm
@@ -21,6 +21,8 @@
 	bounty_types = CIV_JOB_CHEM
 	departments = DEPARTMENT_BITFLAG_MEDICAL
 
+	mind_traits = list(TRAIT_REAGENT_EXPERT) //BLUEMOON ADD use TRAIT system for jobs
+
 	display_order = JOB_DISPLAY_ORDER_CHEMIST
 	threat = 1.5
 

--- a/code/modules/jobs/job_types/medbay/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medbay/medical_doctor.dm
@@ -19,6 +19,8 @@
 	paycheck_department = ACCOUNT_MED
 	bounty_types = CIV_JOB_MED
 
+	mind_traits = list(TRAIT_KNOW_MED_SURGERY_T2) //BLUEMOON ADD use TRAIT system for jobs
+
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
 	threat = 0.5
 

--- a/code/modules/jobs/job_types/medbay/paramedic.dm
+++ b/code/modules/jobs/job_types/medbay/paramedic.dm
@@ -19,6 +19,8 @@
 	bounty_types = CIV_JOB_MED
 	departments = DEPARTMENT_BITFLAG_MEDICAL
 
+	mind_traits = list(TRAIT_QUICK_CARRY) //BLUEMOON ADD use TRAIT system for jobs
+
 	display_order = JOB_DISPLAY_ORDER_PARAMEDIC
 
 	threat = 0.5

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1121,6 +1121,10 @@
 			return TRUE
 	if(isclothing(wear_mask) && (wear_mask.clothing_flags & SCAN_REAGENTS))
 		return TRUE
+	// BLUEMOON ADDITION AHEAD making use of trait system
+	else if (HAS_TRAIT(src.mind, TRAIT_REAGENT_EXPERT))
+		return TRUE
+	// BLUEMOON ADDITION END
 
 /mob/living/carbon/can_hold_items()
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -886,10 +886,15 @@ Mark this mob, then navigate to the preferences of the client you desire and cal
 	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
 		if(HAS_TRAIT_FROM(src, TRAIT_QUICKER_CARRY, GLOVE_TRAIT))
 			gloves_used = TRUE
-		carrydelay = 20
+		carrydelay = 15 // BLUEMOON EDIT making this a little bit useful
 		skills_space = "профессионально "
+	// BLUEMOON ADDITION AHEAD making mind-based condition for job-specific qualification
+	else if(HAS_TRAIT(src.mind, TRAIT_QUICK_CARRY))
+		carrydelay = 20
+		skills_space = "оперативно "
+	// BLUEMOON ADDITION END
 	else if(HAS_TRAIT(src, TRAIT_QUICK_CARRY) || target.mob_weight < MOB_WEIGHT_NORMAL)
-		carrydelay = 30
+		carrydelay = 25 // BLUEMOON EDIT making this a little bit useful
 		skills_space = "быстро "
 	// BLUEMOON ADDITION AHEAD - тяжёлых и сверхтяжёлых персонажей нельзя нести на плече
 	if(target.mob_weight > MOB_WEIGHT_NORMAL)
@@ -899,7 +904,7 @@ Mark this mob, then navigate to the preferences of the client you desire and cal
 	if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE))
 		visible_message("<span class='notice'>[src] [skills_space]поднимает [target] на свои плечи.</span>",
 		//Joe Medic starts quickly/expertly lifting Grey Tider onto their back..
-		"<span class='notice'>[gloves_used ? "Используя перчатки с наночипами, вы" : "Вы"] [skills_space]поднимаете [target] на свои плечи.]</span>")
+		"<span class='notice'>[gloves_used ? "Используя перчатки с наночипами, вы" : "Вы"] [skills_space]поднимаете [target] на свои плечи.</span>")
 		//(Using your gloves' nanochips, you/You) ( /quickly/expertly) start to lift Grey Tider onto your back(, while assisted by the nanochips in your gloves../...)
 		if(do_after(src, carrydelay, target, extra_checks = CALLBACK(src, PROC_REF(can_be_firemanned), target)))
 			//Second check to make sure they're still valid to be carried

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -30,7 +30,7 @@
 /obj/item/projectile/bullet/c10mm_hp
 	name = "10mm hollow-point bullet"
 	damage = 40
-	armour_penetration = -50
+	armour_penetration = -25 // BLUEMOON EDIT balancing, was -50
 
 /obj/item/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -89,6 +89,9 @@
 		var/obj/item/surgical_drapes/advanced/A = tool
 		advanced_surgeries |= A.get_advanced_surgeries()
 
+	if(HAS_TRAIT(user.mind, TRAIT_KNOW_MED_SURGERY_T2))
+		advanced_surgeries |= KNOW_MED_SURGERY_OPERATIONS
+
 	if(replaced_by in advanced_surgeries)
 		return FALSE
 	if(type in advanced_surgeries)

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -239,7 +239,7 @@
 /datum/uplink_item/role_restricted/emitter_cannon
 	name = "Emitter Cannon"
 	desc = "A small emitter fitted into a gun case, do to size constraints and safety it can only shoot about ten times when fully charged."
-	cost = 5 //Low ammo, and deals same as 10mm but emp-able
+	cost = 13 //Low ammo, and deals same as 10mm but emp-able // BLIEMOOD EDIT this rofl about same as 10 mm was fixed, robust weapon
 	item = /obj/item/gun/energy/emitter
 	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -311,6 +311,7 @@
 			return
 		user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [src].</span>")
 		obj_integrity += min(10, max_integrity-obj_integrity)
+		user.DelayNextAction(20) // BLUEMOON ADD balancing instarepair abuse
 		if(obj_integrity == max_integrity)
 			to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
 		return

--- a/modular_bluemoon/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_bluemoon/code/game/objects/structures/ghost_role_spawners.dm
@@ -153,3 +153,24 @@ mob/living/proc/ghost_cafe_traits(switch_on = FALSE, additional_area)
 	. = ..()
 	var/mob/living/carbon/human/H = new_spawn
 	H.mind.make_XenoChangeling()
+
+////////////////////////////////////
+// Проки для выдачи трейтов и навыков отдельным гостролям, например, DS-2
+
+/obj/effect/mob_spawn/human/ds2/syndicate/enginetech/special(mob/living/carbon/human/new_spawn)
+	. = ..()
+	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_ENGI_WIRES, GHOSTROLE_TRAIT)
+	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring))
+
+/obj/effect/mob_spawn/human/ds2/syndicate/researcher/special(mob/living/carbon/human/new_spawn)
+	. = ..()
+	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_CYBORG_WIRES, GHOSTROLE_TRAIT)
+	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/trained, /datum/skill_modifier/job/affinity/wiring))
+
+/obj/effect/mob_spawn/human/ds2/syndicate/stationmed/special(mob/living/carbon/human/new_spawn)
+	. = ..()
+	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_MED_SURGERY_T2, GHOSTROLE_TRAIT)
+	ADD_TRAIT(new_spawn.mind, TRAIT_QUICK_CARRY, GHOSTROLE_TRAIT)
+	ADD_TRAIT(new_spawn.mind, TRAIT_REAGENT_EXPERT, GHOSTROLE_TRAIT)
+
+////////////////////////////////////

--- a/modular_bluemoon/code/modules/antagonists/ert/ert.dm
+++ b/modular_bluemoon/code/modules/antagonists/ert/ert.dm
@@ -112,3 +112,21 @@
 	name = "Maid Squad"
 	outfit = /datum/outfit/ert/maid
 	role = "Горничная"
+
+/////////////////////////////////////////
+// Добавление трейтов ОБР ролям в их mind
+/datum/antagonist/ert/engineer_squadleader/apply_innate_effects(mob/living/mob_override)
+	ADD_TRAIT(owner, TRAIT_KNOW_ENGI_WIRES, JOB_TRAIT)
+	ADD_TRAIT(owner, TRAIT_KNOW_CYBORG_WIRES, JOB_TRAIT)
+
+/datum/antagonist/ert/engineer/apply_innate_effects(mob/living/mob_override)
+	ADD_TRAIT(owner, TRAIT_KNOW_ENGI_WIRES, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_KNOW_CYBORG_WIRES, TRAIT_GENERIC)
+
+/datum/antagonist/ert/medic/apply_innate_effects(mob/living/mob_override)
+	ADD_TRAIT(owner, TRAIT_QUICK_CARRY, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_REAGENT_EXPERT, TRAIT_GENERIC)
+
+/datum/antagonist/ert/hsc/apply_innate_effects(mob/living/mob_override)
+	ADD_TRAIT(owner, TRAIT_QUICK_CARRY, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_REAGENT_EXPERT, TRAIT_GENERIC)

--- a/modular_bluemoon/code/modules/research/designs/weapon_designs.dm
+++ b/modular_bluemoon/code/modules/research/designs/weapon_designs.dm
@@ -82,7 +82,7 @@
 	desc = "A box of 5.8x40 mm  armour piercing titanium bullets. 30 cartridges total."
 	id = "box_acr5_ap"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 24000, /datum/material/titanium = 1000, silver = 500)
+	materials = list(/datum/material/iron = 24000, /datum/material/titanium = 1000, /datum/material/silver = 500)
 	build_path = /obj/item/ammo_box/magazine/acr5m30/ap
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/modular_bluemoon/fluffs/code/melee.dm
+++ b/modular_bluemoon/fluffs/code/melee.dm
@@ -13,7 +13,7 @@
 
 /obj/item/modkit/impactbaton_kit
 	name = "Impact Baton Kit"
-	desc = "A modkit for making a police baton into an impact baton."
+	desc = "A modkit for making a police baton into a jitte baton."
 	product = /obj/item/melee/classic_baton/impactbaton_jitte
 	fromitem = list(/obj/item/melee/classic_baton)
 
@@ -29,7 +29,7 @@
 
 /obj/item/modkit/catcrinbaton_kit
 	name = "3/51-H Telescopic Baton Kit"
-	desc = "A modkit for making a police baton into an impact baton."
+	desc = "A modkit for making a telescopic baton into an impact baton."
 	product = /obj/item/melee/classic_baton/telescopic/catcrin
 	fromitem = list(/obj/item/melee/classic_baton/telescopic)
 

--- a/modular_splurt/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/modular_splurt/code/modules/projectiles/projectile/bullets/smg.dm
@@ -17,9 +17,9 @@
 
 /obj/item/projectile/bullet/c45/hydra
 	name = ".45 Hydra-shock bullet"
-	damage = 15
+	damage = 30 // BLUEMOON CHANGE balancing, was 15
 	stamina = 0
-	armour_penetration = -65
+	armour_penetration = -20 // BLUEMOON CHANGE balancing, was -65
 	sharpness = SHARP_EDGED
 	wound_bonus = 30 // 30 WTF
 	bare_wound_bonus = 30 // 30 WTF


### PR DESCRIPTION
# Описание
1. Медроли: парамедик, медик, бригмедик, химик получили связанные с профессией трейты. СМО получил трейты парамедика и химика.
   - Медики и бригмедики имеют пул операций, доступных раундстарт: тенд вундс адвансд + боди реджув.
   - Парамедики быстрее затаскивают на спину лежачее тело даже без нитриловых перчаток.
   - Химики различают реагенты без научных очков.
2. Бафф нитрилок и латексных перчаток: на полсекунды быстрее подъём на спину.
   - 1.5 секунды нитрилки, 2.5 секунды латеекс, 2 секунды парамедик.
3. Бафф экспансивок 10-мм и гидрашоков .45-мм: бронепробитие. Для гидрошоков и урон тоже.
   - 10 мм ХП: брнепробитие -50 стало -25.
   - .45 гидрашок: бронепробитие -65 стало -20, урон повышен до 30, было 15.
4. Эмиттер карабин повысился в цене. Было 5, стало 13.
5. Фикс абуза инстапочинки мехов. Теперь руки имеют КД 2 секунды после юза сварки на мех.
6. ОБР получили профессиональные трейты стационников. Гостроль ДС-2 тоже. Вмодулярил трейты для ДС.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений
1-2. Реализация задумки "Профы не ассистенты с доступами".
3. Победа в голосовании. Доведение гидрашоков до статуса суть лучше обычных .45.
4. Неадекватное соотношение урон к цене. 45 урона, 10 выстрелов, 5 тк. 
5. Попросили.
6. Логика.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/32fee36a-64a8-4cca-97a2-8ab4622bc9dc)
