### PR TITLE
MedHud HP полоска не видна при 100% здоровья 

### DIFF
--- a/code/_rendering/atom_huds/data_huds.dm
+++ b/code/_rendering/atom_huds/data_huds.dm
@@ -108,7 +108,7 @@
 	var/resulthealth = (M.health / maxi_health) * 100
 	switch(resulthealth)
 		if(100 to INFINITY)
-			return "health100"
+			return
 		if(90.625 to 100)
 			return "health93.75"
 		if(84.375 to 90.625)


### PR DESCRIPTION
# Описание
Медхуд полоской ХП не показывается при условии 100% здоровья и выше.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений
Фильтрация ненужной интерфейсной информации медикам при условии, что они будут обращать внимание на раненых благодаря раздражающей зелёной полоске. Полностью здоровые же будут без неё вовсе.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/01480d64-c917-4099-b99b-9fdc7a629872)