### PR TITLE
trash bag fix

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -50,8 +50,11 @@
 	STR.max_items = 30
 	STR.can_hold_extra = typecacheof(list(/obj/item/organ/lungs, /obj/item/organ/liver, /obj/item/organ/stomach, /obj/item/clothing/shoes)) - typesof(/obj/item/clothing/shoes/magboots, /obj/item/clothing/shoes/clown_shoes, /obj/item/clothing/shoes/jackboots, /obj/item/clothing/shoes/workboots)
 	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear, /obj/item/storage/wallet, /obj/item/organ/brain))
-	STR.limited_random_access = TRUE
-	STR.limited_random_access_stack_position = 3
+	STR.display_numerical_stacking = TRUE // BLUEMOON ADD
+	// BLUEMOON EDIT START || commented
+	//STR.limited_random_access = TRUE
+	//STR.limited_random_access_stack_position = 3
+	// BLUEMOON EDIT END || commented
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.ru_ego()] head and starts chomping at the insides! Disgusting!</span>")
@@ -94,7 +97,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 60
 	STR.max_items = 60
-	STR.limited_random_access_stack_position = 5
+	//STR.limited_random_access_stack_position = 5 // BLUEMOON EDIT || commented
 
 /obj/item/storage/bag/trash/bluespace/cyborg
 	insertable = FALSE

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -50,7 +50,6 @@
 	STR.max_items = 30
 	STR.can_hold_extra = typecacheof(list(/obj/item/organ/lungs, /obj/item/organ/liver, /obj/item/organ/stomach, /obj/item/clothing/shoes)) - typesof(/obj/item/clothing/shoes/magboots, /obj/item/clothing/shoes/clown_shoes, /obj/item/clothing/shoes/jackboots, /obj/item/clothing/shoes/workboots)
 	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear, /obj/item/storage/wallet, /obj/item/organ/brain))
-	STR.display_numerical_stacking = TRUE // BLUEMOON ADD
 	// BLUEMOON EDIT START || commented
 	//STR.limited_random_access = TRUE
 	//STR.limited_random_access_stack_position = 3


### PR DESCRIPTION
# Описание
Пофиксил отображение предметов в мусорном мешке. Раньше он показывал только последние 3/5 предметов и без счетчика кол-ва предметов внутри. Из-за чего вообще не понятно, сколько всего предметов и какие там они.
Проверено на локалке.

## Причина изменений
Мешком тупо не удобно было пользоваться, я ХЗ зачем это добавили, причем это единственный предмет, где такое используется. Ингейм, выглядит вообще как сломанный механ.

## Демонстрация изменений
Было:
<img width="635" height="106" alt="image" src="https://github.com/user-attachments/assets/e22cb588-8e39-4f99-a5b4-1ebed1303264" />
Стало (Предметов одинаковое кол-во):
<img width="1143" height="281" alt="image" src="https://github.com/user-attachments/assets/d2703487-d3e8-4aa4-aef1-3f4bbb4610c3" />
