### PR TITLE
rotary telephone on table

### DIFF
--- a/modular_bluemoon/code/modules/phone/phone.dm
+++ b/modular_bluemoon/code/modules/phone/phone.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 	desc = "The finger plate is a little stiff."
 	anchored = TRUE
 	layer = OBJ_LAYER + 0.01
+	pass_flags = PASSTABLE
 	var/phone_category = PHONE_NET_PUBLIC
 	var/phone_color = "white"
 	var/phone_id = "Telephone"


### PR DESCRIPTION
# Описание
Позволяет передвигать телефон на стол, без разбора стола
Проверено на локалке.
