### PR TITLE
vore flavor fix

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -102,7 +102,7 @@
 #define MAX_MESSAGE_LEN			4096		//Citadel edit: What's the WORST that could happen?
 #define MAX_FLAVOR_LEN			4096
 #define MAX_FLAVOR_PREVIEW_LEN	40
-#define MAX_TASTE_LEN			40 //lick... vore... ew...
+#define MAX_TASTE_LEN			400 //lick... vore... ew... //BLUEMOON EDIT
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80


### PR DESCRIPTION
# Описание
Повышает лимит на флавор вкуса/запаха в vore панельке. Точнее уравнивает лимиты.

## Причина изменений
В описании при установке указано 400 символов, дефайн в vore файле стоит 400, а дефан при сохранении на 40. Фиксим баг