### PR TITLE
Удаление Windows Build CI

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -138,31 +138,3 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci -DCIBUILDING
           bash tools/ci/run_server.sh ${{ matrix.map }}
-  test_windows:
-    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
-    name: Windows Build
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Restore Yarn cache
-        uses: actions/cache@v4
-        with:
-          path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Compile
-        run: pwsh tools/ci/build.ps1
-        env:
-          DM_EXE: "C:\\byond\\bin\\dm.exe"
-      - name: Create artifact
-        run: |
-          md deploy
-          bash tools/deploy.sh ./deploy
-      - name: Deploy artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: deploy
-          path: deploy


### PR DESCRIPTION
# Описание
1) Тг сделали, чем мы хуже (убираем постоянный крестик у всех пров по причине "я не могу скачать бьёнд")
https://github.com/tgstation/tgstation/pull/91186
## Причина изменений
короче крестика не должно быть круто классно
