### PR TITLE
Ещё больше улучшений призываемого

### DIFF
--- a/modular_bluemoon/code/game/objects/items/summon_chalk.dm
+++ b/modular_bluemoon/code/game/objects/items/summon_chalk.dm
@@ -185,6 +185,7 @@
 		if(istype(target.head, /obj/item/clothing/head/mod))
 			modsuit.conceal(target, target.head)
 		target.transferItemToLoc(modsuit, src, TRUE)
+
 	if(target.back && istype(target.back, /obj/item/storage))
 		target.transferItemToLoc(target.back, src, TRUE)
 	if(target.belt && istype(target.belt, /obj/item/storage))
@@ -200,11 +201,7 @@
 		modsuit.conceal(target, target.gloves)
 		if(istype(target.head, /obj/item/clothing/head/mod))
 			modsuit.conceal(target, target.head)
-		target.dropItemToGround(modsuit, TRUE)
-	if(target.back && istype(target.back, /obj/item/storage))
-		target.dropItemToGround(target.back, TRUE)
-	if(target.belt && istype(target.belt, /obj/item/storage))
-		target.dropItemToGround(target.belt, TRUE)
+
 	for(var/obj/item/I in target.contents)
 		if(I in listed_items)
 			listed_items -= I

--- a/modular_bluemoon/code/game/objects/items/summon_chalk.dm
+++ b/modular_bluemoon/code/game/objects/items/summon_chalk.dm
@@ -86,7 +86,11 @@
 			return
 
 	to_chat(M, span_lewd("Something is happening!"))
-	var/old_pos = target.loc
+	var/old_pos = get_turf(target)
+	if(istype(get_area(target), /area/hilbertshotel)) // Отель сворачивается когда в нём нету людей = телепортация в космос = плохо
+		var/area/hilbertshotel/Hhotel = get_area(target)
+		if(Hhotel.parentSphere)
+			old_pos = get_turf(Hhotel.parentSphere)
 	var/summon_nickname = "unus ex satellitibus tuis"
 	if(M.client.prefs.summon_nickname)
 		summon_nickname = M.client.prefs.summon_nickname


### PR DESCRIPTION
# Описание
1) призываемый, призванный из инфинити отеля возвращается в турф где находится сфера отеля, вместо отправки в космос сколько в момент покидания последнего персонажа из комнаты, та сворачивается
2) призываемый теперь не раздевается автоматически при телепортации, а вместо этого его пояс и рюкзак прячутся в руну, а остальные предметы помечаются, и при возврате персонажа при помощи руны возврата, с того снимаются все вещи, которые не были на нём до телепортации и вместе с тем все вещи, которые были с ним до телепортации оказываются у того под ногами вместе с рюкзаком и поясом.

## Причина изменений
Багфиксы и дополнительные фичи для взаимодействия и отыгрыша