### PR TITLE
Окно информации для ОБР 

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -11,7 +11,7 @@
 	var/roles = list(/datum/antagonist/ert/security, /datum/antagonist/ert/medic, /datum/antagonist/ert/engineer) //List of possible roles to be assigned to ERT members.
 	var/rename_team
 	var/code
-	var/mission = "Защити станцию любой ценой и докажи свою состоятельность!"
+	var/mission = "защитите станцию любой ценой и докажите свою состоятельность!"
 	var/teamsize = 5
 	var/polldesc
 	var/ertphrase = 'modular_bluemoon/sound/ert/ert_yes.ogg'
@@ -23,7 +23,7 @@
 /datum/ert/janitor
 	opendoors = FALSE
 	code = "Crap"
-	mission = "Очистите станцию от всевозможной грязи."
+	mission = "очистите станцию от всевозможной грязи."
 	leader_role = /datum/antagonist/ert/janitor
 	roles = list(/datum/antagonist/ert/janitor)
 
@@ -47,6 +47,7 @@
 	roles = list(/datum/antagonist/ert/security/red, /datum/antagonist/ert/medic/red, /datum/antagonist/ert/engineer/red)
 	opendoors = TRUE
 	code = "Red"
+	mission = "устраните угрозы Космической Станции. Её утеря стала бы серьёзным ударом для функционирования Пакта." // BLUEMOON ADD
 
 /datum/ert/deathsquad
 	roles = list(/datum/antagonist/ert/deathsquad)
@@ -54,7 +55,7 @@
 	opendoors = TRUE
 	rename_team = "Deathsquad"
 	code = "Delta"
-	mission = "Уничтожить Космическую Станцию, включая активы, в том числе весь Экипаж."
+	mission = "уничтожить Космическую Станцию, включая активы, в том числе весь Экипаж."
 	polldesc = "an elite Nanotrasen Strike Team"
 	ertphrase = "modular_bluemoon/sound/ert/deathsquad_send_in.ogg"
 
@@ -63,7 +64,7 @@
 	leader_role = /datum/antagonist/ert/asset_protection/leader
 	rename_team = "Asset Protection Team"
 	code = "Epsilon"
-	mission = "Защитите Активы Пакта. Сотрудники Пакта тоже являются Активами Пакта."
+	mission = "защитите Активы Пакта. Сотрудники Пакта тоже являются Активами Пакта."
 	polldesc = "a Nanotrasen Asset Protection Team"
 	ertphrase = "modular_bluemoon/sound/ert/asset_protection_send.ogg"
 
@@ -73,7 +74,7 @@
 	opendoors = TRUE
 	rename_team = "Syndicate Strike Team"
 	code = "Crimson"
-	mission = "Разберитесь с проблемами, достойными Дельта-Кода."
+	mission = "разберитесь с проблемами, достойными Дельта-Кода."
 	polldesc = "an elite Syndicate Strike Team"
 
 /datum/ert/centcom_official
@@ -86,13 +87,13 @@
 	polldesc = "a CentCom Official"
 
 /datum/ert/centcom_official/New()
-	mission = "Разберитесь с проблемами на станции [station_name()], а также проведите плановую проверку всех Отделов и Командования."
+	mission = "разберитесь с проблемами на объекте \"[station_name()]\", а также проведите плановую проверку всех Отделов и Командования."
 
 /datum/ert/inquisition
 	roles = list(/datum/antagonist/ert/security/inquisitor, /datum/antagonist/ert/medic/inquisitor)
 	leader_role = /datum/antagonist/ert/commander/inquisitor
 	rename_team = "Inquisition"
-	mission = "Уничтожьте любые следы паранормальной активности на борту Космической Станции Тринадцатого Сектора."
+	mission = "уничтожьте любые следы паранормальной активности на борту Космической Станции Тринадцатого Сектора."
 	polldesc = "a Nanotrasen paranormal response team"
 	ertphrase = 'modular_bluemoon/sound/ert/ert_inq_send.ogg'
 

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -197,6 +197,7 @@
 		missiondesc += "<li>Следуйте приказам, отданным лидером вашего отряда.</li>"
 	missiondesc += "\n<li>Избегайте жертв среди гражданских, когда это возможно.</li>"
 	missiondesc += "\n<li>Префиксы наушника <b>:y</b> и <b>:н</b> <font color='red'>отвечают за связь</font> через CentCom радиоканал <font color='red'>вашего отряда</font> и <font color='red'>вашего начальства</font>.</li>"
+	missiondesc += "<p>На объекте объявлен код <b>[get_security_level()]</b></p>"
 	missiondesc += "<p><B>Ваша миссия</B>: [ert_team.mission.explanation_text]</p>"
 	to_chat(owner, examine_block(missiondesc))
 // BLUEMOON EDIT END

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -100,6 +100,7 @@
 /datum/antagonist/ert/commander
 	role = "Командир"
 	outfit = /datum/outfit/ert/commander
+	leader = TRUE // BLUEMOON CHANGE enabling greet "if" condition for ERT leaders
 
 /datum/antagonist/ert/commander/amber
 	outfit = /datum/outfit/ert/commander/alert
@@ -153,16 +154,19 @@
 	name = "Deathsquad Officer"
 	outfit = /datum/outfit/death_commando/officer
 	role = "Офицер"
+	leader = TRUE // BLUEMOON CHANGE enabling greet "if" condition for ERT leaders
 
 /datum/antagonist/ert/asset_protection/leader
 	name = "Asset Protection Team Officer"
 	outfit = /datum/outfit/death_commando/officer
 	role = "Офицер"
+	leader = TRUE // BLUEMOON CHANGE enabling greet "if" condition for ERT leaders
 
 /datum/antagonist/ert/syndiesquad/leader
 	name = "Syndiesquad Specialist"
 	outfit = /datum/outfit/syndicate/syndiesquad
 	role = "Мастер-Специалист"
+	leader = TRUE // BLUEMOON CHANGE enabling greet "if" condition for ERT leaders
 
 /datum/antagonist/ert/create_team(datum/team/ert/new_team)
 	if(istype(new_team))
@@ -182,33 +186,38 @@
 	if(!ert_team)
 		return
 
-	to_chat(owner, "<B><font size=3 color=red>You are the [name].</font></B>")
-
-	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by Nanotrasen's Security Division."
+// BLUEMOON EDIT AHEAD - changing desc for beautiful structured box + localisation
+	var/missiondesc = ""
+	missiondesc += "<p class='medium'><B><font size=3 color=red>Вы – [name].</font></B><BR></p>\n"
+	missiondesc += "<p>Ваш отряд отправляется на объект \"[station_name()]\" Отделом Обеспечения Безопасности Nanotrasen.</p>"
+	missiondesc += "<p>Ваша роль в отряде: <font size=3 color=green><b>[role]</b></font></p>"
 	if(leader) //If Squad Leader
-		missiondesc += " Lead your squad to ensure the completion of the mission. Board the shuttle when your team is ready."
+		missiondesc += "<li>Командуйте вашим отрядом для успешного выполнения миссии. Погрузитесь в шаттл по готовности вашей команды.</li>"
 	else
-		missiondesc += " Follow orders given to you by your squad leader."
-
-		missiondesc += "Avoid civilian casualites when possible."
-
-	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
-	to_chat(owner,missiondesc)
+		missiondesc += "<li>Следуйте приказам, отданным лидером вашего отряда.</li>"
+	missiondesc += "\n<li>Избегайте жертв среди гражданских, когда это возможно.</li>"
+	missiondesc += "\n<li>Префиксы наушника <b>:y</b> и <b>:н</b> <font color='red'>отвечают за связь</font> через CentCom радиоканал <font color='red'>вашего отряда</font> и <font color='red'>вашего начальства</font>.</li>"
+	missiondesc += "<p><B>Ваша миссия</B>: [ert_team.mission.explanation_text]</p>"
+	to_chat(owner, examine_block(missiondesc))
+// BLUEMOON EDIT END
 
 /datum/antagonist/ert/deathsquad/greet()
 	if(!ert_team)
 		return
 
-	to_chat(owner, "<B><font size=3 color=red>You are the [name].</font></B>")
-
-	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by Nanotrasen's Security Division."
+// BLUEMOON EDIT AHEAD - changing desc for beautiful structured box + localisation
+	var/missiondesc = ""
+	missiondesc += "<p class='medium'><B><font size=3 color=red>Вы – [name].</font></B><BR></p>\n"
+	missiondesc += "<p>Ваш отряд отправляется на объект \"[station_name()]\" Отделом Специальных Операций Пакта.</p>"
+	missiondesc += "<p>Ваша роль в отряде: <font size=3 color=green><b>[role]</b></font></p>"
 	if(leader) //If Squad Leader
-		missiondesc += " Lead your squad to ensure the completion of the mission. Board the shuttle when your team is ready."
+		missiondesc += "<li>Командуйте вашим отрядом для успешного выполнения миссии. Погрузитесь в шаттл по готовности вашей команды.</li>"
 	else
-		missiondesc += " Follow orders given to you by your squad leader."
-
-	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
-	to_chat(owner,missiondesc)
+		missiondesc += "<li>Следуйте приказам, отданным лидером вашего отряда.</li>"
+	missiondesc += "\n<li>Префиксы наушника <b>:y</b> и <b>:н</b> <font color='red'>отвечают за связь</font> через CentCom радиоканал <font color='red'>вашего отряда</font> и <font color='red'>начальства</font>.</li>"
+	missiondesc += "<p><B>Ваша миссия</B>: [ert_team.mission.explanation_text]</p>"
+	to_chat(owner, examine_block(missiondesc))
+// BLUEMOON EDIT END
 
 /datum/antagonist/ert/families
 	name = "Space Police Responder"

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -12,23 +12,23 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 /proc/get_security_level()
 	switch(GLOB.security_level)
 		if(SEC_LEVEL_GREEN)
-			return "ЗЕЛЁНЫЙ"
+			return "<font color=#b2ff59>ЗЕЛЁНЫЙ</font>"
 		if(SEC_LEVEL_BLUE)
-			return "СИНИЙ"
+			return "<font color=#99ccff>СИНИЙ</font>"
 		if(SEC_LEVEL_ORANGE)
-			return "ОРАНЖЕВЫЙ"
+			return "<font color=fc7d15>ОРАНЖЕВЫЙ</font>"
 		if(SEC_LEVEL_VIOLET)
-			return "ФИОЛЕТОВЫЙ"
+			return "<font color=#a059fe>ФИОЛЕТОВЫЙ</font>"
 		if(SEC_LEVEL_AMBER)
-			return "ЯНТАРНЫЙ"
+			return "<font color=#ffae42>ЯНТАРНЫЙ</font>"
 		if(SEC_LEVEL_RED)
-			return "КРАСНЫЙ"
+			return "<font color=#ff3f34>КРАСНЫЙ</font>"
 		if(SEC_LEVEL_LAMBDA)
-			return "ЛЯМБДА"
+			return "<font color=#ffffff>ЛЯМБДА</font>"
 		if(SEC_LEVEL_EPSILON)
-			return "ЭПСИЛОН"
+			return "<font color=#ffffff>ЭПСИЛОН</font>"
 		if(SEC_LEVEL_DELTA)
-			return "ДЕЛЬТА"
+			return "<font color=purple>ДЕЛЬТА</font>"
 
 /*
   * All security levels, per ascending alert. Nothing too fancy, really.

--- a/modular_bluemoon/code/datums/ert.dm
+++ b/modular_bluemoon/code/datums/ert.dm
@@ -4,7 +4,7 @@
 	enforce_human = TRUE
 	rename_team = "NT Flametroopers Squad"
 	code = "Red"
-	mission = "Экипаж станции не справляется с активной биологической угрозой. Окажите соответствующую поддержку."
+	mission = "экипаж станции не справляется с активной биологической угрозой. Окажите соответствующую поддержку."
 	polldesc = "elite Nanotrasen Fire Team"
 	ertphrase = "modular_bluemoon/sound/ert/ert_firesquad_send.ogg"
 
@@ -13,7 +13,7 @@
 	leader_role = /datum/antagonist/ert/heavysquad/leader
 	rename_team = "NT Heavy Weapons Squad"
 	code = "Delta"
-	mission = "По имеющимся разведанным на станции присутствует особо опасный и тяжеловооруженный противник. Корпорация заинтересована в сохранении своих активов. Разберитесь с проблемой."
+	mission = "по имеющимся разведанным на станции присутствует особо опасный и тяжеловооруженный противник. Корпорация заинтересована в сохранении своих активов. Разберитесь с проблемой."
 	polldesc = "elite Nanotrasen Heavy Team"
 	ertphrase = "modular_bluemoon/sound/ert/ert_heavysquad_send.ogg"
 
@@ -22,7 +22,7 @@
 	leader_role = /datum/antagonist/ert/russian_ert/leader
 	rename_team = "Novaya Rossiyskaya Imperiya Spetsnaz Squad"
 	code = "Delta"
-	mission = "От одной из близлежащих космических станций получен сигнал о помощи. Мы связались с НТ и получили добро на вмешательство. Окажите поддержку."
+	mission = "от одной из близлежащих космических станций получен сигнал о помощи. Мы связались с НТ и получили добро на вмешательство. Окажите поддержку."
 	polldesc = "Novaya Rossiyskaya Imperiya Spetsnaz Squad"
 	ertphrase = "modular_bluemoon/sound/ert/nri_send.ogg"
 
@@ -31,7 +31,7 @@
 	leader_role = /datum/antagonist/ert/sol_ert/leader
 	rename_team = "Solar Federation Marine Squad"
 	code = "Delta"
-	mission = "НТ авторизовало интервенцию сил Солнечной Федерации на космическую станцию. Окажите помощь её экипажу."
+	mission = "Nanotrasen авторизовали интервенцию сил Солнечной Федерации на космическую станцию. Окажите помощь её экипажу."
 	polldesc = "Solar Federation Marine Squad"
 	ertphrase = "modular_bluemoon/sound/ert/sol_send.ogg"
 
@@ -40,7 +40,7 @@
 	leader_role = /datum/antagonist/ert/engineer_squadleader
 	rename_team = "Emergency Engineer Squad"
 	code = "Orange"
-	mission = "Окажите поддержку станции по части ремонтных работ."
+	mission = "окажите поддержку станции по части ремонтных работ."
 	polldesc = "Emergency Engineer Squad"
 	//ertphrase = "modular_bluemoon/sound/ert/sol_send.ogg"
 
@@ -49,7 +49,7 @@
 	leader_role = /datum/antagonist/ert/ntr_ert_leader
 	rename_team = "Internal Affairs Squad"
 	code = "Red"
-	mission = "Слушайтесь Представителя Корпорации. Окажите поддержку Представителю Корпорации в установлении порядка и верховенства права на станции."
+	mission = "слушайтесь Представителя Корпорации. Окажите поддержку Представителю Корпорации в установлении порядка и верховенства права на станции."
 	polldesc = "Internal Affairs Squad"
 	teamsize = 4
 	//ertphrase = "modular_bluemoon/sound/ert/sol_send.ogg"
@@ -59,7 +59,7 @@
 	leader_role = /datum/antagonist/ert/maid_leader
 	rename_team = "Elite maid Squad"
 	code = "Delta"
-	mission = "Наведите порядок на станции, если вы понимаете, что офицер ССО имел ввиду."
+	mission = "наведите порядок на станции, если вы понимаете, что офицер ССО имел ввиду."
 	polldesc = "Elite maid Squad"
 	teamsize = 5
 	//ertphrase = "modular_bluemoon/sound/ert/sol_send.ogg"
@@ -70,7 +70,7 @@
 	rename_team = "Zeal Team Squad"
 	polldesc = "Zeal Team Squad"
 	code = "Delta"
-	mission = "По имеющимся разведанным на станции присутствует особо опасный и тяжеловооруженный противник. Корпорация заинтересована в сохранении своих активов. Разберитесь с проблемой."
+	mission = "по имеющимся разведанным на станции присутствует особо опасный и тяжеловооруженный противник. Корпорация заинтересована в сохранении своих активов. Разберитесь с проблемой."
 	ertphrase = "modular_bluemoon/sound/ert/ert_heavysquad_send.ogg"
 
 /datum/ert/rabbit
@@ -79,7 +79,7 @@
 	teamsize = 6
 	opendoors = FALSE
 	rename_team = "Rabbit Team"
-	mission = "Устраните любые нарушения и/или отклонения от нормы на станции."
+	mission = "устраните любые нарушения и/или отклонения от нормы на станции."
 	polldesc = "a Rabbit Team"
 	code = "Orange"
 	ertphrase = 'modular_bluemoon/sound/ert/rabbit_protocol.ogg'
@@ -90,6 +90,6 @@
 	opendoors = TRUE
 	rename_team = "Tribunal Ordinator"
 	code = "Red"
-	mission = "Уничтожить все угрозы Активам Пакта."
+	mission = "уничтожить все угрозы Активам Пакта."
 	polldesc = "an Nanotrasen Tribunal Ordinator"
 	ertphrase = "modular_bluemoon/sound/ert/ert_tribunal.ogg"

--- a/modular_bluemoon/code/modules/antagonists/ert/ert.dm
+++ b/modular_bluemoon/code/modules/antagonists/ert/ert.dm
@@ -2,12 +2,14 @@
 	name = "Officer Tribunal Ordinator"
 	outfit = /datum/outfit/lfwb_ordinator/officer
 	role = "Офицер"
+	leader = TRUE
 
 /datum/antagonist/ert/lfwb_ordinator
 	name = "Tribunal Ordinator"
 	outfit = /datum/outfit/lfwb_ordinator
 	role = "Солдат"
 
+//////////////////////////////
 /datum/antagonist/ert/security/rabbit
 	role = "Specialist"
 	outfit = /datum/outfit/ert/security/rabbit
@@ -15,7 +17,9 @@
 /datum/antagonist/ert/commander/rabbit
 	role = "Lieutenant"
 	outfit = /datum/outfit/ert/commander/rabbit
+	leader = TRUE
 
+//////////////////////////////
 /datum/antagonist/ert/firesquad
 	name = "Firesquad Trooper"
 	outfit = /datum/outfit/ert/firesquad_trooper
@@ -25,21 +29,25 @@
 	name = "Firesquad Commander"
 	outfit = /datum/outfit/ert/firesquad_commander
 	role = "Командир"
+	leader = TRUE
+
 //////////////////////////////
 /datum/antagonist/ert/heavysquad
-	name = "Heavy Squad"
+	name = "Emergency Heavy Squad"
 	outfit = /datum/outfit/ert/heavysquad_trooper
 	role = "Пехотинец"
 
 /datum/antagonist/ert/heavysquad/machinegun
-	name = "Heavy Squad"
+	name = "Emergency Heavy Squad"
 	outfit = /datum/outfit/ert/heavysquad_machinegun
 	role = "Пулеметчик"
 
 /datum/antagonist/ert/heavysquad/leader
-	name = "Heavy Squad"
+	name = "Emergency Heavy Squad"
 	outfit = /datum/outfit/ert/heavysquad_commander
 	role = "Командир"
+	leader = TRUE
+
 ///////////////////////////
 /datum/antagonist/ert/zeal_team
 	name = "Zeal Team Squad"
@@ -50,6 +58,8 @@
 	name = "Zeal Team Squad"
 	outfit = /datum/outfit/zeal_team/officer
 	role = "Командир"
+	leader = TRUE
+
 ///////////////////////////
 /datum/antagonist/ert/russian_ert
 	name = "NRI Spetsnaz Squad"
@@ -65,6 +75,8 @@
 	name = "NRI Spetsnaz Squad"
 	outfit = /datum/outfit/ert/ert_russian_leader
 	role = "Полковник"
+	leader = TRUE
+
 /////////////////////////
 /datum/antagonist/ert/sol_ert
 	name = "SolFed Squad"
@@ -85,12 +97,15 @@
 	name = "SolFed Squad"
 	outfit = /datum/outfit/ert/sol_soldier_leader
 	role = "Капитан"
+	leader = TRUE
 
 /////////////////////////////////////////
 /datum/antagonist/ert/engineer_squadleader
 	role = "Бригадир"
 	outfit = /datum/outfit/ert/engineer/alert
 	skill_modifiers = list(/datum/skill_modifier/job/level/wiring)
+	leader = TRUE
+
 /////////////////////////////////////////
 /datum/antagonist/ert/ntr_ert_agent
 	name = "Internal Affairs Squad"
@@ -101,12 +116,14 @@
 	name = "Internal Affairs Squad"
 	outfit = /datum/outfit/ert/ntr_ert_leader
 	role = "Следователь"
+	leader = TRUE
 
 //////////////////////////////////////////
 /datum/antagonist/ert/maid_leader
 	name = "Maid Squad"
 	outfit = /datum/outfit/ert/maid_leader
 	role = "Старшая горничная"
+	leader = TRUE
 
 /datum/antagonist/ert/maid
 	name = "Maid Squad"


### PR DESCRIPTION
# Описание
1. ОБР ролям добавлено контекстное окно с информацией вместо нагромождения строк, как у экипажа по прилёту/спавну раундстарт на станции.
3. Эта информация была локализирована. От меня добавлена информация про канал ЦК в наушнике.
4. В ряде мест подправил капитализацию, где она мешала и исправил ряд локализаций.
5. Включил ролям-лидерам ОБР переменную leader для if условия описаний.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений
Огромный QoL срочникам и визуальная эстетика любителям ОБР ролей.

## Демонстрация изменений
[Тут](https://discord.com/channels/875735187449847830/1053678815714484384/1365524099589476394)
