### PR TITLE
Nuclear remap jam

### DIFF
--- a/_maps/RandomZLevels/away_mission/ihategordon.dmm
+++ b/_maps/RandomZLevels/away_mission/ihategordon.dmm
@@ -32,6 +32,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"abs" = (
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/opposing/comlpex)
 "abJ" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating,
@@ -50,6 +57,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"acv" = (
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "acH" = (
 /obj/structure/flora/junglebush{
 	pixel_x = -4;
@@ -212,16 +226,6 @@
 	dir = 6
 	},
 /turf/open/floor/plating/ironsand,
-/area/awaymission/ihategordon/outsideofmesa)
-"ags" = (
-/obj/effect/turf_decal/siding/wideplating_new{
-	color = "#454545";
-	dir = 5
-	},
-/obj/structure/rockpilemesa{
-	icon_state = "stonealt10"
-	},
-/turf/open/floor/plating/cobblestone/sidewalk,
 /area/awaymission/ihategordon/outsideofmesa)
 "agE" = (
 /obj/effect/mob_spawn/human/hlscientist,
@@ -441,6 +445,16 @@
 	icon_state = "bus"
 	},
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"akp" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "akv" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1;
@@ -1112,6 +1126,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"avm" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "avC" = (
 /obj/structure/alien/weeds{
 	color = "#ac3b06";
@@ -1291,6 +1312,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"ayP" = (
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 8
+	},
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt1"
+	},
+/turf/open/floor/plating/cobblestone/sidewalk,
+/area/awaymission/ihategordon/outsideofmesa)
 "aza" = (
 /turf/open/floor/plasteel{
 	icon_state = "damaged1"
@@ -1322,6 +1353,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"aAC" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "aAD" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/ironsand,
@@ -1444,7 +1480,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/underground_tunnels)
 "aDs" = (
 /obj/structure/closet/crate/large/urbanismcratelarge/mil,
@@ -1655,6 +1691,15 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
+"aIR" = (
+/obj/structure/urbanismmachines{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "aJc" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 9
@@ -1877,6 +1922,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/science_tunnel)
+"aLX" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "aMe" = (
 /obj/machinery/light{
 	dir = 8
@@ -1937,7 +1994,6 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/awaymission/ihategordon/opposing/comlpex)
 "aNI" = (
-/obj/structure/frame/machine,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
@@ -2422,9 +2478,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/ihategordon/facility_hallway)
 "aWs" = (
-/turf/open/floor/plasteel{
-	icon_state = "damaged4"
-	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/server_rooms)
 "aWt" = (
 /obj/effect/festive/street/streetlinesouth,
@@ -2544,6 +2600,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"aYu" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "aYI" = (
 /obj/item/keycard/utilization,
 /turf/open/floor/plating,
@@ -2631,6 +2693,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/gonome)
+"ban" = (
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/structure/urbanismbigcrate{
+	icon_state = "cratealt";
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/opposing/comlpex)
 "bas" = (
 /obj/effect/baseturf_helper/black_mesa,
 /turf/closed/mineral/mesarock{
@@ -2803,6 +2876,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"bex" = (
+/obj/item/ammo_casing/c10mm,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "beS" = (
 /obj/effect/mob_spawn/human/deadhecu,
 /turf/open/floor/catwalk_floor,
@@ -2812,6 +2892,13 @@
 /obj/effect/turf_decal/siding/dark_green,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"bfn" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "bfr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -2897,6 +2984,12 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"bgR" = (
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/entrance)
 "bgT" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -2917,6 +3010,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhsecoffices)
+"bhy" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "bhB" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -3046,7 +3148,7 @@
 /area/awaymission/ihategordon/big_offices)
 "bjt" = (
 /mob/living/simple_animal/hostile/blackmesa/xen/bullsquid/alt2,
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "bjz" = (
 /obj/structure/rack/shelf,
@@ -3674,6 +3776,15 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"bvO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "bvQ" = (
 /obj/structure/urbanismcars,
 /turf/open/floor/plating/cobblestone,
@@ -3858,6 +3969,18 @@
 "byh" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/ihategordon/opposing/comlpex)
+"byk" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	color = "#454545";
+	dir = 1
+	},
+/obj/item/storage/toolbox/ammo/surplus{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "byl" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -4008,6 +4131,17 @@
 	icon_state = "damaged5"
 	},
 /area/awaymission/ihategordon/dorm_offices)
+"bBh" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "bBp" = (
 /obj/effect/mob_spawn/human/hlscientist,
 /turf/open/floor/plasteel/white,
@@ -4036,18 +4170,6 @@
 	name = "cable";
 	color = "#222222";
 	pixel_y = 0;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
-"bBJ" = (
-/obj/structure/decorative{
-	icon = 'icons/obj/power_cond/cables.dmi';
-	icon_state = "1-4";
-	anchored = 1;
-	name = "cable";
-	color = "#222222";
-	pixel_y = 1;
 	pixel_x = 0
 	},
 /turf/open/floor/plasteel,
@@ -4175,15 +4297,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/gonome)
-"bDP" = (
-/obj/effect/festive/street/streetlinenorth,
-/obj/structure/rockpilemesa{
-	icon_state = "stone3";
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
 "bDT" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -4556,6 +4669,13 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"bKw" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/headcrab/mesa,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/sectorhsecoffices)
 "bKB" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/alien/weeds{
@@ -4651,6 +4771,17 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
+"bMb" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "bMg" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 4
@@ -4714,6 +4845,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/end)
+"bNb" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "bNi" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -4809,6 +4952,13 @@
 	},
 /turf/open/floor/plating/cobblestone/sidewalk,
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
+"bOZ" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/entrance)
 "bPb" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel,
@@ -5268,6 +5418,12 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"bXN" = (
+/obj/structure/urbanismbigcrate/alt{
+	icon_state = "boxalt6"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "bXO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen,
@@ -5398,6 +5554,13 @@
 /turf/open/floor/plasteel{
 	icon_state = "wasteland11"
 	},
+/area/awaymission/ihategordon/outsideofmesa)
+"bZQ" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt6"
+	},
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
 "bZS" = (
 /obj/structure/chair/sofa/corp/left{
@@ -5875,6 +6038,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"cjq" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/structure/urbanismbigcrate/alt{
+	icon_state = "boxalt4"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "cjX" = (
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_x = -3;
@@ -5890,12 +6064,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/big_offices)
-"ckj" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
 "cko" = (
 /obj/structure/urbanismmounted{
 	icon_state = "wallmount";
@@ -5986,6 +6154,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/facility_hallway)
+"clx" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "clz" = (
 /obj/structure/flora/rock/pile{
 	color = "#f79668"
@@ -6089,6 +6263,9 @@
 "cnK" = (
 /mob/living/simple_animal/hostile/headcrab/mesa,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6232,6 +6409,7 @@
 	pixel_x = -4;
 	pixel_y = -1
 	},
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
 /turf/open/floor/plasteel/airless/dark{
 	icon_state = "bus"
 	},
@@ -6414,7 +6592,8 @@
 /area/awaymission/ihategordon/opposing/end)
 "cuZ" = (
 /obj/item/kirbyplants/hedge{
-	anchored = 1
+	anchored = 1;
+	density = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -6539,6 +6718,17 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"cxW" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "cyw" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel,
@@ -7033,6 +7223,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"cGQ" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "cGR" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -7074,6 +7275,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"cHD" = (
+/obj/effect/festive/street/streetlineeast,
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "cHF" = (
 /obj/machinery/modular_computer/console/preset{
 	dir = 4
@@ -7178,6 +7384,10 @@
 "cIZ" = (
 /obj/effect/mob_spawn/human/deadhecu,
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "cJh" = (
@@ -7318,9 +7528,21 @@
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/big_offices)
 "cMG" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/structure/closet/l3closet/scientist,
-/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/decorative{
+	icon = 'icons/obj/power_cond/cables.dmi';
+	icon_state = "1-2";
+	anchored = 1;
+	name = "cable";
+	color = "#222222";
+	pixel_y = 1;
+	pixel_x = 0
+	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "cMV" = (
@@ -7500,6 +7722,19 @@
 /obj/item/trash/can,
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/science_tunnel)
+"cPk" = (
+/obj/structure/urbanismtire{
+	icon_state = "shina3";
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/structure/urbanismtire{
+	icon_state = "shina2a";
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/floor/catwalk_floor,
+/area/awaymission/ihategordon/underground_tunnels)
 "cPz" = (
 /obj/structure/flora/rock/pile{
 	color = "#f79668"
@@ -7582,6 +7817,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"cQs" = (
+/obj/structure/flora/rock/pile{
+	color = "#f79668"
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "cQu" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -7863,10 +8107,12 @@
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/opposing/comlpex)
 "cUt" = (
-/obj/structure/lattice,
-/mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
-/turf/open/floor/plating,
-/area/awaymission/ihategordon/science_tunnel)
+/obj/effect/festive/street/streetlinene,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "cUy" = (
 /obj/machinery/light/red{
 	dir = 1
@@ -8341,6 +8587,9 @@
 	pixel_y = -1;
 	pixel_x = -2
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "dcn" = (
@@ -8394,7 +8643,7 @@
 /area/awaymission/ihategordon/underground_tunnels)
 "ddy" = (
 /obj/structure/closet/crate/urbanismcrate,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /obj/item/grenade/plastic/c4,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
@@ -8423,9 +8672,8 @@
 /area/awaymission/ihategordon/science_tunnel)
 "ddW" = (
 /obj/effect/festive/street/streetlinese,
-/turf/open/floor/plasteel{
-	icon_state = "wasteland2"
-	},
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "deh" = (
 /obj/item/ammo_box/magazine/mp5,
@@ -8695,6 +8943,15 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"djq" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "djD" = (
 /obj/machinery/door/poddoor{
 	id = "lastlock"
@@ -8837,10 +9094,16 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "dmn" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/plating,
-/area/awaymission/ihategordon/big_offices)
+/obj/effect/festive/street/streetlinenorth,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "dmv" = (
 /obj/machinery/door/airlock/research,
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -9091,7 +9354,7 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
 "dqJ" = (
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/hyperlaser_chamber)
 "dqL" = (
@@ -9144,7 +9407,13 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "drw" = (
 /obj/structure/closet/crate/bin,
@@ -9249,9 +9518,12 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
 "duw" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/turret_lockdown_hall)
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "duK" = (
 /obj/effect/festive/street/streetlinenorth,
 /obj/structure/reagent_dispensers/urbanismbarrel{
@@ -9261,6 +9533,9 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	color = "#454545";
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -9314,13 +9589,18 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/hecu_camp_hall)
 "dvQ" = (
-/obj/structure/barricade/wooden,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = 0;
 	pixel_y = 16
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "dwd" = (
 /obj/machinery/door/airlock/research,
@@ -9360,6 +9640,16 @@
 	},
 /turf/open/floor/plating/cobblestone/sidewalk,
 /area/awaymission/ihategordon/outsideofmesa)
+"dxa" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "dxc" = (
 /obj/machinery/light/red,
 /turf/open/floor/plasteel/showroomfloor,
@@ -9444,6 +9734,7 @@
 	pixel_x = -8;
 	pixel_y = -3
 	},
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
 /turf/open/floor/plasteel/airless/dark{
 	icon_state = "bus"
 	},
@@ -9588,16 +9879,6 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/catwalk_floor/iron,
 /area/awaymission/ihategordon/opposing/comlpex)
-"dBb" = (
-/mob/living/simple_animal/hostile/headcrab/mesa,
-/obj/machinery/light/cold{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
 "dBc" = (
 /obj/structure/urbanismmachines{
 	icon_state = "machine4";
@@ -9844,6 +10125,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sec_armory)
+"dGo" = (
+/obj/structure/urbanismmachines{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "dGI" = (
 /obj/structure/flora/rock/pile{
 	color = "#f79668"
@@ -10046,10 +10335,7 @@
 /obj/structure/statue/diamond/ai1{
 	name = "B.M.A.S statue"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/green,
 /area/awaymission/ihategordon/big_offices)
 "dJB" = (
 /mob/living/simple_animal/hostile/blackmesa/xen/snark,
@@ -10808,15 +11094,9 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/facility_hallway)
 "dZl" = (
-/obj/structure/frame/computer,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/turret_lockdown_hall)
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "dZw" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -10857,6 +11137,16 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/big_offices)
+"eav" = (
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "eaC" = (
 /obj/structure/urbanismdisplay{
 	pixel_x = 0;
@@ -11082,6 +11372,16 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"eef" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "eei" = (
 /obj/machinery/door/keycard{
 	puzzle_id = "utilizationcomplex"
@@ -11313,6 +11613,9 @@
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "eif" = (
 /obj/effect/festive/street/streetlineinnerse,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "eii" = (
@@ -11323,6 +11626,10 @@
 /obj/effect/turf_decal/siding/wideplating_new{
 	color = "#454545";
 	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -11717,12 +12024,9 @@
 	},
 /area/awaymission/ihategordon/big_offices)
 "eqf" = (
-/obj/effect/festive/street/streetlinenorth,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/machinery/power/floodlight/urbanismlight/mesaoutside,
+/turf/open/floor/plating/ironsand,
+/area/awaymission/ihategordon/rocks)
 "eqh" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -11786,11 +12090,11 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
 "eqK" = (
-/obj/structure/urbanismtire{
-	icon_state = "shina2a";
-	pixel_x = 13
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/stripes{
+	dir = 4
 	},
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "eqN" = (
 /obj/structure/filingcabinet,
@@ -13076,6 +13380,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"eLN" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "eMi" = (
 /obj/structure/rack/shelf,
 /obj/item/mod/paint,
@@ -13159,6 +13472,13 @@
 "eNm" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "hoodbottom"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
+"eNp" = (
+/obj/effect/festive/street/streetlineinnerne,
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -13561,6 +13881,16 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"eVw" = (
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "eVA" = (
 /obj/structure/urbanismtire{
 	icon_state = "shina2a";
@@ -13686,7 +14016,10 @@
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -13701,6 +14034,16 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/big_offices)
+"eXH" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security,
+/turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "eXJ" = (
 /obj/structure/table/reinforced,
@@ -14089,10 +14432,11 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/item/clothing/accessory/medal/plasma/nobel_science{
+	pixel_x = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/green,
 /area/awaymission/ihategordon/big_offices)
 "fej" = (
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -14127,7 +14471,7 @@
 "ffr" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/closet/crate/large,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
 "ffA" = (
@@ -14504,13 +14848,17 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "fmA" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 8
+/obj/structure/decorative{
+	icon = 'icons/obj/power_cond/cables.dmi';
+	icon_state = "1-2";
+	anchored = 1;
+	name = "cable";
+	color = "#222222";
+	pixel_y = 1;
+	pixel_x = 0
 	},
-/turf/open/floor/plasteel{
-	icon_state = "damaged3"
-	},
-/area/awaymission/ihategordon/sectorhsecoffices)
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "fmB" = (
 /obj/effect/turf_decal/trimline/dark_green/warning{
 	dir = 5
@@ -14626,10 +14974,6 @@
 /obj/structure/fence/door,
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
-"fpL" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/catwalk_floor,
-/area/awaymission/ihategordon/science_tunnel)
 "fpN" = (
 /obj/structure/table/reinforced,
 /obj/item/ammo_box/magazine/pistolm9mm{
@@ -14678,6 +15022,9 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/entrance)
@@ -14762,6 +15109,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"fsG" = (
+/mob/living/simple_animal/hostile/headcrab/mesa,
+/obj/machinery/light/cold{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/sectorhsecoffices)
 "fsQ" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 8
@@ -14870,12 +15227,21 @@
 /obj/effect/turf_decal/trimline/dark/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/facility_hallway)
+"fuC" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "fuM" = (
 /obj/effect/festive/street/streetlineeast,
 /obj/machinery/door/poddoor/preopen,
 /obj/effect/turf_decal/siding/wideplating_new{
 	color = "#454545";
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -15316,15 +15682,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/sci_medbay)
-"fDA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "fDD" = (
 /obj/machinery/light{
 	dir = 1
@@ -15465,7 +15822,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/big_offices)
 "fGs" = (
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
 "fGu" = (
@@ -15680,6 +16037,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"fKW" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "fKY" = (
 /obj/structure/flora/rock/pile{
 	icon_state = "lavarocks3"
@@ -15816,11 +16180,9 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
 "fOh" = (
-/obj/structure/reagent_dispensers/urbanismbarrel{
-	pixel_y = 2;
-	pixel_x = -9
-	},
-/turf/open/floor/plating/cobblestone,
+/obj/machinery/door/airlock/cmo/glass,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/underground_tunnels)
 "fOn" = (
 /obj/effect/mob_spawn/human/hlguard,
@@ -15880,6 +16242,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"fOV" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/urbanismmachines/server{
+	icon_state = "server2";
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "fOW" = (
 /obj/structure/lattice,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -16230,7 +16602,7 @@
 /area/awaymission/ihategordon/outsideofmesa)
 "fUH" = (
 /obj/structure/closet/crate/urbanismcrate,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /obj/item/ammo_box/magazine/m10mm,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
@@ -16370,6 +16742,16 @@
 	icon_state = "damaged5"
 	},
 /area/awaymission/ihategordon/cryo_room)
+"fWI" = (
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt8"
+	},
+/turf/open/floor/plating/ironsand,
+/area/awaymission/ihategordon/outsideofmesa)
 "fWK" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -16478,6 +16860,7 @@
 /area/awaymission/ihategordon/big_offices)
 "fYW" = (
 /obj/effect/mob_spawn/human/deadhecu,
+/obj/item/gun/ballistic/automatic/pistol/deagle/camo,
 /turf/open/water/jungle,
 /area/awaymission/ihategordon/outsideofmesa)
 "fZh" = (
@@ -16705,6 +17088,15 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"gee" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "geg" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -17285,6 +17677,18 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
+"gmV" = (
+/obj/effect/festive/street/streetlinesouth,
+/mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "gnh" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
@@ -17319,12 +17723,26 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"gnF" = (
+/obj/structure/urbanismmachines/server{
+	icon_state = "server2";
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "gnR" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/machinery/chem_master,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "gnT" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -17490,6 +17908,14 @@
 "gqY" = (
 /obj/effect/festive/street/streetlinewest,
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "grc" = (
@@ -17643,10 +18069,11 @@
 /turf/open/water/safe/electric,
 /area/awaymission/ihategordon/big_offices)
 "gtM" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
+/obj/structure/mesaflora{
+	icon_state = "flora5"
+	},
+/turf/open/floor/plating/ironsand,
+/area/awaymission/ihategordon/rocks)
 "gtN" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/fluff/hologrid,
@@ -17710,6 +18137,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
+"guz" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/rockpilemesa{
+	icon_state = "stone3";
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "guR" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/west,
@@ -18235,15 +18671,6 @@
 	icon_state = "damaged1"
 	},
 /area/awaymission/ihategordon/dining_room)
-"gEk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
 "gEo" = (
 /obj/structure/urbanismmounted{
 	pixel_x = 0;
@@ -18674,6 +19101,11 @@
 	},
 /turf/open/floor/plasteel/smooth/herringbone,
 /area/awaymission/ihategordon/dining_room)
+"gLV" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "gLW" = (
 /obj/machinery/light/cold{
 	dir = 8
@@ -18709,16 +19141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
-"gMa" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "gMo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -18741,11 +19163,6 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
-"gMD" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line,
-/obj/structure/closet/secure_closet/security/science,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
 "gMJ" = (
 /obj/machinery/door/airlock/research,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -18840,27 +19257,16 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "gNL" = (
-/obj/effect/festive/street/streetlinesouth,
-/obj/item/ammo_box/magazine/m16,
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/underground_tunnels)
-"gNW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/mineral/wood/twenty,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
+	dir = 8
 	},
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/item/storage/toolbox/mechanical/old/clean{
-	pixel_x = 0;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "gNY" = (
 /obj/structure/rockpilemesa{
 	icon_state = "stonealt9"
@@ -18960,10 +19366,33 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"gPY" = (
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "gQe" = (
 /mob/living/simple_animal/hostile/blackmesa/xen/vortigaunt/slave,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"gQf" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "gQo" = (
 /obj/item/electronics/firelock,
 /turf/open/floor/plating,
@@ -19116,6 +19545,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/gonome)
+"gUH" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/structure/bed/roller,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "gUL" = (
 /obj/structure/table/reinforced,
 /obj/item/ammo_box/magazine/m16{
@@ -19595,7 +20033,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimulants,
 /obj/item/ammo_box/magazine/pistolm9mm,
 /obj/item/ammo_box/magazine/mp5,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
@@ -19640,13 +20078,12 @@
 /area/awaymission/ihategordon/sectorhsecoffices)
 "heG" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/urbanismmachines{
 	icon_state = "radio";
 	pixel_x = 2;
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "heI" = (
 /obj/structure/rack/shelf,
@@ -19764,6 +20201,7 @@
 	icon_state = "shina2a";
 	pixel_x = 13
 	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "hhj" = (
@@ -19777,6 +20215,13 @@
 /obj/effect/turf_decal/siding/wideplating_new/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"hhz" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "hhC" = (
 /obj/structure/rockpilemesa{
 	icon_state = "stone3";
@@ -20607,12 +21052,14 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/facility_hallway)
 "hvh" = (
-/obj/effect/festive/street/streetlinesouth,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "hvr" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -20646,6 +21093,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"hvK" = (
+/obj/effect/festive/street/streetlinenw,
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "hvZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -21051,7 +21509,13 @@
 "hDY" = (
 /obj/structure/rack/shelf,
 /obj/item/stack/sheet/mineral/wood/twenty,
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "hEn" = (
 /obj/machinery/light/cold{
@@ -21259,6 +21723,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"hIm" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/item/ammo_box/magazine/m16,
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "hIo" = (
 /obj/structure/rack/shelf,
 /obj/item/stack/cable_coil,
@@ -21296,9 +21770,8 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/opposing/comlpex)
 "hIH" = (
-/obj/structure/urbanismpile{
-	pixel_x = -1;
-	pixel_y = 0
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -21359,6 +21832,11 @@
 "hJH" = (
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 5
+	},
+/obj/structure/urbanismbigcrate{
+	icon_state = "cratealt";
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/opposing/comlpex)
@@ -21729,6 +22207,10 @@
 "hPA" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "hPT" = (
@@ -21980,6 +22462,9 @@
 /area/awaymission/ihategordon/sectorhsecoffices)
 "hVT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -22244,6 +22729,10 @@
 	color = "#454545";
 	dir = 2
 	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "hZB" = (
@@ -22335,9 +22824,7 @@
 /turf/open/floor/plasteel/smooth/herringbone,
 /area/awaymission/ihategordon/dining_room)
 "iar" = (
-/turf/open/floor/plasteel{
-	icon_state = "wasteland7"
-	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "iay" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -23018,6 +23505,11 @@
 /obj/item/reagent_containers/pill/antirad,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
+"imL" = (
+/obj/effect/festive/street/streetlineeast,
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "imM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel,
@@ -23939,6 +24431,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/science_tunnel)
+"iDO" = (
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "iDQ" = (
 /obj/structure/closet/crate/large/urbanismcratelarge,
 /obj/item/clothing/suit/radiation,
@@ -24069,13 +24571,11 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/hecu_camp_hall)
 "iGr" = (
-/obj/structure/urbanismmachines{
-	icon_state = "machine4";
-	pixel_x = -2;
-	pixel_y = -1
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+/obj/effect/turf_decal/siding/wideplating_new/dark/end{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -24264,7 +24764,7 @@
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
 "iJO" = (
 /obj/structure/barricade/urbanism/roadblock{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -24306,6 +24806,14 @@
 	initial_temperature = 255.37
 	},
 /area/awaymission/ihategordon/cryo_room)
+"iKV" = (
+/obj/machinery/door/airlock/research,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/sectorhsecoffices)
 "iLb" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -24357,6 +24865,10 @@
 	color = "#454545";
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "iLN" = (
@@ -24861,6 +25373,18 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"iSr" = (
+/obj/effect/festive/street/streetlinesw,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	color = "#454545";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "iTd" = (
 /obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -25180,6 +25704,15 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"jaG" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "jaT" = (
 /obj/structure/alien/weeds{
 	color = "#ac3b06";
@@ -25204,7 +25737,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/box,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
 "jbt" = (
@@ -25402,7 +25935,8 @@
 /area/awaymission/ihategordon/emitter_chambers)
 "jfx" = (
 /obj/item/kirbyplants/hedge{
-	anchored = 1
+	anchored = 1;
+	density = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
@@ -25459,14 +25993,10 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/opposing/comlpex)
 "jgO" = (
-/obj/effect/festive/street/streetlinesouth,
-/obj/structure/reagent_dispensers/urbanismbarrel{
-	pixel_y = 1;
-	pixel_x = -14
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	color = "#454545";
-	dir = 2
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -25850,6 +26380,9 @@
 	pixel_y = 5;
 	pixel_x = 7
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "jov" = (
@@ -25948,7 +26481,6 @@
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "jpU" = (
-/obj/machinery/dna_scannernew,
 /obj/structure/urbanismdisplay{
 	pixel_x = 2;
 	pixel_y = 33
@@ -25956,7 +26488,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/structure/urbanismmachines{
+	icon_state = "microscope";
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "jpY" = (
 /obj/machinery/door/poddoor/preopen,
@@ -26591,6 +27134,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/awaymission/ihategordon/science_tunnel)
+"jzy" = (
+/obj/effect/festive/street/streetlineeast,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "jzC" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
@@ -27368,6 +27918,10 @@
 /obj/structure/lattice,
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/opposing/comlpex)
+"jMC" = (
+/obj/effect/mob_spawn/human/hlscientist,
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "jMQ" = (
 /obj/structure/alien/weeds{
 	color = "#ac3b06";
@@ -27379,6 +27933,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
+"jMT" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "jNv" = (
 /obj/item/extinguisher/advanced{
 	pixel_x = 3;
@@ -27426,7 +27987,7 @@
 	},
 /area/awaymission/ihategordon/cryo_room)
 "jOJ" = (
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/hyperlaser_chamber)
 "jOQ" = (
@@ -27612,6 +28173,10 @@
 "jSd" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "jSh" = (
@@ -27792,9 +28357,12 @@
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/big_offices)
 "jVh" = (
-/obj/machinery/door/airlock/science,
-/turf/open/floor/plasteel/dark,
-/area/awaymission/ihategordon/sectorhnorthoffices)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "jVp" = (
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/sectorhsecoffices)
@@ -28119,6 +28687,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"kaR" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "kaT" = (
 /obj/structure/fluff/bus/dense,
 /turf/open/floor/catwalk_floor,
@@ -28542,13 +29119,6 @@
 	icon_state = "damaged5"
 	},
 /area/awaymission/ihategordon/big_offices)
-"kjS" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/headcrab/mesa,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
 "kjW" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
@@ -28782,8 +29352,7 @@
 /area/awaymission/ihategordon/big_offices)
 "koO" = (
 /obj/machinery/chem_heater,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "koY" = (
 /obj/structure/fluff/broken_flooring{
@@ -28804,8 +29373,8 @@
 	},
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "kpe" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/rockpilemesa{
+	icon_state = "iron1"
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
@@ -28824,6 +29393,10 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"kpo" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/catwalk_floor,
+/area/awaymission/ihategordon/science_tunnel)
 "kpw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
@@ -29039,11 +29612,15 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/facility_hallway)
 "ktT" = (
-/obj/machinery/clonepod,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/chem_heater,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "kua" = (
 /mob/living/simple_animal/hostile/blackmesa/hecu/ranged/smg,
@@ -29098,7 +29675,7 @@
 /area/awaymission/ihategordon/big_offices)
 "kuU" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "kuV" = (
 /obj/structure/table,
@@ -29397,6 +29974,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/ihategordon/big_offices)
+"kzJ" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "kzN" = (
 /obj/machinery/light/cold,
 /obj/structure/rockpilemesa{
@@ -29464,6 +30048,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
+"kAB" = (
+/obj/structure/urbanismmachines{
+	icon_state = "heater";
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/underground_tunnels)
 "kAH" = (
 /obj/effect/festive/street/streetlineeast,
@@ -29620,6 +30212,14 @@
 "kDz" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "kDS" = (
@@ -29692,6 +30292,10 @@
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/cryo_room)
+"kFx" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "kFz" = (
 /obj/structure/table/reinforced,
 /obj/structure/urbanismmachines{
@@ -29766,22 +30370,6 @@
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
-"kGm" = (
-/mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -30308,18 +30896,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/dining_room)
-"kPn" = (
-/obj/structure/fluff/paper/stack{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "kPw" = (
 /obj/structure/urbanismmachines{
 	icon_state = "oldservers"
@@ -30498,17 +31074,6 @@
 	},
 /turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/hyperlaser_chamber)
-"kTP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "damaged2"
-	},
-/area/awaymission/ihategordon/big_offices)
 "kTS" = (
 /obj/machinery/door/airlock/research/glass,
 /turf/open/floor/plating/ice/smooth{
@@ -30660,6 +31225,12 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"kWC" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/rack/shelf,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/rivets/large,
+/area/awaymission/ihategordon/underground_tunnels)
 "kWJ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/cold{
@@ -30707,6 +31278,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/sectorhsecoffices)
+"kXK" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/sectorhsecoffices)
 "kXL" = (
 /obj/effect/festive/street/streetlinesouth,
 /obj/structure/rockpilemesa{
@@ -30714,6 +31292,15 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"kXW" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/turret_lockdown_hall)
 "kYi" = (
 /obj/structure/decorative{
 	icon = 'icons/obj/power_cond/cables.dmi';
@@ -30763,6 +31350,15 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/dorm_offices)
+"kYY" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "kZS" = (
 /obj/structure/table/reinforced,
 /obj/item/radio{
@@ -31101,6 +31697,14 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"lfa" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "lfi" = (
 /obj/structure/reagent_dispensers/urbanismbarrel/red,
 /turf/open/floor/plating/ironsand,
@@ -31139,6 +31743,9 @@
 /area/awaymission/ihategordon/rocks)
 "lfH" = (
 /mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/entrance)
 "lgk" = (
@@ -31321,12 +31928,14 @@
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/opposing)
 "ljs" = (
-/obj/structure/urbanismtire{
-	icon_state = "shina3";
-	pixel_x = 2;
-	pixel_y = 0
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "lju" = (
 /obj/structure/tank_dispenser,
@@ -31364,6 +31973,15 @@
 	color = "#454545";
 	dir = 4
 	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
+"lkm" = (
+/obj/effect/festive/street/streetlineeast,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "lkr" = (
@@ -31508,7 +32126,21 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
+"lnz" = (
+/obj/structure/urbanismtire{
+	icon_state = "shina3";
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "lnL" = (
 /obj/structure/sink/kitchen/directional/east,
@@ -31941,6 +32573,9 @@
 /area/awaymission/ihategordon/hecu_camp_hall)
 "luo" = (
 /obj/effect/festive/street/streetlineinnerne,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/entrance)
 "lur" = (
@@ -32627,9 +33262,8 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/sectorhsecoffices)
 "lEN" = (
-/obj/structure/urbanismpile{
-	pixel_x = 0;
-	pixel_y = -4
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -32741,12 +33375,11 @@
 /area/awaymission/ihategordon/outsideofmesa)
 "lIk" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/urbanismdisplay{
 	pixel_x = 15;
 	pixel_y = -31
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "lIO" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
@@ -32953,7 +33586,6 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "lLs" = (
-/obj/structure/frame/machine,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
@@ -33023,6 +33655,16 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/big_offices)
+"lLT" = (
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 5
+	},
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt10"
+	},
+/turf/open/floor/plating/cobblestone/sidewalk,
+/area/awaymission/ihategordon/outsideofmesa)
 "lLV" = (
 /obj/structure/flora/rock/pile{
 	color = "#f79668"
@@ -33181,6 +33823,9 @@
 	color = "#454545";
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "lNX" = (
@@ -33275,6 +33920,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/dorm_rooms)
+"lOR" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/structure/rockpilemesa{
+	icon_state = "stone3";
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "lPk" = (
 /obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -33516,6 +34170,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
+"lTy" = (
+/mob/living/simple_animal/hostile/headcrab/mesa,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "lTI" = (
@@ -33947,6 +34607,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
+"mbV" = (
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plating/asteroid/snow/temperatre{
+	planetary_atmos = 0
+	},
+/area/awaymission/ihategordon/cryo_room)
 "mbZ" = (
 /obj/structure/lattice,
 /turf/open/floor/plasteel/smooth/herringbone,
@@ -34266,6 +34935,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"miS" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "mjx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -34335,7 +35017,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "mkA" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -34383,10 +35069,10 @@
 "mlI" = (
 /obj/structure/urbanismmachines{
 	icon_state = "machine4";
-	pixel_x = 0;
+	pixel_x = -3;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/underground_tunnels)
 "mlJ" = (
 /mob/living/simple_animal/hostile/headcrab/mesa,
@@ -34566,6 +35252,17 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"mpp" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "mpF" = (
 /obj/effect/festive/street/streetlineeast,
 /obj/structure/barricade/sandbags,
@@ -34706,13 +35403,13 @@
 	},
 /area/awaymission/ihategordon/gonome)
 "mrS" = (
-/obj/structure/window/reinforced/spawner/north,
 /obj/machinery/computer{
 	dir = 1;
 	name = "experimental mech terminal"
 	},
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "mrY" = (
@@ -34754,6 +35451,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"msQ" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/structure/rockpilemesa{
+	icon_state = "stone3";
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "msW" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/window/reinforced/spawner/west,
@@ -35586,8 +36292,8 @@
 	pixel_x = 11;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "mHD" = (
 /obj/effect/mob_spawn/human/hlscientist,
@@ -35625,6 +36331,13 @@
 /obj/item/ammo_box/magazine/mp5,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
+"mIB" = (
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/entrance)
 "mIJ" = (
 /obj/effect/festive/street/streetlinewest,
 /obj/machinery/door/poddoor/preopen,
@@ -35632,6 +36345,10 @@
 	color = "#454545";
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "mIN" = (
@@ -35654,6 +36371,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"mIV" = (
+/obj/structure/reagent_dispensers/urbanismbarrel{
+	pixel_y = 8;
+	pixel_x = 7
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "mJe" = (
 /obj/effect/festive/street/streetlinewest,
 /mob/living/simple_animal/hostile/blackmesa/blackops/ranged,
@@ -35790,6 +36517,20 @@
 	},
 /turf/open/water/safe/electric,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"mLs" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/structure/urbanismmachines{
+	icon_state = "radio";
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "mLt" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 10
@@ -35863,7 +36604,13 @@
 	pixel_x = -28;
 	pixel_y = -16
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "mMz" = (
 /obj/structure/rack/shelf,
@@ -36279,16 +37026,13 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/secret_rooms)
 "mTN" = (
-/obj/machinery/light/cold{
-	dir = 4
+/obj/structure/mesaflora{
+	icon_state = "flora6";
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/obj/structure/urbanismmachines/server{
-	icon_state = "server5";
-	pixel_x = 0;
-	pixel_y = 21
-	},
-/turf/open/floor/plasteel/dark/smooth/small,
-/area/awaymission/ihategordon/big_offices)
+/turf/open/floor/plating/ironsand,
+/area/awaymission/ihategordon/rocks)
 "mTW" = (
 /obj/machinery/suit_storage_unit/open{
 	pixel_x = 0;
@@ -36568,18 +37312,6 @@
 "mYm" = (
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/entrance)
-"mYr" = (
-/obj/structure/decorative{
-	icon = 'icons/obj/power_cond/cables.dmi';
-	icon_state = "1-2";
-	anchored = 1;
-	name = "cable";
-	color = "#222222";
-	pixel_y = 1;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "mYu" = (
 /obj/machinery/light/red{
 	dir = 8
@@ -36589,6 +37321,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"mYU" = (
+/obj/machinery/door/airlock/science,
+/turf/open/floor/plasteel/showroomfloor,
+/area/awaymission/ihategordon/sectorhnorthoffices)
 "mYX" = (
 /obj/machinery/light/cold{
 	dir = 1
@@ -36884,6 +37620,13 @@
 /obj/structure/urbanismbigcrate,
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/opposing/comlpex)
+"nfD" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "nfO" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/window/reinforced/spawner/north{
@@ -36949,8 +37692,13 @@
 /area/awaymission/ihategordon/opposing/comlpex)
 "ngH" = (
 /obj/structure/rack/shelf,
-/obj/item/storage/toolbox/ammo/surplus,
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "ngR" = (
 /obj/structure/urbanismmachines{
@@ -37018,6 +37766,11 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"niE" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "niV" = (
 /obj/structure/flora/junglebush/large{
 	pixel_x = -1;
@@ -37216,6 +37969,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/facility_hallway)
+"nlZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "nmc" = (
 /obj/machinery/shower{
 	pixel_y = -2;
@@ -37414,8 +38176,9 @@
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
 "nqq" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "nqu" = (
 /obj/structure/fluff/broken_flooring{
@@ -37546,7 +38309,7 @@
 /area/awaymission/ihategordon/dining_room)
 "nte" = (
 /obj/structure/table/reinforced,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
@@ -37741,12 +38504,15 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
 "nwr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_x = 31;
 	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -37791,7 +38557,7 @@
 /area/awaymission/ihategordon/underground_tunnels)
 "nxe" = (
 /obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "nxg" = (
 /obj/machinery/light/red{
@@ -37911,6 +38677,11 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/opposing)
+"nyQ" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "nyU" = (
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 4
@@ -38000,6 +38771,9 @@
 /area/awaymission/ihategordon/big_offices)
 "nAM" = (
 /obj/effect/festive/street/streetlineinnerse,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/entrance)
 "nAU" = (
@@ -38158,10 +38932,11 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/hecu_abandoned_camp)
 "nDf" = (
-/obj/effect/festive/street/streetlinenorth,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/facility_hallway)
 "nDm" = (
 /obj/machinery/light{
 	dir = 8
@@ -38410,14 +39185,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
-"nIg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/bed/roller{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/facility_hallway)
 "nIm" = (
 /obj/machinery/modular_computer/console/preset{
 	dir = 4
@@ -38443,6 +39210,16 @@
 /mob/living/simple_animal/hostile/headcrab/mesa,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"nIO" = (
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 4
+	},
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt3"
+	},
+/turf/open/floor/plating/cobblestone/sidewalk,
+/area/awaymission/ihategordon/outsideofmesa)
 "nIS" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/dark_green/line{
@@ -38841,10 +39618,11 @@
 /area/awaymission/ihategordon/big_offices)
 "nQo" = (
 /obj/effect/decal/cleanable/glass,
-/obj/item/kirbyplants/hedge{
-	anchored = 1
-	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
+/obj/item/kirbyplants/hedge{
+	anchored = 1;
+	density = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/hecu_camp_hall)
 "nQs" = (
@@ -38929,6 +39707,9 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39152,11 +39933,11 @@
 	dir = 8
 	},
 /obj/structure/urbanismmachines{
-	icon_state = "oldservers";
-	pixel_x = 0;
+	icon_state = "heater";
+	pixel_x = -5;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/underground_tunnels)
 "nWM" = (
 /obj/machinery/light{
@@ -39182,13 +39963,24 @@
 /area/awaymission/ihategordon/opposing)
 "nXz" = (
 /obj/effect/festive/street/streetlinesouth,
-/obj/structure/urbanismcars{
-	icon_state = "ambulance"
-	},
 /obj/effect/turf_decal/siding/wideplating_new{
 	color = "#454545";
 	dir = 2
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
+"nXP" = (
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "nXQ" = (
@@ -39275,6 +40067,12 @@
 /obj/machinery/door/poddoor,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
+"nZo" = (
+/obj/structure/closet/crate/large/urbanismcratelarge/mil,
+/obj/item/ammo_box/magazine/p90,
+/obj/item/ammo_box/magazine/mp7,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "nZr" = (
 /obj/structure/alien/weeds{
 	color = "#ac3b06";
@@ -39625,13 +40423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
-"odX" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
 "odZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28;
@@ -39826,10 +40617,7 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "oip" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plasteel,
@@ -40345,13 +41133,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/opposing/comlpex)
-"orB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/corporate,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "orD" = (
 /mob/living/simple_animal/hostile/headcrab/mesa,
 /turf/open/floor/plasteel,
@@ -40372,6 +41153,9 @@
 "osf" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/reagent_dispensers/urbanismbarrel/red,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "osg" = (
@@ -40627,6 +41411,7 @@
 	color = "#454545";
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "oxk" = (
@@ -40824,17 +41609,12 @@
 /turf/open/floor/plasteel/rivets/large,
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "oAO" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/machinery/door/airlock/service,
-/obj/effect/turf_decal/trimline/dark/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark/filled/line,
-/turf/open/floor/plasteel/kitchen,
-/area/awaymission/ihategordon/dining_room)
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "oAV" = (
 /obj/structure/rockpilemesa{
 	icon_state = "stone2"
@@ -40940,12 +41720,17 @@
 	},
 /area/awaymission/ihategordon/science_tunnel)
 "oCJ" = (
-/obj/structure/barricade/wooden,
 /obj/structure/urbanismdisplay{
 	pixel_x = -8;
 	pixel_y = 31
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "oCO" = (
 /turf/open/floor/catwalk_floor,
@@ -40993,6 +41778,8 @@
 	pixel_x = -8;
 	pixel_y = 2
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "oDX" = (
@@ -41572,6 +42359,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"oOG" = (
+/obj/machinery/light/cold{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "oOJ" = (
 /obj/machinery/door/airlock/research,
 /obj/structure/alien/weeds{
@@ -41627,14 +42426,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
-"oPN" = (
-/obj/structure/mesaflora{
-	icon_state = "flora6";
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/turf/open/floor/plating/ironsand,
-/area/awaymission/ihategordon/rocks)
 "oPP" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -41684,16 +42475,10 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
 "oQD" = (
-/obj/structure/table/reinforced,
-/obj/structure/urbanismmachines{
-	icon_state = "microscope";
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/computer{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "oQT" = (
 /obj/structure/alien/weeds{
@@ -41787,14 +42572,10 @@
 	},
 /area/awaymission/ihategordon/big_offices)
 "oSE" = (
-/obj/effect/turf_decal/siding/wideplating_new{
-	color = "#454545";
-	dir = 2
-	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plating/cobblestone/sidewalk,
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
 "oSH" = (
 /obj/machinery/computer{
@@ -41932,16 +42713,24 @@
 /area/awaymission/ihategordon/opposing/comlpex)
 "oUE" = (
 /obj/effect/festive/street/streetlinesw,
-/obj/structure/barricade/wooden,
 /obj/effect/turf_decal/siding/wideplating_new/corner{
 	color = "#454545";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
 	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "oUK" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "oUX" = (
 /obj/structure/fluff/bus/dense,
@@ -42014,7 +42803,8 @@
 /area/awaymission/ihategordon/big_offices)
 "oWb" = (
 /obj/structure/salvage/server,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/server_rooms)
 "oWg" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -42037,6 +42827,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"oWn" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "oWp" = (
 /obj/effect/festive/street/streetlinene,
 /turf/open/floor/plating/cobblestone,
@@ -42085,15 +42891,6 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
-"oXm" = (
-/obj/structure/sign/poster/official/wtf_is_co2{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plating/asteroid/snow/temperatre{
-	planetary_atmos = 0
-	},
-/area/awaymission/ihategordon/cryo_room)
 "oXA" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 5
@@ -42242,6 +43039,14 @@
 	planetary_atmos = 0
 	},
 /area/awaymission/ihategordon/opposing/comlpex)
+"pao" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "pax" = (
 /obj/structure/lattice,
 /obj/structure/rockpilemesa{
@@ -43073,9 +43878,9 @@
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "poW" = (
-/obj/structure/reagent_dispensers/urbanismbarrel{
-	pixel_y = 2;
-	pixel_x = -5
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -43112,11 +43917,19 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "ppX" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 10
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/item/storage/toolbox/mechanical/old/clean{
+	pixel_x = 0;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -43249,12 +44062,13 @@
 /area/awaymission/ihategordon/big_offices)
 "prN" = (
 /obj/effect/decal/cleanable/ash,
-/obj/structure/urbanismmachines{
-	icon_state = "oldservers";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "prX" = (
 /obj/item/kirbyplants{
@@ -43452,6 +44266,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"pww" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/structure/rockpilemesa{
+	icon_state = "stone3"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
+"pwQ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/plating,
+/area/awaymission/ihategordon/big_offices)
 "pwU" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 6
@@ -43928,6 +44758,16 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"pGb" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/sectorhsecoffices)
 "pGg" = (
 /obj/item/clothing/suit/blackops,
 /turf/open/floor/plating/cobblestone,
@@ -44102,11 +44942,14 @@
 	},
 /area/awaymission/ihategordon/rocks)
 "pJw" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
+/obj/structure/fluff/paper/stack{
+	dir = 6
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -44415,11 +45258,11 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "pPh" = (
-/obj/machinery/door/airlock/service,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/machinery/door/airlock/service,
 /obj/effect/turf_decal/trimline/dark/filled/line{
 	dir = 1
 	},
@@ -44435,7 +45278,8 @@
 /area/awaymission/ihategordon/underground_tunnels)
 "pPt" = (
 /obj/item/kirbyplants/hedge{
-	anchored = 1
+	anchored = 1;
+	density = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/end{
 	dir = 1
@@ -44483,6 +45327,9 @@
 /obj/structure/reagent_dispensers/urbanismbarrel{
 	pixel_y = -2;
 	pixel_x = -4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -45211,6 +46058,13 @@
 /mob/living/simple_animal/hostile/headcrab/mesa,
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"qgA" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "qgP" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -45809,9 +46663,10 @@
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
 "qsJ" = (
-/obj/item/ammo_box/magazine/pistolm9mm,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
+/obj/structure/window/reinforced/spawner/west,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "qsP" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -45861,6 +46716,14 @@
 /mob/living/simple_animal/hostile/headcrab/mesa,
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/opposing)
+"qtD" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/bed/roller{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/facility_hallway)
 "qtL" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -46120,6 +46983,9 @@
 	color = "#454545";
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "qyH" = (
@@ -46296,6 +47162,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"qBl" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "qBp" = (
 /obj/structure/alien/weeds{
 	color = "#ac3b06";
@@ -46317,9 +47193,16 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/cryo_room)
 "qBP" = (
-/obj/machinery/door/airlock/science,
-/turf/open/floor/plasteel/showroomfloor,
-/area/awaymission/ihategordon/sectorhnorthoffices)
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_x = -33;
+	pixel_y = 0
+	},
+/obj/structure/closet/secure_closet/security/science,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/sectorhsecoffices)
 "qBT" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/ihategordon/sec_armory)
@@ -46557,11 +47440,12 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/dorm_rooms)
 "qFq" = (
-/obj/effect/festive/street/streetlinenorth,
-/obj/structure/rockpilemesa{
-	icon_state = "stone3";
-	pixel_x = 6;
-	pixel_y = -2
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/flora/rock/pile{
+	color = "#f79668"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
@@ -46780,6 +47664,13 @@
 "qJM" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "reartire"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
+"qJT" = (
+/obj/structure/barricade/urbanism,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -47801,6 +48692,21 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"rfy" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "rfD" = (
 /obj/structure/urbanismmounted{
 	icon_state = "ventilation";
@@ -47878,6 +48784,11 @@
 /obj/item/gun/ballistic/automatic/pistol/g22,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
+"rgQ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "rgU" = (
 /turf/open/floor/plasteel{
 	icon_state = "wasteland2"
@@ -48154,6 +49065,15 @@
 /obj/item/storage/firstaid/radbgone,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"rmz" = (
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "rmP" = (
 /obj/structure/rack/shelf,
 /turf/open/floor/plating,
@@ -49165,13 +50085,15 @@
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/hecu_camp_hall)
 "rDK" = (
-/obj/machinery/chem_heater,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/sign/flag/blackmesa{
 	pixel_x = 0;
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
@@ -49233,6 +50155,10 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
+"rFB" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "rFD" = (
 /turf/open/floor/plasteel{
 	icon_state = "wasteland11"
@@ -49287,6 +50213,19 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
+"rGF" = (
+/obj/effect/festive/street/streetlineeast,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "rGW" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -49417,6 +50356,10 @@
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "rJy" = (
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "rJz" = (
@@ -49474,6 +50417,13 @@
 "rKI" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/ihategordon/hecu_camp_medbay)
+"rKJ" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt8"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "rKM" = (
 /obj/effect/festive/street/streetlineeast,
 /mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
@@ -49954,7 +50904,13 @@
 	pixel_x = 0;
 	pixel_y = -1
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "rRK" = (
 /turf/open/chasm/jungle{
@@ -50197,13 +51153,23 @@
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
 "rWi" = (
-/obj/machinery/door/airlock/vault,
-/turf/open/floor/plasteel/rivets/large,
+/obj/machinery/door/airlock/mining,
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "rWl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/entrance)
+"rWn" = (
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "rWp" = (
 /obj/effect/festive/street/streetlinene,
 /mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
@@ -50274,12 +51240,9 @@
 	},
 /area/awaymission/ihategordon/sci_medbay)
 "rXn" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/machinery/door/airlock/science,
+/turf/open/floor/plasteel/dark,
+/area/awaymission/ihategordon/sectorhnorthoffices)
 "rXA" = (
 /obj/machinery/light/red{
 	dir = 4
@@ -50574,6 +51537,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"scn" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "scs" = (
 /obj/structure/urbanismbigcrate,
 /turf/open/floor/plating,
@@ -50602,9 +51572,11 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
 "scM" = (
-/obj/item/gun/ballistic/automatic/pistol/deagle/camo,
-/turf/open/water/jungle,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "sde" = (
 /turf/open/floor/plasteel{
 	icon_state = "damaged3"
@@ -51047,6 +52019,15 @@
 	icon_state = "damaged5"
 	},
 /area/awaymission/ihategordon/big_offices)
+"skt" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "sku" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 29;
@@ -51380,6 +52361,13 @@
 	},
 /turf/open/floor/plasteel/rivets/edge,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"sqH" = (
+/obj/structure/urbanismcars{
+	icon_state = "truck_notwreck";
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "sqJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
@@ -51500,6 +52488,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/awaymission/ihategordon/science_tunnel)
+"ssW" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "std" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
@@ -51883,6 +52882,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "szI" = (
@@ -52253,6 +53255,16 @@
 	},
 /turf/open/floor/plating/cobblestone/sidewalk,
 /area/awaymission/ihategordon/hecu_camp_bus_stop)
+"sFK" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "sFU" = (
 /obj/effect/festive/street/streetlinenorth,
 /mob/living/simple_animal/hostile/blackmesa/xen/vortigaunt/slave,
@@ -52324,6 +53336,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/sectorhsecoffices)
+"sHt" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "damaged2"
+	},
+/area/awaymission/ihategordon/big_offices)
 "sHu" = (
 /obj/structure/fence/corner{
 	dir = 10
@@ -52418,6 +53441,13 @@
 /obj/structure/reagent_dispensers/urbanismbarrel{
 	pixel_y = 1;
 	pixel_x = 7
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -52601,18 +53631,11 @@
 	color = "#454545";
 	dir = 8
 	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/underground_tunnels)
-"sME" = (
-/obj/effect/festive/street/streetlinesouth,
-/obj/structure/flora/rock/pile{
-	color = "#f79668"
-	},
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/turf_decal/stripes/yellow/line{
 	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/area/awaymission/ihategordon/underground_tunnels)
 "sMH" = (
 /obj/structure/table/glass,
 /obj/item/pizzabox/margherita{
@@ -52654,8 +53677,7 @@
 /area/awaymission/ihategordon/science_tunnel)
 "sNG" = (
 /mob/living/simple_animal/hostile/headcrab/mesa,
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	color = "#454545";
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52773,14 +53795,6 @@
 /obj/effect/mob_spawn/human/deadhecu,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
-"sPM" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "damaged1"
-	},
-/area/awaymission/ihategordon/sectorhsecoffices)
 "sPN" = (
 /obj/structure/urbanismmachines{
 	icon_state = "machine3";
@@ -53190,16 +54204,6 @@
 "sXR" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/showroomfloor,
-/area/awaymission/ihategordon/big_offices)
-"sXS" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security,
-/turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "sXZ" = (
 /obj/structure/flora/rock/pile{
@@ -53814,6 +54818,17 @@
 	icon_state = "wasteland1"
 	},
 /area/awaymission/ihategordon/outsideofmesa)
+"tjH" = (
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "tjL" = (
 /obj/structure/rack/shelf{
 	color = "#556B2F"
@@ -54049,7 +55064,7 @@
 "toa" = (
 /obj/structure/closet/crate/urbanismcrate,
 /obj/item/ammo_box/magazine/m16,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /obj/item/ammo_box/magazine/mp7,
 /obj/item/ammo_box/magazine/mp7,
 /turf/open/floor/plating,
@@ -54115,6 +55130,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"tpz" = (
+/obj/structure/rockpilemesa{
+	icon_state = "stonealt6"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "tpB" = (
 /obj/machinery/light{
 	dir = 4
@@ -54169,6 +55190,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"tqM" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/mineral/wood/twenty,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "trd" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 4
@@ -54350,6 +55382,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
+"ttR" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "ttU" = (
@@ -54368,6 +55412,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/big_offices)
+"ttX" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "tub" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/stripes/white/box,
@@ -54900,6 +55960,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"tDI" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/urbanismbarrel/red,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "tDZ" = (
 /obj/structure/sink/puddle/healing,
 /obj/structure/alien/weeds{
@@ -55166,12 +56233,6 @@
 	},
 /turf/open/indestructible,
 /area/awaymission/ihategordon/big_offices)
-"tJM" = (
-/obj/structure/mesaflora{
-	icon_state = "flora5"
-	},
-/turf/open/floor/plating/ironsand,
-/area/awaymission/ihategordon/rocks)
 "tJT" = (
 /obj/structure/fluff/paper/stack{
 	dir = 10
@@ -55241,6 +56302,21 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/sci_medbay)
+"tKw" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "tKA" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 8
@@ -55419,15 +56495,15 @@
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "tOq" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 10
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
 	},
-/obj/structure/sign/poster/official/report_crimes{
-	pixel_x = -33;
-	pixel_y = 0
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
+/turf/open/floor/plating/cobblestone/sidewalk,
+/area/awaymission/ihategordon/outsideofmesa)
 "tOG" = (
 /obj/structure/flora/rock/pile{
 	color = "#f79668"
@@ -55437,6 +56513,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"tOJ" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "tOL" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/item/clothing/suit/space/hardsuit/rd/hev,
@@ -55515,7 +56608,12 @@
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
 "tPz" = (
-/obj/item/ammo_box/magazine/m556,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "tPE" = (
@@ -55906,6 +57004,25 @@
 	},
 /turf/open/floor/plasteel/showroomfloor/shower,
 /area/awaymission/ihategordon/big_offices)
+"tUj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "tUl" = (
 /obj/machinery/computer,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -55938,6 +57055,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/emitter_chambers)
+"tUS" = (
+/obj/structure/salvage/server,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "tVa" = (
 /obj/structure/fluff/paper/stack{
 	dir = 6
@@ -56268,10 +57390,10 @@
 "tZO" = (
 /obj/structure/urbanismmachines{
 	icon_state = "machine4";
-	pixel_x = 0;
+	pixel_x = -3;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel/rivets/large,
+/turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/underground_tunnels)
 "tZT" = (
 /obj/structure/rack/shelf,
@@ -56289,6 +57411,9 @@
 /obj/structure/reagent_dispensers/urbanismbarrel{
 	pixel_y = 8;
 	pixel_x = -3
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -56478,13 +57603,12 @@
 /obj/machinery/light/cold{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+/obj/structure/urbanismmachines/server{
+	icon_state = "server5";
+	pixel_x = 0;
+	pixel_y = 21
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "udT" = (
 /turf/open/floor/plasteel/dark,
@@ -56840,6 +57964,17 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
+"ulg" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
+/obj/structure/urbanismbigcrate/alt{
+	icon_state = "boxalt6"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "ulm" = (
 /obj/item/electronics/airalarm,
 /turf/open/floor/plating,
@@ -56858,6 +57993,14 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"ulS" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "damaged1"
+	},
+/area/awaymission/ihategordon/sectorhsecoffices)
 "ulX" = (
 /obj/item/construction/plumbing{
 	pixel_x = 0;
@@ -56932,6 +58075,22 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/opposing)
+"unf" = (
+/mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "ung" = (
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 9
@@ -57042,6 +58201,12 @@
 /obj/effect/turf_decal/trimline/dark/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/cryo_room)
+"uoX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "upd" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/closet/crate/large/urbanismcratelarge/mil,
@@ -57161,6 +58326,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/dorm_rooms)
+"uqM" = (
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "uqV" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
@@ -57216,19 +58391,6 @@
 	},
 /turf/open/floor/plasteel/smooth/herringbone,
 /area/awaymission/ihategordon/dining_room)
-"urx" = (
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "urF" = (
 /mob/living/simple_animal/hostile/headcrab/mesa,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -57260,6 +58422,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"urQ" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "urZ" = (
 /obj/effect/turf_decal/stripes/yellow/line,
 /obj/structure/urbanismmachines{
@@ -57530,6 +58703,9 @@
 	pixel_y = 5;
 	pixel_x = 7
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "uxu" = (
@@ -57619,6 +58795,18 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/sci_medbay)
+"uyP" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "uyR" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/east,
@@ -57850,11 +59038,15 @@
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/big_offices)
 "uDL" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "uDV" = (
 /obj/structure/table/reinforced,
@@ -57920,6 +59112,15 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"uFg" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "uFr" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 6
@@ -58072,16 +59273,6 @@
 	icon_state = "ambulance"
 	},
 /turf/open/floor/plating/cobblestone/sidewalk,
-/area/awaymission/ihategordon/outsideofmesa)
-"uJL" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
 "uJQ" = (
 /obj/structure/table/reinforced,
@@ -58340,6 +59531,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"uNn" = (
+/obj/effect/festive/street/streetlineeast,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "uNo" = (
 /obj/item/ammo_box/magazine/pistolm9mm,
 /obj/effect/turf_decal/weather/snow/corner{
@@ -58430,7 +59630,7 @@
 /obj/structure/closet/crate/large/urbanismcratelarge/mil,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/flashlight/flare,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
 "uPj" = (
@@ -58442,6 +59642,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/cryo_room)
+"uPk" = (
+/obj/effect/festive/street/streetlineeast,
+/mob/living/simple_animal/hostile/blackmesa/xen/houndeye,
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "uPm" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/trimline/dark/filled/line,
@@ -58657,12 +59863,14 @@
 /turf/open/floor/catwalk_floor,
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "uSJ" = (
-/obj/effect/festive/street/streetlinesouth,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "uSY" = (
 /obj/structure/window/reinforced/spawner/north{
 	dir = 8
@@ -58906,7 +60114,13 @@
 "uXV" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/ifak,
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "uXX" = (
 /obj/effect/festive/street/streetlineeast,
@@ -58941,9 +60155,8 @@
 /area/awaymission/ihategordon/hecu_camp_hall)
 "uYo" = (
 /obj/structure/closet,
-/obj/item/gun/ballistic/automatic/m90/unrestricted,
-/obj/item/ammo_box/magazine/m556,
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
+/obj/item/ammo_box/magazine/p90,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
@@ -58951,6 +60164,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
 	},
+/obj/item/gun/ballistic/automatic/p90,
 /turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/big_offices)
 "uYq" = (
@@ -59483,6 +60697,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/cryo_room)
+"vgR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/corporate,
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "vgU" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/toolbox/electrical{
@@ -59535,6 +60756,9 @@
 /obj/effect/turf_decal/siding/wideplating_new/corner{
 	color = "#454545";
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
@@ -59594,6 +60818,17 @@
 	},
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
+"viG" = (
+/obj/effect/festive/street/streetlinewest,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "viI" = (
 /obj/structure/alien/weeds{
 	color = "#ac3b06";
@@ -59623,12 +60858,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/hecu_camp_medbay)
-"vjq" = (
-/obj/structure/girder,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/awaymission/ihategordon/big_offices)
 "vjs" = (
 /obj/machinery/light/red{
 	dir = 4
@@ -59650,7 +60879,8 @@
 /area/awaymission/ihategordon/hecu_abandoned_camp)
 "vjG" = (
 /obj/item/kirbyplants/hedge{
-	anchored = 1
+	anchored = 1;
+	density = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/big_offices)
@@ -59840,8 +61070,13 @@
 /turf/open/water/safe/electric,
 /area/awaymission/ihategordon/sectorhnorthoffices)
 "vow" = (
-/obj/effect/mob_spawn/human/hlscientist,
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "voP" = (
 /obj/machinery/door/keycard/mesa,
@@ -59971,6 +61206,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"vrC" = (
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "vrN" = (
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/urbanismmounted{
@@ -60728,16 +61972,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/big_offices)
-"vFH" = (
-/obj/effect/turf_decal/siding/wideplating_new{
-	color = "#454545";
-	dir = 8
-	},
-/obj/structure/rockpilemesa{
-	icon_state = "stonealt1"
-	},
-/turf/open/floor/plating/cobblestone/sidewalk,
-/area/awaymission/ihategordon/outsideofmesa)
 "vFJ" = (
 /obj/structure/urbanismmachines{
 	icon_state = "machine4";
@@ -60823,6 +62057,10 @@
 "vIF" = (
 /obj/machinery/door/poddoor/preopen,
 /obj/structure/reagent_dispensers/urbanismbarrel/red,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "vIU" = (
@@ -60870,10 +62108,11 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/item/statuebust{
+	pixel_x = 0;
+	pixel_y = 11
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/green,
 /area/awaymission/ihategordon/big_offices)
 "vJG" = (
 /mob/living/simple_animal/hostile/blackmesa/xen/snark,
@@ -61236,16 +62475,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
-"vPH" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
 "vPS" = (
 /turf/closed/wall/mineral/iron,
 /area/awaymission/ihategordon/rocks)
@@ -62119,12 +63348,30 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"wdX" = (
+/obj/structure/urbanismmachines{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/dark/smooth/small,
+/area/awaymission/ihategordon/server_rooms)
 "wef" = (
 /turf/open/floor/plating{
 	heat_capacity = 1e+006;
 	icon_state = "platingdmg2"
 	},
 /area/awaymission/ihategordon/sci_medbay)
+"wei" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/awaymission/ihategordon/underground_tunnels)
 "wes" = (
 /obj/structure/salvage/server,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -62208,7 +63455,7 @@
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/science_tunnel)
 "wfn" = (
-/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/p90,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -62511,8 +63758,22 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"wkC" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/structure/rockpilemesa{
+	icon_state = "stone2"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "wkL" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/headcrab/mesa,
@@ -62626,24 +63887,6 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plating,
-/area/awaymission/ihategordon/big_offices)
-"wmL" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/decorative{
-	icon = 'icons/obj/power_cond/cables.dmi';
-	icon_state = "1-2";
-	anchored = 1;
-	name = "cable";
-	color = "#222222";
-	pixel_y = 1;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "wnk" = (
 /obj/machinery/light/cold{
@@ -62828,15 +64071,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
-"wrX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "wrY" = (
 /obj/effect/turf_decal/stripes/yellow/line{
 	dir = 4
@@ -63005,6 +64239,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/facility_hallway)
+"wui" = (
+/obj/structure/decorative{
+	icon = 'icons/obj/power_cond/cables.dmi';
+	icon_state = "1-4";
+	anchored = 1;
+	name = "cable";
+	color = "#222222";
+	pixel_y = 1;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "wul" = (
 /obj/structure/mesaflora{
 	icon_state = "flora3"
@@ -63109,6 +64355,19 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/closed/wall/r_wall,
 /area/awaymission/ihategordon/opposing/comlpex)
+"wwm" = (
+/obj/structure/flora/rock/pile{
+	color = "#f79668"
+	},
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "wwy" = (
 /mob/living/simple_animal/hostile/blackmesa/xen/bullsquid/alt1,
 /turf/open/floor/catwalk_floor,
@@ -63648,6 +64907,14 @@
 	color = "#454545";
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	color = "#454545";
+	dir = 2
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "wHF" = (
@@ -63758,15 +65025,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/ihategordon/opposing/comlpex)
-"wJN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
 "wJR" = (
 /obj/machinery/cell_charger,
 /obj/structure/table/reinforced,
@@ -64259,6 +65517,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/awaymission/ihategordon/hecu_camp_hall)
+"wVN" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "damaged3"
+	},
+/area/awaymission/ihategordon/sectorhsecoffices)
 "wVT" = (
 /obj/structure/chair/sofa/corp,
 /obj/structure/urbanismdisplay{
@@ -64339,12 +65605,11 @@
 	pixel_x = -7;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/item/reagent_containers/glass/beaker/noreact{
 	pixel_x = 7;
 	pixel_y = 0
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "wWX" = (
 /obj/effect/decal/cleanable/blood,
@@ -64408,17 +65673,6 @@
 /obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/dining_room)
-"wXJ" = (
-/obj/structure/table/reinforced,
-/obj/item/papercutter,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
 "wXP" = (
 /obj/effect/festive/street/streetlinesouth,
 /obj/effect/decal/cleanable/generic,
@@ -64523,12 +65777,6 @@
 	},
 /turf/open/floor/plasteel/dark/smooth/diagonal,
 /area/awaymission/ihategordon/secret_rooms)
-"xbb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
 "xbd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -64579,11 +65827,15 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
 "xbY" = (
-/obj/structure/rockpilemesa{
-	icon_state = "iron1"
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plating/cobblestone,
-/area/awaymission/ihategordon/outsideofmesa)
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "xcf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -64657,6 +65909,15 @@
 "xew" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/cobblestone/sidewalk,
+/area/awaymission/ihategordon/outsideofmesa)
+"xeD" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
 "xeR" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
@@ -64897,14 +66158,6 @@
 	icon_state = "damaged2"
 	},
 /area/awaymission/ihategordon/hecu_camp_hall)
-"xiR" = (
-/obj/machinery/door/airlock/research,
-/obj/effect/turf_decal/trimline/dark_red/filled/line,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/sectorhsecoffices)
 "xiU" = (
 /obj/machinery/door/airlock/research,
 /obj/structure/barricade/wooden,
@@ -64976,14 +66229,11 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
 "xkA" = (
-/obj/effect/turf_decal/siding/wideplating_new{
-	color = "#454545";
+/obj/effect/festive/street/streetlinesouth,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/structure/rockpilemesa{
-	icon_state = "stonealt3"
-	},
-/turf/open/floor/plating/cobblestone/sidewalk,
+/turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/outsideofmesa)
 "xkN" = (
 /turf/open/floor/plating{
@@ -65045,6 +66295,12 @@
 /obj/structure/lattice,
 /turf/open/floor/plating,
 /area/awaymission/ihategordon/cryo_room)
+"xlC" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/awaymission/ihategordon/big_offices)
 "xlI" = (
 /obj/item/shard{
 	icon_state = "tiny"
@@ -65263,12 +66519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/sectorhsecoffices)
-"xpN" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/closet/crate/large/urbanismcratelarge/mil,
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/facility_hallway)
 "xqc" = (
 /obj/structure/fluff/paper/stack{
 	dir = 10
@@ -65340,8 +66590,7 @@
 "xrM" = (
 /obj/machinery/light,
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "xrP" = (
 /obj/effect/baseturf_helper/black_mesa,
@@ -65416,6 +66665,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/sectorhsecoffices)
+"xtp" = (
+/obj/effect/festive/street/streetlinesouth,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "xtz" = (
 /obj/structure/flora/tree/spookybranch,
 /obj/effect/turf_decal/weather/dirt{
@@ -65426,12 +66686,12 @@
 "xtD" = (
 /obj/effect/festive/street/streetlinesouth,
 /obj/structure/closet/crate/large/urbanismcratelarge/mil,
-/obj/item/gun/ballistic/automatic/mini_uzi,
-/obj/item/ammo_box/magazine/uzim9mm,
 /obj/effect/turf_decal/siding/wideplating_new{
 	color = "#454545";
 	dir = 2
 	},
+/obj/item/gun/ballistic/automatic/mp7,
+/obj/item/ammo_box/magazine/mp7,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "xtN" = (
@@ -65811,7 +67071,13 @@
 /obj/structure/chair/sofa/corp{
 	dir = 4
 	},
-/turf/open/floor/plasteel/rivets/large,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
 /area/awaymission/ihategordon/underground_tunnels)
 "xBI" = (
 /obj/machinery/computer{
@@ -65953,9 +67219,16 @@
 	},
 /area/awaymission/ihategordon/cryo_room)
 "xDX" = (
-/obj/machinery/power/floodlight/urbanismlight/mesaoutside,
-/turf/open/floor/plating/ironsand,
-/area/awaymission/ihategordon/rocks)
+/obj/structure/table/reinforced,
+/obj/item/papercutter,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "xEb" = (
 /obj/effect/mob_spawn/human/hlscientist,
 /turf/open/floor/plating,
@@ -66249,6 +67522,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"xKb" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "xKi" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	color = "#454545";
@@ -66480,6 +67761,11 @@
 	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
+"xOS" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/outsideofmesa)
 "xPb" = (
 /obj/machinery/computer{
 	dir = 8
@@ -66861,6 +68147,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
+"xWk" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "xWs" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -66936,6 +68229,19 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/opposing/comlpex)
+"xXx" = (
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "xXB" = (
 /obj/structure/rack/shelf,
 /obj/item/clothing/glasses/welding,
@@ -66974,6 +68280,7 @@
 	pixel_x = -11;
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "xYy" = (
@@ -67169,8 +68476,8 @@
 	pixel_x = -1;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plasteel/dark/smooth/small,
 /area/awaymission/ihategordon/big_offices)
 "ydD" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -67241,6 +68548,17 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/outsideofmesa/hecu_camp)
+"yeA" = (
+/obj/effect/festive/street/streetlinenorth,
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating/cobblestone,
+/area/awaymission/ihategordon/underground_tunnels)
 "yeQ" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/effect/turf_decal/siding/wideplating_new/dark,
@@ -67269,15 +68587,17 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
 "yfq" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
+/obj/machinery/door/airlock/service,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/trimline/dark/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/filled/line,
+/turf/open/floor/plasteel/kitchen,
+/area/awaymission/ihategordon/dining_room)
 "yfv" = (
 /obj/machinery/light/red{
 	dir = 4
@@ -67341,6 +68661,10 @@
 "yhp" = (
 /obj/effect/festive/street/streetlineeast,
 /obj/machinery/door/poddoor/preopen,
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/underground_tunnels)
 "yhr" = (
@@ -67444,6 +68768,15 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/dark,
 /area/awaymission/ihategordon/sectorhnorthoffices)
+"yjf" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/awaymission/ihategordon/big_offices)
 "yjL" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -67595,12 +68928,6 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/awaymission/ihategordon/big_offices)
-"ylt" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/big_offices)
 "ylv" = (
@@ -68430,7 +69757,7 @@ izu
 bWZ
 bWZ
 wrw
-tWq
+viG
 tWq
 ykL
 tWq
@@ -68458,9 +69785,9 @@ tWq
 tWq
 tWq
 tWq
-tWq
-mIJ
-tWq
+gee
+miS
+viG
 tWq
 tWq
 tWq
@@ -68687,7 +70014,7 @@ izu
 bWZ
 bWZ
 wrw
-xQY
+lEN
 xQY
 xQY
 rjH
@@ -68715,9 +70042,9 @@ rgU
 aeA
 xQY
 khx
-xQY
-rJy
-xQY
+dZl
+jgO
+lEN
 xQY
 xQY
 nWx
@@ -68731,7 +70058,7 @@ xQY
 xQY
 xYv
 jSd
-xQY
+lEN
 xQY
 xQY
 gGx
@@ -68944,7 +70271,7 @@ izu
 bWZ
 bWZ
 wrw
-xQY
+lEN
 xQY
 aqK
 xQY
@@ -68972,9 +70299,9 @@ xQY
 aeA
 xQY
 xQY
-xQY
-rJy
-xQY
+dZl
+jgO
+lEN
 xQY
 khx
 xQY
@@ -68988,7 +70315,7 @@ xQY
 xQY
 hhf
 rJy
-xQY
+lEN
 fmp
 gVu
 prq
@@ -69201,7 +70528,7 @@ izu
 bWZ
 bWZ
 wrw
-xQY
+lEN
 esB
 xQY
 oqM
@@ -69229,23 +70556,23 @@ xQY
 xMC
 xQY
 xQY
-xQY
-rJy
+dZl
+jgO
+kzJ
 hlr
-hlr
 xQY
-aeA
-uXC
-aeA
+xQY
+xQY
+xQY
 hYa
 xQY
 xQY
 xMC
 xQY
 xQY
-xQY
+dZl
 rJy
-xQY
+lEN
 xQY
 eKw
 lcC
@@ -69458,7 +70785,7 @@ vxq
 bWZ
 bWZ
 wrw
-xQY
+lEN
 xQY
 xQY
 oqM
@@ -69486,13 +70813,12 @@ xQY
 xQY
 xQY
 xQY
-xQY
+dZl
 cIZ
-xQY
+lEN
 hlr
 xQY
 xQY
-rgU
 xQY
 xQY
 xQY
@@ -69501,8 +70827,9 @@ xQY
 xQY
 xQY
 xQY
+dZl
 rJy
-xQY
+lEN
 xQY
 lre
 xQY
@@ -69715,7 +71042,7 @@ vxq
 bWZ
 bWZ
 wrw
-exy
+avm
 exy
 exy
 exy
@@ -69743,9 +71070,9 @@ exy
 exy
 exy
 exy
-exy
-gqY
-exy
+nyQ
+djq
+avm
 pJH
 exy
 exy
@@ -69757,9 +71084,9 @@ sja
 pJH
 exy
 exy
-exy
-gqY
-exy
+nyQ
+kaR
+avm
 exy
 bpc
 exy
@@ -69972,7 +71299,7 @@ vxq
 bWZ
 bWZ
 wrw
-qlw
+jzy
 qlw
 qlw
 qlw
@@ -70000,9 +71327,9 @@ dDf
 qlw
 qlw
 qlw
-qlw
+imL
 yhp
-qlw
+jzy
 cVq
 qlw
 qlw
@@ -70014,9 +71341,9 @@ qlw
 cVq
 qlw
 qlw
-rKM
-yhp
-qlw
+uPk
+uNn
+jzy
 qlw
 qlw
 qlw
@@ -70229,7 +71556,7 @@ vxq
 bWZ
 bWZ
 wrw
-xQY
+lEN
 xQY
 xQY
 xQY
@@ -70257,9 +71584,9 @@ lPu
 xQY
 xQY
 xQY
-xQY
-rJy
-xQY
+dZl
+jgO
+lEN
 xQY
 xQY
 khx
@@ -70271,9 +71598,9 @@ xQY
 hlr
 xQY
 xQY
-xQY
+dZl
 rJy
-xQY
+lEN
 esB
 xMC
 xQY
@@ -70486,7 +71813,7 @@ vxq
 bWZ
 bWZ
 wrw
-xQY
+lEN
 khx
 xQY
 xQY
@@ -70514,9 +71841,9 @@ lPu
 xQY
 xQY
 xMC
-xQY
-rJy
-xQY
+dZl
+jgO
+lEN
 xQY
 xQY
 xQY
@@ -70528,9 +71855,9 @@ xQY
 hlr
 hlr
 hYa
-xQY
+dZl
 rJy
-hYa
+cQs
 xQY
 xQY
 aqK
@@ -70743,7 +72070,7 @@ vxq
 bWZ
 bWZ
 wrw
-xQY
+lEN
 xQY
 xQY
 oqM
@@ -70769,11 +72096,11 @@ xQY
 sKa
 uoy
 xQY
-rgU
 xQY
 xQY
-rJy
-xQY
+dZl
+jgO
+lEN
 rgU
 xQY
 fMS
@@ -70785,9 +72112,9 @@ xQY
 xQY
 xQY
 xQY
-xQY
+dZl
 vIF
-fMS
+bex
 xQY
 xQY
 hlr
@@ -71000,7 +72327,7 @@ vxq
 bWZ
 bWZ
 wrw
-xQY
+lEN
 xQY
 xQY
 oqM
@@ -71026,11 +72353,11 @@ xQY
 lWK
 hNC
 xQY
-rgU
-iar
 xQY
-rJy
 xQY
+dZl
+jgO
+lEN
 xQY
 xMC
 xQY
@@ -71042,7 +72369,7 @@ xQY
 khx
 xQY
 xQY
-hlr
+gLV
 hPA
 osf
 xQY
@@ -71257,7 +72584,7 @@ vxq
 bWZ
 bWZ
 wrw
-oWp
+cUt
 xQY
 xQY
 rgU
@@ -71283,11 +72610,11 @@ xQY
 bEl
 gxO
 xQY
-uXC
-rgU
-rgU
-rJy
-oqM
+xQY
+xQY
+dZl
+jgO
+qJT
 xQY
 xQY
 xQY
@@ -71299,9 +72626,9 @@ xQY
 xQY
 xQY
 xQY
-xQY
+dZl
 hPA
-xQY
+lEN
 xQY
 rgU
 xQY
@@ -71556,7 +72883,7 @@ lkj
 mcP
 kAv
 kAv
-kAv
+lkm
 iLD
 vhu
 xQY
@@ -71836,7 +73163,7 @@ tWq
 tWq
 kGf
 tWq
-mIJ
+tOJ
 aXQ
 rPb
 mJe
@@ -72093,7 +73420,7 @@ xQY
 xQY
 wqJ
 xQY
-rJy
+gPY
 jsX
 jsX
 jsX
@@ -72350,7 +73677,7 @@ xQY
 xQY
 xQY
 xQY
-rJy
+gPY
 eVs
 jsX
 jsX
@@ -72553,7 +73880,7 @@ lPu
 fMS
 sGT
 xQY
-gVu
+nZo
 ewA
 sgL
 bWZ
@@ -72607,7 +73934,7 @@ xQY
 xQY
 xQY
 xQY
-rJy
+gPY
 eVs
 jsX
 jsX
@@ -72864,7 +74191,7 @@ xQY
 xQY
 xQY
 xQY
-rJy
+gPY
 jsX
 jsX
 jsX
@@ -73378,7 +74705,7 @@ qlw
 qlw
 cfp
 qlw
-yhp
+rGF
 nmW
 nmW
 nmW
@@ -73635,7 +74962,7 @@ xQY
 xQY
 wqJ
 xQY
-rJy
+gPY
 jsX
 jsX
 jsX
@@ -73892,7 +75219,7 @@ xQY
 xQY
 xQY
 xQY
-rJy
+gPY
 jsX
 jsX
 jsX
@@ -73914,7 +75241,7 @@ jsX
 xSu
 xSu
 jsX
-jsX
+jxh
 jsX
 jsX
 jsX
@@ -74149,7 +75476,7 @@ xQY
 xQY
 xQY
 xQY
-rJy
+gPY
 eVs
 jsX
 jsX
@@ -74170,7 +75497,7 @@ jsX
 jsX
 jsX
 bZP
-jsX
+jxh
 xnb
 jsX
 jsX
@@ -74406,7 +75733,7 @@ xQY
 xQY
 xQY
 xQY
-rJy
+gPY
 eVs
 jsX
 jsX
@@ -75388,15 +76715,15 @@ bWZ
 bWZ
 sgL
 duK
-xQY
+scM
 joo
-xKX
-xQY
+duw
+nfD
 uxc
-lPu
-xQY
-xQY
-xQY
+jMT
+scM
+scM
+scM
 nXz
 sgL
 bWZ
@@ -75644,17 +76971,17 @@ bWZ
 bWZ
 bWZ
 sgL
-nMv
-wqJ
-wqJ
+oWn
+bMb
+bMb
 sII
-wqJ
-ual
-wze
-xKX
-xQY
-xQY
-ewA
+bMb
+uyP
+gmV
+tjH
+uqM
+uqM
+tKw
 sgL
 sgL
 sgL
@@ -75901,17 +77228,17 @@ bWZ
 bWZ
 bWZ
 sgL
-olt
-wqJ
-wqJ
-wqJ
-wqJ
-ual
-qcL
-wqJ
-xQY
-fJP
-oUE
+cGQ
+hIH
+poW
+poW
+poW
+xKb
+pao
+poW
+tDI
+mIV
+iSr
 kGf
 tWq
 tWq
@@ -76012,7 +77339,7 @@ aUh
 hPT
 oVw
 rll
-tJM
+gtM
 fHB
 oVw
 xKx
@@ -76163,13 +77490,13 @@ xQY
 xQY
 xQY
 xQY
-ual
+bEl
 qcL
 fHZ
 wqJ
 wqJ
-wqJ
-wqJ
+xQY
+xQY
 xQY
 xQY
 hlr
@@ -76270,7 +77597,7 @@ hPT
 oVw
 tlv
 tlv
-oPN
+mTN
 oVw
 xKx
 cSA
@@ -76420,11 +77747,11 @@ xQY
 xQY
 xQY
 xQY
-ual
-qcL
-wqJ
-wqJ
-wqJ
+bEl
+lPu
+xQY
+xQY
+xQY
 xQY
 xQY
 xQY
@@ -76679,8 +78006,8 @@ xQY
 xQY
 bEl
 lPu
-wqJ
-wqJ
+xQY
+xQY
 xQY
 xQY
 xQY
@@ -76784,7 +78111,7 @@ hPT
 oVw
 lEH
 tlv
-tJM
+gtM
 oVw
 xKx
 wVT
@@ -76990,7 +78317,7 @@ uKR
 uKR
 uKR
 uKR
-sey
+lfi
 iyn
 gbu
 kZZ
@@ -77298,7 +78625,7 @@ hPT
 oVw
 lfG
 tlv
-oPN
+mTN
 oVw
 xKx
 sgP
@@ -78068,7 +79395,7 @@ aUh
 hPT
 vYo
 fHB
-oPN
+mTN
 tlv
 oVw
 xKx
@@ -78710,19 +80037,19 @@ vxq
 bWZ
 bWZ
 sgL
-olt
-xQY
-xQY
-xQY
-xQY
-xQY
-bEl
-lPu
-xQY
-xQY
-xQY
-xQY
-ewA
+gQf
+wrY
+wrY
+wrY
+wrY
+wrY
+fKW
+hhz
+wrY
+wrY
+wrY
+wrY
+ssW
 sgL
 bWZ
 bWZ
@@ -78761,17 +80088,17 @@ kAv
 kAv
 kAv
 lNQ
-xQY
-xQY
+scM
+scM
 tZX
-xKX
+duw
 dcj
-qcL
-wqJ
-wqJ
-wqJ
-wqJ
-mpl
+lfa
+eqK
+eqK
+eqK
+eqK
+aLX
 sgL
 bWZ
 tFy
@@ -78968,17 +80295,17 @@ bWZ
 bWZ
 sgL
 eii
-wrY
-xQY
-xQY
-xQY
-xQY
-bEl
-lPu
-xQY
-xQY
-xQY
-xQY
+eav
+ljs
+ljs
+ljs
+ljs
+dmn
+mpp
+ljs
+ljs
+ljs
+ljs
 hZp
 sgL
 bWZ
@@ -79017,18 +80344,18 @@ sgL
 sgL
 sgL
 sgL
-nMv
-wqJ
-wqJ
-wqJ
-wqJ
-ual
-qcL
-wqJ
-wqJ
-wqJ
-wqJ
-mpl
+oWn
+bMb
+bMb
+bMb
+bMb
+uyP
+bNb
+bMb
+bMb
+bMb
+nXP
+ttX
 sgL
 bWZ
 tFy
@@ -79227,15 +80554,15 @@ hzd
 mYm
 mYm
 fqF
-rWl
-rWl
-qfP
+bOZ
+bOZ
+bgR
 luo
 nAM
 lfH
-qfP
-qfP
-wDK
+bgR
+bgR
+mIB
 mYm
 mYm
 flw
@@ -79274,18 +80601,18 @@ bWZ
 bWZ
 bWZ
 sgL
-nMv
-wqJ
-wqJ
+cGQ
+hIH
+hIH
 hIH
 pPR
-ual
-qcL
-wqJ
-wqJ
-xQY
-poW
-ewA
+xWk
+bfn
+hIH
+tDI
+hIH
+hIH
+bBh
 sgL
 bWZ
 tFy
@@ -79532,17 +80859,17 @@ bWZ
 bWZ
 sgL
 olt
-lEN
+xQY
 xQY
 xQY
 xQY
 bEl
 lPu
 xQY
-fOh
 xQY
 xQY
-jgO
+xQY
+ewA
 sgL
 bWZ
 tFy
@@ -80562,7 +81889,7 @@ sgL
 olt
 xQY
 xQY
-fmp
+xQY
 xQY
 bEl
 lPu
@@ -81854,7 +83181,7 @@ lPu
 xQY
 xQY
 xQY
-xQY
+nEo
 ewA
 sgL
 bWZ
@@ -82102,7 +83429,7 @@ bWZ
 bWZ
 sgL
 olt
-hYa
+sqH
 xQY
 xQY
 xQY
@@ -82874,7 +84201,7 @@ bWZ
 sgL
 olt
 xQY
-xQY
+vMh
 xQY
 xQY
 bEl
@@ -83131,7 +84458,7 @@ bWZ
 sgL
 olt
 xQY
-xQY
+lnz
 xQY
 hYa
 bEl
@@ -83299,7 +84626,7 @@ jsX
 xnb
 jsX
 sNH
-hvh
+gJP
 gRd
 jsX
 xOA
@@ -83386,10 +84713,10 @@ bWZ
 bWZ
 bWZ
 sgL
-olt
-opZ
-rgU
+wkC
 xQY
+rgU
+opZ
 xQY
 bEl
 lPu
@@ -83643,7 +84970,7 @@ bWZ
 bWZ
 bWZ
 sgL
-olt
+mLs
 xQY
 xQY
 uXC
@@ -83653,8 +84980,8 @@ lPu
 xQY
 xQY
 xQY
-xQY
-ewA
+bXN
+ulg
 sgL
 bWZ
 bWZ
@@ -83900,18 +85227,18 @@ bWZ
 bWZ
 bWZ
 sgL
-olt
+cjq
 xQY
 xQY
 xQY
 xQY
 bEl
-gNL
+lPu
 xQY
 xQY
 xQY
-xQY
-ewA
+bXN
+ulg
 sgL
 bWZ
 bWZ
@@ -84157,7 +85484,7 @@ bWZ
 bWZ
 bWZ
 sgL
-olt
+cjq
 xQY
 xQY
 xQY
@@ -84168,7 +85495,7 @@ xQY
 xQY
 xQY
 xQY
-ewA
+gUH
 sgL
 bWZ
 bWZ
@@ -84414,7 +85741,7 @@ bWZ
 bWZ
 sgL
 sgL
-olt
+hIm
 xQY
 xQY
 xQY
@@ -84425,7 +85752,7 @@ xQY
 xQY
 xQY
 xQY
-ewA
+gUH
 sgL
 bWZ
 bWZ
@@ -84671,7 +85998,7 @@ bWZ
 bWZ
 sgL
 hGs
-tGR
+byk
 xQY
 xQY
 xQY
@@ -84682,7 +86009,7 @@ xQY
 xQY
 xQY
 xQY
-ewA
+jaG
 sgL
 bWZ
 bWZ
@@ -84939,7 +86266,7 @@ xQY
 xQY
 xQY
 xQY
-ewA
+pww
 sgL
 bWZ
 bWZ
@@ -85699,18 +87026,18 @@ bWZ
 bWZ
 bWZ
 sgL
-olt
-xQY
-xQY
-xQY
-xQY
-bEl
-lPu
-xQY
-xQY
-xQY
-xQY
-ewA
+urQ
+scM
+scM
+scM
+scM
+scn
+jMT
+scM
+scM
+scM
+scM
+nXz
 sgL
 bWZ
 bWZ
@@ -85956,18 +87283,18 @@ bWZ
 sgL
 sgL
 sgL
-olt
-hYa
-xQY
-xQY
-xQY
-bEl
-lPu
-xQY
-xQY
-xQY
-wqJ
-ewA
+rfy
+wwm
+uqM
+uqM
+uqM
+yeA
+xtp
+uqM
+uqM
+uqM
+uqM
+tKw
 sgL
 sgL
 sgL
@@ -86213,19 +87540,19 @@ bWZ
 sgL
 hfw
 tWq
-puh
-xQY
-xQY
-xQY
-xQY
-gHJ
+hvK
+hIH
+hIH
+hIH
+hIH
+eNp
 eif
-xQY
-xQY
-xQY
-wqJ
+hIH
+hIH
+hIH
+hIH
 oUE
-kGf
+tWq
 tWq
 tWq
 tWq
@@ -86729,8 +88056,8 @@ olt
 xQY
 xQY
 xQY
-wqJ
-wqJ
+xQY
+xQY
 xQY
 xQY
 xQY
@@ -86768,7 +88095,7 @@ bWZ
 bWZ
 bWZ
 fYW
-scM
+gfo
 gfo
 bWZ
 sey
@@ -86987,8 +88314,8 @@ xQY
 xQY
 xQY
 xQY
-wqJ
-wqJ
+xQY
+xQY
 xQY
 xQY
 xQY
@@ -87497,9 +88824,9 @@ bWZ
 bWZ
 sgL
 tmD
-goJ
-goJ
-goJ
+kav
+uTa
+kWC
 tmD
 xQY
 xQY
@@ -87754,9 +89081,9 @@ bWZ
 bWZ
 sgL
 tmD
-goJ
-goJ
-goJ
+kav
+rIg
+kav
 tWA
 xQY
 xQY
@@ -87918,7 +89245,7 @@ klO
 iTd
 klO
 klO
-gho
+fWI
 sNH
 svF
 fEh
@@ -88012,9 +89339,9 @@ bWZ
 sgL
 tmD
 goJ
-uTa
-oPF
-cVi
+goJ
+goJ
+cPk
 xQY
 xQY
 xQY
@@ -88187,7 +89514,7 @@ jsX
 jsX
 gJP
 sps
-sey
+jmx
 bWZ
 bWZ
 aVx
@@ -88268,10 +89595,10 @@ bWZ
 bWZ
 sgL
 tmD
-eqK
-rIg
 goJ
-cVi
+goJ
+goJ
+tmD
 xQY
 xQY
 eVv
@@ -88525,10 +89852,10 @@ bWZ
 bWZ
 sgL
 tmD
-ljs
-kav
 goJ
-dzy
+goJ
+goJ
+tmD
 xQY
 xQY
 xQY
@@ -88700,7 +90027,7 @@ gJP
 jsX
 xZn
 gJP
-kkT
+xSj
 bWZ
 bWZ
 bWZ
@@ -88783,9 +90110,9 @@ bWZ
 sgL
 tmD
 goJ
-kav
 goJ
-tVc
+goJ
+tmD
 xQY
 xQY
 xQY
@@ -88953,10 +90280,10 @@ jsX
 xZn
 jsX
 sNH
-gJP
+guz
 jsX
 bWZ
-gJP
+rKJ
 bWZ
 bWZ
 bWZ
@@ -89039,9 +90366,9 @@ bWZ
 bWZ
 sgL
 tmD
-goJ
-goJ
-goJ
+kav
+uTa
+kav
 tmD
 xQY
 xQY
@@ -89204,13 +90531,13 @@ gDs
 jDP
 klO
 bWZ
-sNH
+msQ
 jsX
 jsX
 jsX
 bWZ
 sNH
-gJP
+bZQ
 bWZ
 bWZ
 bWZ
@@ -89296,9 +90623,9 @@ bWZ
 bWZ
 sgL
 tmD
-goJ
-goJ
-goJ
+kav
+kav
+uTa
 tmD
 tmD
 fqJ
@@ -89461,7 +90788,7 @@ gDs
 nmK
 klO
 bWZ
-sNH
+uDz
 bWZ
 xZn
 bWZ
@@ -89720,7 +91047,7 @@ klO
 bWZ
 bWZ
 bWZ
-jsX
+tpz
 bWZ
 bWZ
 bWZ
@@ -90324,25 +91651,25 @@ bWZ
 pLa
 uXV
 ngH
-hDY
+gNL
 lny
 xBH
 xBH
 drm
-nxe
-goJ
+eef
+hvh
 mMu
 dvQ
-goJ
-aDn
-aDn
-aDn
+hvh
+rmz
+kAB
+kAB
 nWH
 tZO
 mlI
-hDY
-goJ
-kav
+tqM
+hvh
+iDO
 pLa
 nZs
 nZs
@@ -90579,27 +91906,27 @@ srK
 flv
 bWZ
 pLa
-goJ
-goJ
+bhy
+iar
 nxe
-goJ
-goJ
-goJ
-goJ
-goJ
-oUK
-goJ
-nqq
-goJ
-nqq
-nqq
-goJ
-goJ
-goJ
-oUK
-kav
-goJ
-uTa
+iar
+iar
+iar
+iar
+iar
+kFx
+iar
+iar
+iar
+wei
+hvh
+hvh
+hvh
+hvh
+qBl
+rWn
+iar
+qgA
 pLa
 nZs
 nZs
@@ -90837,26 +92164,26 @@ flv
 bWZ
 pLa
 oCJ
-nqq
-goJ
-goJ
-nqq
+iar
+iar
+iar
+iar
 bjt
-goJ
+iar
 kuU
-vow
-goJ
-goJ
-oPF
-goJ
-goJ
-oUK
-goJ
-goJ
-goJ
-goJ
-goJ
-goJ
+jMC
+iar
+iar
+rFB
+iar
+iar
+kFx
+iar
+iar
+iar
+iar
+iar
+nqq
 pLa
 nZs
 nZs
@@ -90923,11 +92250,11 @@ sNH
 jsX
 jsX
 sNH
-uSJ
+xkA
 jsX
 jsX
 jsX
-uSJ
+xkA
 wVd
 ima
 sey
@@ -91093,26 +92420,26 @@ srK
 flv
 bWZ
 pLa
-goJ
-oUK
+bhy
+kFx
 kuU
-goJ
-nqq
-goJ
-goJ
-goJ
-goJ
-goJ
-goJ
-goJ
+iar
+aAC
+vow
+vow
+vow
+kYY
+iar
+iar
+iar
 nxe
-goJ
-goJ
-goJ
-goJ
-goJ
-goJ
-goJ
+iar
+iar
+iar
+iar
+iar
+iar
+iar
 nqq
 pLa
 nZs
@@ -91179,13 +92506,13 @@ coJ
 aLH
 xnb
 xnb
-nDf
+xOS
 eKA
 eLu
 iwF
 iwF
 eKA
-oSE
+tOq
 sey
 sey
 bWZ
@@ -91350,27 +92677,27 @@ oQT
 flv
 bWZ
 pLa
-goJ
+vrC
 oUK
 vow
-goJ
-nqq
+vow
+acv
 aDn
 aDn
 aDn
-oUK
-uTa
+dxa
+cxW
 rRF
 rRF
 rRF
-uTa
+cxW
 hDY
-kav
+eVw
 prN
-aDn
-nqq
-nqq
-nqq
+vow
+vow
+vow
+acv
 pLa
 nZs
 nZs
@@ -91607,11 +92934,9 @@ srK
 flv
 bWZ
 pLa
-oLa
+fOh
 pLa
-oLa
-pLa
-pLa
+fOh
 pLa
 pLa
 pLa
@@ -91625,9 +92950,11 @@ pLa
 pLa
 pLa
 pLa
-oLa
 pLa
-oLa
+pLa
+fOh
+pLa
+fOh
 pLa
 nZs
 nZs
@@ -92209,7 +93536,7 @@ jsX
 dQX
 sNH
 gJP
-kpe
+uoX
 jsX
 jsX
 lWl
@@ -93237,8 +94564,8 @@ jsX
 jsX
 sNH
 gJP
-ckj
-ckj
+oSE
+oSE
 jsX
 gJP
 wVd
@@ -93496,7 +94823,7 @@ hJY
 eha
 eKA
 eKA
-xbb
+aYu
 gJP
 wVd
 sey
@@ -93572,7 +94899,7 @@ bWZ
 bWZ
 bWZ
 bWZ
-xDX
+eqf
 gho
 sNH
 jsX
@@ -93753,7 +95080,7 @@ sNH
 eha
 eKA
 eKA
-wJN
+xeD
 gJP
 wVd
 aqt
@@ -94009,9 +95336,9 @@ qOW
 sNH
 eha
 eKA
-uJL
+akp
 eKA
-sME
+qFq
 wVd
 srt
 rRK
@@ -94265,9 +95592,9 @@ xZn
 jsX
 lmj
 gJP
-kpe
+uoX
 jsX
-kpe
+uoX
 gJP
 wVd
 pml
@@ -94337,12 +95664,12 @@ rxG
 kJQ
 pfg
 vBm
-xiR
+iKV
 smN
 pud
-fmA
+wVN
 pud
-odX
+kXK
 xKx
 eVh
 sNH
@@ -94519,7 +95846,7 @@ ima
 coJ
 sNH
 jsX
-jsX
+jxh
 sNH
 gJP
 jsX
@@ -94775,7 +96102,7 @@ geW
 sey
 coJ
 sNH
-jsX
+jxh
 xnb
 sNH
 gJP
@@ -95146,7 +96473,7 @@ bWZ
 bWZ
 rxG
 bHy
-qsJ
+bHy
 gKQ
 rxG
 vCF
@@ -95312,7 +96639,7 @@ qcO
 oaH
 sZt
 rgK
-pPh
+yfq
 wss
 lnL
 byl
@@ -95367,9 +96694,9 @@ kvR
 kJQ
 xKx
 ybn
-sPM
+ulS
 vBr
-vPH
+pGb
 eFP
 xKx
 gho
@@ -95402,7 +96729,7 @@ bWZ
 bWZ
 bWZ
 rxG
-tPz
+bHy
 soP
 qML
 rxG
@@ -95826,7 +97153,7 @@ qcO
 lmO
 sZt
 rgK
-oAO
+pPh
 nsg
 sZt
 sZt
@@ -96093,7 +97420,7 @@ sZt
 sZt
 oAa
 fvX
-reR
+kXW
 oUz
 jHj
 jHj
@@ -96903,8 +98230,8 @@ bWZ
 bWZ
 bWZ
 rxG
-fDA
-wXJ
+nlZ
+xDX
 pou
 ivO
 apL
@@ -96912,7 +98239,7 @@ hWx
 rxG
 rYP
 xNO
-nIg
+qtD
 wuY
 gho
 sNH
@@ -97161,7 +98488,7 @@ bWZ
 bWZ
 rxG
 rJr
-pJw
+yjf
 bHy
 bHy
 bHy
@@ -97418,15 +98745,15 @@ bWZ
 bWZ
 rxG
 fQZ
-wmL
-mYr
-bBJ
+cMG
+fmA
+wui
 bHy
 pLM
 dAS
 iFs
 sWU
-xpN
+nDf
 wuY
 gho
 sNH
@@ -97632,9 +98959,9 @@ kgC
 fBQ
 fel
 ieB
-dZl
-duw
-duw
+lJw
+qor
+qor
 qmB
 qor
 xUi
@@ -97675,7 +99002,7 @@ bWZ
 bWZ
 rxG
 uKW
-gNW
+ppX
 ppQ
 fmt
 hrW
@@ -97891,7 +99218,7 @@ hwQ
 ieB
 aNI
 lLs
-duw
+qor
 ffk
 qor
 bNV
@@ -98452,8 +99779,8 @@ hWm
 pjY
 pjY
 vex
-kTP
-gtM
+sHt
+rgQ
 yaC
 rxG
 gho
@@ -98516,7 +99843,7 @@ arS
 arS
 arS
 ups
-qBP
+mYU
 pkt
 dSf
 hhp
@@ -98705,12 +100032,12 @@ bWZ
 bWZ
 rxG
 ply
-wrX
+uSJ
 fQN
 djX
 goL
 bHy
-gtM
+rgQ
 fNq
 rxG
 qcU
@@ -98931,7 +100258,7 @@ hUR
 ieB
 klO
 kbS
-fpL
+kpo
 vCF
 veQ
 wou
@@ -98962,7 +100289,7 @@ bWZ
 bWZ
 rxG
 jPi
-kPn
+pJw
 dnm
 mOT
 ruv
@@ -99030,7 +100357,7 @@ arS
 arS
 paa
 ups
-qBP
+mYU
 pkt
 dSf
 hhp
@@ -99219,12 +100546,12 @@ bWZ
 bWZ
 rxG
 gFS
-urx
+xXx
 bHy
 bHy
 bHy
 bHy
-ylt
+clx
 yek
 rxG
 eVh
@@ -99476,7 +100803,7 @@ bWZ
 bWZ
 rxG
 kGV
-yfq
+sFK
 hGS
 qWw
 eVW
@@ -99733,12 +101060,12 @@ bWZ
 bWZ
 rxG
 oYn
-wrX
+uSJ
 eXd
 dQB
 jTc
 pVq
-gtM
+rgQ
 prw
 rxG
 asD
@@ -99990,12 +101317,12 @@ bWZ
 bWZ
 rxG
 lSN
-kGm
+unf
 ppQ
-gMa
-pJw
+xbY
+yjf
 bHy
-gtM
+rgQ
 uyC
 rxG
 syl
@@ -100173,7 +101500,7 @@ pWl
 coJ
 sNH
 jsX
-ckj
+oSE
 sNH
 nWB
 nWB
@@ -100248,9 +101575,9 @@ bWZ
 rxG
 otu
 cRR
-mTN
-oIj
 udO
+oIj
+oOG
 ppQ
 vsw
 nJK
@@ -100429,9 +101756,9 @@ sey
 iyn
 coJ
 sNH
-rXn
+jVh
 eKA
-eqf
+oAO
 gJP
 jsX
 jsX
@@ -100508,8 +101835,8 @@ rxG
 rxG
 rxG
 rxG
-orB
-orB
+vgR
+vgR
 rxG
 rxG
 rxG
@@ -100685,10 +102012,10 @@ hJO
 vHl
 sey
 coJ
-nDf
+xOS
 eKA
 eKA
-eqf
+oAO
 hWg
 jsX
 apW
@@ -100942,9 +102269,9 @@ sey
 scL
 cCo
 coJ
-nDf
+xOS
 eKA
-gEk
+bvO
 sNH
 gJP
 jsX
@@ -101200,7 +102527,7 @@ iyn
 rDN
 coJ
 sNH
-kpe
+uoX
 jsX
 sNH
 eKA
@@ -103106,12 +104433,12 @@ fQy
 jwo
 hKP
 gai
+qsJ
+dGo
 oWb
-oWb
-oWb
-oWb
-oWb
-pFs
+dGo
+qsJ
+fOV
 pWp
 pWp
 iqZ
@@ -103248,7 +104575,7 @@ osv
 osv
 mcf
 veg
-vFH
+ayP
 mcf
 mcf
 mcf
@@ -103324,16 +104651,16 @@ oCO
 pjq
 flv
 bWZ
-iyG
-iyG
-iyG
-iyG
-iyG
+flv
+flv
+flv
+flv
+flv
 rxG
 jZV
 bHy
 unw
-cMG
+oip
 rxG
 cVu
 rxG
@@ -103363,12 +104690,12 @@ wFk
 ibx
 xKx
 nqu
-eMr
-oWb
-oWb
+aIR
+tUS
+gnF
 aWs
 pWp
-oWb
+wdX
 pWp
 pWp
 pWp
@@ -103566,7 +104893,7 @@ eWt
 xUg
 tnT
 uUB
-oXm
+mbV
 nSL
 eWt
 bWZ
@@ -103581,7 +104908,7 @@ oCO
 vFV
 flv
 bWZ
-iyG
+flv
 aiH
 lxd
 fVp
@@ -103590,7 +104917,7 @@ rxG
 eQO
 ixG
 bHy
-cMG
+oip
 rxG
 rNI
 bRs
@@ -103747,7 +105074,7 @@ szS
 jxi
 rxG
 coJ
-bDP
+lOR
 jsX
 jsX
 jsX
@@ -103838,7 +105165,7 @@ lKJ
 hZW
 flv
 bWZ
-iyG
+flv
 lxd
 lxd
 wXW
@@ -103847,7 +105174,7 @@ rxG
 uLl
 bbd
 hXE
-oip
+eLN
 rxG
 twg
 deX
@@ -104019,7 +105346,7 @@ jsX
 jsX
 jsX
 jsX
-xbY
+kpe
 jsX
 xZn
 jsX
@@ -104095,13 +105422,13 @@ oCO
 awn
 flv
 bWZ
-iyG
+flv
 tIa
 rVE
 tTQ
 ojd
 rxG
-sXS
+eXH
 rxG
 rxG
 rxG
@@ -104352,7 +105679,7 @@ oCO
 qyK
 flv
 bWZ
-iyG
+flv
 lxd
 lxd
 ojd
@@ -104360,8 +105687,8 @@ wXW
 xKx
 smN
 cta
-dBb
-tOq
+fsG
+qBP
 xKx
 pnx
 hwJ
@@ -104396,7 +105723,7 @@ pqL
 bpr
 rxG
 iGr
-pqL
+tUj
 ttO
 szH
 hVT
@@ -104609,16 +105936,16 @@ oCO
 bMs
 flv
 bWZ
-iyG
+flv
 rVE
 aiH
 vCF
 syk
 xKx
-kjS
+bKw
 jwo
 jwo
-gMD
+eCs
 xKx
 twg
 rxt
@@ -104653,10 +105980,10 @@ sPB
 mrS
 rxG
 fdZ
+uSJ
 bHy
-bHy
-bHy
-kpw
+fuC
+wkB
 rxG
 fvn
 oCO
@@ -104776,7 +106103,7 @@ nSM
 dyR
 ogq
 sNH
-xbY
+kpe
 jsX
 uWD
 eml
@@ -104866,7 +106193,7 @@ oCO
 cBr
 flv
 bWZ
-iyG
+flv
 lxd
 lxd
 wXW
@@ -104910,9 +106237,9 @@ bHy
 joz
 rxG
 dJz
+uSJ
 bHy
-bHy
-bHy
+pLM
 mHz
 rxG
 fvn
@@ -105123,7 +106450,7 @@ oCO
 cBr
 flv
 bWZ
-iyG
+flv
 nGN
 rVE
 vCF
@@ -105167,10 +106494,10 @@ tJT
 mrS
 rxG
 vJD
+uSJ
 bHy
-bHy
-gpO
-dPg
+pLM
+oQD
 rxG
 fBF
 oCO
@@ -105380,7 +106707,7 @@ oCO
 kAQ
 flv
 bWZ
-iyG
+flv
 lxd
 rVE
 vCF
@@ -105424,10 +106751,10 @@ bHy
 ljQ
 rxG
 eXm
+skt
 bHy
-bHy
-bHy
-dPg
+pLM
+oQD
 rxG
 uct
 oCO
@@ -105551,7 +106878,7 @@ jsX
 jsX
 xZn
 jsX
-xbY
+kpe
 jsX
 jsX
 jsX
@@ -105637,7 +106964,7 @@ oCO
 mfZ
 flv
 bWZ
-iyG
+flv
 rVE
 lxd
 qXq
@@ -105683,7 +107010,7 @@ iaj
 cnK
 bHy
 vqh
-bHy
+pLM
 lIk
 rxG
 bJV
@@ -105803,7 +107130,7 @@ ewO
 hCD
 rxG
 coJ
-qFq
+msQ
 fEX
 jsX
 jsX
@@ -105894,7 +107221,7 @@ oCO
 tlP
 flv
 bWZ
-iyG
+flv
 rVE
 lxd
 vCF
@@ -105937,10 +107264,10 @@ bHy
 bHy
 cJy
 rxG
-oQD
+uSJ
 bHy
 kJQ
-bHy
+pLM
 xrM
 rxG
 vCF
@@ -105973,7 +107300,7 @@ arS
 arS
 arS
 tbp
-jVh
+rXn
 pAt
 paa
 jzJ
@@ -106151,7 +107478,7 @@ oCO
 vnZ
 flv
 bWZ
-iyG
+flv
 tIa
 nGN
 vCF
@@ -106195,9 +107522,9 @@ gpO
 cqu
 rxG
 rDK
+tPz
 bHy
-bHy
-bHy
+pLM
 koO
 rxG
 obM
@@ -106316,7 +107643,7 @@ brg
 brg
 tPq
 rxG
-ags
+lLT
 ozD
 tHV
 tHV
@@ -106334,7 +107661,7 @@ fds
 enu
 ozD
 rqn
-xkA
+nIO
 ozD
 ozD
 ozD
@@ -106408,7 +107735,7 @@ oCO
 iiS
 flv
 bWZ
-iyG
+flv
 wLH
 lxd
 ojd
@@ -106452,9 +107779,9 @@ bHy
 kmL
 rxG
 jpU
+uSJ
 bHy
-bHy
-bHy
+pLM
 wWF
 rxG
 xLA
@@ -106487,7 +107814,7 @@ kOZ
 kOZ
 arS
 tTd
-jVh
+rXn
 edY
 jzJ
 jzJ
@@ -106665,7 +107992,7 @@ oCO
 wOG
 flv
 bWZ
-iyG
+flv
 jYa
 lxd
 vCF
@@ -106709,7 +108036,7 @@ bHy
 kVE
 rxG
 mkx
-bHy
+uSJ
 ylU
 oDO
 heG
@@ -106922,7 +108249,7 @@ oCO
 kbS
 flv
 bWZ
-iyG
+flv
 rVE
 rVE
 kXm
@@ -106966,9 +108293,9 @@ vqh
 dPg
 rxG
 ktT
+uSJ
 bHy
-bHy
-unw
+lTy
 ydm
 rxG
 lxd
@@ -107179,8 +108506,8 @@ oCO
 bJV
 flv
 bWZ
-vPS
-vPS
+oVw
+oVw
 scs
 vCF
 vCF
@@ -107223,10 +108550,10 @@ bHy
 kym
 rxG
 uDL
+uSJ
 bHy
-bHy
-bHy
-ydm
+ttR
+hVT
 rxG
 lxd
 oCO
@@ -107437,7 +108764,7 @@ gqq
 flv
 bWZ
 bWZ
-vPS
+oVw
 tcM
 rGC
 hbB
@@ -107481,7 +108808,7 @@ mEC
 rxG
 gnR
 nwr
-sLM
+ppQ
 nSG
 wkB
 rxG
@@ -107694,7 +109021,7 @@ kbS
 flv
 bWZ
 bWZ
-vPS
+oVw
 sXZ
 vCF
 ojd
@@ -107951,7 +109278,7 @@ uLP
 flv
 bWZ
 bWZ
-vPS
+oVw
 ojd
 vCF
 ojd
@@ -108208,7 +109535,7 @@ jYV
 flv
 bWZ
 bWZ
-vPS
+oVw
 nBj
 vCF
 qXq
@@ -108465,7 +109792,7 @@ ddy
 flv
 bWZ
 bWZ
-vPS
+oVw
 qsR
 vCF
 vFV
@@ -108722,7 +110049,7 @@ bkS
 flv
 bWZ
 bWZ
-vPS
+oVw
 hWW
 vCF
 hXw
@@ -108979,7 +110306,7 @@ ivh
 flv
 bWZ
 bWZ
-vPS
+oVw
 iBP
 vCF
 nBj
@@ -109236,7 +110563,7 @@ syk
 flv
 bWZ
 bWZ
-vPS
+oVw
 jLS
 vCF
 nBj
@@ -109493,7 +110820,7 @@ qvr
 flv
 bWZ
 bWZ
-vPS
+oVw
 ivh
 vCF
 wXW
@@ -109749,8 +111076,8 @@ oCO
 kbS
 flv
 bWZ
-iyG
-iyG
+flv
+flv
 bkS
 vCF
 ojd
@@ -110006,7 +111333,7 @@ oCO
 scs
 flv
 bWZ
-iyG
+flv
 gBQ
 vCF
 hbB
@@ -110263,7 +111590,7 @@ oCO
 ivh
 flv
 bWZ
-iyG
+flv
 ivh
 ojd
 vCF
@@ -110520,7 +111847,7 @@ oCO
 ivh
 flv
 bWZ
-iyG
+flv
 ivh
 vCF
 ojd
@@ -110777,7 +112104,7 @@ oCO
 wOG
 flv
 bWZ
-iyG
+flv
 sRy
 vCF
 vCF
@@ -111020,7 +112347,7 @@ tPS
 qWw
 bHy
 mGR
-ppX
+uFg
 eBZ
 vCF
 syk
@@ -111034,10 +112361,10 @@ xfj
 wSr
 flv
 bWZ
-iyG
+flv
 ofO
 vCF
-scs
+vCF
 flv
 rxG
 rxG
@@ -111278,7 +112605,7 @@ lad
 lOD
 qRC
 gcX
-vjq
+xlC
 kuN
 kuN
 aBa
@@ -111291,7 +112618,7 @@ mgY
 ubz
 flv
 bWZ
-iyG
+flv
 ojd
 vCF
 nBj
@@ -111548,7 +112875,7 @@ flv
 flv
 flv
 bWZ
-iyG
+flv
 wSr
 vCF
 nBj
@@ -111805,7 +113132,7 @@ bWZ
 bWZ
 bWZ
 bWZ
-iyG
+flv
 scs
 vCF
 nBj
@@ -112052,17 +113379,17 @@ bWZ
 bWZ
 bWZ
 bWZ
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
 fWg
 hbB
 bJV
@@ -112283,7 +113610,7 @@ lCP
 shg
 iZA
 vFC
-dmn
+pwQ
 nmD
 xKx
 wDm
@@ -112577,7 +113904,7 @@ vCF
 jLS
 vCF
 fyI
-cUt
+ojd
 bJV
 bWZ
 bWZ
@@ -113078,20 +114405,20 @@ wXW
 aZq
 wXW
 vCF
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
-iyG
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
+flv
 vPS
 vPS
 vPS
@@ -114080,7 +115407,7 @@ xQY
 xQY
 xQY
 xQY
-xQY
+xKX
 hlr
 hlr
 xQY
@@ -114844,7 +116171,7 @@ exy
 exy
 exy
 exy
-exy
+niE
 exy
 exy
 alt
@@ -115100,7 +116427,7 @@ qlw
 qlw
 qlw
 qlw
-qlw
+cHD
 cVq
 qlw
 qlw
@@ -120224,7 +121551,7 @@ vhm
 xjf
 glG
 jER
-bvo
+abs
 rLn
 rLn
 rLn
@@ -120481,7 +121808,7 @@ vhm
 xjf
 glG
 uXc
-bvo
+abs
 rLn
 rLn
 rLn
@@ -120738,7 +122065,7 @@ vhm
 eco
 glG
 jER
-bvo
+abs
 rLn
 rLn
 rLn
@@ -120995,7 +122322,7 @@ vhm
 sZI
 glG
 jER
-bvo
+ban
 rLn
 rLn
 rLn


### PR DESCRIPTION
# Описание

Небольшие правки в мезе. дапдап

## Причина изменений

Просто чистка устаревших локаций 

## Демонстрация изменений

Мало. Ебучий мапдиффбот уже не вывозит и не может отрендерить всю карту
<img width="854" height="604" alt="image" src="https://github.com/user-attachments/assets/1e22ca4b-5140-4680-bd6c-8b3e145aed4b" />


<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->
