### PR TITLE
drink fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -369,6 +369,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	boozepwr = 45
 	quality = DRINK_FANTASTIC
 	taste_description = "scaley sweetness"
+	glass_icon_state = "plumwineglass"
+	glass_name = "glass of Lizard wine"
+	glass_desc = "It looks like dark wine."
+	shot_glass_icon_state = "shotglassred"
 	pH = 3
 	value = REAGENT_VALUE_VERY_RARE
 

--- a/modular_bluemoon/code/modules/reagents/chemistry/reagents/drink_synth.dm
+++ b/modular_bluemoon/code/modules/reagents/chemistry/reagents/drink_synth.dm
@@ -358,6 +358,7 @@
 
 // Вариация рестарта для нон-конеров, после него синт не проснётся, пока реагент не закончится
 /datum/reagent/consumable/synthdrink/synthanol/restart/hard
+	name = "Hard Restart"
 	description = "Sometimes you just need to start anew... Welp, this one comes with BIOS update, oh shit."
 	color = "#0095ff"
 	synthetic_taste = "перезагрузки с установкой дополнительного ПО? Оу, это будет долго..."


### PR DESCRIPTION
# Описание
Добавил описание вину из хвоста ящериц, плюс спрайт, который просто не использовался
Добавил имя Хард рестарту, ибо он не корректно отображался в картридже рецептов, подменяя собой обычный рестарт
Проверено на локалке.