### PR TITLE
Lust soft moan + fixes

### DIFF
--- a/code/__SANDCODE/DEFINES/lewd.dm
+++ b/code/__SANDCODE/DEFINES/lewd.dm
@@ -26,6 +26,16 @@ GLOBAL_LIST_INIT(lewd_moans_female, list(
 	'modular_sand/sound/interactions/moan_f6.ogg',
 	'modular_sand/sound/interactions/moan_f7.ogg'
 ))
+// BLUEMOON ADD START
+GLOBAL_LIST_INIT(lewd_softmoans_female, list(
+	'modular_bluemoon/sound/emotes/softmoan1.ogg',
+	'modular_bluemoon/sound/emotes/softmoan2.ogg',
+	'modular_bluemoon/sound/emotes/softmoan3.ogg',
+	'modular_bluemoon/sound/emotes/softmoan4.ogg',
+	'modular_bluemoon/sound/emotes/softmoan5.ogg',
+	'modular_bluemoon/sound/emotes/softmoan6.ogg'
+))
+// BLUEMOON ADD END
 // Kissing sounds
 GLOBAL_LIST_INIT(lewd_kiss_sounds, list(
 	'modular_sand/sound/interactions/kiss1.ogg',

--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -1,6 +1,6 @@
 /mob/living
-	var/mb_cd_length = 1 SECONDS						//5 second cooldown for masturbating because fuck spam. // BLUEMOON EDIT
-	var/mb_cd_timer = 0									//The timer itself
+	//var/mb_cd_length = 1 SECONDS						//5 second cooldown for masturbating because fuck spam. // BLUEMOON EDIT commented
+	var/last_climax = 0									// BLUEMOON EDIT
 
 /mob/living/carbon/human
 	var/arousal_rate = 1
@@ -86,6 +86,7 @@
 		var/obj/item/organ/genital/penis/P = sender
 		condomning = locate(/obj/item/genital_equipment/condom) in P.contents
 	sender.generate_fluid(R)
+	last_climax = world.time // BLUEMOON ADD
 	log_message("Кончает [sender] благодаря [target]", LOG_EMOTE)
 
 	client?.plug13.send_emote(PLUG13_EMOTE_GROIN, PLUG13_STRENGTH_MAX, PLUG13_DURATION_ORGASM)
@@ -194,7 +195,7 @@
 								cummed_on.apply_status_effect(STATUS_EFFECT_DRIPPING_CUM, copy, get_blood_dna_list(), receiver)
 						break
 
-				if(!it_a_portal)
+				if(!it_a_portal && (!last_genital || last_genital.type == sender.type)) // some lewd interactions are broken, so we checking type
 					if(istype(receiver, /obj/item/organ/stomach))	//in mouth
 						switch(sender.type)
 							if(/obj/item/organ/genital/penis)
@@ -362,10 +363,6 @@
 //skyrat edit - forced partner and spillage
 /mob/living/carbon/human/proc/mob_climax(forced_climax = FALSE, cause = "", var/mob/living/forced_partner = null, var/forced_spillage = TRUE, var/obj/item/organ/genital/forced_receiving_genital = null, anonymous = FALSE)
 	set waitfor = FALSE
-	if(mb_cd_timer > world.time)
-		if(!forced_climax) //Don't spam the message to the victim if forced to come too fast
-			to_chat(src, "<span class='warning'>Вы должны подождать [DisplayTimeText((mb_cd_timer - world.time), TRUE)] до того, как можете сделать это снова!</span>")
-		return
 
 	if(!(client?.prefs.arousable || !ckey) || !has_dna())
 		return
@@ -424,7 +421,6 @@
 			mob_climax_outside(G, mb_time = 0) //removed climax timer for sudden, forced orgasms
 		//Now all genitals that could climax, have.
 		//Since this was a forced climax, we do not need to continue with the other stuff
-		mb_cd_timer = world.time + mb_cd_length
 		return
 	//If we get here, then this is not a forced climax and we gotta check a few things.
 
@@ -462,7 +458,6 @@
 			var/obj/item/organ/genital/picked_organ = pick_climax_genitals()
 			if(picked_organ && available_rosie_palms(TRUE))
 				mob_climax_outside(picked_organ)
-				mb_cd_timer = world.time + mb_cd_length
 		if("Оргазмировать совместно с кем-то")
 			//We need no hands, we can be restrained and so on, so let's pick an organ
 			var/obj/item/organ/genital/picked_organ = pick_climax_genitals()
@@ -472,7 +467,6 @@
 					var/spillage = alert(src, "Кончить внутрь?", "При возможности", "Да", "Нет")
 					if(in_range(src, partner))
 						mob_climax_partner(picked_organ, partner, spillage == "Нет" ? TRUE : FALSE, Lgen = pick_receiving_organ(partner))
-						mb_cd_timer = world.time + mb_cd_length
 		if("Наполнить контейнер половыми жидкостями")
 			//We'll need hands and no restraints.
 			if(!available_rosie_palms(FALSE, /obj/item/reagent_containers))
@@ -485,7 +479,6 @@
 				var/obj/item/reagent_containers/fluid_container = pick_climax_container()
 				if(fluid_container && available_rosie_palms(TRUE, /obj/item/reagent_containers))
 					mob_fill_container(picked_organ, fluid_container)
-					mb_cd_timer = world.time + mb_cd_length
 		if("Оргазмировать на кого-то")
 			//We need no hands, we can be restrained and so on, so let's pick an organ
 			var/obj/item/organ/genital/picked_organ = pick_climax_genitals()
@@ -493,7 +486,6 @@
 				var/mob/living/partner = pick_partner(covering = TRUE) //Get someone
 				if(partner && in_range(src, partner))
 					mob_climax_over(picked_organ, partner, TRUE)
-					mb_cd_timer = world.time + mb_cd_length
 
 	// BLUEMOON EDIT END
 

--- a/modular_bluemoon/code/modules/arousal/arousal_robot.dm
+++ b/modular_bluemoon/code/modules/arousal/arousal_robot.dm
@@ -188,10 +188,6 @@
 	if (!iscyborg(src))
 		return
 	R = src
-	if(mb_cd_timer > world.time)
-		if(!forced_climax)
-			to_chat(src, "<span class='warning'>Вы должны подождать [DisplayTimeText((mb_cd_timer - world.time), TRUE)] до того, как можете сделать это снова!</span>")
-		return
 
 	if(!(client?.prefs.arousable || !ckey))
 		return
@@ -226,7 +222,6 @@
 			if(partner)
 				mob_climax_partner_silicon(R, partner, forced_spillage, 0, forced_receiving_genital, forced_climax, anonymous)
 		mob_climax_outside_silicon(R, mb_time = 0)
-		mb_cd_timer = world.time + mb_cd_length
 		return
 
 	if(stat == UNCONSCIOUS)
@@ -256,5 +251,3 @@
 			var/mob/living/partner = pick_partner_silicon()
 			if(partner)
 				mob_climax_over_silicon(R, partner, TRUE)
-
-	mb_cd_timer = world.time + mb_cd_length

--- a/modular_bluemoon/code/modules/mob/emotes.dm
+++ b/modular_bluemoon/code/modules/mob/emotes.dm
@@ -348,7 +348,7 @@
 	emote_pitch_variance = FALSE
 
 /datum/emote/sound/human/girlymoan/run_emote(mob/user, params)
-	sound = pick('modular_bluemoon/sound/emotes/softmoan1.ogg', 'modular_bluemoon/sound/emotes/softmoan2.ogg', 'modular_bluemoon/sound/emotes/softmoan3.ogg', 'modular_bluemoon/sound/emotes/softmoan4.ogg', 'modular_bluemoon/sound/emotes/softmoan5.ogg', 'modular_bluemoon/sound/emotes/softmoan6.ogg')
+	sound = pick(GLOB.lewd_softmoans_female)
 	. = ..()
 
 /datum/emote/sound/human/squeal

--- a/modular_bluemoon/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/modular_bluemoon/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -17,5 +17,5 @@
 			handle_post_sex(amount*5)
 		else // proc/handle_post_sex() won't work here if mob is not CONSCIOUS
 			add_lust(amount*5)
-			if(get_lust() >= get_lust_tolerance()*3)
+			if(get_lust() >= get_climax_threshold()) // BLUEMOON EDIT
 				mob_climax(forced_climax=TRUE, cause="choke_slut")

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -124,7 +124,7 @@
 	.["target"] = target // target == self can distinguish
 	.["selfAttributes"] = self.list_interaction_attributes(self)
 	.["lust"] = self.get_lust()
-	.["maxLust"] = self.get_lust_tolerance() * 3
+	.["maxLust"] = self.get_climax_threshold() // BLUEMOON EDIT
 
 	.["max_distance"] = 0
 	.["user_is_blacklisted"] = SSinteractions.is_blacklisted(self)
@@ -389,7 +389,7 @@
 			.["theyAllowUnholy"] = !!pref_to_num(target.client.prefs.unholypref) //SPLURT EDIT
 		if(HAS_TRAIT(user, TRAIT_ESTROUS_DETECT))
 			.["theirLust"] = target.get_lust()
-			.["theirMaxLust"] = target.get_lust_tolerance() * 3
+			.["theirMaxLust"] = target.get_climax_threshold() // BLUEMOON EDIT
 		//SPLURT EDIT
 		.["theyHaveBondage"] = FALSE
 		if(iscarbon(target))

--- a/modular_sand/code/datums/interactions/interaction_datums/lewd/self/breasts.dm
+++ b/modular_sand/code/datums/interactions/interaction_datums/lewd/self/breasts.dm
@@ -51,12 +51,7 @@
 				"мурлыкает и звучно вздыхает",
 				"тихонько вздрагивает",
 				"вздрагивает, хватаясь за причинное место")]</span>")
-		playlewdinteractionsound(get_turf(user), pick('modular_bluemoon/sound/emotes/softmoan1.ogg',
-					'modular_bluemoon/sound/emotes/softmoan2.ogg',
-					'modular_bluemoon/sound/emotes/softmoan3.ogg',
-					'modular_bluemoon/sound/emotes/softmoan4.ogg',
-					'modular_bluemoon/sound/emotes/softmoan5.ogg',
-					'modular_bluemoon/sound/emotes/softmoan6.ogg'), 70, 1, -1)
+		playlewdinteractionsound(get_turf(user), pick(GLOB.lewd_softmoans_female), 70, 1, -1)
 
 	if(liquid_container)
 		message += " прямо в [liquid_container]"

--- a/modular_sand/code/datums/interactions/lewd_definitions.dm
+++ b/modular_sand/code/datums/interactions/lewd_definitions.dm
@@ -298,7 +298,12 @@
 	// Get reference of the list we're using based on gender.
 	var/list/moans
 	if (gender == FEMALE || (gender == PLURAL && isfeminine(src)))
-		moans = GLOB.lewd_moans_female
+	// BLUEMOON EDIT START
+		if(lust/get_climax_threshold() < 0.40)
+			moans = GLOB.lewd_softmoans_female
+		else
+			moans = GLOB.lewd_moans_female
+	// BLUEMOON EDIT END
 	else
 		moans = GLOB.lewd_moans_male
 
@@ -941,18 +946,16 @@
 			add_lust(amount * (arousal_multiplier/100))
 		else
 			add_lust(amount)
-
-	if (use_moaning_multiplier)
-		if(prob(moaning_multiplier))
-			moan()
+	if (amount > 0 && use_moaning_multiplier && prob(moaning_multiplier)) // BLUEMOON EDIT
+		moan()
 
 	// Below is an overengineered bezier curve based chance of moaning.
 	/// The current lust (arousal) amount.
 	var/lust = get_lust()
 	/// The lust tolerance as defined in preferences.
-	var/lust_tolerance = get_lust_tolerance()
+	//var/lust_tolerance = get_lust_tolerance() // BLUEMOON EDIT commeted, check proc get_lust_tolerance()
 	/// The arousal limit upon which you climax.
-	var/climax = lust_tolerance * 3
+	var/climax = get_climax_threshold() // BLUEMOON EDIT
 	/// Threshold where you start moaning.
 	var/threshold = climax/2
 	///Calculation of 't' in bezier quadratic curve. It's a 0 to 1 version of threshold to climax.
@@ -965,10 +968,11 @@
 	if (lust >= threshold)
 		if(prob(30))
 			to_chat(src, "<b>Вам трудно удержаться от оргазма!</b>")
-
-		if (!use_moaning_multiplier)
-			if(prob(chance))
-				moan()
+		
+		// BLUEMOON EDIT START
+		if (!use_moaning_multiplier && amount > 0 && prob(chance))
+			moan()
+		// BLUEMOON EDIT END
 
 		if (lust > climax)
 			if (cum(partner, orifice, cum_inside, anonymous)) //SPLURT EDIT - extra argument `cum_inside` and `anonymous`
@@ -988,3 +992,12 @@
 		else
 			nope += M
 	return nope
+
+// BLUEMOON ADD START
+/mob/living/proc/get_climax_threshold()
+	/// The lust tolerance as defined in preferences.
+	var/lust_tolerance = get_lust_tolerance()
+
+	/// The arousal limit upon which you climax.
+	return lust_tolerance * 3
+// BLUEMOON ADD END

--- a/modular_sand/code/datums/interactions/lewd_definitions.dm
+++ b/modular_sand/code/datums/interactions/lewd_definitions.dm
@@ -299,7 +299,7 @@
 	var/list/moans
 	if (gender == FEMALE || (gender == PLURAL && isfeminine(src)))
 	// BLUEMOON EDIT START
-		if(lust/get_climax_threshold() < 0.40)
+		if(lust/get_climax_threshold() < 0.55 && last_climax + min(3 MINUTES, world.time) <= world.time)
 			moans = GLOB.lewd_softmoans_female
 		else
 			moans = GLOB.lewd_moans_female
@@ -968,7 +968,7 @@
 	if (lust >= threshold)
 		if(prob(30))
 			to_chat(src, "<b>Вам трудно удержаться от оргазма!</b>")
-		
+
 		// BLUEMOON EDIT START
 		if (!use_moaning_multiplier && amount > 0 && prob(chance))
 			moan()

--- a/modular_sand/code/datums/interactions/lewd_definitions.dm
+++ b/modular_sand/code/datums/interactions/lewd_definitions.dm
@@ -299,7 +299,7 @@
 	var/list/moans
 	if (gender == FEMALE || (gender == PLURAL && isfeminine(src)))
 	// BLUEMOON EDIT START
-		if(lust/get_climax_threshold() < 0.55 && last_climax + min(3 MINUTES, world.time) <= world.time)
+		if(lust/get_climax_threshold() < 0.55 && last_climax + min(8 MINUTES, world.time) <= world.time)
 			moans = GLOB.lewd_softmoans_female
 		else
 			moans = GLOB.lewd_moans_female

--- a/modular_splurt/code/datums/interactions/lewd/lewd_definitions.dm
+++ b/modular_splurt/code/datums/interactions/lewd/lewd_definitions.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_INIT(lust_modifiers, list("[GENITAL_HYPERSENS]" = 3, "[GENITAL_OVERS
 GLOBAL_LIST_INIT(anus_traits, list("[TRAIT_HYPERSENS_ANUS]" = 3, "[TRAIT_OVERSTIM_ANUS]" = 1.8, "[TRAIT_DISAPPOINTING_ANUS]" = 0.75, "[TRAIT_EDGINGONLY_ANUS]" = 0.5, "[TRAIT_IMPOTENT_ANUS]" = 0))
 
 /mob/living/proc/lustcap(amt)
-	var/lust_cap = (get_lust_tolerance() * 3) * 0.8 // 80% of the mob's orgasm arousal (lust_tolerance * 3)
+	var/lust_cap = (get_climax_threshold()) * 0.8 // 80% of the mob's orgasm arousal (lust_tolerance * 3) // BLUEMOON EDIT
 	if((get_lust() + amt) >= lust_cap)
 		set_lust(lust_cap - 1)
 

--- a/modular_splurt/code/game/objects/items/sucking_machine.dm
+++ b/modular_splurt/code/game/objects/items/sucking_machine.dm
@@ -116,7 +116,7 @@
 		victim.emote("moan")
 
 	victim.add_lust(20 + rand(0, 50))
-	if(victim.get_lust() >= (victim.get_lust_tolerance() * 3)) //checked before + if a human doesn't have dna something is seriously wrong
+	if(victim.get_lust() >= (victim.get_climax_threshold())) //checked before + if a human doesn't have dna something is seriously wrong // BLUEMOON EDIT
 		victim.mob_fill_container(genital, inserted_item, milking_speed, src) //why is this a mob proc
 		victim.do_jitter_animation()
 

--- a/modular_splurt/code/modules/arousal/arousal.dm
+++ b/modular_splurt/code/modules/arousal/arousal.dm
@@ -149,7 +149,7 @@
 		to_chat(H, span_love("Кажется тебя немножко забрызгали~"))
 
 /mob/living/carbon/human/proc/getPercentAroused()
-    var/percentage = ((get_lust() / (get_lust_tolerance() * 3)) * 100)
+    var/percentage = ((get_lust() / (get_climax_threshold())) * 100) // BLUEMOON EDIT
     return percentage
 
 /atom/proc/wash_cum()

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -25,6 +25,7 @@ interface CharacterProfileContext {
   directory_visible: boolean;
   is_unknown: boolean;
   headshot_links?: (string | null)[];
+  headshot_naked_links?: (string | null)[]; // BLUEMOON ADD
   character_ref: any,
   flavortext: string;
   flavortext_naked: string;


### PR DESCRIPTION
# Описание
- Теперь при Lust < 55% и последнем climax больше 8и минут назад, женский персонаж при lewd интеракциях будет издавать тихий softmoan, а не громкий moan. Т.е. при всяких поглаживаниях, поцелуях, ударах по заднице и прочем, персонаж будет тихо стонать. На ЕРП влияет только в начале, потом обычные стоны, до 8и минутного перекура.
- Пофикшен трансфер реагентов у одной интеракции vagina to vagina
- Юзлесс переменная заменена на last_climax, не работающие задержки (после перехода на круговое меню) вырезаны.
- Все get_lust_tolerance() * 3 заменены на общий прок get_climax_threshold()
- Пофиксил момент, на что ругался контекст VScode из [ПРа headshot naked](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/pull/2096). На работоспособность не влияет, но фиксит CI проверку.