### PR TITLE
Полировка MOD + трейт священнику

### DIFF
--- a/code/modules/jobs/job_types/service/chaplain.dm
+++ b/code/modules/jobs/job_types/service/chaplain.dm
@@ -38,6 +38,7 @@
 	. = ..()
 	if(H.mind)
 		H.mind.isholy = TRUE
+		ADD_TRAIT(H.mind, TRAIT_ANTIMAGIC_NO_SELFBLOCK, JOB_TRAIT) // BLUEMOON ADD trait system
 
 	var/obj/item/storage/book/bible/booze/B = new
 

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -596,7 +596,7 @@
 		A small tag hangs off of it reading; 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
 		All rights reserved, tampering with suit will void warranty."
 	default_skin = "syndicate"
-	armor = list(MELEE = 40, BULLET = 50, LASER = 30, ENERGY = 15, BOMB = 35, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 15, BULLET = 20, LASER = 15"
+	armor = list(MELEE = 30, BULLET = 40, LASER = 25, ENERGY = 15, BOMB = 30, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 15, BULLET = 20, LASER = 15"
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_inactive = 1
@@ -639,7 +639,7 @@
 		'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
 		All rights reserved, tampering with suit will void life expectancy.'"
 	default_skin = "elite"
-	armor = list(MELEE = 60, BULLET = 60, LASER = 50, ENERGY = 35, BOMB = 55, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 35, BULLET = 30, LASER = 35"
+	armor = list(MELEE = 50, BULLET = 50, LASER = 35, ENERGY = 30, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 35, BULLET = 30, LASER = 35"
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -596,7 +596,7 @@
 		A small tag hangs off of it reading; 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
 		All rights reserved, tampering with suit will void warranty."
 	default_skin = "syndicate"
-	armor = list(MELEE = 30, BULLET = 40, LASER = 25, ENERGY = 15, BOMB = 30, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 15, BULLET = 20, LASER = 15"
+	armor = list(MELEE = 25, BULLET = 35, LASER = 25, ENERGY = 15, BOMB = 30, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 15, BULLET = 20, LASER = 15"
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_inactive = 1
@@ -639,7 +639,7 @@
 		'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
 		All rights reserved, tampering with suit will void life expectancy.'"
 	default_skin = "elite"
-	armor = list(MELEE = 50, BULLET = 50, LASER = 35, ENERGY = 30, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 35, BULLET = 30, LASER = 35"
+	armor = list(MELEE = 45, BULLET = 45, LASER = 35, ENERGY = 30, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25, RAD = 0) // BLUEMOON EDIT - was "MELEE = 35, BULLET = 30, LASER = 35"
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0

--- a/modular_bluemoon/code/modules/mod/mod_theme.dm
+++ b/modular_bluemoon/code/modules/mod/mod_theme.dm
@@ -3,7 +3,7 @@
 	desc = "A highly advanced combat suit, decorated with a sinister-looking dark blue colors, manufactured and crafted for special operations mercenaries. "
 	extended_desc = "A highly advanced combat suit, decorated with a sinister-looking dark blue colors, manufactured and crafted for special operations mercenaries. The design is a streamlined layered construction composed of molded plasteel and composite ceramics, while the undersuit is lined with lightweight kevlar and hybrid duratri weave. A small tag hangs on it that reads: Made by Fox and Ghost inc cooperation. All rights reserved, tampering with the suit's design will result in immediate suit annihilation."
 	default_skin = "InteQ"
-	armor = list(MELEE = 50, BULLET = 50, LASER = 35, ENERGY = 25, BOMB = 55, BIO = 100, RAD = 70, FIRE = 100, ACID = 100, WOUND = 25)
+	armor = list(MELEE = 45, BULLET = 45, LASER = 35, ENERGY = 25, BOMB = 55, BIO = 100, RAD = 70, FIRE = 100, ACID = 100, WOUND = 25)
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_inactive = 1

--- a/modular_bluemoon/code/modules/mod/mod_theme.dm
+++ b/modular_bluemoon/code/modules/mod/mod_theme.dm
@@ -1,9 +1,9 @@
-/datum/mod_theme/InteQ
+/datum/mod_theme/inteq
 	name = "InteQ"
 	desc = "A highly advanced combat suit, decorated with a sinister-looking dark blue colors, manufactured and crafted for special operations mercenaries. "
 	extended_desc = "A highly advanced combat suit, decorated with a sinister-looking dark blue colors, manufactured and crafted for special operations mercenaries. The design is a streamlined layered construction composed of molded plasteel and composite ceramics, while the undersuit is lined with lightweight kevlar and hybrid duratri weave. A small tag hangs on it that reads: Made by Fox and Ghost inc cooperation. All rights reserved, tampering with the suit's design will result in immediate suit annihilation."
 	default_skin = "InteQ"
-	armor = list(MELEE = 60, BULLET = 60, LASER = 50, ENERGY = 25, BOMB = 55, BIO = 100, RAD = 70, FIRE = 100, ACID = 100, WOUND = 30)
+	armor = list(MELEE = 50, BULLET = 50, LASER = 35, ENERGY = 25, BOMB = 55, BIO = 100, RAD = 70, FIRE = 100, ACID = 100, WOUND = 25)
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
 	slowdown_inactive = 1

--- a/modular_bluemoon/code/modules/mod/mod_types.dm
+++ b/modular_bluemoon/code/modules/mod/mod_types.dm
@@ -1,5 +1,5 @@
-/obj/item/mod/control/pre_equipped/InteQ
-	theme = /datum/mod_theme/InteQ
+/obj/item/mod/control/pre_equipped/inteq
+	theme = /datum/mod_theme/inteq
 	cell = /obj/item/stock_parts/cell/bluespace
 	initial_modules = list(
 		/obj/item/mod/module/storage,

--- a/modular_bluemoon/code/modules/uplink/uplink_items/uplink_clothing.dm
+++ b/modular_bluemoon/code/modules/uplink/uplink_items/uplink_clothing.dm
@@ -5,7 +5,7 @@
 /datum/uplink_item/mod/core //
 	name = "InteQ MOD"
 	desc = "A highly advanced combat suit,decorated with a sinister-looking dark blue colors, manufactured and crafted for special operations mercenaries. The design is a streamlined layered construction composed of molded plasteel and composite ceramics, while the undersuit is lined with lightweight kevlar and hybrid duratri weave. A small tag hangs on it that reads: Made by Fox and Ghost inc cooperation. All rights reserved, tampering with the suit's design will result in immediate suit annihilation."
-	item = /obj/item/mod/control/pre_equipped/InteQ
+	item = /obj/item/mod/control/pre_equipped/inteq
 	cost = 18 // 39 ---> 18
 	purchasable_from = (UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 


### PR DESCRIPTION
# Описание
1. Ребаланс синди и интекью МОДов.
   - Синди и элит-синди МОДы были ухудшены в защите в сравнении с РИГами.
   - Интекью мод сведён в балансе до элитМОДа Синдиката.
2. Исправление капитализации пути интекью мода.
3. Священнику добавлен трейт антимагии. Сам он кастовать при этом может.

## Причина изменений
1. МОДы не должны заменять собой РИГ при возможности установки полезных модулей. Баланс требует выбора между или защищённостью, или универсальностью.
2. Капитализация в путях - харам в программировании.
3. Балансная правка должна сделать святого отца, который есть в кол-ве 1 шт. на любой станции, подспорьем станции против мага с таймстопами и культистов с фумаджинами. Он не должен становиться ассистентом в дрипе, если разоружить его от нулрода.

## Демонстрация изменений
Не требуется. 