### PR TITLE
Сервера теперь работают (в рнд)

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -293,7 +293,7 @@ SUBSYSTEM_DEF(research)
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
 	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 35)	//citadel edit - techwebs nerf
-	var/multiserver_calculation = FALSE
+	var/multiserver_calculation = TRUE
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
 
@@ -339,6 +339,8 @@ SUBSYSTEM_DEF(research)
 	if(multiserver_calculation)
 		var/eff = calculate_server_coefficient()
 		for(var/obj/machinery/rnd/server/miner in servers)
+			if(!miner.working)
+				continue
 			var/list/result = (miner.mine())	//SLAVE AWAY, SLAVE.
 			for(var/i in result)
 				result[i] *= eff

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -67,8 +67,6 @@
 	refresh_working()
 
 /obj/machinery/rnd/server/proc/mine()
-	if(machine_stat & (BROKEN|NOPOWER))
-		return
 	. = base_mining_income.Copy()
 	var/penalty = max((get_env_temp() - temp_tolerance_high), 0) * temp_penalty_coefficient
 	for(var/i in .)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -6,12 +6,15 @@
 	req_access = list(ACCESS_RD) //ONLY THE R&D CAN CHANGE SERVER SETTINGS.
 	circuit = /obj/item/circuitboard/machine/rdserver
 
+	idle_power_usage = 500
+	power_channel = 1
 	var/datum/techweb/stored_research
 	//Code for point mining here.
 	var/working = TRUE			//temperature should break it.
 	var/server_id = 0
-	var/base_mining_income = 2
+	var/list/base_mining_income = list(TECHWEB_POINT_TYPE_GENERIC = 2)
 	var/heat_gen = 1
+	var/income_gen = 1
 	var/heating_power = 40000
 	var/delay = 5
 	var/temp_tolerance_low = 0
@@ -23,15 +26,27 @@
 	SSresearch.servers |= src
 	stored_research = SSresearch.science_tech
 
+/obj/machinery/rnd/server/process()
+	if(!(machine_stat & NOPOWER))
+		produce_heat(base_mining_income[1])
+
 /obj/machinery/rnd/server/Destroy()
 	SSresearch.servers -= src
 	return ..()
 
 /obj/machinery/rnd/server/RefreshParts()
 	var/tot_rating = 0
-	for(var/obj/item/stock_parts/SP in src)
+	for(var/obj/item/stock_parts/SP in src.component_parts)
 		tot_rating += SP.rating
 	heat_gen = initial(src.heat_gen) / max(1, tot_rating)
+	income_gen = 1 + ((tot_rating - 1) * 0.2)
+
+/obj/machinery/rnd/server/power_change()
+	. = ..()
+	if(machine_stat & NOPOWER)
+		working = FALSE
+	else
+		working = TRUE
 
 /obj/machinery/rnd/server/proc/refresh_working()
 	if(machine_stat & EMPED)
@@ -52,10 +67,12 @@
 	refresh_working()
 
 /obj/machinery/rnd/server/proc/mine()
-	. = base_mining_income
+	if(machine_stat & (BROKEN|NOPOWER))
+		return
+	. = base_mining_income.Copy()
 	var/penalty = max((get_env_temp() - temp_tolerance_high), 0) * temp_penalty_coefficient
-	. = max(. - penalty, 0)
-	produce_heat(. / base_mining_income)
+	for(var/i in .)
+		.[i] = max((.[i] * income_gen) - penalty, 0)
 
 /obj/machinery/rnd/server/proc/get_env_temp()
 	var/datum/gas_mixture/environment = loc.return_air()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -7,7 +7,6 @@
 	circuit = /obj/item/circuitboard/machine/rdserver
 
 	idle_power_usage = 500
-	power_channel = 1
 	var/datum/techweb/stored_research
 	//Code for point mining here.
 	var/working = TRUE			//temperature should break it.


### PR DESCRIPTION
# Описание
1) количество рнд серверов теперь влияет на количество генерируемых очков, базовая конфигурация 2 сервера генерирует 28 очков, каждый последующий сервер делает общий модификатор серверов по sqrt(100 / (количество серверов)), от чего эффективность сильно падает вниз с каждым новым сервером, однако это балансируется тем, что сервера можно улучшить, с тир 4 деталями при конфигурации 2 сервера выходит 50 очков
(ранее генерировалось ровно 35 и точка)
2) рнд сервера потребляют энергию (500 ватт)
## Причина изменений
фиксы кода (система не работала) и доработка кода и фич