### PR TITLE
subtler updt

### DIFF
--- a/code/modules/keybindings/keybind/communication.dm
+++ b/code/modules/keybindings/keybind/communication.dm
@@ -54,6 +54,26 @@
 	full_name = "Subtler Anti-Ghost Emote"
 	clientside = "subtler-anti-ghost"
 
+//BLUEMOON ADD START
+/datum/keybinding/client/communication/subtler_target
+	hotkey_keys = list("Unbound")
+	name = "Subtler Target"
+	full_name = "Subtler Target Emote"
+	clientside = "subtler-target"
+
+/datum/keybinding/client/communication/subtler_target_indicatored
+	hotkey_keys = list("Unbound")
+	name = "Subtler Target (Indicator)"
+	full_name = "Subtler Target Emote (with indicator)"
+	clientside = "subtler-target-indicatored"
+
+/datum/keybinding/client/communication/subtler_target_indicatored/down(client/user)
+	var/mob/living/L = user.mob
+	if(istype(L))
+		L.subtler_target_indicatored()
+	return TRUE
+//BLUEMOON ADD END
+
 /datum/keybinding/client/communication/whisper
 	hotkey_keys = list("CtrlY")
 	classic_keys = list("Unbound")

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -77,6 +77,7 @@
 	return FALSE
 
 /datum/emote/sound/human/subtler/run_emote(mob/user, params, type_override = null)
+	var/const/vision_dist = 1
 	if(jobban_isbanned(user, "emote"))
 		to_chat(user, "You cannot send subtle emotes (banned).")
 		return FALSE
@@ -84,7 +85,7 @@
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 	else if(!params)
-		var/subtle_emote = stripped_multiline_input_or_reflect(user, "Choose an emote to display.", "Subtler" , null, MAX_MESSAGE_LEN)
+		var/subtle_emote = stripped_multiline_input_or_reflect(user, "Введите сообщение, которое увидят персонажи в упор к вам. Призраки его не увидят.", "Введите скрытое сообщение", null, MAX_MESSAGE_LEN)
 		if(subtle_emote && !check_invalid(user, subtle_emote))
 			message = subtle_emote
 		else
@@ -100,7 +101,35 @@
 	user.log_message(message, LOG_SUBTLER)
 	message = "<span class='emote'><b>[user]</b> <i>[user.say_emphasis(message)]</i></span>"
 
-	user.visible_message(message = message, self_message = message, vision_distance = 1, ignored_mobs = GLOB.dead_mob_list, omni = TRUE)
+	var/list/ignored_mobs_list = LAZYCOPY(GLOB.dead_mob_list)
+	var/see_invis = user.see_invisible
+	for(var/atom/A in range(vision_dist, get_turf(user)))
+		// ищем всех мобов, включая тех что внутри contents
+		var/list/stack = list(A)
+		while(stack.len)
+			var/atom/B = stack[stack.len]
+			stack.len-- // pop
+
+			if(ismob(B))
+				var/mob/living/M = B
+				if(M != user)
+					// ищем максимальную невидимость по цепочке loc вверх
+					var/invis = M.invisibility
+					var/atom/movable/x = M
+					while(istype(x.loc, /atom/movable))
+						x = x.loc
+						if(x.invisibility > invis)
+							invis = x.invisibility
+
+					if(see_invis < invis)
+						LAZYADD(ignored_mobs_list, M) // Исключаем мобов, которые должны быть невидимы для нас
+			
+			if(istype(B, /atom/movable))
+				var/atom/movable/MV = B
+				if(MV.contents && MV.contents.len)
+					stack += MV.contents
+
+	user.visible_message(message = message, self_message = message, vision_distance = vision_dist, ignored_mobs = ignored_mobs_list, omni = TRUE)
 
 ///////////////// SUBTLE 3: DARE DICE
 
@@ -157,6 +186,105 @@
 		var/mob/M = i
 		M.show_message(message)
 
+//BLUEMOON ADD START
+///////////////// SUBTLE 4: TARGET
+
+/datum/emote/sound/human/subtler_target
+	key = "subtler_target"
+	key_third_person = "subtler_target"
+	message = null
+	mob_type_blacklist_typecache = list(/mob/living/brain)
+	emote_cooldown = 0
+
+/datum/emote/sound/human/subtler_target/proc/check_invalid(mob/user, input)
+	if(stop_bad_mime.Find(input, 1, 1))
+		to_chat(user, "<span class='danger'>Invalid emote.</span>")
+		return TRUE
+	return FALSE
+
+/datum/emote/sound/human/subtler_target/run_emote(mob/user, params, type_override = null)
+	var/const/work_distance = 5
+	. = TRUE
+	var/list/parameters = list("text" = "", "indicator" = FALSE, "target" = null) // Параметры для использования
+
+	if(jobban_isbanned(user, "emote"))
+		to_chat(user, "You cannot send subtle emotes (banned).")
+		return FALSE
+	else if(user.client && user.client.prefs.muted & MUTE_IC)
+		to_chat(user, "You cannot send IC messages (muted).")
+		return FALSE
+
+	if(type_override)
+		emote_type = type_override
+	if(!can_run_emote(user))
+		return FALSE
+
+	if(params) // Копируем нужные пераметры
+		if(islist(params))
+			for(var/list_key in parameters)
+				if(params[list_key] != null)
+					parameters[list_key] = params[list_key]
+		else if(istext(params))
+			parameters["text"] = params
+
+	var/mob/living/target
+
+	// Определяем цель
+	if(parameters["target"])
+		target = parameters["target"]
+	else
+		var/list/possible_target = list()
+		for(var/mob/living/L in oview(work_distance, user))
+			LAZYADD(possible_target, L)
+
+		if(possible_target.len > 13) // Много целей, TGUI с поиском
+			target = tgui_input_list(user, "Выберете персонажа, который увидит ваши действия", "Выбор персонажа", possible_target)
+		else // Радиальное меню
+			for(var/mob/living/listed in possible_target)
+				possible_target[listed] = new /mutable_appearance(listed)
+
+			if(!possible_target || !possible_target.len)
+				to_chat(user, span_warning("No target around."))
+				return FALSE
+
+			target = possible_target.len == 1 ? possible_target[1] : show_radial_menu(user, user, possible_target, radius = 40)
+
+		if(!target)
+			return FALSE
+
+	var/target_name = target.get_visible_name()
+
+	// Текст сообщения
+	if(parameters["text"])
+		message = parameters["text"]
+	else
+		if(parameters["indicator"]) // Показываем индикатор
+			user.display_typing_indicator(isMe = TRUE)
+		// Вводим сообщение
+		var/subtle_emote = stripped_multiline_input_or_reflect(user, "Введите сообщение, которое увидит, ТОЛЬКО [target_name].", "Введите скрытое сообщение", null, MAX_MESSAGE_LEN)
+		if(parameters["indicator"]) // Удаляем индикатор
+			user.clear_typing_indicator()
+		
+		if(subtle_emote && !check_invalid(user, subtle_emote))
+			message = subtle_emote
+		else
+			return FALSE
+
+	message = "<span class='emote'><b>[user]</b> <i>[user.say_emphasis(message)]</i></span>"
+	
+	// Отправка сообщений
+	if(target in view(work_distance, user))
+		to_chat(target, "[span_nicegreen("Ты замечаешь, как")] [message]")
+		// Логи
+		user.log_message("[message] (SUBTLER-TARGET to [target.name])", LOG_SUBTLER)
+	else
+		to_chat(user, span_alert("[target_name] удалился слишком далеко и не увидел твои действия."))
+		// Логи
+		user.log_message("[message] (SUBTLER-TARGET to [target.name] (unheard))", LOG_SUBTLER)
+	to_chat(user, message)
+
+//BLUEMOON ADD END
+
 ///////////////// VERB CODE
 /mob/living/verb/subtle()
 	set name = "Subtle"
@@ -183,3 +311,26 @@
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	usr.emote("subtler_table")
+
+//BLUEMOON ADD START
+///////////////// VERB CODE 4
+/mob/living/verb/subtler_target()
+	set name = "Subtler Target"
+	set category = "Say"
+	if(GLOB.say_disabled)	//This is dumb but it's here because heehoo copypaste, who the FUCK uses this to identify lag?
+		to_chat(usr, span_danger("Speech is currently admin-disabled."))
+		return
+
+	usr.emote("subtler_target", message = list("indicator" = FALSE))
+
+/mob/living/verb/subtler_target_indicatored()
+	set name = "Subtler Target (Indicator)"
+	set category = "Say"
+	// Check if say is disabled
+	if(GLOB.say_disabled)
+		// Warn user and return
+		to_chat(usr, span_danger("Speech is currently admin-disabled."))
+		return
+
+	usr.emote("subtler_target", message = list("indicator" = TRUE))
+//BLUEMOON ADD END

--- a/modular_bluemoon/code/modules/mob/say_vr.dm
+++ b/modular_bluemoon/code/modules/mob/say_vr.dm
@@ -16,6 +16,9 @@
 	// Remove typing indicator
 	clear_typing_indicator()
 
+	if(!input_message)
+		return
+	
 	// Run subtle emote with input
 	usr.emote("subtler", message = input_message)
 
@@ -45,4 +48,3 @@
 
 /datum/emote/sound/human/subtler_table
 	emote_cooldown = 0
-


### PR DESCRIPTION
# Описание
- Добавлен Subtler Target, работает как эмоут направленный конкретному мобу в радиусе 5 клеток. (Т.е. госты и вообще никто его не увидит, кроме админов). К нему добавлены вербы в Say меню и горячие клавиши.
- Выбор персонажа осуществляется радиальным меню, но если персонажей больше, чем на 2 "страницы", то включается обычный TGUI с поиском
- Если персонаж отошел во время написания лога за радиус, вы увидите сообщение об этом, а персонаж ваше сообщение не получит. Если цель успешно получила сообщение, оно будет выделено небольшим зеленым цветом, для заметности.
- В Subtler Anti-Ghost добавлена проверка на персонажей, которые находятся в реальной невидимости по отношению к игроку
> Пример:

> Не видят: Госты, ЕРП призрак карен _(в невидимости)_, ползающие по крови _(способность демона крови)_ и т.д. 
> Видят, как раньше: Вендиго, спрятавшиеся в кустах, скушанные через VORE, переносимые в сумках и т.д.

Багфиксы:
- Пофикшено двойное открытие субтайтлера при отмене варианта с индикатором.

Протестировано на локалке с нескольких клиентов, но **пускай в тестмерже помаринуется немного**.
## Причина изменений
Прямо вытекает из этого [ПРа](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/pull/2141). А идея нового субтайтлера была предложена [тут](https://discord.com/channels/875735187449847830/1052875182672449617/1406764946485805167) _(Вроде на ново ТГ есть такой)_

## Демонстрация изменений
<img width="163" height="185" alt="image" src="https://github.com/user-attachments/assets/2b8ab814-7c90-43da-8179-88d1c844b9c3" />