### PR TITLE
Бокс фикс шаттерсов в переговорной на боксе

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15677,7 +15677,7 @@
 /area/command/meeting_room)
 "bnP" = (
 /obj/machinery/button/door{
-	id = "QMPrivate";
+	id = "heads_meeting";
 	name = "Security Shutters";
 	pixel_y = 24
 	},
@@ -71637,15 +71637,6 @@
 	dir = 8
 	},
 /area/security/detectives_office/evidence_room)
-"tPT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "tRE" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/tile/brown/anticorner,
@@ -105179,17 +105170,17 @@ bGq
 rGq
 bLw
 bUx
-tPT
-tPT
-tPT
-tPT
-tPT
-tPT
-tPT
-tPT
-tPT
-tPT
-tPT
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
 bBB
 xgk
 bHE


### PR DESCRIPTION
# Описание
1) у кнопки в переговорной была привязка к шаттерсом кма (упс)
2) поправлены зоны около телекомов

## Причина изменений
мапфиксы