### PR TITLE
Больше гемблинга

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -319,7 +319,7 @@
 	AddElement(/datum/element/tactical)
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/datum, _AddElement), list(/datum/element/beauty, 500)), 0)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
-	// BLUEMOON ADD спрятать предмет в кустах
+	// BLUEMOON ADD предметы в кустах
 	AddComponent(/datum/component/storage/concrete/pockets/plants)
 	// BLUEMOON ADD END
 
@@ -367,6 +367,27 @@
 	if(!states)
 		generate_states()
 	icon_state = pick(states)
+
+/obj/item/kirbyplants/Initialize(mapload)
+	. = ..()
+	var/static/list/random_stuff = list(
+		/obj/item/reagent_containers/syringe/heroin = 5,
+		/obj/item/toy/plush/teddybear = 5,
+		/obj/item/reagent_containers/pill/labebium = 1,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/schizoshroom = 5,
+		/obj/item/toy/plush/bm/millie = 5,
+		/obj/item/genital_equipment/condom = 10,
+		/obj/item/assembly/mousetrap/armed = 5,
+		/obj/item/reagent_containers/food/snacks/special_candy = 5,
+		/obj/item/buttplug/small = 10,
+		/obj/item/reagent_containers/food/snacks/donut/semen = 10,
+		/obj/item/reagent_containers/glass/bottle/semen = 10,
+		/obj/item/restraints/handcuffs/fake/kinky = 10,
+		/obj/item/reagent_containers/pill/pendosovka = 5,
+		/obj/item/reagent_containers/pill/zvezdochka = 5)
+	if(prob(20))
+		var/picked = pickweight(random_stuff)
+		new picked(src)
 
 /obj/item/kirbyplants/random/proc/generate_states()
 	states = list()


### PR DESCRIPTION
# Описание
Теперь в кустиках с достаточно малым шансом будут спавниться: героин, звездочка, грибы пендосовка, плюшевый мишка, лабебиум, шизогрибы, гандоны, вкусные и очень полезные конфетки, анальная пробка, обдроченный пончик, банка спермы, наручники для ХРП ЕРП. 
- [х] Изменения были проверены на локальном сервере

## Причина изменений
На сервере не хватает бомжей, которые будут рыться в кустах. Так называемая гача, где тебе могут предложить пятизвездочную зависимость. 