### PR TITLE
Микропатч

### DIFF
--- a/modular_bluemoon/Gardelin0/code/obj/custom_portal.dm
+++ b/modular_bluemoon/Gardelin0/code/obj/custom_portal.dm
@@ -22,6 +22,6 @@
 	if(isnull(AM))
 		return
 
-	for(var/obj/effect/mob_spawn/human/hotel_staff/splurt/manager/g in world)
+	for(var/obj/effect/mob_spawn/human/hotel_staff/splurt/guest/g in world)
 		AM.forceMove(g.loc)
 		playsound(src.loc, get_sfx("spark"), 100, 1)

--- a/modular_bluemoon/code/game/objects/items/storage/briefcase.dm
+++ b/modular_bluemoon/code/game/objects/items/storage/briefcase.dm
@@ -1,0 +1,17 @@
+/obj/item/storage/briefcase/lawyer/family/loadout //changed due to PopulateContents() containing other stuff
+	name = "battered  briefcase"
+	icon_state = "gbriefcase"
+	lefthand_file = 'icons/mob/inhands/equipment/briefcase_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/briefcase_righthand.dmi'
+	desc = "An old briefcase with a golden trim. It's clear they don't make them as good as they used to. Comes with an added belt clip!"
+	slot_flags = ITEM_SLOT_BELT
+
+/obj/item/storage/briefcase/lawyer/family/loadout/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = 14
+
+/obj/item/storage/briefcase/lawyer/family/loadout/PopulateContents()
+	new /obj/item/pen/fountain(src)
+	new /obj/item/paper_bin(src)

--- a/modular_bluemoon/code/modules/client/loadout/backpack.dm
+++ b/modular_bluemoon/code/modules/client/loadout/backpack.dm
@@ -147,3 +147,8 @@
 	name = "Clipboard"
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_GENERAL
 	path = /obj/item/clipboard
+
+/datum/gear/backpack/lawyerbriefcase
+	name = "Battered  Briefcase"
+	path = /obj/item/storage/briefcase/lawyer/family/loadout
+	cost = 3

--- a/modular_bluemoon/code/modules/client/loadout/backpack.dm
+++ b/modular_bluemoon/code/modules/client/loadout/backpack.dm
@@ -142,3 +142,8 @@
 	name = "Army Multitool"
 	path = /obj/item/armyknife
 	cost = 3
+
+/datum/gear/backpack/clipboard
+	name = "Clipboard"
+	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_GENERAL
+	path = /obj/item/clipboard

--- a/modular_splurt/_maps/RandomRuins/SpaceRuins/spacehotelbluemoon.dmm
+++ b/modular_splurt/_maps/RandomRuins/SpaceRuins/spacehotelbluemoon.dmm
@@ -534,6 +534,12 @@
 	},
 /turf/closed/wall,
 /area/ruin/space/has_grav/bluemoon/hotel/guestroom)
+"cY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/item/beacon,
+/turf/open/floor/wood/wood_large,
+/area/ruin/space/has_grav/bluemoon/hotel/dock)
 "cZ" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/green,
@@ -11183,7 +11189,7 @@ NL
 NL
 eM
 Jf
-rd
+cY
 fU
 RO
 Bm

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4318,6 +4318,7 @@
 #include "modular_bluemoon\code\game\objects\items\stacks\tiles\tile_plasteel.dm"
 #include "modular_bluemoon\code\game\objects\items\storage\bags.dm"
 #include "modular_bluemoon\code\game\objects\items\storage\belt.dm"
+#include "modular_bluemoon\code\game\objects\items\storage\briefcase.dm"
 #include "modular_bluemoon\code\game\objects\items\storage\boxes.dm"
 #include "modular_bluemoon\code\game\objects\items\storage\firstaid.dm"
 #include "modular_bluemoon\code\game\objects\items\storage\toolbox.dm"


### PR DESCRIPTION
# Описание

- Добавлен clipboard в лодаут.
- Добавлен урезанный battered briefcase в лодаут за 3 очка. Ранее был доступен лишь одной работе как реликвия.
- Исправлено отсутствие маячка на старте отеля, предотвращая телепортацию туда, привнося неудобства.
- Исправлено использование портала, что перемещал прямо в комнату менеджера - теперь перемещает в лобби, где спавнеры гостей.


- [X] Изменения были проверены на локальном сервере
- [X] Этот пулл-реквест готов к тест-мерджу.

## Демонстрация изменений
<img width="939" height="146" alt="WWQpznPavv" src="https://github.com/user-attachments/assets/83378300-b01a-4251-9cae-03add9173d71" />

========
<img width="246" height="219" alt="dreamseeker_hg1DLbEbeb" src="https://github.com/user-attachments/assets/e4a8e8dd-3634-4ea9-b568-909009683276" />
<img width="360" height="130" alt="XOiCiHYJhw" src="https://github.com/user-attachments/assets/98f8fc9f-5cf5-4ad4-9e7c-f55a182c6fa8" />

========
<img width="218" height="129" alt="dreamseeker_cNWjP4Uodt" src="https://github.com/user-attachments/assets/feee2656-a354-4455-863e-4cfc1724b24c" />
<img width="324" height="245" alt="dreamseeker_K79SZGJGGP" src="https://github.com/user-attachments/assets/742b9aaf-b8e2-4566-8b40-8229550cd18c" />
