### PR TITLE
Syndie Cyborg updated

### DIFF
--- a/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_sand/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -23,7 +23,7 @@
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/thermal,
-		/obj/item/extinguisher,
+		/obj/item/extinguisher/mini,
 		/obj/item/weldingtool/experimental,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/wrench/cyborg,
@@ -52,7 +52,9 @@
 		/obj/item/gun/medbeam,
 		/obj/item/reagent_containers/borghypo/syndicate,
 		/obj/item/stack/medical/bone_gel,
-		/obj/item/bonesetter/bone,
+		/obj/item/bonesetter,
+		/obj/item/organ_storage,
+		/obj/item/borg/cyborghug/medical,
 		/obj/item/borg/lollipop,
 		/obj/item/borg_shapeshifter,
 		/obj/item/cyborg_inducer


### PR DESCRIPTION
# Обновление предметов у "Синдикатского" модуля у DS-овцев 
### <sup> [И Интеков конечно-же, ибо у них альтернативы на создания "Интековских" юнитов нету.]</sup>

- [ ] Проверено на локальном сервере, всё имеется и работает нормально.
- [ ] Можно спокойно мёрджить.

## Причина изменений
#### Играя на данном юните, заметил парочку проблем и большое кол-во вопросов от одной вещи, находящихся у данного модуля - А именно:
- Костяной Костоправ - Зачем, не знаю. Но, он там есть и это странно с логики. Исправлено!
- Отсутствие предмета/вещи/инструмента, которое позволит манипулировать с органами. Исправлено!
- У юнитов зачем-то стандартный огнетушитель. Но он не инженерный... Исправлено!
<sub><sup>ОТКУДА У ЮНИТОВ КОСТЯННОЙ КОСТОПРАВ?!!</sup></sub>
## Что изменилось у "Синдикатского" модуля:
### Добавлено: 
- Мешочек для органов
- Модуль "обнимашек" (Нужен для того чтобы будить/трясти игроков).
### Изменено: 
- Обычный огнетушитель на Мини огнетушитель
- Костяной костоправ на Обычный костоправ.