### PR TITLE
INTEK FOREVER!!

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -3450,7 +3450,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/syndicate/cybersun,
+/obj/machinery/suit_storage_unit/syndicate/inteq,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "se" = (
@@ -3586,7 +3586,6 @@
 /obj/item/storage/belt/esabre_belt,
 /obj/item/inteq/uplink/radio,
 /obj/item/paper/fluff/ruins/forgottenship/missionobj,
-/obj/item/melee/rapier,
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "st" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -5605,7 +5605,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/syndicate/chameleon,
+/obj/machinery/suit_storage_unit/syndicate/cybersun,
 /turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/admiral)
 "vB" = (


### PR DESCRIPTION
2131

# Описание

<!-- небольшей нерф интека и ап синдибазы -->

- [ ] Изменения были проверены на локальном сервере
- [ ] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->
ПОТОМУ ЧТО ПИЗДЕЛОВКЕ БЫТЬ!!
## Демонстрация изменений
-У интека удален емаг в сейфе.
- У интека заменены 3 элитки на 6 смг
- Интеку вернули томбольсков
- У синдиката отобрали 2 эмки
-Синдикату подарили АСГ 5М30 в 3 штуках и патроны к ним.И Резину на единственную эмку
<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
