### PR TITLE
Old FTU suppressor fix

### DIFF
--- a/modular_splurt/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_splurt/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -136,6 +136,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	automatic_burst_overlay = FALSE
 	spread = 8 //You are shooting a full power catraige from a light automatic rifle, what do you expect?
+	can_suppress = FALSE // BLUEMOON ADD fixing the sprite
 
 /obj/item/gun/ballistic/automatic/fal/nomag
 	spawnwithmagazine = FALSE


### PR DESCRIPTION
# Описание
Больше нельзя нацепить глушитель на Old FTU rifle (,308), чтобы не пропадал спрайт.

## Причина изменений
[Багрепорт](https://discord.com/channels/875735187449847830/1364954490477744128/1364954490477744128)

## Демонстрация изменений
Не нужно