### PR TITLE
Общие доступы изнутри сервисхолла Бокса

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -59284,6 +59284,7 @@
 	req_one_access_txt = "25;26;35;28";
 	name = "Service Hall"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "peG" = (
@@ -70414,6 +70415,9 @@
 /obj/machinery/door/airlock/service{
 	req_one_access_txt = "25;26;35;28";
 	name = "Service Hall"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6352,6 +6352,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "aCR" = (
@@ -53276,6 +53279,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone2)
 "lSa" = (
@@ -74416,6 +74420,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "xVK" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -65081,7 +65081,7 @@
 "lFY" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
-	req_access_txt = "19;32"
+	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
@@ -66748,7 +66748,7 @@
 "msv" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Area";
-	req_access_txt = "19; 61"
+	req_access_txt = "32"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
@@ -71549,7 +71549,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/engineering/atmos)
 "oCy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{

--- a/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
+++ b/_maps/map_files/SyndicateStation/SyndicateBoxStation.dmm
@@ -46215,6 +46215,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/medical/surgery)
 "drG" = (
@@ -62097,6 +62100,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/mineral/plastitanium,
 /area/medical/medbay/zone2)
 "oQp" = (
@@ -64352,6 +64356,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/medical/surgery)
 "qEm" = (
@@ -71207,6 +71214,9 @@
 	req_one_access_txt = "25;26;35;28";
 	name = "Service Hall"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/secondary/service)
 "vEM" = (
@@ -73427,6 +73437,7 @@
 	req_one_access_txt = "25;26;35;28";
 	name = "Service Hall"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/mineral/plastitanium,
 /area/hallway/secondary/service)
 "xkZ" = (


### PR DESCRIPTION
# Описание
- Добавлены флажки доступа изнутри комнаты для шлюзов, чтобы спавнящиеся раундстарт внутри игроки могли выйти из комнаты.
   - Хирургия и клонёрка тоже получили эти флажки, чтобы люди не застревали в комнатах.
- Гравген Меты теперь требует инженерные общие доступы. Для доступов инженеров к гравгену.

## Причина изменений
Люди спавнились, орали, плакали что их замуровали демоны, и писали атикеты.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/07c43d11-a670-4a81-8147-0c04c80eecec)