### PR TITLE
cryo nodeconstruct and electrochromatic kit drop

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -23,6 +23,7 @@ GLOBAL_LIST_EMPTY(ghost_records)
 	interaction_flags_machine = INTERACT_MACHINE_OFFLINE
 	req_one_access = list(ACCESS_HEADS, ACCESS_ARMORY) // Heads of staff or the warden can go here to claim recover items from their department that people went were cryodormed with.
 	var/mode = null
+	flags_1 = NODECONSTRUCT_1 // BLUEMOON ADD
 
 	max_integrity = 10000
 	obj_integrity = 10000

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -496,9 +496,6 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 		if(!(flags_1 & NODECONSTRUCT_1))
 			for(var/obj/item/shard/debris in spawnDebris(drop_location()))
 				transfer_fingerprints_to(debris) // transfer fingerprints to shards only
-	if(electrochromatic_status != NOT_ELECTROCHROMATIC)		//eh fine keep your kit.
-		new /obj/item/electronics/electrochromatic_kit(drop_location())
-		// Intentionally not setting the ID so you can't decon one to know all of the IDs.
 	qdel(src)
 	update_nearby_icons()
 
@@ -546,6 +543,9 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 	density = FALSE
 	air_update_turf(TRUE)
 	update_nearby_icons()
+	if(electrochromatic_status != NOT_ELECTROCHROMATIC)
+		new /obj/item/electronics/electrochromatic_kit(drop_location())
+		// Intentionally not setting the ID so you can't decon one to know all of the IDs.
 	remove_electrochromatic()
 	return ..()
 


### PR DESCRIPTION
# Описание
- Консоль крио нельзя разобрать инструментами
- Теперь окошко с набором для электрохромофикации, будет выкидывать его плату не только при уничтожении, но и при разборе инструментами

Проверено на локалке.
## Причина изменений
- Больше никаких "Я достал вещи всех, кто ушел в крио с помощью одной отвертки, еще и сломал консоль до конца смены"
- Оч. странно, что окно выкидывало плату только при уничтожении, а при нормальном разборе - нет.