### PR TITLE
[BLUEMOON] Vote power difference

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(autotransfer)
 		return
 	SSticker.midround_record_check()
 	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
-		SSvote.initiate_vote("transfer","server", votesystem=APPROVAL_VOTING, vote_time = 1800)
+		SSvote.initiate_vote("transfer","server", votesystem=APPROVAL_VOTING, vote_time = 1800, UseVotePower = TRUE)
 		targettime = targettime + voteinterval
 		curvotes++
 	else

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -500,31 +500,35 @@ SUBSYSTEM_DEF(vote)
 	if(mode)
 		if(CONFIG_GET(flag/no_dead_vote) && usr.stat == DEAD && !usr.client.holder)
 			return FALSE
+		if(use_vote_power)
+			if(!users_vote_power[usr.ckey])
+				users_vote_power[usr.ckey] = get_vote_power_by_role(usr.client)
+			vote_power = users_vote_power[usr.ckey]
 		if(vote && ISINRANGE(vote, 1, choices.len))
 			switch(vote_system)
 				if(PLURALITY_VOTING)
 					if(usr.ckey in voted)
-						choices[choices[voted[usr.ckey]]]--
+						choices[choices[voted[usr.ckey]]] -= vote_power
 						voted[usr.ckey] = vote
-						choices[choices[vote]]++
+						choices[choices[vote]] += vote_power
 						return vote
 					else
 						voted += usr.ckey
 						voted[usr.ckey] = vote
-						choices[choices[vote]]++	//check this
+						choices[choices[vote]] += vote_power	//check this
 						return vote
 				if(APPROVAL_VOTING)
 					if(usr.ckey in voted)
 						if(vote in voted[usr.ckey])
 							voted[usr.ckey] -= vote
-							choices[choices[vote]]--
+							choices[choices[vote]] -= vote_power
 						else
 							voted[usr.ckey] += vote
-							choices[choices[vote]]++
+							choices[choices[vote]] += vote_power
 					else
 						voted += usr.ckey
 						voted[usr.ckey] = list(vote)
-						choices[choices[vote]]++
+						choices[choices[vote]] += vote_power
 						return vote
 				if(SCHULZE_VOTING,INSTANT_RUNOFF_VOTING)
 					if(usr.ckey in voted)

--- a/modular_bluemoon/code/controllers/subsystem/vote.dm
+++ b/modular_bluemoon/code/controllers/subsystem/vote.dm
@@ -39,6 +39,9 @@
 	//Antags control the story of the round, they should be able to delay evac in order to enact their
 	//fun and interesting plans
 	if(is_special_character(M))
+		//all ghost roles are considered as antags for some reason.
+		if(M.mind?.has_antag_datum(/datum/antagonist/ghost_role))
+			return VOTE_WEIGHT_NORMAL
 		return VOTE_WEIGHT_HIGH
 
 	//How long has this player been alive

--- a/modular_bluemoon/code/controllers/subsystem/vote.dm
+++ b/modular_bluemoon/code/controllers/subsystem/vote.dm
@@ -29,8 +29,8 @@
 	if(!istype(C))
 		return VOTE_WEIGHT_NONE //Shouldnt be possible, but safety
 
-	// if(C.holder) //is admin
-	// 	return VOTE_WEIGHT_NORMAL
+	if(C.holder) //is admin
+		return VOTE_WEIGHT_NORMAL
 
 	var/mob/M = C.mob
 	if(!M || M.stat == DEAD || isobserver(M) || isnewplayer(M) || ismouse(M) || isdrone(M))

--- a/modular_bluemoon/code/controllers/subsystem/vote.dm
+++ b/modular_bluemoon/code/controllers/subsystem/vote.dm
@@ -1,0 +1,63 @@
+#define VOTE_WEIGHT_NONE   0
+#define VOTE_WEIGHT_LOW    0.5
+#define VOTE_WEIGHT_NORMAL 1
+#define VOTE_WEIGHT_HIGH   2
+
+/datum/controller/subsystem/vote
+	/**
+	 * Players' power during votes is determined on their role: mob, antag or ghost.
+	 * Right now it is working only with PLURALITY_VOTING and APPROVAL_VOTING.
+	 * 										And only during autotransfer vote.
+	 *  */
+	var/use_vote_power = FALSE
+	var/vote_power = VOTE_WEIGHT_NORMAL
+	/**
+	 * Users' ckeys and their current vote power will be stored here to prevent messing with vote powers when user is ghosting or changing roles.
+	 * Resets every vote reset.
+	 *  */
+	var/list/users_vote_power = list()
+
+/datum/controller/subsystem/vote/initiate_vote(vote_type, initiator_key, display, votesystem, forced, vote_time, UseVotePower = FALSE)
+	use_vote_power = UseVotePower
+	. = ..()
+
+/datum/controller/subsystem/vote/reset()
+	. = ..()
+	vote_power = initial(vote_power)
+	users_vote_power = list()
+
+/datum/controller/subsystem/vote/proc/get_vote_power_by_role(client/C) //taken from TauCetiClassic
+	if(!istype(C))
+		return VOTE_WEIGHT_NONE //Shouldnt be possible, but safety
+
+	// if(C.holder) //is admin
+	// 	return VOTE_WEIGHT_NORMAL
+
+	var/mob/M = C.mob
+	if(!M || M.stat == DEAD || isobserver(M) || isnewplayer(M) || ismouse(M) || isdrone(M))
+		return VOTE_WEIGHT_LOW
+
+	//Antags control the story of the round, they should be able to delay evac in order to enact their
+	//fun and interesting plans
+	if(is_special_character(M))
+		return VOTE_WEIGHT_HIGH
+
+	//How long has this player been alive
+	//This comes after the antag check because that's more important
+	// var/lifetime = world.time - M.mind.creation_time
+	// if(lifetime <= MINIMUM_VOTE_LIFETIME)
+	// 	//If you just spawned for the vote, your weight is still low
+	// 	return VOTE_WEIGHT_LOW
+
+	//Heads of staff are in a better position to understand the state of the ship and round,
+	//their vote is more important.
+	//This is after the lifetime check to prevent exploits of instaspawning as a head when a vote is called
+	if(M.mind?.assigned_role in GLOB.command_positions)
+		return VOTE_WEIGHT_HIGH
+
+	return VOTE_WEIGHT_NORMAL
+
+#undef VOTE_WEIGHT_NONE
+#undef VOTE_WEIGHT_LOW
+#undef VOTE_WEIGHT_NORMAL
+#undef VOTE_WEIGHT_HIGH

--- a/modular_bluemoon/code/controllers/subsystem/vote.dm
+++ b/modular_bluemoon/code/controllers/subsystem/vote.dm
@@ -7,7 +7,6 @@
 	/**
 	 * Players' power during votes is determined on their role: mob, antag or ghost.
 	 * Right now it is working only with PLURALITY_VOTING and APPROVAL_VOTING.
-	 * 										And only during autotransfer vote.
 	 *  */
 	var/use_vote_power = FALSE
 	var/vote_power = VOTE_WEIGHT_NORMAL

--- a/modular_bluemoon/code/controllers/subsystem/vote.dm
+++ b/modular_bluemoon/code/controllers/subsystem/vote.dm
@@ -2,6 +2,7 @@
 #define VOTE_WEIGHT_LOW    0.5
 #define VOTE_WEIGHT_NORMAL 1
 #define VOTE_WEIGHT_HIGH   2
+#define MINIMUM_VOTE_LIFETIME 5 MINUTES
 
 /datum/controller/subsystem/vote
 	/**
@@ -36,6 +37,10 @@
 	if(!M || M.stat == DEAD || isobserver(M) || isnewplayer(M) || ismouse(M) || isdrone(M))
 		return VOTE_WEIGHT_LOW
 
+	if((world.time - M.creation_time) <= MINIMUM_VOTE_LIFETIME)
+		//If you just spawned for the vote, your weight is still low
+		return VOTE_WEIGHT_LOW
+
 	//Antags control the story of the round, they should be able to delay evac in order to enact their
 	//fun and interesting plans
 	if(is_special_character(M))
@@ -63,3 +68,4 @@
 #undef VOTE_WEIGHT_LOW
 #undef VOTE_WEIGHT_NORMAL
 #undef VOTE_WEIGHT_HIGH
+#undef MINIMUM_VOTE_LIFETIME

--- a/modular_bluemoon/code/modules/mob/mob.dm
+++ b/modular_bluemoon/code/modules/mob/mob.dm
@@ -1,0 +1,6 @@
+/mob
+	var/creation_time = 0
+
+/mob/Initialize()
+	. = ..()
+	creation_time = world.time

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4449,6 +4449,7 @@
 #include "modular_bluemoon\code\modules\mining\equipment\survival_pod.dm"
 #include "modular_bluemoon\code\modules\mob\emotes.dm"
 #include "modular_bluemoon\code\modules\mob\living.dm"
+#include "modular_bluemoon\code\modules\mob\mob.dm"
 #include "modular_bluemoon\code\modules\mob\mob_defines.dm"
 #include "modular_bluemoon\code\modules\mob\say.dm"
 #include "modular_bluemoon\code\modules\mob\say_vr.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4210,6 +4210,7 @@
 #include "modular_bluemoon\code\controllers\subsystem\player_ranks\_player_rank_controller.dm"
 #include "modular_bluemoon\code\controllers\subsystem\player_ranks\mentor_controller.dm"
 #include "modular_bluemoon\code\controllers\subsystem\player_ranks\player_ranks.dm"
+#include "modular_bluemoon\code\controllers\subsystem\vote.dm"
 #include "modular_bluemoon\code\datums\action.dm"
 #include "modular_bluemoon\code\datums\bark.dm"
 #include "modular_bluemoon\code\datums\dna.dm"


### PR DESCRIPTION
Добавлена система веса у игроков в голосованиях в зависимости от роли игрока в раунде. Взято с [TauCeti](https://github.com/TauCetiStation/TauCetiClassic) + адаптированно.
0.5 - Призраки (+ мертвецы, мышки, микродрончики, недавно появившиеся персонажи)
1 - Обычные игроки
2 - Антаги и главы
Работает на PLURALITY_VOTING (выбор одного) и APPROVAL_VOTING (мультивыборка).
Пока что включено только на автоголосовалку для вызова шаттла.

Тестмерж обязателен.