### PR TITLE
maso and trait updt

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -184,6 +184,22 @@
 
 		L.DefaultCombatKnockdown(shockStrength)
 
+		//BLUEMOON ADD START
+		var/mob/living/carbon/human/H = L
+		if(H)
+			if(HAS_TRAIT(H, TRAIT_MASO))
+				var/genits = H.adjust_arousal(40, "masochism", maso = TRUE)
+				H.handle_post_sex(HIGH_LUST, null, null) // Big cooldown = high_lust
+				if(prob(30))
+					H.emote(pick("moan", "shiver", "blush"))
+				for(var/g in genits)
+					var/obj/item/organ/genital/G = g
+					to_chat(H, span_userlove("[G.arousal_verb]!"))
+			else
+				if(prob(30))
+					H.emote(pick("groan", "shiver", "twitch_s"))
+				H.add_lust(-1*HIGH_LUST)
+		//BLUEMOON ADD END
 	if(master)
 		master.receive_signal()
 	return

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -1042,9 +1042,13 @@
 		return
 	var/mob/living/silicon/robot/R = user
 	var/mob/living/L = target
+	// BLUEMOON EDIT START commented P.S. This is not a vore mechanic, the check has been removed by analogy with the living tongue
+	/*
 	if(L.ckey && !(L.client?.prefs.vore_flags & LICKABLE))
 		to_chat(R, "<span class='danger'>ERROR ERROR: Target not lickable. Aborting display-of-affection subroutine.</span>")
 		return
+	*/
+	// BLUEMOON EDIT END commented
 
 	if(check_zone(R.zone_selected) == "head")
 		R.visible_message("<span class='warning'>\the [R] affectionally licks \the [L]'s face!</span>", "<span class='notice'>You affectionally lick \the [L]'s face!</span>")

--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -52,10 +52,10 @@
 		if(istype(G, /obj/item/organ/genital/penis))
 			//SPLURT edit
 			if(CHECK_BITFIELD(G.genital_flags, GENITAL_CHASTENED) && enabling)
-				to_chat(src, "<span class='userlove'>Your [pick(GLOB.dick_nouns)] twitches against its cage!</span>")
+				to_chat(src, "<span class='userlove'>Твой [pick("член","пенис")] дергается в своей клетке!</span>") // BLUEMOON EDIT
 				continue
 			if(CHECK_BITFIELD(G.genital_flags, GENITAL_IMPOTENT) && enabling)
-				to_chat(src, "<span class='userlove'>Your [pick(GLOB.dick_nouns)] simply won't go up!</span>")
+				to_chat(src, "<span class='userlove'>Твой [pick("член","пенис")] просто не может возбудиться!</span>") // BLUEMOON EDIT
 				continue
 		//
 		if(G.genital_flags & GENITAL_CAN_AROUSE && !G.aroused_state && prob(abs(strength)*G.sensitivity * arousal_rate))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2023,9 +2023,15 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 						target_message = span_lewd("[user] шлёпает по сочной заднице [target]! Она [pick("пульсирует","покачивается","трясётся","хлопает","колеблется","трясётся")] после хорошего удара и мешает вам стоять ровно!"))
 				return FALSE
 		//SPLURT ADDITION END
-		target.adjust_arousal(20,"masochism", maso = TRUE)
-		if (ishuman(target) && HAS_TRAIT(target, TRAIT_MASO) && target.has_dna() && prob(10))
-			target.mob_climax(forced_climax=TRUE, cause = "masochism")
+		// BLUEMOON EDIT START || It's easy to get aroused, but it's hard to cum.
+		if(ishuman(target) && HAS_TRAIT(target, TRAIT_MASO) && target.has_dna() && prob(40))
+			var/genits = target.adjust_arousal(20,"masochism", maso = TRUE)
+			for(var/g in genits)
+				var/obj/item/organ/genital/G = g
+				to_chat(target, span_userlove("[G.arousal_verb]!"))
+			if(prob(60)) // ~ 25% considering the first prob
+				target.handle_post_sex(NORMAL_LUST, null, null)
+		// BLUEMOON EDIT END
 		if (!HAS_TRAIT(target, TRAIT_PERMABONER))
 			stop_wagging_tail(target)
 		// playsound(target.loc, 'sound/weapons/slap.ogg', 50, 1, -1) // BLUEMOON REMOVAL - это дубль звука сверху (почему он вообще существует?)
@@ -2448,7 +2454,13 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	switch(damagetype)
 		if(BRUTE)
 			H.damageoverlaytemp = 20
-			var/damage_amount
+			// BLUEMOON EDIT START
+			var/damage_amount = forced ? damage : damage * hit_percent * brutemod * H.physiology.brute_mod
+			// Да, проверка специально написана, до проверки на прочную кожу
+			if(HAS_TRAIT(H, TRAIT_MASO))
+				if(!(H.IsSleeping() || H.stat >= 2 || H.IsUnconscious())) // BLUEMOON ADD - персонаж не спит, не без сознания и не мертв
+					H.handle_post_sex(min(damage_amount, HIGH_LUST), null, null)
+			// BLUEMOON EDIT END
 			if (HAS_TRAIT(H, TRAIT_TOUGHT) && !forced) // проверка на трейт стойкости
 				if (damage < 10) //если урон до применения модификаторов не привышает 10, то он не учитывается
 					if(HAS_TRAIT(H, TRAIT_ROBOTIC_ORGANISM))
@@ -2462,12 +2474,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			if(BP)
 				if(BP.receive_damage(damage_amount, 0, wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness))
 					H.update_damage_overlays()
-					if(HAS_TRAIT(H, TRAIT_MASO) && prob(damage_amount))
-						if(!(H.IsSleeping() || H.stat >= 2 || H.IsUnconscious())) // BLUEMOON ADD - персонаж не спит, не без сознания и не мертв
-							H.mob_climax(forced_climax=TRUE, cause = "masochism")
-
+			//BLUEMOON EDIT START
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage_amount)
+			//BLUEMOON EDIT END
 		if(BURN)
 			H.damageoverlaytemp = 20
 			var/damage_amount = forced ? damage : damage * hit_percent * burnmod * H.physiology.burn_mod

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2029,8 +2029,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			for(var/g in genits)
 				var/obj/item/organ/genital/G = g
 				to_chat(target, span_userlove("[G.arousal_verb]!"))
-			if(prob(60)) // ~ 25% considering the first prob
-				target.handle_post_sex(NORMAL_LUST, null, null)
+			target.handle_post_sex(NORMAL_LUST, null, null)
 		// BLUEMOON EDIT END
 		if (!HAS_TRAIT(target, TRAIT_PERMABONER))
 			stop_wagging_tail(target)

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -403,7 +403,7 @@
 	else
 		if(ishuman(src))
 			var/mob/living/carbon/human/H = src
-			smell_message += "a normal [H.custom_species ? H.custom_species : H.dna.species]"
+			taste_message += "a normal [H.custom_species ? H.custom_species : H.dna.species]"
 		else
 			taste_message += "a plain old normal [src]"
 	return taste_message

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -364,7 +364,7 @@
 
 	var/list/lickable = list()
 	for(var/mob/living/L in view(1))
-		if(L != src && (!L.ckey || L.client?.prefs.vore_flags & LICKABLE) && Adjacent(L))
+		if(L != src && Adjacent(L))
 			LAZYADD(lickable, L)
 	for(var/mob/living/listed in lickable)
 		lickable[listed] = new /mutable_appearance(listed)
@@ -374,7 +374,7 @@
 
 	var/mob/living/tasted = lickable.len == 1 ? lickable[1] : show_radial_menu(src, src, lickable, radius = 40, require_near = TRUE) // BLUEMOON EDIT
 
-	if(QDELETED(tasted) || (tasted.ckey && !(tasted.client?.prefs.vore_flags & LICKABLE)) || !Adjacent(tasted) || incapacitated(ignore_restraints = TRUE))
+	if(QDELETED(tasted) || !Adjacent(tasted) || incapacitated(ignore_restraints = TRUE)) // BLUEMOON EDIT
 		return
 
 	//BLUEMOON ADD START // Delay like licking tongue
@@ -391,16 +391,19 @@
 	playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1) //BLUEMOON ADD
 	visible_message("<span class='warning'><b>[src]</b> licks <b>[tasted]</b>!</span>","<span class='notice'>You lick <b>[tasted]</b>. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>") //BLUEMOON EDIT
 
-/mob/living/proc/get_taste_message(allow_generic = TRUE, datum/species/mrace)
+// BLUEMOON EDIT START
+/mob/living/proc/get_taste_message(allow_generic = TRUE)
 	if(!vore_taste && !allow_generic)
 		return FALSE
 
 	var/taste_message = ""
-	if(vore_taste && (vore_taste != ""))
+	if((!ckey || client?.prefs.vore_flags & LICKABLE) && vore_taste && vore_taste != "")
+// BLUEMOON EDIT END
 		taste_message += "[vore_taste]"
 	else
 		if(ishuman(src))
-			taste_message += "they haven't bothered to set their flavor text"
+			var/mob/living/carbon/human/H = src
+			smell_message += "a normal [H.custom_species ? H.custom_species : H.dna.species]"
 		else
 			taste_message += "a plain old normal [src]"
 	return taste_message
@@ -424,7 +427,7 @@
 
 	var/list/smellable = list()
 	for(var/mob/living/L in view(1))
-		if(L != src && (!L.ckey || L.client?.prefs.vore_flags & SMELLABLE) && Adjacent(L))
+		if(L != src && Adjacent(L))
 			LAZYADD(smellable, L)
 	for(var/mob/living/listed in smellable)
 		smellable[listed] = new /mutable_appearance(listed)
@@ -434,18 +437,18 @@
 
 	var/mob/living/sniffed = smellable.len == 1 ? smellable[1] : show_radial_menu(src, src, smellable, radius = 40, require_near = TRUE) // BLUEMOON EDIT
 
-	if(QDELETED(sniffed) || (sniffed.ckey && !(sniffed.client?.prefs.vore_flags & SMELLABLE)) || !Adjacent(sniffed) || incapacitated(ignore_restraints = TRUE))
+	if(QDELETED(sniffed) || !Adjacent(sniffed) || incapacitated(ignore_restraints = TRUE))
 		return
 
 	emote("sniff") //BLUEMOON ADD
 	visible_message("<span class='warning'><b>[src]</b> smells <b>[sniffed]</b>!</span>","<span class='notice'>You smell <b>[sniffed]</b>. They smell like [sniffed.get_smell_message()].</span>","<b>Sniff!</b>") //BLUEMOON EDIT
 
-/mob/living/proc/get_smell_message(allow_generic = TRUE, datum/species/mrace)
-	if(!vore_smell && !allow_generic)
-		return FALSE
+// BLUEMOON EDIT START
+/mob/living/proc/get_smell_message()
 
 	var/smell_message = ""
-	if(vore_smell && (vore_smell != ""))
+	if((!ckey || client?.prefs.vore_flags & SMELLABLE) && vore_smell && vore_smell != "")
+	// BLUEMOON EDIT END
 		smell_message += "[vore_smell]"
 	else
 		if(ishuman(src))

--- a/modular_splurt/code/_onclick/observer.dm
+++ b/modular_splurt/code/_onclick/observer.dm
@@ -19,9 +19,15 @@
 		playsound(src.loc, 'sound/weapons/tap.ogg', 50, 1, -1)
 		return
 	if(istype(H))
-		H.adjust_arousal(20, "masochism", maso=TRUE)
-		if(HAS_TRAIT(H, TRAIT_MASO) && H.has_dna() && prob(10))
-			H.mob_climax(forced_climax=TRUE, cause="masochism")
+		// BLUEMOON EDIT START || It's easy to get aroused, but it's hard to cum.
+		if(HAS_TRAIT(H, TRAIT_MASO) && H.has_dna() && prob(40))
+			var/genits = H.adjust_arousal(20,"masochism", maso = TRUE)
+			for(var/g in genits)
+				var/obj/item/organ/genital/G = g
+				to_chat(H, span_userlove("[G.arousal_verb]!"))
+			if(prob(60)) // ~ 25% considering the first prob
+				H.handle_post_sex(NORMAL_LUST, null, null)
+		// BLUEMOON EDIT END
 	if(!HAS_TRAIT(src, TRAIT_PERMABONER))
 		H.dna.species.stop_wagging_tail(src)
 	playsound(src.loc, 'sound/weapons/slap.ogg', 50, 1, -1)

--- a/modular_splurt/code/_onclick/observer.dm
+++ b/modular_splurt/code/_onclick/observer.dm
@@ -25,8 +25,7 @@
 			for(var/g in genits)
 				var/obj/item/organ/genital/G = g
 				to_chat(H, span_userlove("[G.arousal_verb]!"))
-			if(prob(60)) // ~ 25% considering the first prob
-				H.handle_post_sex(NORMAL_LUST, null, null)
+			H.handle_post_sex(NORMAL_LUST, null, null)
 		// BLUEMOON EDIT END
 	if(!HAS_TRAIT(src, TRAIT_PERMABONER))
 		H.dna.species.stop_wagging_tail(src)

--- a/modular_splurt/code/datums/traits/positive_quirks/bloodfledge.dm
+++ b/modular_splurt/code/datums/traits/positive_quirks/bloodfledge.dm
@@ -650,6 +650,10 @@
 		if(!HAS_TRAIT(bite_target, TRAIT_MASO))
 			// Force bite_target to play the scream emote
 			bite_target.emote("scream")
+		//BLUEMOON ADD START
+		else
+			bite_target.emote("moan")
+		//BLUEMOON ADD END
 
 		// Log the biting action failure
 		log_combat(action_owner,bite_target,"bloodfledge bitten (interrupted)")

--- a/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/chastity/estim_chastity_cage.dm
+++ b/modular_splurt/code/game/objects/items/lewd_items/genital_equipment/chastity/estim_chastity_cage.dm
@@ -26,43 +26,42 @@
 	if(!COOLDOWN_FINISHED(src, last_activation))
 		return
 	var/mob/living/carbon/human/H = estim_cage.equipment.holder_genital.owner
-
+	var/genits = null // BLUEMOON ADD
 	switch(estim_cage.mode)
 		if("shock")
 			playsound(H, get_sfx("sparks"), 20*power)
 
 			if(power >= max_power)
-				H.do_jitter_animation()
+				if(H.client?.prefs.cit_toggles & SEX_JITTER)
+					H.do_jitter_animation()
 				H.Stun(3 SECONDS)
 
 			if(HAS_TRAIT(H, TRAIT_MASO))
-				H.adjust_arousal(20*power, "masochism", maso = TRUE)
-				H.set_lust(5)
+				//BLUEMOON EDIT START
+				genits = H.adjust_arousal(20*power, "masochism", maso = TRUE)
+				H.handle_post_sex(NORMAL_LUST*power, null, null, H.getorganslot(CUM_TARGET_PENIS))
 
 				if(prob(30))
 					H.emote(pick("moan", "shiver", "blush"))
-				return
-
-			if(prob(30))
-				H.emote("groan")
-			H.adjust_arousal(-20*power, "e-stimcage")
-			H.set_lust(0)
-
+			else
+				if(prob(30))
+					if(power > 4)
+						H.emote(pick("scream", "pain", "twitch"))
+					else
+						H.emote(pick("groan", "shiver", "twitch_s"))
+				H.add_lust(-1*NORMAL_LUST*power)
 		if("stimulation")
 			playsound(H, 'modular_splurt/sound/lewd/vibrate.ogg', 20*power)
-			if(HAS_TRAIT(H, TRAIT_MASO) && prob(30))
-				H.adjust_arousal(-20*power, "e-stimcage")
-				H.set_lust(0)
-
-				if(prob(30))
-					H.emote("groan")
-				return
-
 			if(prob(30))
 				H.emote(pick("moan", "shiver", "blush"))
 
-			H.adjust_arousal(20*power, "e-stimcage")
-			H.set_lust(5)
+			genits = H.adjust_arousal(20*power, "e-stimcage")
+			H.handle_post_sex(LOW_LUST*power, null, null, H.getorganslot(CUM_TARGET_PENIS))
+	if(genits)
+		for(var/g in genits)
+			var/obj/item/organ/genital/G = g
+			to_chat(H, span_userlove("[G.arousal_verb]!"))
+		//BLUEMOON EDIT END
 
 	COOLDOWN_START(src, last_activation, 1 SECONDS)
 


### PR DESCRIPTION
# Описание
- Трейт мазохизм теперь дает lust при уроне, а не заставляет кончать с рандомным шансом
- Трейт мазохизм теперь дает lust при ударах по заднице, а не заставляет кончать с шансом 10%
- Пофикшена E-Stim клетка, она корректно накапливает lust при стимуляции, и в зависимости от мазохизма при шоке
- Трейт мазохизм теперь дает lust от шокового ошейника, по аналогии с E-Stim клеткой
- Небольшой рефактор префов на запах/вкус, перенес проверку в общий прок.
Проверено на локалке.