### PR TITLE
Религия = Библия, без дополнительных

### DIFF
--- a/code/modules/jobs/job_types/service/chaplain.dm
+++ b/code/modules/jobs/job_types/service/chaplain.dm
@@ -119,7 +119,7 @@
 		if("weeaboo","kawaii")
 			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
 		else
-			B.name = "The Holy Book of [new_religion]"
+			B.name = "[new_religion]"
 
 	GLOB.religion = new_religion
 	GLOB.bible_name = B.name


### PR DESCRIPTION
Всё просто и крайне нужно. Теперь строчка с Религией может менять полностью название для Библии. Комментарии излишне