### PR TITLE
vore and panel

### DIFF
--- a/modular_sand/code/datums/interactions/_interaction.dm
+++ b/modular_sand/code/datums/interactions/_interaction.dm
@@ -119,7 +119,7 @@
 	if(get_dist(user, target) > max_distance)
 		to_chat(user, span_warning("Слишком далеко."))
 		return FALSE
-	if(interaction_flags & INTERACTION_FLAG_ADJACENT && !(user.Adjacent(target) && target.Adjacent(user)))
+	if(interaction_flags & INTERACTION_FLAG_ADJACENT && !(user.Adjacent(target) && target.Adjacent(user) || isbelly(user.loc) && user.loc:owner == target || isbelly(target.loc) && target.loc:owner == user)) // BLUEMOON EDIT can interact if in belly
 		to_chat(user, span_warning("Ты не достаёшь."))
 		return FALSE
 	if(!evaluate_user(user, silent = FALSE, apply_cooldown = apply_cooldown))


### PR DESCRIPTION
# Описание
Теперь можно использовать панельку если вы в животе, но только на том, кто употребил (или на себе). Аналогично, употребивший может использовать панельку на вас (если открыл ее предварительно)
Проверено на локалке.

## Причина изменений
Логи логами, но механом подкрепить не помешает.