### PR TITLE
[BLUEMOON] Precise wallframes placement

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -24,13 +24,13 @@
 	if(A.always_unpowered)
 		to_chat(user, "<span class='warning'>You cannot place [src] in this area!</span>")
 		return
-	if(gotwallitem(T, ndir, inverse*2))
-		to_chat(user, "<span class='warning'>There's already an item on this wall!</span>")
-		return
+	// if(gotwallitem(T, ndir, inverse*2))
+	// 	to_chat(user, "<span class='warning'>There's already an item on this wall!</span>")
+	// 	return
 
 	return TRUE
 
-/obj/item/wallframe/proc/attach(turf/on_wall, mob/user)
+/obj/item/wallframe/proc/attach(turf/on_wall, mob/user, params)
 	if(result_path)
 		playsound(src.loc, 'sound/machines/click.ogg', 75, 1)
 		user.visible_message("[user.name] attaches [src] to the wall.",
@@ -51,6 +51,16 @@
 					O.pixel_x = pixel_shift
 				if(WEST)
 					O.pixel_x = -pixel_shift
+		var/list/click_params = params2list(params)
+		//Center the icon where the user clicked.
+		if(click_params && click_params["icon-x"] && click_params["icon-y"])
+			if(O.pixel_x != 0)
+				O.pixel_x = O.pixel_x > 0 ? 32 : -32
+			if(O.pixel_y != 0)
+				O.pixel_y = O.pixel_y > 0 ? 32 : -32
+			//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
+			O.pixel_x += clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
+			O.pixel_y += clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
 		after_attach(O)
 
 	qdel(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -47,6 +47,13 @@
 
 	AddElement(/datum/element/contextual_screentip_bare_hands, rmb_text_combat_mode = barehanded_interactions)
 
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/wallframe = list(
+			SCREENTIP_CONTEXT_LMB = list(INTENT_GRAB = "Install frame on the table"),
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	. += deconstruction_hints(user)
@@ -264,7 +271,11 @@
 				user.unbuckle_mob(carried_mob)
 				tableplace(user, carried_mob)
 		return TRUE
-
+	if(istype(I, /obj/item/wallframe) && user.a_intent == INTENT_GRAB)
+		var/obj/item/wallframe/W = I
+		if(W.try_build(src, user))
+			W.attach(src, user, params)
+		return TRUE
 	if(user.a_intent != INTENT_HARM && !(I.item_flags & ABSTRACT))
 		if(user.transferItemToLoc(I, drop_location()))
 			var/list/click_params = params2list(params)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -197,7 +197,7 @@
 
 	//the istype cascade has been spread among various procs for easy overriding
 	var/srctype = type
-	if(try_clean(W, user, T) || try_wallmount(W, user, T) || try_decon(W, user, T) || (type == srctype && try_destroy(W, user, T)))
+	if(try_clean(W, user, T) || try_wallmount(W, user, T, params) || try_decon(W, user, T) || (type == srctype && try_destroy(W, user, T)))
 		return
 
 	return ..()
@@ -220,12 +220,12 @@
 
 	return FALSE
 
-/turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user, turf/T)
+/turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user, turf/T, params)
 	//check for wall mounted frames
 	if(istype(W, /obj/item/wallframe))
 		var/obj/item/wallframe/F = W
 		if(F.try_build(src, user))
-			F.attach(src, user)
+			F.attach(src, user, params)
 		return TRUE
 	//Poster stuff
 	else if(istype(W, /obj/item/poster))


### PR DESCRIPTION
Установка настенных механизмов и конструкций учитывает конкретное место клика игрока на объект, что позволяет точечно устанавливать их в конкретное место клика. Убрано ограничение на 1 конструкцию на стену за ненадобностью.

Позволяется устанавливать конструкции на стол (прямо как на стену) в желтом GRAB интенте -> игроки могут ставить кнопочки и выключатели на стол и даже сразу несколько.

Тестмерж на недельку.
<img width="92" height="73" alt="246842984529" src="https://github.com/user-attachments/assets/8db16e45-f679-4496-b85e-ef3e27c09ebc" />
<img width="73" height="68" alt="5389357937095" src="https://github.com/user-attachments/assets/ad78fdc4-a4d2-4f8f-ba20-c018ff221b15" />
