### PR TITLE
Исправление категории флаффа 1DarkWater1

### DIFF
--- a/modular_bluemoon/fluffs/code/donator.dm
+++ b/modular_bluemoon/fluffs/code/donator.dm
@@ -1635,14 +1635,14 @@
 	name = "Inlaid Data Dress"
 	slot = ITEM_SLOT_ICLOTHING
 	path = /obj/item/clothing/under/donator/bm/inlaid_data_dress
-	category = LOADOUT_SUBCATEGORIES_DON01
+	subcategory = LOADOUT_SUBCATEGORIES_DON01
 	ckeywhitelist = list("1darkwater1")
 
 /datum/gear/donator/bm/hair_module
 	name = "Hair Module"
 	slot = ITEM_SLOT_MASK
 	path = /obj/item/clothing/mask/gas/hair_module
-	category = LOADOUT_SUBCATEGORIES_DON01
+	subcategory = LOADOUT_SUBCATEGORIES_DON01
 	ckeywhitelist = list("1darkwater1")
 
 /datum/gear/donator/bm/aviator_helmet


### PR DESCRIPTION
# Описание

Заменено category на subcategory

## Причина изменений

Вместо subcategory было category у датума флафф предметов, из за чего их не было в игре

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
