### PR TITLE
Удаление пилонов зена с гейта чёрной мезы

### DIFF
--- a/_maps/RandomZLevels/away_mission/ihategordon.dmm
+++ b/_maps/RandomZLevels/away_mission/ihategordon.dmm
@@ -2248,10 +2248,6 @@
 /obj/item/gun/ballistic/revolver/mateba,
 /turf/open/indestructible/newmesacobble,
 /area/awaymission/outsideofmesa)
-"bDv" = (
-/obj/structure/xen_pylon,
-/turf/open/floor/catwalk_floor,
-/area/awaymission/ihategordon/hyperlaser_chamber)
 "bDG" = (
 /obj/structure/urbanismbigcrate,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -2757,14 +2753,6 @@
 	icon_state = "bus"
 	},
 /area/awaymission/ihategordon/underground_tunnels)
-"bUN" = (
-/obj/structure/xen_pylon,
-/obj/structure/alien/weeds{
-	color = "#ac3b06";
-	name = "xen floor"
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/gonome)
 "bVk" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/window/reinforced/spawner/west,
@@ -9846,14 +9834,6 @@
 	icon_state = "damaged2"
 	},
 /area/awaymission/ihategordon/big_offices)
-"gMV" = (
-/obj/structure/alien/weeds{
-	color = "#ac3b06";
-	name = "xen floor"
-	},
-/obj/structure/xen_pylon,
-/turf/open/floor/plasteel/dark,
-/area/awaymission/ihategordon/science_tunnel)
 "gMW" = (
 /obj/structure/closet/crate/large/urbanismcratelarge/mil,
 /turf/open/floor/plating,
@@ -18646,14 +18626,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/festive/sidewalk/mesawalk,
 /area/awaymission/outsideofmesa)
-"mDg" = (
-/obj/structure/alien/weeds{
-	color = "#ac3b06";
-	name = "xen floor"
-	},
-/obj/structure/xen_pylon,
-/turf/open/indestructible/mesasand,
-/area/awaymission/ihategordon/secret_rooms)
 "mDl" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -31455,14 +31427,6 @@
 /obj/item/relic,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
-"vjL" = (
-/obj/structure/alien/weeds{
-	color = "#ac3b06";
-	name = "xen floor"
-	},
-/obj/structure/xen_pylon,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/dorm_offices)
 "vkg" = (
 /turf/open/floor/plasteel{
 	icon_state = "damaged5"
@@ -45552,7 +45516,7 @@ idK
 hzO
 ggT
 idK
-vjL
+idK
 idK
 vfU
 hzO
@@ -58511,7 +58475,7 @@ pfj
 ahe
 srK
 srK
-gMV
+srK
 srK
 srK
 flv
@@ -68931,7 +68895,7 @@ hZd
 lUV
 deh
 hZd
-bDv
+hZd
 jtl
 hZd
 uAy
@@ -71887,7 +71851,7 @@ ukn
 ukn
 sYv
 foL
-mDg
+foL
 foL
 foL
 sYv
@@ -73424,7 +73388,7 @@ ukY
 foL
 foL
 foL
-mDg
+foL
 jaT
 foL
 foL
@@ -93025,7 +92989,7 @@ wCh
 dFs
 wHN
 wCh
-bUN
+wCh
 wCh
 bPb
 jrx
@@ -94056,7 +94020,7 @@ wCh
 ykw
 wCh
 wCh
-bUN
+wCh
 wCh
 lRd
 mAf
@@ -95081,7 +95045,7 @@ wCh
 wgs
 wCh
 wCh
-bUN
+wCh
 wCh
 baO
 wCh


### PR DESCRIPTION
# Описание

Удалил пилоны зена с карты

## Причина изменений

Слишком имбалансная фича для мобов, которая работала слишком некорректно и мешала прохождению гейта

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
