### PR TITLE
funclaw weight updt + lightweight pick up delay

### DIFF
--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -91,7 +91,7 @@
 		span_userdanger("[user] starts picking you up!"))
 	source.balloon_alert(user, "picking up")
 	var/time_required = COMPARE_SIZES(source, user) * 4 SECONDS //Scale how fast the pickup will be depending on size difference
-	if(user.mob_weight < MOB_WEIGHT_NORMAL && source.mob_weight <= user.mob_weight && get_size(source) > 0.5) //BLUEMOON ADD лёгкие большие персонажи дольше поднимают тех, кто имеет размер больше 50%, если это тоже не легкий персонаж
+	if(user.mob_weight < MOB_WEIGHT_NORMAL && source.mob_weight > user.mob_weight && get_size(source) > 0.5) //BLUEMOON ADD лёгкие большие персонажи дольше поднимают тех, кто имеет размер больше 50%, если это тоже не легкий персонаж
 		time_required += 8 SECONDS //BLUEMOON ADD END
 	if(!do_after(user, time_required, source))
 		return FALSE

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -91,7 +91,7 @@
 		span_userdanger("[user] starts picking you up!"))
 	source.balloon_alert(user, "picking up")
 	var/time_required = COMPARE_SIZES(source, user) * 4 SECONDS //Scale how fast the pickup will be depending on size difference
-	if(get_size(source) > 0.5 && user.mob_weight < MOB_WEIGHT_NORMAL) //BLUEMOON ADD лёгкие большие персонажи дольше поднимают тех, кто имеет размер больше 50%
+	if(user.mob_weight < MOB_WEIGHT_NORMAL && source.mob_weight <= user.mob_weight && get_size(source) > 0.5) //BLUEMOON ADD лёгкие большие персонажи дольше поднимают тех, кто имеет размер больше 50%, если это тоже не легкий персонаж
 		time_required += 8 SECONDS //BLUEMOON ADD END
 	if(!do_after(user, time_required, source))
 		return FALSE

--- a/modular_splurt/code/modules/mob/living/simple_animal/hostile/deathclaw/funclaw.dm
+++ b/modular_splurt/code/modules/mob/living/simple_animal/hostile/deathclaw/funclaw.dm
@@ -7,6 +7,11 @@
 	gold_core_spawnable = NO_SPAWN // Admin only
 	deathclaw_mode = "rape"
 
+/mob/living/simple_animal/hostile/deathclaw/funclaw/Initialize(mapload)
+	. = ..()
+	if(aggro_vision_range) // Если это не мирный моб, то его нельзя таскать, прятать в ящики и т.д.
+		mob_weight = MOB_WEIGHT_HEAVY_SUPER
+
 /mob/living/simple_animal/hostile/deathclaw/funclaw/gentle
 	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match. This one has the bedroom eyes.."
 	deathclaw_mode = "gentle"


### PR DESCRIPTION
# Описание
- Агресивных фанклавов больше нельзя тянуть, прятать в ящики и катать на стульях. _(Вся логика уже прописана в весе, поэтому я просто воткнул им сверхтяжелый, так что технически их можно перевозить на сверхтяжелых каталках или сверхтяжелыми персонажами, другие бонусы фанклавы не получают, т.к. они не карбоны)_
- Легкие персонажи получали задержку, при поднятии других персонажей, если их размер был больше 50% (Короче когда легкие были гигантами), теперь если цель тоже легкого веса, задержки не будет

## Причина изменений
Писали про кейсы, когда агрессивных факнлавов вытаскивали с техов, например на шаттл, что бы те напали на персов. Считаю, раз ты отказываешься от контента с фанклавами, ввиду префов, то нефиг их трогать и портить другим игру, не для тебя сделаны.