### PR TITLE
Portallight in loadout and replacetext update

### DIFF
--- a/modular_bluemoon/code/modules/client/loadout/backpack.dm
+++ b/modular_bluemoon/code/modules/client/loadout/backpack.dm
@@ -41,6 +41,11 @@
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS
 
 /datum/gear/backpack/portallight
+	name = "Портальный Фонарик"
+	path = /obj/item/portallight
+	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS
+
+/datum/gear/backpack/portallight_box
 	name = "Portal Fleshlight and Underwear"
 	path = /obj/item/storage/box/portallight
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_TOYS

--- a/modular_sand/code/game/objects/items/fleshlight.dm
+++ b/modular_sand/code/game/objects/items/fleshlight.dm
@@ -726,8 +726,10 @@
 	
 	if (targetting == CUM_TARGET_MOUTH)
 		name = replacetext(name, "Трусики", "Маска")
+		name = replacetext(name, "Портальные", "Портальная")
 	else
 		name = replacetext(name, "Маска", "Трусики")
+		name = replacetext(name, "Портальная", "Портальные")
 
 	to_chat(user, "<span class='notice'>Теперь при надевании портал будет обращен к вашему [targetting].</span>")
 	update_portal()

--- a/modular_sand/code/game/objects/items/fleshlight.dm
+++ b/modular_sand/code/game/objects/items/fleshlight.dm
@@ -638,7 +638,11 @@
 			if(CUM_TARGET_URETHRA)
 				organ = mutable_appearance('modular_sand/icons/obj/fleshlight.dmi', "portal_anus") // i refuse to even attempt spriting this, have a placeholder
 				organ.color = G.color
-		name = portalunderwear.targetting == CUM_TARGET_PENIS ? "Портальный Дилдо" : "Портальный Фонарик"
+
+		if (portalunderwear.targetting == CUM_TARGET_PENIS)
+			name = replacetext(name, "Фонарик", "Дилдо")
+		else
+			name = replacetext(name, "Дилдо", "Фонарик")
 
 		useable = TRUE
 		add_overlay(organ)
@@ -719,7 +723,11 @@
 	slot_flags         = targetting == CUM_TARGET_MOUTH ? ITEM_SLOT_MASK  : ITEM_SLOT_UNDERWEAR
 	flags_cover        = targetting == CUM_TARGET_MOUTH ? MASKCOVERSMOUTH : NONE
 	visor_flags_cover  = targetting == CUM_TARGET_MOUTH ? MASKCOVERSMOUTH : NONE
-	name               = targetting == CUM_TARGET_MOUTH ? "Портальная Маска"   : "Портальные Трусики"
+	
+	if (targetting == CUM_TARGET_MOUTH)
+		name = replacetext(name, "Трусики", "Маска")
+	else
+		name = replacetext(name, "Маска", "Трусики")
 
 	to_chat(user, "<span class='notice'>Теперь при надевании портал будет обращен к вашему [targetting].</span>")
 	update_portal()

--- a/modular_splurt/code/modules/client/loadout/donator/first_tier.dm
+++ b/modular_splurt/code/modules/client/loadout/donator/first_tier.dm
@@ -1,5 +1,5 @@
 //Misc
-/datum/gear/donator/portallight
+/datum/gear/donator/portallight_box
 	name = "Portal Fleshlight and Underwear"
 	path = /obj/item/storage/box/portallight
 	ckeywhitelist = list()


### PR DESCRIPTION
# Описание

Вместо полной замены имени у портального фонарика/дилдо и трусиков/маски теперь используется функция replacetext()
Портальный фонарик добавлен в общий лодаут.

Все, что мне только пришло в голову, проверено на локальном сервере.

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->
![image](https://github.com/user-attachments/assets/786b38a8-ede7-40b3-bd09-b09a169c771a)

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
