### PR TITLE
headpat hater icon QOL

### DIFF
--- a/modular_splurt/code/datums/traits/neutral_quirks/headpat_hater.dm
+++ b/modular_splurt/code/datums/traits/neutral_quirks/headpat_hater.dm
@@ -37,10 +37,10 @@
 	if(HAS_TRAIT(action_owner, TRAIT_DISTANT))
 		REMOVE_TRAIT(action_owner, TRAIT_DISTANT, ROUNDSTART_TRAIT)
 		to_chat(action_owner, span_notice("You let your headpat-guard down!"))
-		button_icon_state = "pain_medium"
+		button_icon_state = "pain_medium" // BLUEMOON ADD
 	else
 		ADD_TRAIT(action_owner, TRAIT_DISTANT, ROUNDSTART_TRAIT)
 		to_chat(action_owner, span_warning("You let your headpat-guard up!"))
-		button_icon_state = "pain_max"
+		button_icon_state = "pain_max" // BLUEMOON ADD
 
-	UpdateButtons()
+	UpdateButtons() // BLUEMOON ADD

--- a/modular_splurt/code/datums/traits/neutral_quirks/headpat_hater.dm
+++ b/modular_splurt/code/datums/traits/neutral_quirks/headpat_hater.dm
@@ -37,6 +37,10 @@
 	if(HAS_TRAIT(action_owner, TRAIT_DISTANT))
 		REMOVE_TRAIT(action_owner, TRAIT_DISTANT, ROUNDSTART_TRAIT)
 		to_chat(action_owner, span_notice("You let your headpat-guard down!"))
+		button_icon_state = "pain_medium"
 	else
 		ADD_TRAIT(action_owner, TRAIT_DISTANT, ROUNDSTART_TRAIT)
 		to_chat(action_owner, span_warning("You let your headpat-guard up!"))
+		button_icon_state = "pain_max"
+
+	UpdateButtons()


### PR DESCRIPTION
# Описание
Иконка теперь будет меняться на другую при активации, что бы сразу видеть активность квирка, не шифткликая и не активируя повторно.
<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере

