### PR TITLE
Ревизия нод исследования: инструменты

### DIFF
--- a/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","biobag_holding","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "bluespacesmartdart", "bluespace_tray", "light_replacer_blue")
+	design_ids = list("bs_rped","biobag_holding","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "bluespacesmartdart", "bluespace_tray") // BLUEMOON REMOIVAL of "light_replacer_blue" to /datum/techweb_node/janitor/bspspray
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_bluespace

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -135,7 +135,7 @@
 	id = "advance_surgerytools"
 	display_name = "Advanced Surgery Tools"
 	description = "Refined and improved redesigns for the run-of-the-mill medical utensils."
-	prereq_ids = list("adv_biotech", "adv_surgery")
+	prereq_ids = list("basic_tools", "adv_biotech", "adv_surgery") // BLUEMOON ADD basic_tools for order consistency
 	design_ids = list("drapes", "retractor_adv", "surgicaldrill_adv", "scalpel_adv", "bonesetter", "surgical_tape")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 

--- a/code/modules/research/techweb/nodes/tools_nodes.dm
+++ b/code/modules/research/techweb/nodes/tools_nodes.dm
@@ -28,7 +28,7 @@
 	id = "janitor"
 	display_name = "Advanced Sanitation Technology"
 	description = "Clean things better, faster, stronger, and harder!"
-	prereq_ids = list("adv_engi")
+	prereq_ids = list("basic_tools", "adv_engi") // BLUEMOON ADD basic_tools for order consistency
 	design_ids = list("advmop", "advbroom", "buffer", "light_replacer", "spraybottle", "beartrap", "ci-janitor", "paint_remover")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1750) // No longer has its bag
 
@@ -45,7 +45,7 @@
 	display_name = "Experimental Tools"
 	description = "Highly advanced construction tools."
 	design_ids = list("exwelder", "jawsoflife", "handdrill", "holosigncombifan", "ranged_analyzer", "tricorder")
-	prereq_ids = list("adv_engi")
+	prereq_ids = list("basic_tools", "adv_engi") // BLUEMOON ADD basic_tools for order consistency
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2750)
 
 /datum/techweb_node/sec_basic

--- a/code/modules/research/techweb/nodes/weaponry_nodes.dm
+++ b/code/modules/research/techweb/nodes/weaponry_nodes.dm
@@ -4,7 +4,7 @@
 	id = "weaponry"
 	display_name = "Weapon Development Technology"
 	description = "Our researchers have found new to weaponize just about everything now."
-	prereq_ids = list("engineering")
+	prereq_ids = list("sec_basic", "engineering") // BLUEMOON ADD sec_basic for order consistency
 	design_ids = list("pin_testing", "tele_shield", "lasercarbine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 

--- a/modular_sand/code/modules/research/techweb/nodes/all_nodes.dm
+++ b/modular_sand/code/modules/research/techweb/nodes/all_nodes.dm
@@ -2,8 +2,8 @@
 	id = "bspspray"
 	display_name = "Advanced Janitoring"
 	description = "A better sprayer for your job!"
-	prereq_ids = list("janitor")
-	design_ids = list("bluespacespray")
+	prereq_ids = list("practical_bluespace", "janitor") // BLUEMOON ADD practical_bluespace
+	design_ids = list("bluespacespray", "light_replacer_blue") // BLUEMOON ADD light_replacer_blue
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 750)
 
 /datum/techweb_node/syndicate_basic/cool

--- a/modular_splurt/code/modules/clothing/suits/heavy.dm
+++ b/modular_splurt/code/modules/clothing/suits/heavy.dm
@@ -274,7 +274,7 @@
 	display_name = "CBRN gear"
 	description = "Chemical, Biological, Radiological and Nuclear protective gear"
 	prereq_ids = list("engineering")
-	design_ids = list("cbrn_civi", "cbrn_sec", "cbrn_engi", "cbrn_serv", "cbrn_cargo", "cbrn_sci", "cbrn_med", "cbrn_mask", "cbrn_boots", "cbrn_gloves", "cbrn_glovesengi", "cbrn_hood", "cbrn_oxy", "cbrn_plasma","cbrn_nitrogen", "cbrn_glovesmed") // BLUEMOON ADD of cbrn medgloves
+	design_ids = list("cbrn_civi", "cbrn_sec", "cbrn_engi", "cbrn_serv", "cbrn_cargo", "cbrn_sci", "cbrn_med", "cbrn_mask", "cbrn_boots", "cbrn_gloves", "cbrn_glovesengi", "cbrn_glovesmed", "cbrn_hood", "cbrn_oxy", "cbrn_plasma","cbrn_nitrogen") // BLUEMOON ADD cbrn_glovesmed
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
 /datum/techweb_node/mopp


### PR DESCRIPTION
# Описание
1. Дополнен порядок исследования инструментов:
   - Ноды инструментов: меда, инженеров и уборщика требуют ноду basic_tools (С обычными инструментами из автолата).
   - Первая нода оружия с тренировочными пинами требует sec_basic ноду с болами и наручниками.
2. Блюспейс лампозаменитель перешёл в ноду Advanced Janitoring. Упомянутая нода требует practical_bluespace ноду для исследования.
3. Правка порядка путей id в CBRN ноде.
- [X] Изменения были проверены на локальном сервере

## Причина изменений
1. "Мы можем изучить дрель, не зная, как печатать отвёртку". Также это правит порядок в списке крафтов протолата и простые инструменты никогда не будут под продвинутыми.
2. Логика: лампозаменитель и обычный спрей есть в базовой ноде инструментов уборщика, в адвансд есть спрей, но без блюспейс-лампозаменителя. К тому же теперь блюспейс потребует блюспейс-ноды, как это и должно быть.
3. Косметическое.

## Демонстрация изменений
![image2](https://github.com/user-attachments/assets/8c962779-7af2-445b-8669-aa461dc36152)
![image1](https://github.com/user-attachments/assets/d06d59bf-5fd6-4230-85a0-fe673065995a)