### PR TITLE
[BLUEMOON] Фикс одежды с замком

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -444,28 +444,39 @@
 						return
 
 					strippable_item.finish_equip(owner, held_item, user)
-			else if (strippable_item.try_unequip(owner, user))
-				LAZYORASSOCLIST(interactions, user, key)
+			else
+				//stripper is trying to use item in his hand on owner's worn item, directly, as it is still on owner.
+				//only certain items can be interacted with while being worn by owner: set "interactable_in_strip_menu" flag.
+				//if held item has been used on worn item we just cancel stripping process.
+				if(istype(item, /obj/item) && ismob(owner))
+					var/obj/item/selected_item = item
+					var/obj/item/held_item = user.get_active_held_item()
+					if(istype(held_item))
+						if(selected_item.use_item_on_strippable(user, owner, held_item))
+							return
 
-				var/should_unequip = strippable_item.start_unequip(owner, user)
+				if (strippable_item.try_unequip(owner, user))
+					LAZYORASSOCLIST(interactions, user, key)
 
-				LAZYREMOVEASSOC(interactions, user, key)
+					var/should_unequip = strippable_item.start_unequip(owner, user)
 
-				// Yielding call
-				if (!should_unequip)
-					return
+					LAZYREMOVEASSOC(interactions, user, key)
 
-				if (QDELETED(src) || QDELETED(owner))
-					return
+					// Yielding call
+					if (!should_unequip)
+						return
 
-				// They changed the item in the meantime
-				if (strippable_item.get_item(owner) != item)
-					return
+					if (QDELETED(src) || QDELETED(owner))
+						return
 
-				if (!user.Adjacent(owner))
-					return
+					// They changed the item in the meantime
+					if (strippable_item.get_item(owner) != item)
+						return
 
-				strippable_item.finish_unequip(owner, user)
+					if (!user.Adjacent(owner))
+						return
+
+					strippable_item.finish_unequip(owner, user)
 		if ("alt")
 			var/key = params["key"]
 			var/datum/strippable_item/strippable_item = strippable.items[key]

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -220,9 +220,13 @@
 		if(lock != FALSE)
 			to_chat(user, "<span class='warning'>With a click the collar unlocks!</span>")
 			lock = FALSE
+			if(HAS_TRAIT(src, TRAIT_NODROP))
+				REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 		else
 			to_chat(user, "<span class='warning'>With a click the collar locks!</span>")
 			lock = TRUE
+			if(current_equipped_slot == ITEM_SLOT_NECK)
+				ADD_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 	return
 
 /obj/item/clothing/neck/petcollar/locked/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)

--- a/modular_bluemoon/code/game/objects/items.dm
+++ b/modular_bluemoon/code/game/objects/items.dm
@@ -17,6 +17,5 @@
 	owner.visible_message(
 			span_warning("[stripper] is using [held_item] on [owner]'s [name]."),
 			span_userdanger("[stripper] is using [held_item] on your [name]."),
-			ignored_mobs = stripper,
 		)
 	attackby(held_item, owner) //WARNING! We pretend wearer is using item to prevent errors. We adjust this proc to already existing mechanics.

--- a/modular_bluemoon/code/game/objects/items.dm
+++ b/modular_bluemoon/code/game/objects/items.dm
@@ -1,0 +1,22 @@
+/obj/item
+	var/interactable_in_strip_menu = FALSE
+
+/**
+ * This proc is called when mob (stripper) opens other's mob invetory menu (owner), then selects a worn item to be unequipped,
+ * but instead of beginning unequipping selected item, stripper tries to use his in hand item on seleted item.
+ * Only certain items can be interacted with while being worn by owner: set "interactable_in_strip_menu" flag.
+ * Proc returns TRUE if held item can and will be used on worn item (attackby()).
+ */
+/obj/item/proc/use_item_on_strippable(mob/stripper, mob/owner, obj/item/held_item)
+	. = TRUE
+	if(!istype(held_item))
+		return FALSE
+	if(!interactable_in_strip_menu)
+		// to_chat(stripper, span_warning("Selected item can not be interacted by in hand items while being worn."))
+		return FALSE
+	owner.visible_message(
+			span_warning("[stripper] is using [held_item] on [owner]'s [name]."),
+			span_userdanger("[stripper] is using [held_item] on your [name]."),
+			ignored_mobs = stripper,
+		)
+	attackby(held_item, owner) //WARNING! We pretend wearer is using item to prevent errors. We adjust this proc to already existing mechanics.

--- a/modular_bluemoon/code/game/objects/items/fleshlight.dm
+++ b/modular_bluemoon/code/game/objects/items/fleshlight.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_EMPTY(fleshlight_portallight)
 	var/seamless = FALSE 		// Закрытие трусиков на латексный ключ
 	var/free_use = FALSE 		// Общий доступ для использования
 	var/last_free_use_change	// Последнее изменение общего доступа у трусиков
+	interactable_in_strip_menu = TRUE
 
 /mob/living/carbon/human
 	var/fleshlight_nickname //Используется для анонимизации персонажа
@@ -132,7 +133,7 @@ GLOBAL_LIST_EMPTY(fleshlight_portallight)
 /obj/item/clothing/underwear/briefs/panties/portalpanties/attack_hand(mob/user)
 	if(!ishuman(user))
 		return ..()
-	if(seamless && (user.get_item_by_slot(ITEM_SLOT_UNDERWEAR) == src))
+	if(seamless && (user.get_item_by_slot(ITEM_SLOT_UNDERWEAR) == src || user.get_item_by_slot(ITEM_SLOT_MASK) == src))
 		to_chat(user, span_purple(pick("You pull your panties as you search for some sort of escape.",
 									"You can't find any leverage to remove these panties!",
 									"Your pointless clawing seems to only make things more skin tight")))
@@ -146,7 +147,17 @@ GLOBAL_LIST_EMPTY(fleshlight_portallight)
 	if(istype(K, /obj/item/key/latex))
 		seamless = !seamless
 		to_chat(user, span_warning("The panties suddenly [seamless ? "tighten" : "loosen"]!"))
+		if(HAS_TRAIT(src, TRAIT_NODROP))
+			REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
+		else if(current_equipped_slot == ITEM_SLOT_UNDERWEAR || current_equipped_slot == ITEM_SLOT_MASK)
+			ADD_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 	return ..()
+
+/obj/item/clothing/underwear/briefs/panties/portalpanties/equipped(mob/user, slot)
+	. = ..()
+	if(seamless)
+		if(slot == ITEM_SLOT_UNDERWEAR || slot == ITEM_SLOT_MASK)
+			ADD_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 
 // Приватный режим с переключением на AltClick
 /obj/item/clothing/underwear/briefs/panties/portalpanties/verb/free_use()

--- a/modular_bluemoon/code/modules/clothing/neck/_neck.dm
+++ b/modular_bluemoon/code/modules/clothing/neck/_neck.dm
@@ -72,3 +72,12 @@
 	if((current_equipped_slot == ITEM_SLOT_NECK) && (type in list(/obj/item/clothing/neck/petcollar, /obj/item/clothing/neck/petcollar/locked, /obj/item/clothing/neck/necklace/cowbell)))
 		var/mob/living/carbon/human/H = user
 		UnregisterSignal(H, COMSIG_MOVABLE_MOVED)
+
+/obj/item/clothing/neck/petcollar/locked
+	interactable_in_strip_menu = TRUE
+
+/obj/item/clothing/neck/petcollar/locked/equipped(mob/user, slot)
+	. = ..()
+	if(lock)
+		if(slot == ITEM_SLOT_NECK)
+			ADD_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)

--- a/modular_sand/code/game/objects/items/fleshlight.dm
+++ b/modular_sand/code/game/objects/items/fleshlight.dm
@@ -725,6 +725,7 @@
 	else
 		. += "<span class='notice'>Устройство сопряжено и ожидает использования по прямому назначению. Количество сопряженных устройств: <b>[portallight.len]</b>.</span>"
 	. += "<span class='notice'>Публичный доступ к устройству <b>[free_use ? "включен" : "отключен"]</b>. (Alt+Click для смены режима)</span>"
+	. += span_notice("Использование \"Latex Adjustment Override\" переключает возможность снятия предмета.")
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/attackby(obj/item/I, mob/living/user) //pairing
 	if(istype(I, /obj/item/portallight))

--- a/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/chastity/chastity_belt.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/chastity/chastity_belt.dm
@@ -7,7 +7,7 @@
 	var/obj/item/genital_equipment/chastity_cage/belt
 	var/obj/item/organ/genital/bepis
 	var/break_require = TOOL_WIRECUTTER //Which tool is required to break the chastity_cage
-	var/break_time = 25 SECONDS
+	interactable_in_strip_menu = TRUE
 
 /obj/item/clothing/underwear/chastity_belt/Initialize(mapload, obj/item/genital_equipment/chastity_cage/initial_belt)
 	if(initial_belt)
@@ -33,28 +33,23 @@
 			belt.belt = src
 			belt.forceMove(src)
 
-	if(belt && loc == user && current_equipped_slot && current_equipped_slot != ITEM_SLOT_HANDS)
+	if(belt && loc == user && current_equipped_slot == ITEM_SLOT_UNDERWEAR)
 		if(current_equipped_slot in user.check_obscured_slots())
 			to_chat(user, "<span class='warning'>You are unable to unequip that while wearing other garments over it!</span>")
 			return FALSE
 		//var/mob/living/carbon/human/H = istype(G) ? G.owner : G["wearer"]
-		var/obj/item/I = user.get_active_held_item()
-		if(!I)
-			to_chat(user, "<span class='warning'>You need \a [break_require] or its key to take it off!</span>")
-			return FALSE
-		if(I == belt.key)
-			to_chat(user, "<span class='warning'>You wield \the [I.name] and unlock the belt!</span>")
+		if(W == belt.key)
+			to_chat(user, "<span class='warning'>You wield \the [W.name] and unlock the belt!</span>")
+			REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 			src.dropped(user)
 			user.dropItemToGround(src)
-		else if(break_require == TOOL_WIRECUTTER && I.tool_behaviour == break_require)
-			if(!do_mob(user, src, break_time))
-				return FALSE
-			else
-				to_chat(user, "<span class='warning'>You manage to break \the [src] with \the [I.name]!</span>")
-				src.dropped(user)
-				qdel(src)
+		else if(W.tool_behaviour == break_require)
+			to_chat(user, "<span class='warning'>You manage to break \the [src] with \the [W.name]!</span>")
+			REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
+			src.dropped(user)
+			qdel(src)
 		else
-			to_chat(user, "<span class='warning'>You can't take it off with \the [I.name]</span>")
+			to_chat(user, "<span class='warning'>You can't take it off with \the [W.name]</span>")
 			return FALSE
 	. = ..()
 
@@ -111,6 +106,7 @@
 	if(belt)
 		belt.item_inserted(belt, bepis, null)
 		belt.equipment.holder_genital = bepis
+	ADD_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 	. = ..()
 
 /obj/item/clothing/underwear/chastity_belt/dropped(mob/user)
@@ -153,6 +149,8 @@
 		to_chat(user, "<span class='warning'>You need \a [break_require] or its key to take it off!</span>")
 		return FALSE
 	. = ..()
+
+/obj/item/clothing/underwear/chastity_belt/MouseDrop(atom/over_object)
 
 /obj/item/clothing/underwear/chastity_belt/proc/handle_cage_dropping(datum/source, obj/item/organ/genital/G, mob/user)
 	. = TRUE

--- a/modular_splurt/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_splurt/code/modules/mob/living/carbon/carbon.dm
@@ -51,7 +51,7 @@
 			user_disrobed = TRUE
 
 			// Drop the target item
-			dropItemToGround(item_worn, TRUE)
+			dropItemToGround(item_worn, FALSE)
 
 			// Throw item to a random spot
 			if(throw_clothes)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4269,6 +4269,7 @@
 #include "modular_bluemoon\code\game\objects\effects\decals\cleanable\misc.dm"
 #include "modular_bluemoon\code\game\objects\effects\spawners\lootdrop.dm"
 #include "modular_bluemoon\code\game\objects\effects\temporary_visuals\miscellaneous.dm"
+#include "modular_bluemoon\code\game\objects\items.dm"
 #include "modular_bluemoon\code\game\objects\items\ashtray.dm"
 #include "modular_bluemoon\code\game\objects\items\cards_ids.dm"
 #include "modular_bluemoon\code\game\objects\items\cooling_device.dm"


### PR DESCRIPTION
- Одежда, закрывающаяся на замок, могла быть снята другими игроками через интеракривное меню снимания предметов, а также через срыв одежды с помощью панельки. Теперь эта одежда имеет статус NO_DROP, закрывающий данную проблему.
- Была разработана механика применения предметов к избранной одежде, которую носит другой игрок, чтобы, например, открывать ключом замок на одежде другого игрока.
- На данный момент механ и данная правка касаются только: ошейника к замком, портальных трусов, пояса верности. Также ошейник и трусы можно закрывать заранее перед надеванием на игрока, после экипирования предмета замок закроется.

Тестмерж обязателен.