### PR TITLE
Cum overlay fix

### DIFF
--- a/code/__SPLURTCODE/DEFINES/lewd.dm
+++ b/code/__SPLURTCODE/DEFINES/lewd.dm
@@ -17,3 +17,19 @@
 #define CUM_TARGET_THIGHS "thighs"
 #define CUM_TARGET_BELLY "belly"
 #define CUM_TARGET_ARMPIT "armpit"
+
+//Cum overlays
+#define CUM_DMI 'modular_splurt/icons/effects/cumoverlay.dmi'
+#define CUM_STATES list( \
+    "cum_normal", \
+    "cum_normal_1", \
+    "cum_normal_2", \
+    "cum_normal_3", \
+    "cum_normal_4", \
+    "cum_large" \
+)
+#define CUM_STATES_NEUTRAL list( \
+    "cum_normal_1", \
+    "cum_normal_2", \
+    "cum_normal_3"	\
+)

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -112,6 +112,35 @@
 		var/mob/living/carbon/human/H = owner
 		H.update_genitals()
 
+/obj/item/organ/genital/proc/pick_cum_overlay()
+	var/result = pick(CUM_STATES_NEUTRAL)
+
+	if(istype(src, /obj/item/organ/genital/penis) || istype(src, /obj/item/organ/genital/testicles))
+		var/obj/item/organ/genital/testicles/balls
+		if(istype(src, /obj/item/organ/genital/testicles))
+			balls = src
+		else if(linked_organ)
+			balls = linked_organ
+
+		var/list/states = CUM_STATES
+		for(var/i in 1 to states.len) // Делаем список с весом
+			var/key = states[i]
+			states -= key
+			states[key] = 1
+
+		var/const/state_large = "cum_large" // Подменяем вес у state_large в зависимости от размера (Такая оригинальная логика была)
+		if(state_large in states)
+			if(balls.size < BALLS_SIZE_3)
+				states -= state_large
+			else if(balls.size == BALLS_SIZE_3)
+				states[state_large] = 4
+			else
+				states[state_large] = 10
+
+		result = pickweight(states) // Выбираем state
+
+	return result
+
 /mob/living/carbon/verb/toggle_genitals()
 	set category = "IC"
 	set name = "Expose/Hide genitals"

--- a/modular_splurt/code/modules/arousal/arousal.dm
+++ b/modular_splurt/code/modules/arousal/arousal.dm
@@ -69,34 +69,24 @@
 			sender.set_fluid_id(default)
 
 	if(istype(sender, /obj/item/organ/genital/penis))
-		var/obj/item/organ/genital/penis/bepis = sender
-		if(locate(/obj/item/genital_equipment/sounding) in bepis.contents)
-			spill = TRUE
-			to_chat(src, "<span class='userlove'>Ты чувствуешь, как стержень выталкивается из твоей уретры вместе со струей оргазменной жидкости!</span>")
-			var/obj/item/genital_equipment/sounding/rod = locate(/obj/item/genital_equipment/sounding) in bepis.contents
-			rod.forceMove(get_turf(src))
+		var/obj/item/genital_equipment/sounding/sounding_rod = locate(/obj/item/genital_equipment/sounding) in sender.contents
+		if(sounding_rod)
+			var/message = ""
+			if(locate(/obj/item/genital_equipment/chastity_cage) in sender.contents)
+				message = "Ты ощущаешь, как стержень упирается в клетку и не может выйти, поток жидкости обтекает его, раздувая твой член и вызывая болезненную пульсацию!"
+				if(HAS_TRAIT(src, TRAIT_MASO))
+					message = span_userlove(message)
+				else
+					message = span_alertwarning(message)
+			else
+				spill = TRUE
+				message = span_userlove("Ты чувствуешь, как стержень выталкивается из твоей уретры вместе со струей оргазменной жидкости!")
+				sounding_rod.forceMove(get_turf(src))
+			to_chat(src, message)
 
 	if(cover == TRUE)
-		if(istype(sender, /obj/item/organ/genital/penis))
-			var/obj/item/organ/genital/testicles/testicles = sender
-			var/size = testicles.size
-			var/balls_size_0 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4")
-			var/balls_size_1 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4")
-			var/balls_size_2 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4")
-			var/balls_size_3 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large")
-			var/balls_size_4 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large")
-			switch(size)
-				if(BALLS_SIZE_MIN)
-					size = pick(balls_size_0)
-				if(BALLS_SIZE_DEF)
-					size = pick(balls_size_1)
-				if(BALLS_SIZE_2)
-					size = pick(balls_size_2)
-				if(BALLS_SIZE_3)
-					size = pick(balls_size_3)
-				if(BALLS_SIZE_MAX)
-					size = pick(balls_size_4)
-			target.add_cum_overlay(size)
+		if(istype(sender, /obj/item/organ/genital/penis) || HAS_TRAIT(src, TRAIT_MESSY))
+			target.add_cum_overlay(sender.pick_cum_overlay(), initial(sender.fluid_id.color))
 
 	. = ..()
 
@@ -140,17 +130,19 @@
 	var/covered_in_cum = FALSE
 
 /atom/proc/add_cum_overlay(state = "cum_normal", cum_color = "#FFFFFF") //This can go in a better spot, for now its here.
+	var/const/overlays_limit = 10
 	if(!istype(src, /mob/living/carbon/human))
 		return
 
 	if(initial(icon) && initial(icon_state))
 		//BLUEMOON ADD START
 		var/list/active_overlays = list()
-		for(var/mutable_appearance/appearance_mirror/MA in src.overlays)
-			if(MA.icon == CUM_DMI && (MA.icon_state in CUM_STATES))
+		for(var/over in src.overlays)
+			var/image/MA = over
+			if(MA && MA.icon == CUM_DMI && (MA.icon_state in CUM_STATES))
 				active_overlays += MA
 		//BLUEMOON ADD END
-		if(active_overlays.len <= 10) // BLUEMOON EDIT || Не больше 10 оверлеев, иначе будет срабатывать VALIDATE_OVERLAY_LIMIT
+		if(active_overlays.len < overlays_limit) // BLUEMOON EDIT || Ограничение на оверлеи, иначе будет срабатывать VALIDATE_OVERLAY_LIMIT
 			add_overlay(mutable_appearance(CUM_DMI, state, color = cum_color), ICON_MULTIPLY)
 		var/mob/living/carbon/human/H = src
 		H.covered_in_cum = TRUE

--- a/modular_splurt/code/modules/arousal/arousal.dm
+++ b/modular_splurt/code/modules/arousal/arousal.dm
@@ -69,20 +69,12 @@
 			sender.set_fluid_id(default)
 
 	if(istype(sender, /obj/item/organ/genital/penis))
-		var/obj/item/genital_equipment/sounding/sounding_rod = locate(/obj/item/genital_equipment/sounding) in sender.contents
-		if(sounding_rod)
-			var/message = ""
-			if(locate(/obj/item/genital_equipment/chastity_cage) in sender.contents)
-				message = "Ты ощущаешь, как стержень упирается в клетку и не может выйти, поток жидкости обтекает его, раздувая твой член и вызывая болезненную пульсацию!"
-				if(HAS_TRAIT(src, TRAIT_MASO))
-					message = span_userlove(message)
-				else
-					message = span_alertwarning(message)
-			else
-				spill = TRUE
-				message = span_userlove("Ты чувствуешь, как стержень выталкивается из твоей уретры вместе со струей оргазменной жидкости!")
-				sounding_rod.forceMove(get_turf(src))
-			to_chat(src, message)
+		var/obj/item/organ/genital/penis/bepis = sender
+		if(locate(/obj/item/genital_equipment/sounding) in bepis.contents)
+			spill = TRUE
+			to_chat(src, "<span class='userlove'>Ты чувствуешь, как стержень выталкивается из твоей уретры вместе со струей оргазменной жидкости!</span>")
+			var/obj/item/genital_equipment/sounding/rod = locate(/obj/item/genital_equipment/sounding) in bepis.contents
+			rod.forceMove(get_turf(src))
 
 	if(cover == TRUE)
 		if(istype(sender, /obj/item/organ/genital/penis) || HAS_TRAIT(src, TRAIT_MESSY))

--- a/modular_splurt/code/modules/arousal/arousal.dm
+++ b/modular_splurt/code/modules/arousal/arousal.dm
@@ -80,8 +80,8 @@
 		if(istype(sender, /obj/item/organ/genital/penis))
 			var/obj/item/organ/genital/testicles/testicles = sender
 			var/size = testicles.size
-			var/balls_size_0 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4", "", "", "", "", "", "", "", "", "", "")
-			var/balls_size_1 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4", "", "", "", "", "")
+			var/balls_size_0 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4")
+			var/balls_size_1 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4")
 			var/balls_size_2 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4")
 			var/balls_size_3 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large")
 			var/balls_size_4 = list("cum_normal", "cum_normal_1", "cum_normal_2", "cum_normal_3", "cum_normal_4", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large", "cum_large")
@@ -139,11 +139,19 @@
 /mob/living/carbon/human
 	var/covered_in_cum = FALSE
 
-/atom/proc/add_cum_overlay(size = "cum_normal", cum_color = "#FFFFFF") //This can go in a better spot, for now its here.
+/atom/proc/add_cum_overlay(state = "cum_normal", cum_color = "#FFFFFF") //This can go in a better spot, for now its here.
 	if(!istype(src, /mob/living/carbon/human))
 		return
+
 	if(initial(icon) && initial(icon_state))
-		add_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', size, color = cum_color), ICON_MULTIPLY)
+		//BLUEMOON ADD START
+		var/list/active_overlays = list()
+		for(var/mutable_appearance/appearance_mirror/MA in src.overlays)
+			if(MA.icon == CUM_DMI && (MA.icon_state in CUM_STATES))
+				active_overlays += MA
+		//BLUEMOON ADD END
+		if(active_overlays.len <= 10) // BLUEMOON EDIT || Не больше 10 оверлеев, иначе будет срабатывать VALIDATE_OVERLAY_LIMIT
+			add_overlay(mutable_appearance(CUM_DMI, state, color = cum_color), ICON_MULTIPLY)
 		var/mob/living/carbon/human/H = src
 		H.covered_in_cum = TRUE
 		to_chat(H, span_love("Кажется тебя немножко забрызгали~"))
@@ -153,12 +161,8 @@
     return percentage
 
 /atom/proc/wash_cum()
-	cut_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', "cum_normal"))
-	cut_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', "cum_normal_1"))
-	cut_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', "cum_normal_2"))
-	cut_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', "cum_normal_3"))
-	cut_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', "cum_normal_4"))
-	cut_overlay(mutable_appearance('modular_splurt/icons/effects/cumoverlay.dmi', "cum_large"))
+	for(var/state in CUM_STATES)
+		cut_overlay(mutable_appearance(CUM_DMI, state))
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		H.covered_in_cum = FALSE

--- a/modular_splurt/code/modules/arousal/organs/breasts.dm
+++ b/modular_splurt/code/modules/arousal/organs/breasts.dm
@@ -88,5 +88,7 @@
 			break
 
 	// splash affected objects
+	var/overlay_state = pick_cum_overlay()
+	var/overlay_color = initial(fluid_id.color)
 	for(var/atom/object in cumsplashed_items)
-		object.add_cum_overlay(initial(fluid_id.color), width_multiplier > 1 ? TRUE : FALSE)
+		object.add_cum_overlay(overlay_state, overlay_color)

--- a/modular_splurt/code/modules/arousal/organs/penis.dm
+++ b/modular_splurt/code/modules/arousal/organs/penis.dm
@@ -88,5 +88,7 @@
 			break
 
 	// splash affected objects
+	var/overlay_state = pick_cum_overlay()
+	var/overlay_color = initial(linked_organ.fluid_id.color)
 	for(var/atom/object in cumsplashed_items)
-		object.add_cum_overlay(length_multiplier > 1 ? "cum_large" : "cum_normal", initial(linked_organ.fluid_id.color))	//тут можно миллиард проверок впихнуть на наличие BIG BALLS/etc но пусть хотя бы так пока работает.
+		object.add_cum_overlay(overlay_state, overlay_color)

--- a/modular_splurt/code/modules/arousal/organs/vagina.dm
+++ b/modular_splurt/code/modules/arousal/organs/vagina.dm
@@ -24,6 +24,8 @@
 		return
 
 	// splash affected objects
+	var/overlay_state = pick_cum_overlay()
+	var/overlay_color = initial(linked_organ.fluid_id.color)
 	for(var/atom/object in target_turf.contents)
 		if(!istype(object) || isturf(object) || object == owner)
 			continue
@@ -31,4 +33,4 @@
 			var/mob/living/carbon/human/H = object
 			if(!(H.client?.prefs.cit_toggles & CUM_ONTO))
 				continue
-		object.add_cum_overlay(initial(linked_organ.fluid_id.color), get_size(owner) >= 1.5)
+		object.add_cum_overlay(overlay_state, overlay_color)


### PR DESCRIPTION
# Описание
- Минорное, добавлен общий прок для выбора оверлея cum на куклу, старый код отрефакторен _(который частично не работал, ибо переменные местами перепутали)_
- Поставлено ограничение в 10 оверлеев cum на куклу, иначе может упереться в лимит по оверлеям общий

Проверено на локалке.