### PR TITLE
НАРУШИТЕЛЬ ЗАКОНА: Убираем комментирование, актуализируем статьи, доб…

### DIFF
--- a/modular_bluemoon/code/datums/traits/neutral/criminal_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/neutral/criminal_quirk.dm
@@ -1,4 +1,4 @@
-/* GLOBAL_VAR_INIT(bluemoon_criminal_quirk_warden_name, "") // имя для вардена, чтобы во всех записях было одинаковым
+GLOBAL_VAR_INIT(bluemoon_criminal_quirk_warden_name, "") // имя для вардена, чтобы во всех записях было одинаковым
 GLOBAL_VAR_INIT(bluemoon_criminal_quirk_sergeants_names, "")
 GLOBAL_VAR_INIT(bluemoon_criminal_quirk_hos_name, "")
 GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
@@ -78,9 +78,10 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 			crime_issued_by_officer = "Central Command Intern [random_unique_name(pick(MALE,FEMALE))]"
 			crime_issued_by_officer_type = ISSUER_TYPE_INTERN
 
-	if(prob(60))
-		target_records.fields["criminal"] = SEC_RECORD_STATUS_ARREST
-		sec_hud_set_security_status()
+	target_records.fields["criminal"] = SEC_RECORD_STATUS_ARREST
+	sec_hud_set_security_status()
+
+	to_chat(src, span_info("OOC: Наличие квирка нарушителя НЕ ЯВЛЯЕТСЯ оправданием для самоантагонизма. Он создан для интересных ситуаций и взаимодействию СБ с персоналом на почве нарушений вне станции. Be cool."))
 
 	var/know_about_crime_title = pick( // заголовок
 	"Вы нарушили закон!", "За вами охотятся арбитры!", "Ваши нарушения не остались без внимания!", "О вас не забыли!", "О вас не забудут!", \
@@ -143,7 +144,7 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 
 			if(2) // Оскорбления младших глав
 				victim_job = pick(victim_job_senior)
-				crime_number = "101-O-3"
+				crime_number = "101"
 				crime_description = pick(\
 				"[pick("Выкрикивал[ru_a()] оскорбительные выражения о", "Очень много ругани о", "Оскорбление", "Оскорбления", "Унижение личного достоинства")] [victim_name] ([victim_job])")
 				know_about_crime_description = pick("Кажется, вы наговорили много лишнего и оскорбительного в адрес [victim_name]... Кажется, это был [victim_job]?...")
@@ -159,9 +160,6 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 				crime_description = pick(\
 				"[pick("Засорял[ru_a()] эфир", "Неприлично спорил[ru_a()] в радиоканал", "Засорение рации", "Долго руга[ru_sya()] в радио")]")
 				know_about_crime_description = pick("Вы очень неплохо поругались с кем-то в рацию не так давно. Почему ощущение, что это может аукнуться?")
-
-
-	// СТАТЬИ 200-ОЙ КАТЕГОРИИ
 			if(5) // Оскорбления глав/корпораций
 				var/major_disgrace = FALSE
 				var/major_name = pick("НаноТрейзен", "НТ", "Синдиката", "Триглава", "Корпорации")
@@ -171,7 +169,7 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 					"[pick("Выкрикивал[ru_a()] оскорбительные выражения о", "Очень много ругани о", "Оскорбление", "Оскорбления", "Распространние недостоверных слухов о", "Распространение клеветы о", "Распространение слухов о", "Клевета в адрес", "Оскорбление сотрудников")] [major_name]")
 				else
 					victim_job = pick(victim_job_command)
-				crime_number = "201-1"
+				crime_number = "101"
 				crime_description = pick(\
 				"[pick("Выкрикивал[ru_a()] оскорбительные выражения о", "Очень много ругани о", "Оскорбление", "Оскорбления", "Унижение личного достоинства")] [victim_name] ([victim_job])")
 				if(major_disgrace)
@@ -179,26 +177,16 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 				else
 					know_about_crime_description = pick("Кажется, вы наговорили много лишнего и оскорбительного в адрес [victim_name]... Кажется, это был [victim_job]?")
 
+	// СТАТЬИ 200-ОЙ КАТЕГОРИИ
 			if(6) // Драка
-				var/punched = FALSE
 				crime_number = "202"
 				crime_description = pick(\
-				"[pick("Толкал[ru_a()]","Пихал[ru_a()]","Толкнул[ru_a()]")] [victim_name] ([victim_job])")
-				if(prob(60))
-					punched = TRUE
-					crime_description = pick(\
-					"[pick("Побил[ru_a()]","Вступил[ru_a()] в драку с","Нападение на","Напал[ru_a()] на","Атаковал[ru_a()]","Ударил[ru_a()]","Ударил[ru_a()] несколько раз")] [victim_name] ([victim_job])")
-				if(punched)
-					know_about_crime_description = pick("Вы [pick("устроили драку","подрались")] с [victim_name] ([victim_job])")
-					know_about_crime_description += pick(\
-					", но уже плохо помните, за что.", " за оскорбление вашего родственника. Повезло, что вас оттащили друзья - иначе синяками бы не отделался.",\
-					" из-за какой-то хрени... Даже стыдно сейчас.", " из-за разных политических взглядов. С такими иначе не получается.")
-				else
-					know_about_crime_description = pick("Вы пару раз толкнули [victim_name] ([victim_job])")
-					know_about_crime_description += pick(\
-					", но уже плохо помните, за что.", " за оскорбление вашего родственника.",\
-					" из-за какой-то хрени... Даже стыдно сейчас.", " из-за разных политических взглядов.")
-				know_about_crime = TRUE // Будет странно, если персонаж не будет помнить, как писал гадости о ГСБ
+				"[pick("Побил[ru_a()]","Вступил[ru_a()] в драку с","Нападение на","Напал[ru_a()] на","Атаковал[ru_a()]","Ударил[ru_a()]","Ударил[ru_a()] несколько раз")] [victim_name] ([victim_job])")
+				know_about_crime_description = pick("Вы [pick("устроили драку","подрались")] с [victim_name] ([victim_job])")
+				know_about_crime_description += pick(\
+				", но уже плохо помните, за что.", " за оскорбление вашего родственника. Повезло, что вас оттащили друзья - иначе синяками бы не отделался.",\
+				" из-за какой-то хрени... Даже стыдно сейчас.", " из-за разных политических взглядов. С такими иначе не получается.")
+				know_about_crime = TRUE // Будет странно, если персонаж не будет помнить, как подрался
 
 			if(7) // Нежелательный контакт
 				victim_job = pick(victim_job_generic + victim_job_senior + victim_job_command)
@@ -211,7 +199,7 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 				"Вы на спор попытались переспать с [victim_name]. То, как вам ответили - отличная смешная история, которую можно будет рассказать друзьям.")
 
 			if(8) // Превышение самообороны
-				crime_number = "302-П-2"
+				crime_number = "302"
 				crime_description = pick(\
 				"Во время драки с [victim_name] превысил[ru_a()] самооборону, чуть не убив", \
 				"Добивал[ru_a()] лежавшего на полу [victim_name] после нападения на себя", \
@@ -221,7 +209,7 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 				"Вы помните, как на вас напал какой-то обмудок, из-за чего вы жёстко его избили. Охране это не понравилось, но удалось уйти.",\
 				"На вас кто-то напал и пришлось защититься, но кажется, вы превысили самооборону...",\
 				"Этот мудила, что влетев на вас с ножом, явно не ожидал, что один удар ногой сложит его пополам. Интересно, после пятого удара ногой в голову он вообще живой остался?")
-				know_about_crime = TRUE // Будет странно, если персонаж не будет помнить, как писал гадости о ГСБ
+				know_about_crime = TRUE // Будет странно, если персонаж не будет помнить, как подрался
 
 			if(9) // Неисполнение приказа
 				crime_number = "203"
@@ -367,4 +355,4 @@ GLOBAL_VAR_INIT(bluemoon_criminal_quirk_commander_name, "")
 #undef ISSUER_TYPE_SECURITY_SERGEANT
 #undef ISSUER_TYPE_SECURITY_HEAD
 #undef ISSUER_TYPE_COMMANDER
-#undef ISSUER_TYPE_INTERN */
+#undef ISSUER_TYPE_INTERN


### PR DESCRIPTION
Возвращён квирк нарушителя закона.

Проведённая работа:
- Актуализированы статьи и нарушения.
- Добавлена сноска, что квирк НЕ ЯВЛЯЕТСЯ оправданием для самоантагонизма и создан для интересных ситуаций.
- Убран шанс, что нарушителю не выставится статус, чтобы СБ не нужно было прокликивать каждого человека без статуса в поиске подобного нарушителя и ускорить переход к ролевой игре.
- Добавлена приписка к каждому нарушению, что ордер авторизован ЦК.

Он изначально созадн для отыгрыша АР и взаимодействия с СБ обычного персонала, начиная от выдачи штрафов и заканчивания беготней с задержаниями, и какой-никакой отыгрыгровкой ордеров.