### PR TITLE
Naked (NSFW) headshots

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -274,6 +274,9 @@
 		"headshot_link"		= "", //SPLURT edit
 		"headshot_link1"		= "", //BLUEMOON edit
 		"headshot_link2"		= "", //BLUEMOON edit
+		"headshot_naked_link"		= "", //BLUEMOON ADD
+		"headshot_naked_link1"		= "", //BLUEMOON ADD
+		"headshot_naked_link2"		= "", //BLUEMOON ADD
 		"meat_type"			= "Mammalian",
 		"body_model"		= body_model,
 		"body_size"			= RESIZE_DEFAULT_SIZE,

--- a/code/datums/character_profile.dm
+++ b/code/datums/character_profile.dm
@@ -102,6 +102,7 @@ GLOBAL_LIST_EMPTY(cached_previews)
 					can_see_naked = FALSE
 					break
 			data["flavortext_naked"] = can_see_naked ? (C.dna?.naked_flavor_text || "") : ""
+			data["headshot_naked_links"] =  (check_rights_for(user.client, R_ADMIN) && isobserver(user)) || ((!unknown) && can_see_naked) ? (C.dna.headshot_naked_links.Copy() || "") : list()
 	// BLUEMOON EDIT END
 
 	data["is_unknown"] = unknown

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -27,6 +27,7 @@ GLOBAL_DATUM(dna_for_copying, /datum/dna)
 	var/ooc_notes // hate this
 	var/list/headshot_links = list()
 	// BLUEMOON EDIT END
+	var/list/headshot_naked_links = list() // BLUEMOON ADD
 
 /datum/dna/New(mob/living/new_holder)
 	if(istype(new_holder))
@@ -83,6 +84,7 @@ GLOBAL_DATUM(dna_for_copying, /datum/dna)
 		destination.dna.ooc_notes = ooc_notes
 		destination.dna.headshot_links = headshot_links.Copy()
 		// BLUEMOON EDIT END
+		destination.dna.headshot_naked_links = headshot_naked_links.Copy() // BLUEMOON ADD
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
 		destination.dna.default_mutation_genes = default_mutation_genes
@@ -116,6 +118,7 @@ GLOBAL_DATUM(dna_for_copying, /datum/dna)
 	new_dna.ooc_notes = ooc_notes
 	new_dna.headshot_links = headshot_links.Copy()
 	// BLUEMOON EDIT END
+	new_dna.headshot_naked_links = headshot_naked_links.Copy()
 
 //See mutation.dm for what 'class' does. 'time' is time till it removes itself in decimals. 0 for no timer
 /datum/dna/proc/add_mutation(mutation, class = MUT_OTHER, time)

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -154,7 +154,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		var/mob/living/carbon/our_mob = src
 		if(!our_mob.dna)
 			return
-		changeable_texts.Add("Флавор", "Обнажённый Флавор", "Лор Расы", "Хедшоты")
+		changeable_texts.Add("Флавор", "Обнажённый Флавор", "Лор Расы", "Хедшоты", "Хедшоты без одежды")
 
 	else if(issilicon(src))
 		if(!src.mind)
@@ -191,23 +191,22 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 				var/new_text = tgui_input_text(our_borgy, "Введите новые ООС-заметки своего киборга (максимум [MAX_FLAVOR_LEN] символов).", "Новые ООС-заметки", our_borgy.mind.ooc_notes, MAX_FLAVOR_LEN, TRUE, TRUE)
 				if(new_text)
 					our_borgy.mind.ooc_notes = new_text
-		if("Хедшоты")
+		if("Хедшоты", "Хедшоты без одежды")
 			var/mob/living/carbon/our_mob = src
 			var/chosen_headshot_id = tgui_input_list(our_mob, "Выберите номер хедшота, который хотите изменить.", "Управление флавор-текстами", list("1", "2", "3"), "1")
 			// var/max_headshots = 3
 			if(!chosen_headshot_id || !isnum(text2num(chosen_headshot_id)))
 				return
 			chosen_headshot_id = text2num(chosen_headshot_id)
-			if(chosen_headshot_id >= our_mob.dna.headshot_links.len)
-				chosen_headshot_id = our_mob.dna.headshot_links.len || 1
-			var/old_link = our_mob.dna.headshot_links[chosen_headshot_id]
-			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg')", "Headshot Image", old_link, 100, FALSE, FALSE)
+			var/list/headshots = chosen == "Хедшоты без одежды" ? our_mob.dna.headshot_naked_links : our_mob.dna.headshot_links
+			var/has_headshot_id = chosen_headshot_id <= headshots.len
+			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
 			if(isnull(usr_input))
 				return
 
-			if(!usr_input)
-				our_mob.dna.headshot_links[chosen_headshot_id] = null
-				listclearnulls(our_mob.dna.headshot_links)
+			if(!usr_input && has_headshot_id)
+				headshots[chosen_headshot_id] = null
+				listclearnulls(headshots)
 				return
 
 			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/)")
@@ -223,13 +222,16 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 
 			var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
 			var/new_link = sanitize(usr_input, repl_chars)
-			if(our_mob.dna.headshot_links[chosen_headshot_id] == new_link)
+			if(has_headshot_id && headshots[chosen_headshot_id] == new_link)
 				return
 
 			to_chat(our_mob, span_notice("Если картинка не отображается в игре должным образом, убедитесь, что это прямая ссылка на изображение, которая правильно открывается в обычном браузере."))
 			to_chat(our_mob, span_notice("Имейте в виду, что размер фотографии будет уменьшен до 256x256 пикселей, поэтому чем квадратнее фотография, тем лучше она будет выглядеть."))
 
-			our_mob.dna.headshot_links[chosen_headshot_id] = new_link
+			if(has_headshot_id)
+				headshots[chosen_headshot_id] = new_link
+			else
+				LAZYADD(headshots, new_link)
 		if("Временный Флавор (Поза)")
 			var/mob/living/our_mob = src
 			var/new_text = tgui_input_text(our_mob, "Введите новую позу своего персонажа (максимум 1024 символа).", "Новая поза", our_mob.tempflavor, 1024, TRUE, TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -769,19 +769,18 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						dat += "[TextPreview(medical_records)]..."
 
 					// BLUEMOON ADD
-					dat += "<h2>Headshot 1 Image</h2>"
+					dat += "<h2>Headshots</h2>"
+
 					dat += "<a href='?_src_=prefs;preference=headshot'><b>Set Headshot 1 Image</b></a><br>"
 					if(features["headshot_link"])
 						dat += "<img src='[features["headshot_link"]]' style='border: 1px solid black' width='140px' height='140px'>"
 					dat += "<br><br>"
 
-					dat += "<h2>Headshot 2 Image</h2>"
 					dat += "<a href='?_src_=prefs;preference=headshot1'><b>Set Headshot 2 Image</b></a><br>"
 					if(features["headshot_link1"])
 						dat += "<img src='[features["headshot_link1"]]' style='border: 1px solid black' width='140px' height='140px'>"
 					dat += "<br><br>"
 
-					dat += "<h2>Headshot 3 Image</h2>"
 					dat += "<a href='?_src_=prefs;preference=headshot2'><b>Set Headshot 3 Image</b></a><br>"
 					if(features["headshot_link2"])
 						dat += "<img src='[features["headshot_link2"]]' style='border: 1px solid black' width='140px' height='140px'>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -784,6 +784,23 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<a href='?_src_=prefs;preference=headshot2'><b>Set Headshot 3 Image</b></a><br>"
 					if(features["headshot_link2"])
 						dat += "<img src='[features["headshot_link2"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					//dat += "<br><br>"
+
+					dat += "<h2>Naked (NSFW) Headshots</h2>"
+
+					dat += "<a href='?_src_=prefs;preference=headshot_naked'><b>Set Headshot 1 Image</b></a><br>"
+					if(features["headshot_naked_link"])
+						dat += "<img src='[features["headshot_naked_link"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += "<br><br>"
+
+					dat += "<a href='?_src_=prefs;preference=headshot_naked1'><b>Set Headshot 2 Image</b></a><br>"
+					if(features["headshot_naked_link1"])
+						dat += "<img src='[features["headshot_naked_link1"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += "<br><br>"
+
+					dat += "<a href='?_src_=prefs;preference=headshot_naked2'><b>Set Headshot 3 Image</b></a><br>"
+					if(features["headshot_naked_link2"])
+						dat += "<img src='[features["headshot_naked_link2"]]' style='border: 1px solid black' width='140px' height='140px'>"
 					dat += "<br><br>"
 					// BLUEMOON ADD END
 					dat += "</td></tr></table>"
@@ -4833,6 +4850,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		character.dna.headshot_links.Add(features["headshot_link1"])
 	if (features["headshot_link2"])
 		character.dna.headshot_links.Add(features["headshot_link2"])
+	// BLUEMOON ADD START
+	if (features["headshot_naked_link"])
+		character.dna.headshot_naked_links.Add(features["headshot_naked_link"])
+	if (features["headshot_naked_link1"])
+		character.dna.headshot_naked_links.Add(features["headshot_naked_link1"])
+	if (features["headshot_naked_link2"])
+		character.dna.headshot_naked_links.Add(features["headshot_naked_link2"])
+	// BLUEMOON ADD END
 	character.dna.ooc_notes = features["ooc_notes"]
 	if(custom_blood_color)
 		character.dna.species.exotic_blood_color = blood_color //а раньше эта строчка была немного выше и всё ломалось, думайте, когда делаете врезки

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -971,6 +971,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["headshot"] 							>> features["headshot_link"] //SPLURT edit
 	S["headshot1"] 							>> features["headshot_link1"] //BLUEMOON edit
 	S["headshot2"] 							>> features["headshot_link2"] //BLUEMOON edit
+	S["headshot_naked"] 						>> features["headshot_naked_link"] //BLUEMOON ADD
+	S["headshot_naked1"] 					>> features["headshot_naked_link1"] //BLUEMOON ADD
+	S["headshot_naked2"] 					>> features["headshot_naked_link2"] //BLUEMOON ADD
 	S["shriek_type"] 						>> shriek_type // BLUEMOON ADD - выбор вида крика для квирка
 	S["summon_nickname"] 					>> summon_nickname // BLUEMOON ADD - выбор прозвища для призываемого
 	S["feature_hardsuit_with_tail"] 		>> features["hardsuit_with_tail"]
@@ -1710,6 +1713,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["headshot1"], features["headshot_link1"])
 	WRITE_FILE(S["headshot2"], features["headshot_link2"])
 	//SPLURT EDIT END
+	// BLUEMOON ADD START
+	WRITE_FILE(S["headshot_naked"], features["headshot_naked_link"])
+	WRITE_FILE(S["headshot_naked1"], features["headshot_naked_link1"])
+	WRITE_FILE(S["headshot_naked2"], features["headshot_naked_link2"])
+	// BLUEMOON ADD END
+
 
 	//gear loadout
 	if(islist(loadout_data))

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -16,6 +16,12 @@
 			set_headshot_link(user, "headshot_link1")
 		if ("headshot2")
 			set_headshot_link(user, "headshot_link2")
+		if ("headshot_naked")
+			set_headshot_link(user, "headshot_naked_link")
+		if ("headshot_naked1")
+			set_headshot_link(user, "headshot_naked_link1")
+		if ("headshot_naked2")
+			set_headshot_link(user, "headshot_naked_link2")
 
 	return ..()
 

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -132,7 +132,10 @@ const CharacterProfileImageElement = (props, context) => {
   const { data } = useBackend<CharacterProfileContext>(context);
 
   const headshot_links =
-    data.headshot_links?.filter(link => link?.length) || [];
+    [
+      ...(data.headshot_links || []),
+      ...(data.headshot_naked_links || [])
+    ].filter(link => link?.length) || [];
 
   const [
     selectedHeadshot,

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -74,11 +74,14 @@ export const CharacterProfile = (props, context) => {
                 {data.flavortext || "———"}
               </Section>
             </Collapsible>
-            <Collapsible title="Описание Голого Тела Персонажа" open>
-              <Section style={{ "white-space": "pre-line" }}>
-                {data.flavortext_naked || "———"}
-              </Section>
-            </Collapsible>
+
+            {data.flavortext_naked ? (
+               <Collapsible title="Описание Голого Тела Персонажа" open>
+                <Section style={{ "white-space": "pre-line" }}>
+                  {data.flavortext_naked || "———"}
+                </Section>
+              </Collapsible>
+            ) : (<Box />)}
 
             {data.security_records ? (
               <Collapsible title="База Данных Службы Безопасности" open>


### PR DESCRIPTION
# Описание
- Добавлено 3 хедшота для обнаженного тела (работает по аналогии с флавором)
- Админы видят хедшоты вне зависимости от одежды (в гостах)
- Пофикшена в функции IC -> Manage Flavor (убрал приписку Text) установка хедшотов, ранее можно было менять только первый, сейчас все
- Блок с описанием голого тела будет удаляться, а не заменяться на "———", если отсутствует или скрыт одеждой

## Демонстрация изменений
<img width="363" height="1280" alt="image" src="https://github.com/user-attachments/assets/d8d2bb4b-8f9d-4a37-a5f6-d5bae0746e12" />

В одежде:
<img width="468" height="369" alt="image" src="https://github.com/user-attachments/assets/f2ce53b9-cf8e-4bd2-8ba5-e29d6fe84efe" />
Без одежды:
<img width="475" height="369" alt="image" src="https://github.com/user-attachments/assets/bf99f751-7396-4cb4-84ac-2be29ca6a6cc" />
