### PR TITLE
Присвоение ряду вендомат-напитков mood-качества  

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -380,7 +380,7 @@
 	description = "Tea mixed with honey, has both antitoxins and sweetness in one!"
 	color = "#101000" // rgb: 16, 16, 0
 	nutriment_factor = 0
-	quality = DRINK_NICE
+	quality = DRINK_GOOD // BLUEMOON ADD
 	taste_description = "sweet tea"
 	glass_icon_state = "tea_forest"
 	glass_name = "glass of forest tea"
@@ -612,6 +612,7 @@
 	glass_icon_state = "glass_red"
 	glass_name = "glass of Shambler's juice"
 	glass_desc = "Mmm mm, shambly."
+	quality = DRINK_NICE // BLUEMOON ADD
 
 /datum/reagent/consumable/shamblers/on_mob_life(mob/living/carbon/M)
 	M.adjust_bodytemperature(-8 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -451,6 +451,7 @@
 	glass_icon_state  = "chocolateglass"
 	glass_name = "glass of chocolate"
 	glass_desc = "Tasty."
+	quality = DRINK_NICE // BLUEMOON ADD
 
 /datum/reagent/consumable/hot_coco/on_mob_life(mob/living/carbon/M)
 	M.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, BODYTEMP_NORMAL)


### PR DESCRIPTION
# Описание
Ряд напитков из вендоматов получили влияющее на муд куклы качество (`quality`): 
   - Dutch Hot Coco (Качество 1 уровня), 60 кредитов
   - Royal Forest Tea (Качество 2 уровня), 100 кредитов.
   - Shambler's Juice (Качество 2 уровня), 100 кредитов

## Причина изменений
Попытка сделать затраты экипажа на горячий шоколад (Который греет хуже чая в вопросе метаболизма, но дороже кредитами) и прочие напитки более рентабельными механически.
Для понимания, уже были напитки вроде Nuka Cola за 100 кредитов, что имели качество 2-го уровня для повышения муда. Теперь их будет чуть больше.

## Демонстрация изменений
Не требуется.