### PR TITLE
Мета; перенос ксено спавнов из дорм в теха

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5838,6 +5838,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "auc" = (
@@ -65347,7 +65348,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "lOt" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/plasteel/freezer,
 /area/commons/toilet/restrooms)


### PR DESCRIPTION
# Описание
1) ксено спавны перенесены из дорм в теха, сколько те должны проходить в редко используемых местах

## Причина изменений
мапфикс