### PR TITLE
plushes box menu updt

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -32,7 +32,7 @@
 		var/list/stored_options_radial = list()
 		for(var/listed in stored_options)
 			stored_options_radial[listed] = new /mutable_appearance(stored_options[listed])
-		choice = stored_options_radial.len == 1 ? stored_options_radial[1] : show_radial_menu(M, src, stored_options_radial, radius = 40, require_near = TRUE, no_repeat_close = TRUE)
+		choice = stored_options_radial.len == 1 ? stored_options_radial[1] : show_radial_menu(M, src, stored_options_radial, radius = 40, require_near = TRUE)
 	else
 		choice = tgui_input_list(M, "Select an item", "Which item would you like to order?", stored_options)
 	// BLEMOON EDIT END
@@ -280,6 +280,8 @@
 	name = "choice box (plushie)"
 	desc = "Using the power of quantum entanglement, this box contains every plush, until the moment it is opened!"
 	icon = 'icons/obj/plushes.dmi'
+	lefthand_file = 'icons/mob/inhands/misc/plushes-lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/plushes-right.dmi'
 	icon_state = "box"
 	item_state = "box"
 

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -21,12 +21,21 @@
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, 1)
 		return FALSE
 
-/obj/item/choice_beacon/proc/generate_options(mob/living/M)
+/obj/item/choice_beacon/proc/generate_options(mob/living/M, radial_menu = FALSE)
 	if(!stored_options || force_refresh)
 		stored_options = generate_display_names()
 	if(!stored_options.len)
 		return
-	var/choice = input(M,"Which item would you like to order?","Select an Item") as null|anything in stored_options
+	// BLEMOON EDIT START
+	var/choice
+	if(radial_menu)
+		var/list/stored_options_radial = list()
+		for(var/listed in stored_options)
+			stored_options_radial[listed] = new /mutable_appearance(stored_options[listed])
+		choice = stored_options_radial.len == 1 ? stored_options_radial[1] : show_radial_menu(M, src, stored_options_radial, radius = 40, require_near = TRUE, no_repeat_close = TRUE)
+	else
+		choice = tgui_input_list(M, "Select an item", "Which item would you like to order?", stored_options)
+	// BLEMOON EDIT END
 	if(!choice || !M.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
 
@@ -288,6 +297,17 @@
 		for(var/V in plushies_set_two)
 			plushie_list[V] = V //easiest way to do this which works with how selecting options works, despite being snowflakey to have the key equal the value
 	return plushie_list
+
+// BLUEMOON ADD START
+/obj/item/choice_beacon/box/plushie/AltClick(mob/user)
+	. = ..()
+	if(user.get_active_held_item() == src && canUseBeacon(user))
+		generate_options(user, TRUE)
+
+/obj/item/choice_beacon/box/plushie/examine(mob/user)
+	. = ..()
+	. += span_notice("Alt-click to show radial menu.")
+// BLUEMOON ADD END
 
 /// Don't allow these special ones (you can still get narplush/hugbox)
 /obj/item/choice_beacon/box/plushie/proc/remove_bad_plushies(list/plushies)

--- a/modular_bluemoon/code/modules/vending/games.dm
+++ b/modular_bluemoon/code/modules/vending/games.dm
@@ -91,6 +91,7 @@
 		/obj/item/airlock_painter/decal/tile = 1,
 		/obj/item/melee/skateboard/pro = 3,
 		/obj/item/melee/skateboard/hoverboard = 1,
+		/obj/item/choice_beacon/box/plushie = 5,
 	)
 	refill_canister = /obj/item/vending_refill/games
 	default_price = PRICE_CHEAP


### PR DESCRIPTION
# Описание
- Перевел выбор из любого маяка призыва (включая коробку игрушек) на TGUI
- Для коробки с игрушками добавил на ALT радиальное меню (вообще, можно и всем прикрутить его, вопрос нужно ли).
- Добавил 5 простых коробок с игрушками в премиум сегмент FUN вендора (по логике, что 5 коробок, игрок может залутать из 5 инфинити комнат, а так просто купить)

Проверено на локалке.

## Причина изменений
Круто и удобно. Можно посмотреть все игрушки за раз и выбрать.

## Демонстрация изменений
<img width="355" height="324" alt="image" src="https://github.com/user-attachments/assets/e86babf8-4004-4385-ac6e-3f61d084a44b" /> 
<img width="347" height="330" alt="image" src="https://github.com/user-attachments/assets/656a358c-7e0b-4f94-990b-6c9fed97f429" />


<img width="434" height="35" alt="image" src="https://github.com/user-attachments/assets/bbfe07e3-cbbf-4ebc-bb56-f59a68740e00" />
