### PR TITLE
cum wash fix

### DIFF
--- a/modular_splurt/code/modules/arousal/arousal.dm
+++ b/modular_splurt/code/modules/arousal/arousal.dm
@@ -86,7 +86,10 @@
 
 	if(cover == TRUE)
 		if(istype(sender, /obj/item/organ/genital/penis) || HAS_TRAIT(src, TRAIT_MESSY))
-			target.add_cum_overlay(sender.pick_cum_overlay(), initial(sender.fluid_id.color))
+			var/overlay_color
+			if((istype(sender, /obj/item/organ/genital/penis) || istype(sender, /obj/item/organ/genital/vagina)) && sender.linked_organ)
+				overlay_color = sender.linked_organ.fluid_id.color
+			target.add_cum_overlay(sender.pick_cum_overlay(), overlay_color)
 
 	. = ..()
 
@@ -135,26 +138,29 @@
 		return
 
 	if(initial(icon) && initial(icon_state))
-		//BLUEMOON ADD START
-		var/list/active_overlays = list()
-		for(var/over in src.overlays)
-			var/image/MA = over
-			if(MA && MA.icon == CUM_DMI && (MA.icon_state in CUM_STATES))
-				active_overlays += MA
-		//BLUEMOON ADD END
+		var/list/active_overlays = get_cum_overlays() //BLUEMOON ADD
 		if(active_overlays.len < overlays_limit) // BLUEMOON EDIT || Ограничение на оверлеи, иначе будет срабатывать VALIDATE_OVERLAY_LIMIT
 			add_overlay(mutable_appearance(CUM_DMI, state, color = cum_color), ICON_MULTIPLY)
 		var/mob/living/carbon/human/H = src
 		H.covered_in_cum = TRUE
 		to_chat(H, span_love("Кажется тебя немножко забрызгали~"))
 
+//BLUEMOON ADD START
+/atom/proc/get_cum_overlays()
+	var/list/active_overlays = list()
+	for(var/over in src.overlays)
+		var/image/MA = over
+		if(MA && MA.icon == CUM_DMI && (MA.icon_state in CUM_STATES))
+			active_overlays += MA
+	return active_overlays
+//BLUEMOON ADD END
+
 /mob/living/carbon/human/proc/getPercentAroused()
     var/percentage = ((get_lust() / (get_climax_threshold())) * 100) // BLUEMOON EDIT
     return percentage
 
 /atom/proc/wash_cum()
-	for(var/state in CUM_STATES)
-		cut_overlay(mutable_appearance(CUM_DMI, state))
+	overlays -= get_cum_overlays()
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		H.covered_in_cum = FALSE

--- a/modular_splurt/code/modules/arousal/organs/breasts.dm
+++ b/modular_splurt/code/modules/arousal/organs/breasts.dm
@@ -89,6 +89,6 @@
 
 	// splash affected objects
 	var/overlay_state = pick_cum_overlay()
-	var/overlay_color = initial(fluid_id.color)
+	var/overlay_color = fluid_id.color
 	for(var/atom/object in cumsplashed_items)
 		object.add_cum_overlay(overlay_state, overlay_color)

--- a/modular_splurt/code/modules/arousal/organs/penis.dm
+++ b/modular_splurt/code/modules/arousal/organs/penis.dm
@@ -89,6 +89,6 @@
 
 	// splash affected objects
 	var/overlay_state = pick_cum_overlay()
-	var/overlay_color = initial(linked_organ.fluid_id.color)
+	var/overlay_color = linked_organ.fluid_id.color
 	for(var/atom/object in cumsplashed_items)
 		object.add_cum_overlay(overlay_state, overlay_color)

--- a/modular_splurt/code/modules/arousal/organs/vagina.dm
+++ b/modular_splurt/code/modules/arousal/organs/vagina.dm
@@ -25,7 +25,7 @@
 
 	// splash affected objects
 	var/overlay_state = pick_cum_overlay()
-	var/overlay_color = initial(linked_organ.fluid_id.color)
+	var/overlay_color = linked_organ.fluid_id.color
 	for(var/atom/object in target_turf.contents)
 		if(!istype(object) || isturf(object) || object == owner)
 			continue


### PR DESCRIPTION
# Описание
- Теперь оверлеи cum корректно удаляются, вне зависимости от цвета
- Оверлеи cum имеют цвет, не начальный у куклы, а текущий (влияет только на имплант по смене жидкостей или VVшку)
- Оверлеи cum через ic -> Climax теперь имеют корректный цвет

Проверено на локалке.