### PR TITLE
qareen fix

### DIFF
--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -100,7 +100,12 @@
 	user.log_message(message, LOG_SUBTLER)
 	message = "<span class='emote'><b>[user]</b> <i>[user.say_emphasis(message)]</i></span>"
 
-	user.visible_message(message = message, self_message = message, vision_distance = 1, ignored_mobs = GLOB.dead_mob_list, omni = TRUE)
+	var/list/ignored_mobs_list = LAZYCOPY(GLOB.dead_mob_list)
+	for(var/mob/living/simple_animal/qareen/Q in range(1, user))
+		if(Q != user && !Q.revealed)
+			LAZYADD(ignored_mobs_list, Q)
+
+	user.visible_message(message = message, self_message = message, vision_distance = 1, ignored_mobs = ignored_mobs_list, omni = TRUE)
 
 ///////////////// SUBTLE 3: DARE DICE
 
@@ -151,6 +156,10 @@
 		for(var/obj/structure/table/T2 in T.connected_floodfill(25))
 			processed[T2] = TRUE
 			for(var/mob/living/L in range(T2, 1))
+				if(istype(L, /mob/living/simple_animal/qareen))
+					var/mob/living/simple_animal/qareen/Q = L
+					if(!Q.revealed)
+						continue
 				show_to |= L
 
 	for(var/i in show_to)


### PR DESCRIPTION
# Описание
ЕРП призрак qareen **В РЕЖИМЕ ПРИЗРАКА** не будет видеть Subtler Anti-Ghost. (Как только становиться видимым, будет видеть логи как и все остальные)

Проверено на локалке.
## Причина изменений
ЕРП антаги, так-же как и другие антаги, призваны разнообразить раунд и устраивать какой-то контент. Данный же антаг обладает всеми особенностями гостов _(ну кроме телепорта)_, при этом спокойно может наблюдать за ЕРП процессом других игроков, игнорируя их префы и не вмешиваясь, просто занимая слот и куколдируя. При этом игнорируя все возможные предосторожности, которые игроки сделали, вроде скрытых комнат, локнутых дверей и прочего.
Считаю, что если человек взял рольку, пускай играет и контактирует с экипажем, а не сидит в "гостах".
Плюс это халявный инструмент для **меташейминга**, после _возможного_ слива чужих логов, человечка то может и забанят, но приятного мало, для всех.