### PR TITLE
Дополнение UI фабрикатора робо подкатегориями крафта

### DIFF
--- a/code/__DEFINES/exosuit_fabs.dm
+++ b/code/__DEFINES/exosuit_fabs.dm
@@ -35,3 +35,36 @@
 #define EXOSUIT_MODULE_COMBAT		EXOSUIT_MODULE_GYGAX | EXOSUIT_MODULE_HONK | EXOSUIT_MODULE_DURAND | EXOSUIT_MODULE_PHAZON | EXOSUIT_MODULE_SAVANNAH
 /// Module is compatible with "Medical" Exosuit modelsm - Odysseus
 #define EXOSUIT_MODULE_MEDICAL		EXOSUIT_MODULE_ODYSSEUS | EXOSUIT_MODULE_GYGAX_MED
+
+// BLUEMOON ADD START MOD modules & exosuit modules sub-categories
+
+/// Module is from general MODsuit node
+#define MOD_MODULE_GENERAL 					(1<<0)
+/// Module is from engineering MODsuit node
+#define MOD_MODULE_ENGINEERING				(1<<1)
+/// Module is from medical MODsuit node
+#define MOD_MODULE_SECURITY					(1<<2)
+/// Module is from service MODsuit node
+#define MOD_MODULE_MEDICAL					(1<<3)
+/// Module is from SCIENCE MODsuit node
+#define MOD_MODULE_SCIENCE					(1<<4)
+/// Module is from supply MODsuit node
+#define MOD_MODULE_SUPPLY					(1<<5)
+/// Module is from HUD-visor MODsuit node
+#define MOD_MODULE_VISOR					(1<<6)
+
+/// Module is exosuit ballistic weapon
+#define EXISUIT_WEAPON_MODULE_BALLISTIC		(1<<0)
+/// Module is exosuit ballistic weapon
+#define EXISUIT_WEAPON_MODULE_ENERGY		(1<<1)
+/// Module is exosuit launcher or missile weapon
+#define EXISUIT_WEAPON_MODULE_AOE			(1<<2)
+/// Module is exosuit department modules
+#define EXISUIT_MODULE_NONWEAPON			(1<<3)
+
+/// MOD part is construction type
+#define MOD_CONSTRUCTION					(1<<0)
+/// MOD part is a plating
+#define MOD_PLATING							(1<<1)
+
+// BLUEMOON ADD END

--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -2,6 +2,7 @@
 	desc = "A part used in MOD construction."
 	icon = 'icons/obj/clothing/modsuit/mod_construction.dmi'
 	item_state = "rack_parts"
+	mod_flags = MOD_CONSTRUCTION // BLUEMOON ADD
 
 /obj/item/mod/construction/helmet
 	name = "MOD helmet"
@@ -61,6 +62,7 @@
 	desc = "External plating used to finish a MOD control unit."
 	icon_state = "standard-plating"
 	var/datum/mod_theme/theme = /datum/mod_theme
+	mod_flags = MOD_PLATING // BLUEMOON ADD
 
 /obj/item/mod/construction/armor/Initialize(mapload)
 	. = ..()

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -8,6 +8,8 @@
 	icon = 'modular_bluemoon/icons/obj/clothing/modsuit/mod_clothing.dmi'
 	mob_overlay_icon = 'modular_bluemoon/icons/mob/clothing/modsuit/mod_clothing.dmi'
 	anthro_mob_worn_overlay = 'modular_bluemoon/icons/mob/clothing/modsuit/mod_clothing_anthro.dmi'
+	// Bitflags for exosuit subcategories
+	var/mod_flags
 // BLUEMOON ADDITION END
 	icon_state = "standard-control"
 	item_state = "standard-control"

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -44,6 +44,8 @@
 	var/allowed_inactive = FALSE
 	/// Timer for the cooldown
 	COOLDOWN_DECLARE(cooldown_timer)
+	/// BLUEMOON ADD Bitflag for exosuit fabricator sub-categories
+	var/mod_module_flags
 
 /obj/item/mod/module/Initialize(mapload)
 	. = ..()

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -10,6 +10,7 @@
 	complexity = 1
 	incompatible_modules = list(/obj/item/mod/module/welding)
 	overlay_state_inactive = "module_welding"
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/welding/on_suit_activation()
 	mod.helmet.flash_protect = 2
@@ -33,6 +34,7 @@
 	cooldown_time = 0.5 SECONDS
 	/// T-ray scan range.
 	var/range = 4
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/t_ray/on_active_process(delta_time)
 	t_ray_scan(mod.wearer, 0.8 SECONDS, range)
@@ -52,6 +54,7 @@
 	cooldown_time = 0.5 SECONDS
 	/// Slowdown added onto the suit.
 	var/slowdown_active = 2
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/magboot/on_activation()
 	. = ..()
@@ -91,6 +94,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/tether)
 	cooldown_time = 1.5 SECONDS
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/tether/on_use()
 	if(mod.wearer.has_gravity(get_turf(src)))
@@ -146,6 +150,7 @@
 	complexity = 2
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	incompatible_modules = list(/obj/item/mod/module/rad_protection)
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/rad_protection/on_suit_activation()
 	mod.armor = mod.armor.modifyRating(rad = 65)
@@ -174,6 +179,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 2
 	incompatible_modules = list(/obj/item/mod/module/constructor, /obj/item/mod/module/quick_carry)
 	cooldown_time = 11 SECONDS
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/constructor/on_suit_activation()
 	ADD_TRAIT(mod.wearer, TRAIT_QUICK_BUILD, MOD_TRAIT)
@@ -194,6 +200,7 @@
 	cooldown_time = 0.5 SECONDS
 	/// Volume of our reagent holder.
 	var/volume = 500
+	mod_module_flags = MOD_MODULE_ENGINEERING // BLUEMOON ADD
 
 /obj/item/mod/module/mister/Initialize(mapload)
 	create_reagents(volume, OPENCONTAINER)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -13,6 +13,7 @@
 	allowed_inactive = TRUE
 	/// Bag we have stored.
 	var/obj/item/storage/backpack/stored
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/storage/attackby(obj/item/I, mob/user, params)
 	if(!istype(I, /obj/item/storage/backpack))
@@ -93,6 +94,7 @@
 	/// Do we give the wearer a speed buff.
 	var/full_speed = FALSE
 	var/datum/effect_system/trail_follow/ion/ion_trail
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/jetpack/Initialize(mapload)
 	. = ..()
@@ -166,6 +168,7 @@
 	var/former_flags = NONE
 	/// Former visor flags of the helmet.
 	var/former_visor_flags = NONE
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/mouthhole/on_install()
 	former_flags = mod.helmet.flags_cover
@@ -189,6 +192,7 @@
 	complexity = 1
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	incompatible_modules = list(/obj/item/mod/module/emp_shield)
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/emp_shield/on_install()
 	mod.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_WIRES|EMP_PROTECT_CONTENTS)
@@ -231,6 +235,7 @@
 	var/min_range = 2
 	/// Maximum range we can set.
 	var/max_range = 5
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/flashlight/on_activation()
 	. = ..()
@@ -297,6 +302,7 @@
 	var/dispense_type = /obj/item/reagent_containers/food/snacks/burger/plain
 	/// Time it takes for us to dispense.
 	var/dispense_time = 0 SECONDS
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/dispenser/on_use()
 	. = ..()
@@ -330,6 +336,7 @@
 	cooldown_time = 0.5 SECONDS
 	/// The DNA we lock with.
 	var/dna = null
+	mod_module_flags = MOD_MODULE_GENERAL // BLUEMOON ADD
 
 /obj/item/mod/module/dna_lock/on_install()
 	RegisterSignal(mod, COMSIG_MOD_ACTIVATE, PROC_REF(on_mod_activation))

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -22,6 +22,7 @@
 	var/mode = HEALTH_SCAN
 	/// List of all scanning modes.
 	var/static/list/modes = list(HEALTH_SCAN, WOUND_SCAN, CHEM_SCAN)
+	mod_module_flags = MOD_MODULE_MEDICAL // BLUEMOON ADD
 
 /obj/item/mod/module/health_analyzer/add_ui_data()
 	. = ..()
@@ -69,6 +70,7 @@
 	complexity = 1
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	incompatible_modules = list(/obj/item/mod/module/quick_carry, /obj/item/mod/module/constructor)
+	mod_module_flags = MOD_MODULE_MEDICAL // BLUEMOON ADD
 
 /obj/item/mod/module/quick_carry/on_suit_activation()
 	ADD_TRAIT(mod.wearer, TRAIT_QUICKER_CARRY, MOD_TRAIT)
@@ -106,6 +108,7 @@
 	incompatible_modules = list(/obj/item/mod/module/defibrillator)
 	cooldown_time = 0.5 SECONDS
 	var/defib_cooldown = 5 SECONDS
+	mod_module_flags = MOD_MODULE_MEDICAL // BLUEMOON ADD
 
 /obj/item/mod/module/defibrillator/Initialize(mapload)
 	. = ..()
@@ -166,6 +169,7 @@
 	device = /obj/item/surgical_processor/mod
 	incompatible_modules = list(/obj/item/mod/module/surgical_processor)
 	cooldown_time = 0.5 SECONDS
+	mod_module_flags = MOD_MODULE_MEDICAL // BLUEMOON ADD
 
 /obj/item/surgical_processor/mod
 	name = "MOD surgical processor"

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -12,6 +12,7 @@
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.2
 	incompatible_modules = list(/obj/item/mod/module/reagent_scanner)
 	cooldown_time = 0.5 SECONDS
+	mod_module_flags = MOD_MODULE_SCIENCE // BLUEMOON ADD
 
 /obj/item/mod/module/reagent_scanner/on_activation()
 	. = ..()
@@ -69,6 +70,7 @@
 	incompatible_modules = list(/obj/item/mod/module/anomaly_locked)
 	cooldown_time = 0.5 SECONDS
 	accepted_anomalies = list(/obj/item/assembly/signaler/anomaly/grav)
+	mod_module_flags = MOD_MODULE_SCIENCE // BLUEMOON ADD
 
 /obj/item/mod/module/anomaly_locked/antigrav/on_activation()
 	. = ..()
@@ -107,6 +109,7 @@
 	accepted_anomalies = list(/obj/item/assembly/signaler/anomaly/bluespace)
 	/// Time it takes to teleport
 	var/teleport_time = 3 SECONDS
+	mod_module_flags = MOD_MODULE_SCIENCE // BLUEMOON ADD
 
 /obj/item/mod/module/anomaly_locked/teleporter/on_select_use(atom/target)
 	. = ..()

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -17,6 +17,7 @@
 	var/bumpoff = TRUE
 	/// The alpha applied when the cloak is on.
 	var/stealth_alpha = 50
+	mod_module_flags = MOD_MODULE_SECURITY // BLUEMOON ADD
 
 /obj/item/mod/module/stealth/on_activation()
 	. = ..()
@@ -75,6 +76,7 @@
 	var/static/list/guns_typecache
 	/// The guns already allowed by the modsuit chestplate.
 	var/list/already_allowed_guns = list()
+	mod_module_flags = MOD_MODULE_SECURITY // BLUEMOON ADD
 
 /obj/item/mod/module/magnetic_harness/Initialize(mapload)
 	. = ..()
@@ -131,6 +133,7 @@
 	allowed_inactive = TRUE
 	/// Gun we have holstered.
 	var/obj/item/gun/holstered
+	mod_module_flags = MOD_MODULE_SECURITY // BLUEMOON ADD
 
 /obj/item/mod/module/holster/on_use()
 	. = ..()

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -13,6 +13,7 @@
 	incompatible_modules = list(/obj/item/mod/module/gps)
 	cooldown_time = 0.5 SECONDS
 	allowed_inactive = TRUE
+	mod_module_flags = MOD_MODULE_SUPPLY // BLUEMOON ADD
 
 /obj/item/mod/module/gps/Initialize(mapload)
 	. = ..()
@@ -44,6 +45,7 @@
 	var/max_crates = 3
 	/// The crates stored in the module.
 	var/list/stored_crates = list()
+	mod_module_flags = MOD_MODULE_SUPPLY // BLUEMOON ADD
 
 /obj/item/mod/module/clamp/on_select_use(atom/target)
 	. = ..()
@@ -110,6 +112,7 @@
 	load_time = 1 SECONDS
 	max_crates = 5
 	use_mod_colors = TRUE
+	mod_module_flags = MOD_MODULE_SUPPLY // BLUEMOON ADD
 
 ///Drill - Lets you dig through rock and basalt.
 /obj/item/mod/module/drill // TODO: Would be cooler with a built-in drill, but meh
@@ -123,6 +126,7 @@
 	module_type = MODULE_USABLE
 	/// Pickaxe we have stored.
 	var/obj/item/pickaxe/stored
+	mod_module_flags = MOD_MODULE_SUPPLY // BLUEMOON ADD
 
 /obj/item/mod/module/drill/on_use()
 	. = ..()
@@ -171,6 +175,7 @@
 	allowed_inactive = TRUE
 	/// Pickaxe we have stored.
 	var/obj/item/storage/bag/ore/stored
+	mod_module_flags = MOD_MODULE_SUPPLY // BLUEMOON ADD
 
 /obj/item/mod/module/orebag/on_use()
 	. = ..()

--- a/code/modules/mod/modules/modules_visor.dm
+++ b/code/modules/mod/modules/modules_visor.dm
@@ -13,6 +13,7 @@
 	var/hud_type
 	/// The traits given by the visor.
 	var/list/visor_traits = list()
+	mod_module_flags = MOD_MODULE_VISOR // BLUEMOON ADD
 
 /obj/item/mod/module/visor/on_activation()
 	. = ..()

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -20,6 +20,7 @@
 	var/selectable = 1	// Set to 0 for passive equipment such as mining scanner or armor plates
 	var/harmful = FALSE //Controls if equipment can be used to attack by a pacifist.
 	var/destroy_sound = 'sound/mecha/critdestr.ogg'
+	var/mecha_subcategory_flags // BLUEMOON ADD
 
 /obj/item/mecha_parts/mecha_equipment/proc/update_chassis_page()
 	if(chassis)

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -60,6 +60,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy
 	name = "general energy weapon"
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
+	mecha_subcategory_flags = EXISUIT_WEAPON_MODULE_ENERGY // BLUEMOON ADD
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
@@ -206,6 +207,7 @@
 	var/projectile_energy_cost
 	var/disabledreload //For weapons with no cache (like the rockets) which are reloaded by hand
 	var/ammo_type
+	mecha_subcategory_flags = EXISUIT_WEAPON_MODULE_BALLISTIC // BLUEMOON ADD
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/action_checks(target)
 	. = ..()
@@ -343,6 +345,7 @@
 	equip_cooldown = 60
 	harmful = TRUE
 	ammo_type = "missiles_he"
+	mecha_subcategory_flags = EXISUIT_WEAPON_MODULE_AOE // BLUEMOON ADD
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/spacecops
 	projectiles = 420
@@ -366,6 +369,7 @@
 	var/missile_speed = 2
 	var/missile_range = 30
 	var/diags_first = FALSE
+	mecha_subcategory_flags = EXISUIT_WEAPON_MODULE_AOE // BLUEMOON ADD
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/action(mob/source, atom/target, params)
 	if(!action_checks(target))

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -178,6 +178,52 @@
 					category_override += "Phazon"
 				if(mech_types & EXOSUIT_MODULE_SAVANNAH)
 					category_override += "Savannah-Ivanov"
+		// BLUEMOON ADD START
+			// Sorting exosuit modules & weapons in subcategories
+			var/mecha_modules = initial(E.mecha_subcategory_flags)
+			sub_category = list()
+			if(mecha_modules)
+				if(mecha_modules & EXISUIT_WEAPON_MODULE_BALLISTIC)
+					sub_category += "Ballistic Weapon"
+				if(mecha_modules & EXISUIT_WEAPON_MODULE_ENERGY)
+					sub_category += "Energy Weapon"
+				if(mecha_modules & EXISUIT_WEAPON_MODULE_AOE)
+					sub_category += "Missile & Launcher Weapon"
+			else
+				sub_category += "Modules"
+		// Sorting mod modules in subcategories
+		else if(built_item in typesof(/obj/item/mod/module))
+			var/obj/item/mod/module/M = built_item
+			var/mod_module_types = initial(M.mod_module_flags)
+			sub_category = list()
+			if(mod_module_types)
+				if(mod_module_types & MOD_MODULE_GENERAL)
+					sub_category += "General"
+				if(mod_module_types & MOD_MODULE_ENGINEERING)
+					sub_category += "Engineering"
+				if(mod_module_types & MOD_MODULE_SECURITY)
+					sub_category += "Security"
+				if(mod_module_types & MOD_MODULE_MEDICAL)
+					sub_category += "Medical"
+				if(mod_module_types & MOD_MODULE_SCIENCE)
+					sub_category += "Science & Bluespace"
+				if(mod_module_types & MOD_MODULE_SUPPLY)
+					sub_category += "Supply & Mining"
+				if(mod_module_types & MOD_MODULE_VISOR)
+					sub_category += "HUD & Visors"
+			else
+				sub_category += "Miscellaneous"
+		// Sorting mod parts and platings in subcategories
+		else if(built_item in typesof(/obj/item/mod/construction))
+			var/obj/item/mod/construction/C = built_item
+			var/mod_parts = initial(C.mod_flags)
+			sub_category = list()
+			if(mod_parts)
+				if(mod_parts & MOD_CONSTRUCTION)
+					sub_category += "Parts"
+				if(mod_parts & MOD_PLATING)
+					sub_category += "Platings"
+		// BLUEMOON ADD END
 
 	var/list/part = list(
 		"name" = D.name,


### PR DESCRIPTION
# Описание
В экзостют фабрикатор робототехников добавлена фильтрация на субкатегории для: 
- Модулей мехов (Модули и типы оружий). 
- MOD (Детали и оболочки).
- Модулей MOD (По отделам).
- [X] Изменения были проверены на локальном сервере
- [X] Этот пулл-реквест готов к тест-мерджу.

## Причина изменений
Поиграл на робототехнике и устал от сплошного списка без сортировки.

## Демонстрация изменений
![image](https://github.com/user-attachments/assets/5b0b92aa-aac0-4091-8aad-ca14faaa4279)