### PR TITLE
Advtools implant фикс

### DIFF
--- a/modular_sand/code/modules/surgery/organs/augments_arms.dm
+++ b/modular_sand/code/modules/surgery/organs/augments_arms.dm
@@ -5,14 +5,15 @@
 /obj/item/organ/cyberimp/arm/toolset/advanced
 	name = "advanced integrated toolset implant"
 	desc = "A very advanced version of the regular toolset implant, has alien stuff!"
-/*	contents = newlist(/obj/item/screwdriver/abductor, // BLUEMOON COMMENTING OUT: using own list of tools here
-						/obj/item/wrench/abductor,
-						/obj/item/weldingtool/abductor,
-						/obj/item/crowbar/abductor,
-						/obj/item/wirecutters/abductor,
-						/obj/item/multitool/abductor,
-						/obj/item/analyzer/ranged)
-*/ 	// BLUEMOON ADD START
+// 	BLUEMOON COMMENTING OUT using own list of tools below
+//	contents = newlist(/obj/item/screwdriver/abductor,
+//						/obj/item/wrench/abductor,
+//						/obj/item/weldingtool/abductor,
+//						/obj/item/crowbar/abductor,
+//						/obj/item/wirecutters/abductor,
+//						/obj/item/multitool/abductor,
+//						/obj/item/analyzer/ranged)
+// 	BLUEMOON ADD START
 	contents = newlist(/obj/item/screwdriver/advanced,
 						/obj/item/wrench/advanced,
 						/obj/item/weldingtool/advanced,
@@ -20,7 +21,7 @@
 						/obj/item/wirecutters/advanced,
 						/obj/item/multitool/advanced,
 						/obj/item/analyzer/ranged)
-	// BLUEMOON ADD END
+// 	BLUEMOON ADD END
 
 /obj/item/organ/cyberimp/arm/toolset/advanced/emag_act()
 	. = ..()

--- a/modular_sand/code/modules/surgery/organs/augments_arms.dm
+++ b/modular_sand/code/modules/surgery/organs/augments_arms.dm
@@ -5,13 +5,22 @@
 /obj/item/organ/cyberimp/arm/toolset/advanced
 	name = "advanced integrated toolset implant"
 	desc = "A very advanced version of the regular toolset implant, has alien stuff!"
-	contents = newlist(/obj/item/screwdriver/abductor,
+/*	contents = newlist(/obj/item/screwdriver/abductor, // BLUEMOON COMMENTING OUT: using own list of tools here
 						/obj/item/wrench/abductor,
 						/obj/item/weldingtool/abductor,
 						/obj/item/crowbar/abductor,
 						/obj/item/wirecutters/abductor,
 						/obj/item/multitool/abductor,
 						/obj/item/analyzer/ranged)
+*/ 	// BLUEMOON ADD START
+	contents = newlist(/obj/item/screwdriver/advanced,
+						/obj/item/wrench/advanced,
+						/obj/item/weldingtool/advanced,
+						/obj/item/crowbar/advanced,
+						/obj/item/wirecutters/advanced,
+						/obj/item/multitool/advanced,
+						/obj/item/analyzer/ranged)
+	// BLUEMOON ADD END
 
 /obj/item/organ/cyberimp/arm/toolset/advanced/emag_act()
 	. = ..()


### PR DESCRIPTION
# Описание
Продвинутый имплантат инструментов давал Т5 алиенки, не адванседы. Исправляем это под репликацию технологии абдукторов.
- [X] Изменения были проверены на локальном сервере

## Причина изменений
Хороший человек уведомил, дошлифовываем переделку Т5.

## Демонстрация изменений
Не думаю, что нужно.
