### PR TITLE
Фикс декалей на турфе

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -46,5 +46,4 @@
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
-	var/turn_dir = 180 - dir2angle(T.dir) //Turning a dir by 0 results in a roulette of random dirs.
-	T.AddElement(/datum/element/decal, icon, icon_state, turn_dir ? turn(dir, turn_dir) : dir, CLEAN_GOD, color, null, null, alpha, FALSE)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, CLEAN_GOD, color, null, null, alpha, FALSE)


### PR DESCRIPTION
# Описание
1) фикс того, что декали поворачиваются за турфом при спавне

## Причина изменений
Фикс кривых декалей когда при маппинге всё окей