### PR TITLE
snuffle add + vore updt

### DIFF
--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -47,7 +47,7 @@ Bonus
 	switch(A.stage)
 		if(1, 2, 3)
 			if(!suppress_warning)
-				M.emote("sniff")
+				M.emote("snuffle") //BLUEMOON EDIT
 		else
 			M.emote("sneeze")
 			if(M.CanSpreadAirborneDisease()) //don't spread germs if they covered their mouth

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1323,7 +1323,7 @@
 					"<span class='userdanger'>[pick("Your lungs hurt!", "It hurts to breathe!")]</span>",
 					"<span class='warning'>[pick("You feel nauseated.", "You feel like you're going to throw up!")]</span>")
 				else
-					fake_emote = pick("cough", "sniff", "sneeze")
+					fake_emote = pick("cough", "snuffle", "sneeze") //BLUEMOON EDIT
 	if(fake_emote)
 		owner.emote(fake_emote)
 	else if(fake_msg)

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -27,5 +27,5 @@
 			if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
 				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), onecoughman, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>"), rand(30,150))
 			else
-				addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob, emote), pick("cough", "sniff", "sneeze")), rand(30,150))//deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
+				addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob, emote), pick("cough", "snuffle", "sneeze")), rand(30,150)) //BLUEMOON EDIT //deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
 			fake_virus_victims -= onecoughman

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -515,7 +515,7 @@
 /datum/emote/sound/human/sniff
 	key = "sniff"
 	key_third_person = "sniffs"
-	message = "sniffs."
+	message = "нюхает."
 	emote_type = EMOTE_AUDIBLE
 	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -515,7 +515,7 @@
 /datum/emote/sound/human/sniff
 	key = "sniff"
 	key_third_person = "sniffs"
-	message = "шмыгает носом."
+	message = "sniffs."
 	emote_type = EMOTE_AUDIBLE
 	stat_allowed = SOFT_CRIT // BLUEMOON EDIT - некоторые эмоуты можно использовать в софткрите
 

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -381,6 +381,7 @@
 		var/mob/living/carbon/human/H = tasted
 		H.wash_cream()
 
+	playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1) //BLUEMOON ADD
 	visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>")
 
 /mob/living/proc/get_taste_message(allow_generic = TRUE, datum/species/mrace)
@@ -429,6 +430,7 @@
 	if(QDELETED(sniffed) || (sniffed.ckey && !(sniffed.client?.prefs.vore_flags & SMELLABLE)) || !Adjacent(sniffed) || incapacitated(ignore_restraints = TRUE))
 		return
 
+	emote("sniff") //BLUEMOON ADD
 	visible_message("<span class='warning'>[src] smells [sniffed]!</span>","<span class='notice'>You smell [sniffed]. They smell like [sniffed.get_smell_message()].</span>","<b>Sniff!</b>")
 
 /mob/living/proc/get_smell_message(allow_generic = TRUE, datum/species/mrace)

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -377,6 +377,13 @@
 	if(QDELETED(tasted) || (tasted.ckey && !(tasted.client?.prefs.vore_flags & LICKABLE)) || !Adjacent(tasted) || incapacitated(ignore_restraints = TRUE))
 		return
 
+	//BLUEMOON ADD START // Delay like licking tongue
+	var/lickspeed = initial((/obj/item/soap/tongue/organic)::cleanspeed)
+	visible_message("<span class='warning'><b>[src]</b> begins to lick \the <b>[tasted]</b>.", "<span class='warning'>You begin to lick \the <b>[tasted]</b>...</span>")
+	if(!do_after(src, lickspeed, tasted) || !in_range(src, tasted))
+		return //If they moved away, you can't lick them.
+	//BLUEMOON ADD END
+
 	if(ishuman(tasted))
 		var/mob/living/carbon/human/H = tasted
 		H.wash_cream()

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -382,7 +382,7 @@
 		H.wash_cream()
 
 	playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1) //BLUEMOON ADD
-	visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>")
+	visible_message("<span class='warning'><b>[src]</b> licks <b>[tasted]</b>!</span>","<span class='notice'>You lick <b>[tasted]</b>. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>") //BLUEMOON EDIT
 
 /mob/living/proc/get_taste_message(allow_generic = TRUE, datum/species/mrace)
 	if(!vore_taste && !allow_generic)
@@ -431,7 +431,7 @@
 		return
 
 	emote("sniff") //BLUEMOON ADD
-	visible_message("<span class='warning'>[src] smells [sniffed]!</span>","<span class='notice'>You smell [sniffed]. They smell like [sniffed.get_smell_message()].</span>","<b>Sniff!</b>")
+	visible_message("<span class='warning'><b>[src]</b> smells <b>[sniffed]</b>!</span>","<span class='notice'>You smell <b>[sniffed]</b>. They smell like [sniffed.get_smell_message()].</span>","<b>Sniff!</b>") //BLUEMOON EDIT
 
 /mob/living/proc/get_smell_message(allow_generic = TRUE, datum/species/mrace)
 	if(!vore_smell && !allow_generic)

--- a/modular_bluemoon/SmiLeY/code/serverside/emote_panel.dm
+++ b/modular_bluemoon/SmiLeY/code/serverside/emote_panel.dm
@@ -358,6 +358,11 @@
 	set category = "Эмоции.2: Звуковые Действия"
 	emote("sniff")
 
+/mob/living/verb/emote_snuffle()
+	set name = "~ Шмыгнуть "
+	set category = "Эмоции.2: Звуковые Действия"
+	emote("snuffle")
+
 /mob/living/verb/emote_snore1()
 	set name = "> Тихо Храпеть "
 	set category = "Эмоции.3: Простые Действия"

--- a/modular_bluemoon/code/modules/mob/living/emote.dm
+++ b/modular_bluemoon/code/modules/mob/living/emote.dm
@@ -4,3 +4,8 @@
 /datum/emote/sound/human_emote/laugh/soft
 	key = "laugh_soft"
 	key_third_person = "laughs soft"
+
+/datum/emote/sound/human/sniff/snuffle
+	key = "snuffle"
+	key_third_person = "snuffles"
+	message = "шмыгает носом."


### PR DESCRIPTION
# Описание
Добавил новый эмоут snuffle (Шмыгать носом). Эмоуту sniff прописал действие "Нюхает".
Все авто эмоуты sniff в контексте "Шмыгает" (при болезнях), заменил на snuffle. Добавил snuffle в панельку.
При обнюхивании из Vore панельки теперь будет эмоут sniff.
При облизывании из Vore панельки теперь будет звук, как при облизывании языком. А так-же задержка.
Проверено на локалке.

## Причина изменений
Эмоут sniff  в большинстве случаев юзается как "Нюхать", а не как "Шмыгает носом", второе лишь автоматически при болезни. Адекватный перевод, что бы звучало красиво, подобрать у меня не получилось, так что добавил его вариацию, как посоветовали. Добавил в Vore панельку, ибо логично + визуально помечает действие, а не только мелким шрифтом в чатике