### PR TITLE
Dildo machine updt

### DIFF
--- a/modular_bluemoon/Gardelin0/code/obj/lewd_devices/dildo_machine.dm
+++ b/modular_bluemoon/Gardelin0/code/obj/lewd_devices/dildo_machine.dm
@@ -5,16 +5,33 @@
 	icon_state = "dilmachine"
 	anchored = 0
 	var/mode = "normal"
-	var/intencity = 12
+	var/fuck_delay = 4
 	var/on = 0
 	var/hole = CUM_TARGET_VAGINA
-	var/fuck_hole
+	var/obj/item/dildo/attached_dildo = new /obj/item/dildo/custom
 	buckle_lying = TRUE
 	flags_1 = NODECONSTRUCT_1
 
 /obj/structure/bed/dildo_machine/New()
 	..()
 	add_overlay(mutable_appearance('modular_bluemoon/Gardelin0/icons/obj/lewd_devices.dmi', "dilmachine_over", MOB_LAYER + 1))
+
+/obj/structure/bed/dildo_machine/examine(mob/user)
+	. = ..()
+	if(attached_dildo)
+		. += "There is a <span class='notice'>[attached_dildo.name]</span> attached to it."
+		. += span_notice("Ctrl-Click \the [src.name] to detach dildo.")
+
+/obj/structure/bed/dildo_machine/CtrlClick(mob/user)
+	. = ..()
+	if(!(attached_dildo) || !iscarbon(user) || !in_range(src, user))
+		return
+	if(on)
+		to_chat(user, span_userlove("You can't detach the dildo from the machine while it's on."))
+		return
+	user.put_in_hands(attached_dildo)
+	attached_dildo = null
+	to_chat(user, span_userlove("You detach the dildo from the machine."))
 
 /obj/structure/bed/dildo_machine/verb/change_hole()
 	set name = "Change hole"
@@ -36,20 +53,23 @@
 	if(input)
 		mode = input
 		if(mode == "low")
-			intencity = 6
+			fuck_delay = 5
 		if(mode == "normal")
-			intencity = 12
+			fuck_delay = 4
 		if(mode == "high")
-			intencity = 18
+			fuck_delay = 2
 
 /obj/structure/bed/dildo_machine/verb/toggle()
 	set name = "Toggle dildo machine"
 	set category = "Object"
 	set src in oview(1)
+	if(!on && !attached_dildo) // not active and missing dildo
+		to_chat(usr, span_userlove("You can't toggle machine, without dildo."))
+		return
 	on = !on
 	spawn()
 		while(on)
-			if(activate_after(src, 5))
+			if(activate_after(src, fuck_delay))
 				fuck()
 	if(on)
 		to_chat(usr, "[src] вкл.")
@@ -57,18 +77,34 @@
 		to_chat(usr, "[src] выкл.")
 
 /obj/structure/bed/dildo_machine/proc/fuck()
-	if(!on)
+	if(!on || !attached_dildo || !hole)
 		return
 
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
 			var/mob/living/carbon/human/M = m
+
+			var/obj/item/organ/genital/organ = M.getorganslot(hole)
+			if(!organ || !(organ.is_exposed() || organ.always_accessible))
+				return
+
+			attached_dildo.target_reaction(M,null,1,hole,null,TRUE,TRUE,TRUE,TRUE)
+			M.client?.plug13.send_emote(hole == CUM_TARGET_ANUS ? PLUG13_EMOTE_ANUS : PLUG13_EMOTE_GROIN, min(fuck_delay * 5, 100), PLUG13_DURATION_NORMAL)
+			playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg", 30, 1)
+			var/message = "[pick("вгоняет дилдо в", "трахает")] [hole == CUM_TARGET_VAGINA ? "вагину" : "попку"] [M]"
+			switch(mode)
+				if("high")
+					message = "[pick("активно","безжалостно","жестоко")] [pick("трахает", "насилует", "долбит")] [hole == CUM_TARGET_VAGINA ? "вагину" : "попку"] [M]"
+				if("low")
+					message = "[pick("медленно","плавно","мягко")] [pick("вводит дилдо в", "погружает дилдо в")] [hole == CUM_TARGET_VAGINA ? "вагину" : "попку"] [M]"
+			visible_message(span_love("\the [src] [message]"))
+			/*
 			switch(hole)
 				if(CUM_TARGET_VAGINA)
 					if(M.has_vagina(REQUIRE_EXPOSED))
 						fuck_hole = "pussy"
-						M.handle_post_sex(intencity, null, src)
-						M.client?.plug13.send_emote(PLUG13_EMOTE_GROIN, min(intencity * 5, 100), PLUG13_DURATION_NORMAL)
+						M.handle_post_sex(fuck_delay, null, src)
+						M.client?.plug13.send_emote(PLUG13_EMOTE_GROIN, min(fuck_delay * 5, 100), PLUG13_DURATION_NORMAL)
 						playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg", 30, 1)
 						switch(mode)
 							if("low")
@@ -83,8 +119,8 @@
 									M.emote("moan")
 				if(CUM_TARGET_ANUS)
 					if(M.has_anus(REQUIRE_EXPOSED))
-						M.handle_post_sex(intencity, null, src)
-						M.client?.plug13.send_emote(PLUG13_EMOTE_ANUS, min(intencity * 5, 100), PLUG13_DURATION_NORMAL)
+						M.handle_post_sex(fuck_delay, null, src)
+						M.client?.plug13.send_emote(PLUG13_EMOTE_ANUS, min(fuck_delay * 5, 100), PLUG13_DURATION_NORMAL)
 						playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg.ogg", 30, 1)
 						switch(mode)
 							if("low")
@@ -97,8 +133,9 @@
 								M.Stun(3)
 								if(prob(50))
 									M.emote("moan")
-
+				*/
 /obj/structure/bed/dildo_machine/attackby(obj/item/used_item, mob/user, params)
+	add_fingerprint(user)
 	if(used_item.tool_behaviour == TOOL_WRENCH)
 		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
 		if(used_item.use_tool(src, user, 20, volume=30))
@@ -109,8 +146,18 @@
 		playsound(loc, "'sound/items/screwdriver.ogg'", 30, 1)
 		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 			to_chat(user, span_notice("You disassemble it."))
-			new /obj/item/dildo_machine_kit (src.loc)
+			var/obj/item/dildo_machine_kit/machine = new /obj/item/dildo_machine_kit (src.loc)
+			qdel(machine.attached_dildo)
+			machine.attached_dildo = null
+			if(attached_dildo)
+				attached_dildo.forceMove(machine)
+				machine.attached_dildo = attached_dildo
+				attached_dildo = null
 			qdel(src)
+	else if(!attached_dildo && istype(used_item, /obj/item/dildo) && !(used_item.item_flags & ABSTRACT))
+		if(user.transferItemToLoc(used_item, src))
+			attached_dildo = used_item
+			return TRUE
 	else
 		return ..()
 
@@ -122,6 +169,12 @@
 	throwforce = 0
 	var/unwrapped = 0
 	w_class = WEIGHT_CLASS_HUGE
+	var/obj/item/dildo/attached_dildo = new /obj/item/dildo/custom
+
+/obj/item/dildo_machine_kit/examine(mob/user)
+	. = ..()
+	if(attached_dildo)
+		. += "There is a <span class='notice'>[attached_dildo.name]</span> inside, but you can't pull it out."
 
 /obj/item/dildo_machine_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
@@ -131,7 +184,13 @@
 			playsound(loc, "'sound/items/screwdriver.ogg'", 30, 1)
 			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 				to_chat(user, span_notice("You assemble it."))
-				new /obj/structure/bed/dildo_machine (src.loc)
+				var/obj/structure/bed/dildo_machine/machine = new /obj/structure/bed/dildo_machine (src.loc)
+				qdel(machine.attached_dildo)
+				machine.attached_dildo = null
+				if(attached_dildo)
+					attached_dildo.forceMove(machine)
+					machine.attached_dildo = attached_dildo
+					attached_dildo = null
 				qdel(src)
 			return
 	else

--- a/modular_bluemoon/Gardelin0/code/obj/lewd_devices/dildo_machine.dm
+++ b/modular_bluemoon/Gardelin0/code/obj/lewd_devices/dildo_machine.dm
@@ -3,13 +3,14 @@
 	desc = "It provides pleasure."
 	icon = 'modular_bluemoon/Gardelin0/icons/obj/lewd_devices.dmi'
 	icon_state = "dilmachine"
-	anchored = 0
-	var/mode = "normal"
-	var/fuck_delay = 4
+	anchored = TRUE
+	var/mode = "low"
 	var/on = 0
 	var/hole = CUM_TARGET_VAGINA
 	var/obj/item/dildo/attached_dildo = new /obj/item/dildo/custom
-	buckle_lying = TRUE
+	var/dual_mode = FALSE
+	var/obj/item/dildo/dual_mode_attached_dildo
+	buckle_lying = 90
 	flags_1 = NODECONSTRUCT_1
 
 /obj/structure/bed/dildo_machine/New()
@@ -18,146 +19,193 @@
 
 /obj/structure/bed/dildo_machine/examine(mob/user)
 	. = ..()
+
+	if(dual_mode)
+		. += span_alert("\the [src.name] in dual mode.")
+
 	if(attached_dildo)
-		. += "There is a <span class='notice'>[attached_dildo.name]</span> attached to it."
-		. += span_notice("Ctrl-Click \the [src.name] to detach dildo.")
+		. += "There is attached [span_lewd(attached_dildo.name)]."
+	else
+		. += span_alert("There in no attached dildo.")
+
+	if(dual_mode_attached_dildo)
+		. += "There is a [span_lewd(dual_mode_attached_dildo.name)] attached to second spot."
+	else if(dual_mode)
+		. += span_alert("There in no second attached dildo.")
+
+	if(attached_dildo || dual_mode_attached_dildo)
+		. += span_notice("Ctrl-Click to detach dildo.")
+
+	. += span_notice("Alt-Click to open menu.")
 
 /obj/structure/bed/dildo_machine/CtrlClick(mob/user)
 	. = ..()
-	if(!(attached_dildo) || !iscarbon(user) || !in_range(src, user))
+	if(!iscarbon(user) || !in_range(src, user))
 		return
+	detach_dildo(user)
+
+/obj/structure/bed/dildo_machine/proc/detach_dildo(mob/living/carbon/user, only_dual_dildo = FALSE)
 	if(on)
-		to_chat(user, span_userlove("You can't detach the dildo from the machine while it's on."))
+		to_chat(user, span_warning("You can't detach the dildo from the machine while it's on."))
 		return
-	user.put_in_hands(attached_dildo)
-	attached_dildo = null
-	to_chat(user, span_userlove("You detach the dildo from the machine."))
+	if(dual_mode_attached_dildo)
+		if(user)
+			user.put_in_hands(dual_mode_attached_dildo)
+			to_chat(user, span_notice("You detach second dildo from the machine."))
+		else
+			dual_mode_attached_dildo.forceMove(get_turf(src))
+		dual_mode_attached_dildo = null
+	if(!only_dual_dildo && attached_dildo)
+		if(user)
+			user.put_in_hands(attached_dildo)
+			to_chat(user, span_notice("You detach the dildo from the machine."))
+		else
+			attached_dildo.forceMove(get_turf(src))
+		attached_dildo = null
 
-/obj/structure/bed/dildo_machine/verb/change_hole()
-	set name = "Change hole"
-	set category = "Object"
-	set src in oview(1)
-	var/input = input(usr,"Change intensity mode") as null|anything in list("vagina", "anus")
-	switch(input)
-		if("vagina")
-			hole = CUM_TARGET_VAGINA
-		if("anus")
-			hole = CUM_TARGET_ANUS
-
-/obj/structure/bed/dildo_machine/verb/change_mode()
-	set name = "Change mode"
-	set category = "Object"
-	set src in oview(1)
-
-	var/input = input(usr,"Change intensity mode") as null|anything in list("low", "normal", "high")
-	if(input)
-		mode = input
-		if(mode == "low")
-			fuck_delay = 5
-		if(mode == "normal")
-			fuck_delay = 4
-		if(mode == "high")
-			fuck_delay = 2
-
-/obj/structure/bed/dildo_machine/verb/toggle()
-	set name = "Toggle dildo machine"
-	set category = "Object"
-	set src in oview(1)
-	if(!on && !attached_dildo) // not active and missing dildo
-		to_chat(usr, span_userlove("You can't toggle machine, without dildo."))
+/obj/structure/bed/dildo_machine/AltClick(mob/user)
+	. = ..()
+	if(!iscarbon(user) || !in_range(src, user))
 		return
+
+	var/static/list/INTERACTIONS = list("Toggle machine", "Change hole", "Change speed mode", "Detach dildo")
+	var/static/list/HOLE_CHOICES = list("Vagina", "Anus", "Dual mode")
+	var/static/list/HOLE_MAP = list(
+		"Vagina" = CUM_TARGET_VAGINA,
+		"Anus"   = CUM_TARGET_ANUS
+	)
+	var/static/list/SPEED_CHOICES = list("Low", "Normal", "High")
+
+	var/choice = input(user, "Interactions") as null|anything in INTERACTIONS
+	if(!choice) return
+
+	switch(choice)
+		if("Toggle machine")
+			toggle(user)
+		if("Change hole")
+			if(on)
+				to_chat(usr, span_warning("You can't change hole, while machine is working."))
+				return
+			var/h = input(user, "Choose hole") as null|anything in HOLE_CHOICES
+			if(h)
+				if(h == "Dual mode")
+					dual_mode = TRUE
+				else
+					if(dual_mode)
+						dual_mode = FALSE
+					if(dual_mode_attached_dildo)
+						detach_dildo(user, TRUE)
+					hole = HOLE_MAP[h]
+		if("Change speed mode")
+			var/m = input(user, "Change speed mode") as null|anything in SPEED_CHOICES
+			if(m)
+				mode = lowertext(m)
+		if("Detach dildo")
+			detach_dildo(user)
+
+/obj/structure/bed/dildo_machine/proc/toggle(mob/living/carbon/user)
+	if(!on)
+		if(!attached_dildo)
+			if(user)
+				to_chat(user, span_warning("You can't toggle machine, without dildo."))
+			return
+		if(dual_mode && !dual_mode_attached_dildo)
+			if(user)
+				to_chat(user, span_warning("You can't toggle machine in dual mode, without second dildo."))
+			return
+
+	var/static/list/speed_delay = list(
+		"low"    = 8,
+		"normal" = 5,
+		"high"   = 3
+	)
 	on = !on
-	spawn()
-		while(on)
-			if(activate_after(src, fuck_delay))
-				fuck()
 	if(on)
-		to_chat(usr, "[src] вкл.")
-	else
-		to_chat(usr, "[src] выкл.")
+		spawn()
+			while(on)
+				if(activate_after(src, speed_delay[mode]))
+					fuck()
+	if(user)
+		to_chat(user, span_notice("[src] в[on ? "" : "ы"]ключена."))
 
 /obj/structure/bed/dildo_machine/proc/fuck()
-	if(!on || !attached_dildo || !hole)
+	if(!on || !attached_dildo || (dual_mode && !dual_mode_attached_dildo) || !hole || !has_buckled_mobs())
+		visible_message(span_alert("The machine warning: the subject or dildo is missing."))
+		on = FALSE
 		return
 
-	if(has_buckled_mobs())
-		for(var/m in buckled_mobs)
-			var/mob/living/carbon/human/M = m
+	for(var/m in buckled_mobs)
+		var/mob/living/carbon/human/M = m
 
-			var/obj/item/organ/genital/organ = M.getorganslot(hole)
+		var/list/organ_slots = list()
+		if(dual_mode)
+			organ_slots = list(CUM_TARGET_VAGINA, CUM_TARGET_ANUS)
+		else
+			organ_slots += hole
+
+		for(var/organ_slot in organ_slots)
+			var/obj/item/organ/genital/organ = M.getorganslot(organ_slot)
 			if(!organ || !(organ.is_exposed() || organ.always_accessible))
+				visible_message(span_alert("The machine warning: cannot reach the hole."))
+				on = FALSE
 				return
 
-			attached_dildo.target_reaction(M,null,1,hole,null,TRUE,TRUE,TRUE,TRUE)
-			M.client?.plug13.send_emote(hole == CUM_TARGET_ANUS ? PLUG13_EMOTE_ANUS : PLUG13_EMOTE_GROIN, min(fuck_delay * 5, 100), PLUG13_DURATION_NORMAL)
-			playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg", 30, 1)
-			var/message = "[pick("вгоняет дилдо в", "трахает")] [hole == CUM_TARGET_VAGINA ? "вагину" : "попку"] [M]"
-			switch(mode)
-				if("high")
-					message = "[pick("активно","безжалостно","жестоко")] [pick("трахает", "насилует", "долбит")] [hole == CUM_TARGET_VAGINA ? "вагину" : "попку"] [M]"
-				if("low")
-					message = "[pick("медленно","плавно","мягко")] [pick("вводит дилдо в", "погружает дилдо в")] [hole == CUM_TARGET_VAGINA ? "вагину" : "попку"] [M]"
-			visible_message(span_love("\the [src] [message]"))
-			/*
-			switch(hole)
-				if(CUM_TARGET_VAGINA)
-					if(M.has_vagina(REQUIRE_EXPOSED))
-						fuck_hole = "pussy"
-						M.handle_post_sex(fuck_delay, null, src)
-						M.client?.plug13.send_emote(PLUG13_EMOTE_GROIN, min(fuck_delay * 5, 100), PLUG13_DURATION_NORMAL)
-						playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg", 30, 1)
-						switch(mode)
-							if("low")
-								to_chat(M, span_love(pick("Я чувствую слабые фрикции в киске!", "Оно слабо стимулирует мне вагину!")))
-							if("normal")
-								to_chat(M, span_love(pick("Я чувствую фрикции в киске!", "Оно стимулирует мне вагину!")))
-							if("high")
-								to_chat(M, span_userdanger(pick("Сильные фрикции в киске сводят меня с ума!", "Вы чувствуете мучительное удовольствие от сильной стимуляции вагины!")))
-								M.Jitter(3)
-								M.Stun(3)
-								if(prob(50))
-									M.emote("moan")
-				if(CUM_TARGET_ANUS)
-					if(M.has_anus(REQUIRE_EXPOSED))
-						M.handle_post_sex(fuck_delay, null, src)
-						M.client?.plug13.send_emote(PLUG13_EMOTE_ANUS, min(fuck_delay * 5, 100), PLUG13_DURATION_NORMAL)
-						playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg.ogg", 30, 1)
-						switch(mode)
-							if("low")
-								to_chat(M, span_love(pick("Я чувствую слабые фрикции в попе!", "Оно слабо стимулирует мне анус!")))
-							if("normal")
-								to_chat(M, span_love(pick("Я чувствую фрикции в попе!", "Оно стимулирует мне анус!")))
-							if("high")
-								to_chat(M, span_userdanger(pick("Сильные фрикции в попе сводят меня с ума!", "Вы чувствуете мучительное удовольствие от сильной стимуляции ануса!")))
-								M.Jitter(3)
-								M.Stun(3)
-								if(prob(50))
-									M.emote("moan")
-				*/
+		var/i = 1
+		for(var/organ_slot in organ_slots)
+			var/gained_lust = attached_dildo.target_reaction(M,null, i>1 ? 0 : 1, organ_slot,null,FALSE,TRUE,TRUE,FALSE)
+			M.client?.plug13.send_emote(organ_slot == CUM_TARGET_ANUS ? PLUG13_EMOTE_ANUS : PLUG13_EMOTE_GROIN, min(gained_lust * 5, 100), PLUG13_DURATION_NORMAL)
+			i += 1
+
+		M.Jitter(3)
+
+		var/message_end = "[dual_mode ? "обе дырочки" : (hole == CUM_TARGET_VAGINA ? "вагину" : "попку")] [M]"
+		var/message = "[pick("вгоняет дилдо в", "трахает", "разрабатывает")] [message_end]" // normal mode
+		switch(mode)
+			if("high")
+				message = "[pick("активно","безжалостно","жестоко")] [pick("трахает", "насилует", "долбит")] [message_end]"
+			if("low")
+				message = "[pick("медленно","плавно","мягко")] [pick("вводит дилдо в", "погружает дилдо в")] [message_end]"
+
+		playsound(loc, "modular_bluemoon/Gardelin0/sound/effect/lewd/interactions/bang[rand(1, 6)].ogg", 30, 1)
+		visible_message(span_lewd("\the [src] [message]"))
+
+
 /obj/structure/bed/dildo_machine/attackby(obj/item/used_item, mob/user, params)
 	add_fingerprint(user)
+	// It's bed, no moving, use screwdriver
+	/*
 	if(used_item.tool_behaviour == TOOL_WRENCH)
 		to_chat(user, "<span class='notice'>You begin to [anchored ? "unwrench" : "wrench"] [src].</span>")
 		if(used_item.use_tool(src, user, 20, volume=30))
 			to_chat(user, "<span class='notice'>You successfully [anchored ? "unwrench" : "wrench"] [src].</span>")
 			setAnchored(!anchored)
-	else if(istype(used_item, /obj/item/screwdriver))
+	*/
+	if(istype(used_item, /obj/item/screwdriver))
 		to_chat(user, span_notice("You unscrew the frame and begin to deconstruct it..."))
 		playsound(loc, "'sound/items/screwdriver.ogg'", 30, 1)
 		if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 			to_chat(user, span_notice("You disassemble it."))
-			var/obj/item/dildo_machine_kit/machine = new /obj/item/dildo_machine_kit (src.loc)
-			qdel(machine.attached_dildo)
-			machine.attached_dildo = null
+			var/obj/item/dildo_machine_kit/kit = new /obj/item/dildo_machine_kit (src.loc)
+			if(kit.attached_dildo)
+				qdel(kit.attached_dildo)
+				kit.attached_dildo = null
+			if(dual_mode_attached_dildo)
+				dual_mode_attached_dildo.forceMove(get_turf(src))
+				dual_mode_attached_dildo = null
 			if(attached_dildo)
-				attached_dildo.forceMove(machine)
-				machine.attached_dildo = attached_dildo
+				attached_dildo.forceMove(kit)
+				kit.attached_dildo = attached_dildo
 				attached_dildo = null
 			qdel(src)
-	else if(!attached_dildo && istype(used_item, /obj/item/dildo) && !(used_item.item_flags & ABSTRACT))
-		if(user.transferItemToLoc(used_item, src))
-			attached_dildo = used_item
-			return TRUE
+	else if(istype(used_item, /obj/item/dildo) && !(used_item.item_flags & ABSTRACT))
+		if(!attached_dildo)
+			if(user.transferItemToLoc(used_item, src))
+				attached_dildo = used_item
+				return TRUE
+		else if(dual_mode && !dual_mode_attached_dildo)
+			if(user.transferItemToLoc(used_item, src))
+				dual_mode_attached_dildo = used_item
+				return TRUE
 	else
 		return ..()
 
@@ -174,7 +222,9 @@
 /obj/item/dildo_machine_kit/examine(mob/user)
 	. = ..()
 	if(attached_dildo)
-		. += "There is a <span class='notice'>[attached_dildo.name]</span> inside, but you can't pull it out."
+		. += "There is a [span_lewd(attached_dildo.name)] inside, but you can't pull it out, deploy machine first."
+	else
+		. += "There in [span_alert("no dildo inside")] and you can't insert it, deploy machine first."
 
 /obj/item/dildo_machine_kit/attackby(obj/item/used_item, mob/user, params) //constructing a bed here.
 	add_fingerprint(user)
@@ -185,8 +235,9 @@
 			if(used_item.use_tool(src, user, 8 SECONDS, volume = 50))
 				to_chat(user, span_notice("You assemble it."))
 				var/obj/structure/bed/dildo_machine/machine = new /obj/structure/bed/dildo_machine (src.loc)
-				qdel(machine.attached_dildo)
-				machine.attached_dildo = null
+				if(machine.attached_dildo)
+					qdel(machine.attached_dildo)
+					machine.attached_dildo = null
 				if(attached_dildo)
 					attached_dildo.forceMove(machine)
 					machine.attached_dildo = attached_dildo

--- a/modular_bluemoon/Gardelin0/code/obj/lewd_devices/sybian.dm
+++ b/modular_bluemoon/Gardelin0/code/obj/lewd_devices/sybian.dm
@@ -3,7 +3,7 @@
 	desc = "It provides vibration."
 	icon = 'modular_bluemoon/Gardelin0/icons/obj/lewd_devices.dmi'
 	icon_state = "sybian"
-	anchored = 0
+	anchored = TRUE
 	var/mode = "normal"
 	var/intencity
 	var/on = 0

--- a/modular_bluemoon/code/modules/lewd_structures/bdsm_furniture.dm
+++ b/modular_bluemoon/code/modules/lewd_structures/bdsm_furniture.dm
@@ -41,12 +41,10 @@
 	return NONE
 
 /obj/structure/bed/bdsm_bed/post_buckle_mob(mob/living/affected_mob)
-	density = TRUE
 	//Push them up from the normal lying position
 	affected_mob.pixel_y = affected_mob.base_pixel_y
 
 /obj/structure/bed/bdsm_bed/post_unbuckle_mob(mob/living/affected_mob)
-	density = FALSE
 	//Set them back down to the normal lying position
 	affected_mob.pixel_y = affected_mob.base_pixel_y + affected_mob.body_position_pixel_y_offset
 


### PR DESCRIPTION
# Описание
Небольшой апдейт и реворк дилдо машины.
- Теперь для работы машины, нужен реальный дилдо. По умолчанию рандомный всегда установлен. Получаемы Lust теперь зависит от размера дилдо.
- Добавлен двойной режим (_трахать во все щели_), нужно установить второй дилдо.
- Режим работы машины теперь влияет на ее скорость, а не на получаемый lust.
- Все вербы на ПКМ вырезаны, добавлено общее меню на Alt клик. На Ctrl клик, дополнительно, быстро можно вытащить дилдо из машины.
- Добавлено описание для интеракций машины.
- Машина (а по факту кровать) теперь будет прикручена к полу по умолчанию, как другие нормальные кровати.
- При укладке на машину, теперь голова будет всегда в нужную сторону, как у других кроватей.

Проверено на локалке, но **лучше в тестмерж на пару дней**
### Что не касается дилдо
- Sibian (напольный вибратор) теперь по умолчанию прикручена к полу.
- BDSM кровать, теперь не становиться непроходимой, когда на ней кто-то лежит.
