### PR TITLE
швейцарский нож в лодаут

### DIFF
--- a/modular_bluemoon/code/modules/client/loadout/backpack.dm
+++ b/modular_bluemoon/code/modules/client/loadout/backpack.dm
@@ -137,3 +137,8 @@
 	name = "NRI poster"
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_GENERAL
 	path = /obj/item/poster/nri
+
+/datum/gear/backpack/armyknife
+	name = "Army Multitool"
+	path = /obj/item/armyknife
+	cost = 3

--- a/modular_bluemoon/krashly/code/game/objects/items/item.dm
+++ b/modular_bluemoon/krashly/code/game/objects/items/item.dm
@@ -318,11 +318,3 @@
 	ckeywhitelist = list("trollandrew")
 	subcategory = LOADOUT_SUBCATEGORIES_DON02
 	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION
-
-/datum/gear/donator/bm/armyknife
-	name = "Army Knife"
-	slot = ITEM_SLOT_BACKPACK
-	path = /obj/item/armyknife
-	ckeywhitelist = list("trollandrew")
-	subcategory = LOADOUT_SUBCATEGORIES_DON02
-	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION


### PR DESCRIPTION
# Описание
1) добавлен швейцарский нож в лодаут (нож, отвёртка, кусачки (медленнее на 10% чем обычные инструменты)) за 3 поинта (его можно раундстарт скрафтить на автолате) 
2) убран личный донатерский лодаут со швейцарским ножом 
## Причина изменений
прикольная штука, чья цена всего 300 см3 железа и пластика