### PR TITLE
[BLUEMOON] Осмотровые фичи и микрофикс на лаве

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -172,7 +172,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/closet/crate/necropolis,
+/obj/structure/closet/crate/necropolis/tendril,
 /turf/open/indestructible/boss,
 /area/lavaland/necropolis)
 "agp" = (

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -172,14 +172,7 @@
 	if (length(status_examines))
 		. += status_examines
 	//Approximate character height based on current sprite scale
-	var/dispSize = round(12*get_size(src)) // gets the character's sprite size percent and converts it to the nearest half foot
-	if(dispSize % 2) // returns 1 or 0. 1 meaning the height is not exact and the code below will execute, 0 meaning the height is exact and the else will trigger.
-		dispSize = dispSize - 1 //makes it even
-		dispSize = dispSize / 2 //rounds it out
-		. += "[t_on], кажется, чуть выше или около [dispSize] футов в высоту."
-	else
-		dispSize = dispSize / 2
-		. += "[t_on], кажется, около [dispSize] футов в высоту."
+	. += "[t_on], кажется, около [round(180*get_size(src))] сантиметров в высоту."
 	if(has_status_effect(/datum/status_effect/pregnancy))
 		. += "<b>[t_on] имеет выступающую часть на уровне живота. Кажется, это беременность.\n</b>"
 	//CIT CHANGES START HERE - adds genital details to examine text

--- a/modular_sand/code/datums/elements/skirt_peeking.dm
+++ b/modular_sand/code/datums/elements/skirt_peeking.dm
@@ -47,8 +47,12 @@
 	return FALSE
 
 /datum/element/skirt_peeking/proc/on_examine(mob/living/carbon/human/peeked, mob/peeker, list/examine_list)
-	if(can_skirt_peek(peeked, peeker))
-		examine_list += span_purple("[peeked.ru_who(TRUE)] одет[peeked.ru_a()] в юбку! Наверное, под неё можно <b>подсмотреть</b>...")
+	var/obj/item/clothing/suit/outer_clothing = peeked.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if(!(outer_clothing && CHECK_MULTIPLE_BITFIELDS(outer_clothing.body_parts_covered, CHEST | GROIN | LEGS | FEET)))
+		// Valid clothing section
+		var/obj/item/clothing/under/worn_uniform = peeked.get_item_by_slot(ITEM_SLOT_ICLOTHING)
+		if(worn_uniform && is_type_in_typecache(worn_uniform.type, GLOB.skirt_peekable))
+			examine_list += span_purple("[peeked.ru_who(TRUE)] одет[peeked.ru_a()] в юбку! Наверное, под неё можно <b>подсмотреть</b>...")
 
 /datum/element/skirt_peeking/proc/on_closer_look(mob/living/carbon/human/peeked, mob/peeker, list/examine_content)
 	if(can_skirt_peek(peeked, peeker))


### PR DESCRIPTION
- Высота персонажа отображается в метрической системе.
- Текст о возможности подсмотреть под юбку выводится при обычном осмотре персонажа.
- Вечно пустой сундук тендрилла в некрополисе теперь не пустой.