### PR TITLE
Фикс крестика на гитхабе

### DIFF
--- a/modular_bluemoon/SmiLeY/code/nanosuit/nanosuit.dm
+++ b/modular_bluemoon/SmiLeY/code/nanosuit/nanosuit.dm
@@ -1009,7 +1009,7 @@
 		NS.kill_cloak()
 
 /obj/item/clothing/suit/space/hardsuit/nano/proc/kill_cloak()
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER_DOES_SLEEP
 	if(mode == NANO_CLOAK)
 		var/obj/item/W = Wearer.get_active_held_item()
 		if(istype(W, /obj/item/gun))

--- a/modular_bluemoon/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/modular_bluemoon/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -2,8 +2,7 @@
 	. = ..()
 	if(!.)
 		return
-	var/mob/living/carbon/human/H = src
-	if(!istype(H) || !has_dna())
+	if(!has_dna())
 		return
 	if(HAS_TRAIT(src, TRAIT_CHOKE_SLUT))
 		if(amount <= 0)


### PR DESCRIPTION
# Описание
по причине крайне замысловатых последовательностей прок kill_cloak() у нанокостюма рантаймил ибо чуял наличие прока взаимодействия с удушьем которое оооочень далеко при не отрицательных значениях доводит до оргазма
короче попросил 1 проверку и поставил что хандлер может спать, всеравно это ничего не меняет в этой ситуации
## Причина изменений
фикс ругающегося линтера