### PR TITLE
Квирк на воображаемого друга

### DIFF
--- a/code/__BLUEMOONCODE/_DEFINES/traits.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/traits.dm
@@ -13,6 +13,7 @@
 #define TRAIT_SHY							"shy"
 #define TRAIT_COMMON_PREGNANCY				"common_pregnancy"
 #define TRAIT_BONDAGED						"bondaged"
+#define TRAIT_IMAGINARYFRIEND				"imaginaryfriend"
 
 // Отдельные наименования для квирков, чтобы не повторять их в настройках
 #define BLUEMOON_TRAIT_NAME_SHRIEK				"Крикун"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -53,9 +53,9 @@
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return
-	if(isobserver(user))
+	if(isobserver(user) && !skip_reentry_check)
 		var/mob/dead/observer/O = user
-		if(!O.can_reenter_round() && !skip_reentry_check)
+		if(!O.can_reenter_round())
 			return FALSE
 	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and as such, it's very likely to be off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Да","Нет")
 	if(ghost_role == "Нет" || !loc)

--- a/modular_bluemoon/code/datums/brain_damage/imaginary_friend.dm
+++ b/modular_bluemoon/code/datums/brain_damage/imaginary_friend.dm
@@ -1,102 +1,41 @@
-/datum/brain_trauma/special/imaginary_friend/quirk
-	var/obj/effect/mob_spawn/imaginary_friend/friend_inside_me
-
-/datum/brain_trauma/special/imaginary_friend/quirk/on_gain()
-	make_friend()
-
-/datum/brain_trauma/special/imaginary_friend/quirk/on_life() // Не травму
-	if(get_dist(owner, friend) > 9)
-		friend.recall()
-
-/datum/brain_trauma/special/imaginary_friend/quirk/on_death() // Не травму
-	return
-
-/datum/brain_trauma/special/imaginary_friend/quirk/reroll_friend()
-	if(friend.client) //reconnected
-		return
-	friend_initialized = FALSE
-	UnregisterSignal(friend, COMSIG_MOB_GHOSTIZE)
-	QDEL_NULL(friend)
-	make_friend()
-
-/datum/brain_trauma/special/imaginary_friend/quirk/proc/real_reroll_friend()
-	SIGNAL_HANDLER
-	if(friend.client) //reconnected
-		return
-	friend_initialized = FALSE
-	UnregisterSignal(friend, COMSIG_MOB_GHOSTIZE)
-	QDEL_NULL(friend)
-	make_friend()
-
-/datum/brain_trauma/special/imaginary_friend/quirk/make_friend()
-	friend = new(get_turf(owner), src)
-	friend_inside_me = new(friend, src)
-
-/datum/brain_trauma/special/imaginary_friend/quirk/get_ghost()
-	return
-
 /obj/effect/mob_spawn/imaginary_friend
 	//job_description ставим при иницализации
-	short_desc = "Вы воображаемый друг. Главное не косплейте одного рокера с протезом."
-	flavour_text = "FRIEND INSIDE ME"
-	important_info = "FRIEND INSIDE ME"
+	short_desc = "Вы воображаемый друг. Вы абсолютно преданы своему другу, несмотря ни на что."
+	flavour_text = "Главное не косплейте одного рокера с протезом."
+	important_info = "Учитывайте, павергейм наказуем."
 	show_flavour = TRUE
 	banType = ROLE_PAI
 	loadout_enabled = FALSE
 	can_load_appearance = TRUE
 	roundstart = FALSE
-	category = "trauma" // BLUEMOON ADD - категоризация для отображения по спискам
+	skip_reentry_check = TRUE
+	category = "trauma"
+	mob_type = /mob/living/carbon/human // чат верим? Нужно чтобы не менять проверку на can_load_appearance
 	var/mob/camera/imaginary_friend/friend
 	var/datum/brain_trauma/special/imaginary_friend/trauma
 	var/mob/living/carbon/owner
 
-/obj/effect/mob_spawn/imaginary_friend/Initialize(mapload, datum/brain_trauma/special/imaginary_friend/quirk/quirk)
+/obj/effect/mob_spawn/imaginary_friend/Initialize(mapload, datum/brain_trauma/special/imaginary_friend/quirk)
 	trauma = quirk
-	owner = quirk.owner
 	friend = quirk.friend
-	job_description = "[owner.real_name] Imaginary Friend"
+	job_description = "[trauma.owner.real_name] Imaginary Friend"
 	. = ..()
 
-/obj/effect/mob_spawn/imaginary_friend/attack_ghost(mob/user, latejoinercalling)
-	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
+/obj/effect/mob_spawn/imaginary_friend/create(ckey, name, load_character)
+	if(!ckey || trauma.friend_initialized)
 		return
-	if(jobban_isbanned(user, banType))
-		to_chat(user, "<span class='warning'>You are jobanned!</span>")
-		return
-	if(QDELETED(src) || QDELETED(user))
-		return
-//	if(isobserver(user))
-//		var/mob/dead/observer/O = user
-//		if(!O.can_reenter_round() && !skip_reentry_check)
-//			return FALSE
-	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and as such, it's very likely to be off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Да","Нет")
-	if(ghost_role == "Нет" || !loc)
-		return
-	var/requested_char = FALSE
-	if(can_load_appearance)
-		switch(alert(user, "Желаете загрузить текущего своего выбранного персонажа?", "Play as your character!", "Yes", "No", "Actually nevermind"))
-			if("Yes")
-				requested_char = TRUE
-			if("Actually nevermind")
-				return
-	if(QDELETED(src) || QDELETED(user))
-		return
-	if(latejoinercalling)
-		var/mob/dead/new_player/NP = user
-		if(istype(NP))
-			NP.close_spawn_windows()
-			NP.stop_sound_channel(CHANNEL_LOBBYMUSIC)
-	log_game("[key_name(user)] становится [mob_name]!")
 	trauma.friend_initialized = TRUE
-	friend.setup_friend(user, requested_char)
-	user.transfer_ckey(trauma.friend, FALSE)
-	trauma.RegisterSignal(friend, COMSIG_MOB_GHOSTIZE, TYPE_PROC_REF(/datum/brain_trauma/special/imaginary_friend/quirk, real_reroll_friend))
-	qdel(src)
-	return TRUE
+	var/mob/new_user = get_mob_by_ckey(ckey) // я сам в шоке, что в crate передаётся ckey, а не моб юзер
+	new_user.transfer_ckey(friend, FALSE)
+	friend.setup_friend(load_character)
+	trauma.friend_spawner = null
+	friend.reset_perspective(owner)
+	QDEL_NULL(src)
 
-/mob/camera/imaginary_friend/setup_friend(mob/user, use_pref = FALSE)
-	if(!use_pref || !user.client.prefs)
-		return ..()
-	real_name = user.client.prefs.real_name
-	name = real_name
-	human_image = get_flat_human_icon(null, pick(SSjob.occupations), user.client.prefs)
+/mob/camera/imaginary_friend/reset_perspective(atom/A)
+	if(!client)
+		return
+	client.eye = owner
+	client.perspective = EYE_PERSPECTIVE
+	SEND_SIGNAL(src, COMSIG_MOB_RESET_PERSPECTIVE, A)
+	return TRUE

--- a/modular_bluemoon/code/datums/brain_damage/imaginary_friend.dm
+++ b/modular_bluemoon/code/datums/brain_damage/imaginary_friend.dm
@@ -1,0 +1,102 @@
+/datum/brain_trauma/special/imaginary_friend/quirk
+	var/obj/effect/mob_spawn/imaginary_friend/friend_inside_me
+
+/datum/brain_trauma/special/imaginary_friend/quirk/on_gain()
+	make_friend()
+
+/datum/brain_trauma/special/imaginary_friend/quirk/on_life() // Не травму
+	if(get_dist(owner, friend) > 9)
+		friend.recall()
+
+/datum/brain_trauma/special/imaginary_friend/quirk/on_death() // Не травму
+	return
+
+/datum/brain_trauma/special/imaginary_friend/quirk/reroll_friend()
+	if(friend.client) //reconnected
+		return
+	friend_initialized = FALSE
+	UnregisterSignal(friend, COMSIG_MOB_GHOSTIZE)
+	QDEL_NULL(friend)
+	make_friend()
+
+/datum/brain_trauma/special/imaginary_friend/quirk/proc/real_reroll_friend()
+	SIGNAL_HANDLER
+	if(friend.client) //reconnected
+		return
+	friend_initialized = FALSE
+	UnregisterSignal(friend, COMSIG_MOB_GHOSTIZE)
+	QDEL_NULL(friend)
+	make_friend()
+
+/datum/brain_trauma/special/imaginary_friend/quirk/make_friend()
+	friend = new(get_turf(owner), src)
+	friend_inside_me = new(friend, src)
+
+/datum/brain_trauma/special/imaginary_friend/quirk/get_ghost()
+	return
+
+/obj/effect/mob_spawn/imaginary_friend
+	//job_description ставим при иницализации
+	short_desc = "Вы воображаемый друг. Главное не косплейте одного рокера с протезом."
+	flavour_text = "FRIEND INSIDE ME"
+	important_info = "FRIEND INSIDE ME"
+	show_flavour = TRUE
+	banType = ROLE_PAI
+	loadout_enabled = FALSE
+	can_load_appearance = TRUE
+	roundstart = FALSE
+	category = "trauma" // BLUEMOON ADD - категоризация для отображения по спискам
+	var/mob/camera/imaginary_friend/friend
+	var/datum/brain_trauma/special/imaginary_friend/trauma
+	var/mob/living/carbon/owner
+
+/obj/effect/mob_spawn/imaginary_friend/Initialize(mapload, datum/brain_trauma/special/imaginary_friend/quirk/quirk)
+	trauma = quirk
+	owner = quirk.owner
+	friend = quirk.friend
+	job_description = "[owner.real_name] Imaginary Friend"
+	. = ..()
+
+/obj/effect/mob_spawn/imaginary_friend/attack_ghost(mob/user, latejoinercalling)
+	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
+		return
+	if(jobban_isbanned(user, banType))
+		to_chat(user, "<span class='warning'>You are jobanned!</span>")
+		return
+	if(QDELETED(src) || QDELETED(user))
+		return
+//	if(isobserver(user))
+//		var/mob/dead/observer/O = user
+//		if(!O.can_reenter_round() && !skip_reentry_check)
+//			return FALSE
+	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and as such, it's very likely to be off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Да","Нет")
+	if(ghost_role == "Нет" || !loc)
+		return
+	var/requested_char = FALSE
+	if(can_load_appearance)
+		switch(alert(user, "Желаете загрузить текущего своего выбранного персонажа?", "Play as your character!", "Yes", "No", "Actually nevermind"))
+			if("Yes")
+				requested_char = TRUE
+			if("Actually nevermind")
+				return
+	if(QDELETED(src) || QDELETED(user))
+		return
+	if(latejoinercalling)
+		var/mob/dead/new_player/NP = user
+		if(istype(NP))
+			NP.close_spawn_windows()
+			NP.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	log_game("[key_name(user)] становится [mob_name]!")
+	trauma.friend_initialized = TRUE
+	friend.setup_friend(user, requested_char)
+	user.transfer_ckey(trauma.friend, FALSE)
+	trauma.RegisterSignal(friend, COMSIG_MOB_GHOSTIZE, TYPE_PROC_REF(/datum/brain_trauma/special/imaginary_friend/quirk, real_reroll_friend))
+	qdel(src)
+	return TRUE
+
+/mob/camera/imaginary_friend/setup_friend(mob/user, use_pref = FALSE)
+	if(!use_pref || !user.client.prefs)
+		return ..()
+	real_name = user.client.prefs.real_name
+	name = real_name
+	human_image = get_flat_human_icon(null, pick(SSjob.occupations), user.client.prefs)

--- a/modular_bluemoon/code/datums/brain_damage/imaginary_friend.dm
+++ b/modular_bluemoon/code/datums/brain_damage/imaginary_friend.dm
@@ -8,7 +8,6 @@
 	loadout_enabled = FALSE
 	can_load_appearance = TRUE
 	roundstart = FALSE
-	skip_reentry_check = TRUE
 	category = "trauma"
 	mob_type = /mob/living/carbon/human // чат верим? Нужно чтобы не менять проверку на can_load_appearance
 	var/mob/camera/imaginary_friend/friend

--- a/modular_bluemoon/code/datums/traits/neutral.dm
+++ b/modular_bluemoon/code/datums/traits/neutral.dm
@@ -160,3 +160,21 @@
 /datum/quirk/bondage_lover/remove()
 	// Remove mood event
 	SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, QMOOD_BONDAGE)
+
+/datum/quirk/imaginary_friend
+	name = "Воображаемый друг"
+	desc = "У вас появился друг в голове. Кто знает, поможет он вам, или нет... Только не соглашайтесь на его предложение сделать клуб!"
+	value = 0
+	mob_trait = TRAIT_IMAGINARYFRIEND
+	gain_text = span_notice("You feel in good company, for some reason.")
+	lose_text = span_warning("You feel lonely again.")
+	medical_record_text = "У пациента присутсвует \"Воображаемый Друг\"."
+	on_spawn_immediate = FALSE
+
+/datum/quirk/imaginary_friend/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/special/imaginary_friend/quirk, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/imaginary_friend/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.cure_trauma_type(/datum/brain_trauma/special/imaginary_friend/quirk, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/modular_bluemoon/code/datums/traits/neutral.dm
+++ b/modular_bluemoon/code/datums/traits/neutral.dm
@@ -166,15 +166,15 @@
 	desc = "У вас появился друг в голове. Кто знает, поможет он вам, или нет... Только не соглашайтесь на его предложение сделать клуб!"
 	value = 0
 	mob_trait = TRAIT_IMAGINARYFRIEND
-	gain_text = span_notice("You feel in good company, for some reason.")
-	lose_text = span_warning("You feel lonely again.")
+	//gain_text handled be trauma
+	//lose_text handled be trauma
 	medical_record_text = "У пациента присутсвует \"Воображаемый Друг\"."
 	on_spawn_immediate = FALSE
 
 /datum/quirk/imaginary_friend/add()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.gain_trauma(/datum/brain_trauma/special/imaginary_friend/quirk, TRAUMA_RESILIENCE_ABSOLUTE)
+	H.gain_trauma(/datum/brain_trauma/special/imaginary_friend, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/imaginary_friend/remove()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.cure_trauma_type(/datum/brain_trauma/special/imaginary_friend/quirk, TRAUMA_RESILIENCE_ABSOLUTE)
+	H.cure_trauma_type(/datum/brain_trauma/special/imaginary_friend, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4221,6 +4221,7 @@
 #include "modular_bluemoon\code\datums\ert.dm"
 #include "modular_bluemoon\code\datums\shuttles.dm"
 #include "modular_bluemoon\code\datums\world_topic.dm"
+#include "modular_bluemoon\code\datums\brain_damage\imaginary_friend.dm"
 #include "modular_bluemoon\code\datums\components\demoraliser.dm"
 #include "modular_bluemoon\code\datums\components\follow_component.dm"
 #include "modular_bluemoon\code\datums\components\mood_events.dm"

--- a/tgui/packages/tgui/interfaces/SpawnersMenu.js
+++ b/tgui/packages/tgui/interfaces/SpawnersMenu.js
@@ -23,6 +23,7 @@ export const SpawnerContent = (props, context) => {
   const midround = spawners.filter((spawner) => spawner.category === 'midround');
   const special = spawners.filter((spawner) => spawner.category === 'special');
   const offstation = spawners.filter((spawner) => spawner.category === 'offstation');
+  const trauma = spawners.filter((spawner) => spawner.category === 'trauma');
 
   return (
     <Box>
@@ -84,6 +85,14 @@ export const SpawnerContent = (props, context) => {
               Off-Station ({offstation.length})
             </Tabs.Tab>
           )}
+          {trauma.length > 0 && (
+            <Tabs.Tab
+              icon="heartbeat"
+              selected={tab === 'trauma'}
+              onClick={() => setTab('trauma')}>
+              Trauma ({trauma.length})
+            </Tabs.Tab>
+          )}
         </Tabs>
       </Section>
       {tab === 'misc' && <RolelistMisc spawners={misc} />}
@@ -93,6 +102,7 @@ export const SpawnerContent = (props, context) => {
       {tab === 'midround' && <RolelistMidround spawners={midround} />}
       {tab === 'special' && <RolelistSpecial spawners={special} />}
       {tab === 'offstation' && <RolelistOffstation spawners={offstation} />}
+      {tab === 'trauma' && <RolelistSyndicate spawners={trauma} />}
     </Box>
   );
 };
@@ -212,6 +222,16 @@ export const RolelistSpecial = ({ spawners, context }) => {
 };
 
 export const RolelistOffstation = ({ spawners, context }) => {
+  return (
+    <Section>
+      {spawners.map((spawner) => (
+        <RolelistItem key={spawner.name} spawner={spawner} />
+      ))}
+    </Section>
+  );
+};
+
+export const RolelistTrauma = ({ spawners, context }) => {
   return (
     <Section>
       {spawners.map((spawner) => (


### PR DESCRIPTION
# Описание
1) добавлен квирк на воображаемого друга
2) пофикшен баг, что воображаемый друг видел от своих глаз (мог смотреть за стены)
3) теперь вместо предложения сыграть гостам за воображаемого друга появляется гост слот который можно выбрать через меню спавнеров
4) за воображаемого друга можно зайти за своего персонажа
5) ну и дабавлен таб в спавнер меню для травм (может кто решит ещё и сплит персоналити так-же сделать)
## Причина изменений
Круто прикольно и вообще Mrowl платный запрос висящий непойми сколько