### PR TITLE
TWEAK: fix advanced pathfinder

### DIFF
--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -99,7 +99,7 @@
 	if(!assembly)
 		activate_pin(3)
 		return
-	idc.access = get_pin_data(IC_INPUT, 4)
+	idc.access = assembly.access_card.access
 	var/turf/a_loc = get_turf(assembly)
 	var/list/P = get_path_to(assembly, locate(get_pin_data(IC_INPUT, 1),get_pin_data(IC_INPUT, 2),a_loc.z), 200, id=idc, exclude=get_turf(get_pin_data_as_type(IC_INPUT,3, /atom)), simulated_only = 0)
 


### PR DESCRIPTION
# Описание

<!--Advanced pathfinder вновь может строить путь через двери к которому ему дали доступ и вместо string доступа использует list -->
+ [ ] Изменения были проверены на локальном сервере
+ [ ] Этот пулл-реквест готов к тест-мерджу.
+ [ ] Изменения были портированы с другого сервера <!-- https://github.com/Citadel-Station-13/Citadel-Station-13/blob/8d663aed3f1ccf7ce81f9263bceaa278c7dfc4e6/code/modules/integrated_electronics/subtypes/smart.dm#L75 -->

## Причина изменений

<!--Мы вновь сможем делать умненьковых ботов-->
