### PR TITLE
Фикс возможности запихнуть в название бумажки хтмл

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -337,7 +337,7 @@
 			H.damageoverlaytemp = 9001
 			H.update_damage_hud()
 			return
-	var/n_name = tgui_input_text(usr, "Enter a paper label", "Paper Labelling", max_length = MAX_NAME_LEN)
+	var/n_name = tgui_input_text(usr, "Enter a paper label", "Paper Labelling", max_length = MAX_NAME_LEN, encode = TRUE)
 	if(isnull(n_name) || n_name == "")
 		return
 	if(((loc == usr || istype(loc, /obj/item/clipboard)) && usr.stat == CONSCIOUS))


### PR DESCRIPTION
# Описание
Это позволяло недобросовестным игрокам переименовать бумажку в какой-нибудь неправильный хтмл запрос который крашит чат при любом упоминании бумажки (даже поджигание её)
## Причина изменений
багфикс