### PR TITLE
Трейт для быстрой починки

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -659,6 +659,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 //BLUEMOON ADD SKILLS START
 #define TRAIT_REAGENT_EXPERT "reagent_expert"
+#define TRAIT_MECHA_EXPERT "mecha_expert"
 //BLUEMOON ADD SKILLS END
 
 ///Movement type traits for movables. See elements/movetype_handler.dm

--- a/code/modules/jobs/job_types/command/research_director.dm
+++ b/code/modules/jobs/job_types/command/research_director.dm
@@ -37,7 +37,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_RESEARCH_DIRECTOR
 	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/basic) //BLUEMOON CHANGE job/level to basic
-	mind_traits = list(TRAIT_KNOW_CYBORG_WIRES) //BLUEMOON ADD use #define TRAIT system
+	mind_traits = list(TRAIT_KNOW_CYBORG_WIRES, TRAIT_MECHA_EXPERT) //BLUEMOON ADD use #define TRAIT system
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/insanity, /datum/quirk/bluemoon_criminal)
 	threat = 5
 

--- a/code/modules/jobs/job_types/research/roboticist.dm
+++ b/code/modules/jobs/job_types/research/roboticist.dm
@@ -23,7 +23,7 @@
 
 	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/basic, /datum/skill_modifier/job/affinity/wiring) //BLUEMOON CHANGE job/level to basic
 
-	mind_traits = list(TRAIT_KNOW_CYBORG_WIRES) //BLUEMOON ADD use #define TRAIT system
+	mind_traits = list(TRAIT_KNOW_CYBORG_WIRES, TRAIT_MECHA_EXPERT) //BLUEMOON ADD use #define TRAIT system
 
 	display_order = JOB_DISPLAY_ORDER_ROBOTICIST
 	threat = 1

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -311,7 +311,12 @@
 			return
 		user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [src].</span>")
 		obj_integrity += min(10, max_integrity-obj_integrity)
-		user.DelayNextAction(20) // BLUEMOON ADD balancing instarepair abuse
+		// BLUEMOON ADDITION AHEAD balancing instarepair abuse
+		if(HAS_TRAIT(user.mind, TRAIT_MECHA_EXPERT))
+			user.DelayNextAction(10)
+		else
+			user.DelayNextAction(20)
+		// BLUEMOON ADDITION END
 		if(obj_integrity == max_integrity)
 			to_chat(user, "<span class='notice'>It looks to be fully repaired now.</span>")
 		return

--- a/modular_bluemoon/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_bluemoon/code/game/objects/structures/ghost_role_spawners.dm
@@ -165,6 +165,7 @@ mob/living/proc/ghost_cafe_traits(switch_on = FALSE, additional_area)
 /obj/effect/mob_spawn/human/ds2/syndicate/researcher/special(mob/living/carbon/human/new_spawn)
 	. = ..()
 	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_CYBORG_WIRES, GHOSTROLE_TRAIT)
+	ADD_TRAIT(new_spawn.mind, TRAIT_MECHA_EXPERT, GHOSTROLE_TRAIT)
 	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/trained, /datum/skill_modifier/job/affinity/wiring))
 
 /obj/effect/mob_spawn/human/ds2/syndicate/stationmed/special(mob/living/carbon/human/new_spawn)
@@ -172,5 +173,11 @@ mob/living/proc/ghost_cafe_traits(switch_on = FALSE, additional_area)
 	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_MED_SURGERY_T2, GHOSTROLE_TRAIT)
 	ADD_TRAIT(new_spawn.mind, TRAIT_QUICK_CARRY, GHOSTROLE_TRAIT)
 	ADD_TRAIT(new_spawn.mind, TRAIT_REAGENT_EXPERT, GHOSTROLE_TRAIT)
+
+/obj/effect/mob_spawn/human/inteqspace/engineer/special(mob/living/carbon/human/new_spawn)
+	. = ..()
+	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_ENGI_WIRES, GHOSTROLE_TRAIT)
+	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_CYBORG_WIRES, GHOSTROLE_TRAIT)
+	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring))
 
 ////////////////////////////////////

--- a/modular_bluemoon/code/modules/antagonists/ert/ert.dm
+++ b/modular_bluemoon/code/modules/antagonists/ert/ert.dm
@@ -115,18 +115,26 @@
 
 /////////////////////////////////////////
 // Добавление трейтов ОБР ролям в их mind
-/datum/antagonist/ert/engineer_squadleader/apply_innate_effects(mob/living/mob_override)
+/datum/antagonist/ert/engineer_squadleader/on_gain()
+	. = ..()
 	ADD_TRAIT(owner, TRAIT_KNOW_ENGI_WIRES, JOB_TRAIT)
 	ADD_TRAIT(owner, TRAIT_KNOW_CYBORG_WIRES, JOB_TRAIT)
+	ADD_TRAIT(owner, TRAIT_MECHA_EXPERT, TRAIT_GENERIC)
 
-/datum/antagonist/ert/engineer/apply_innate_effects(mob/living/mob_override)
+/datum/antagonist/ert/engineer/on_gain()
+	. = ..()
 	ADD_TRAIT(owner, TRAIT_KNOW_ENGI_WIRES, TRAIT_GENERIC)
 	ADD_TRAIT(owner, TRAIT_KNOW_CYBORG_WIRES, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_MECHA_EXPERT, TRAIT_GENERIC)
 
-/datum/antagonist/ert/medic/apply_innate_effects(mob/living/mob_override)
+/datum/antagonist/ert/medic/on_gain()
+	. = ..()
 	ADD_TRAIT(owner, TRAIT_QUICK_CARRY, TRAIT_GENERIC)
 	ADD_TRAIT(owner, TRAIT_REAGENT_EXPERT, TRAIT_GENERIC)
 
-/datum/antagonist/ert/hsc/apply_innate_effects(mob/living/mob_override)
+/datum/antagonist/ert/hsc/on_gain()
+	. = ..()
 	ADD_TRAIT(owner, TRAIT_QUICK_CARRY, TRAIT_GENERIC)
 	ADD_TRAIT(owner, TRAIT_REAGENT_EXPERT, TRAIT_GENERIC)
+
+/////////////////////////////////////////

--- a/modular_splurt/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_splurt/code/game/objects/structures/ghost_role_spawners.dm
@@ -208,13 +208,6 @@
 	can_load_appearance = TRUE
 	outfit = /datum/outfit/inteqspace/inteq_engineer
 
-// BLUEMOON ADD wires trait system
-/obj/effect/mob_spawn/human/inteqspace/engineer/special(mob/living/carbon/human/new_spawn)
-	. = ..()
-	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_ENGI_WIRES, GHOSTROLE_TRAIT)
-	ADD_TRAIT(new_spawn.mind, TRAIT_KNOW_CYBORG_WIRES, GHOSTROLE_TRAIT)
-	new_spawn.mind.add_skill_modifier(list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring))
-
 /datum/outfit/inteqspace/inteq_crew/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_INTEQ
 


### PR DESCRIPTION
# Описание
Создал и добавил трейт на быструю починку мехов. 
- Трейт даёт при починке сваркой меха КД на руки 1, у всех остальных 2. Обычный КД на руки равен 0.8 секунды.
- Трейт получил робототехник, РД, инженеры ОБР и гостроль учёного ДС-2.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений
Дополнение логики, что мех-related роли должны быть квалифицированными для работы с ними.

## Демонстрация изменений
Мелкое изменение, не требуется.