### PR TITLE
chem master fix

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -295,9 +295,9 @@
 		var/amount = text2num(params["amount"])
 		if(amount == null)
 			amount = text2num(input(usr,
-				"Max 20. Buffer content will be split evenly.",
+				"Max [20 * max_create_amount_multiplier]. Buffer content will be split evenly.",
 				"How many to make?", 1))
-		amount = clamp(round(amount), 0, 20)
+		amount = clamp(round(amount), 0, 20 * max_create_amount_multiplier)
 		if (amount <= 0)
 			return FALSE
 		// Get units per item


### PR DESCRIPTION
# Описание
Небольшой фикс хим. мастера из [ПРа](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/pull/2161), значение схлопывалось после TGUI и не давало сделать больше чем 20 бутылок/таблеток и т.д.

Проверено на локалке.