### PR TITLE
glass direction

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 	var/hitsound = 'sound/effects/Glasshit.ogg'
 	rad_insulation = RAD_VERY_LIGHT_INSULATION
 	rad_flags = RAD_PROTECT_CONTENTS
+	obj_flags = CAN_BE_HIT | BLOCKS_CONSTRUCTION_DIR | IGNORE_DENSITY //BLUEMOON ADD
 	flags_1 = ON_BORDER_1|DEFAULT_RICOCHET_1
 	flags_ricochet =  RICOCHET_HARD
 	ricochet_chance_mod = 0.4
@@ -715,6 +716,7 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 	max_integrity = 50
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1
+	obj_flags = CAN_BE_HIT //BLUEMOON ADD
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(
 		/turf/closed/wall,


### PR DESCRIPTION
# Описание
Эти флаги изначально для направленных стекол придумали (буквально в их описании написано). Почему их не оказалось, у самих стекол, не понятно. Позволяет застроить себя в 1 тайле направленными стеклами, по всем 4м направлениям. Проверено на локалке.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/1ae611f3-9b3c-47c2-8887-e21df4300d29)
