### PR TITLE
Небольшие изменения поста Прослушки.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -8,7 +8,8 @@
 "aj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/plasteel/dark/smooth/herringbone,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ak" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -54,7 +55,10 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white/smooth/small,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "aI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
@@ -171,22 +175,25 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "by" = (
 /obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bF" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "slp_rtgs"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bL" = (
 /obj/machinery/computer/camera_advanced,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bQ" = (
 /obj/effect/turf_decal/siding/white{
@@ -196,7 +203,7 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "bS" = (
 /obj/machinery/status_display/syndie,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bU" = (
 /obj/machinery/door/firedoor,
@@ -214,7 +221,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/hatch{
 	name = "Private Quarters Access";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	id_tag = "slp_dorm1"
 	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -247,7 +255,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/edge,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ci" = (
 /obj/machinery/light/small{
@@ -269,7 +277,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/edge,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "cw" = (
 /obj/structure/table/reinforced,
@@ -288,7 +296,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "cD" = (
 /obj/effect/turf_decal/siding/red,
@@ -332,12 +340,20 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "dp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/ale,
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"ds" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/rtg/advanced/fullupgrade,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "dD" = (
 /obj/machinery/door/airlock/hatch{
@@ -361,7 +377,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "dT" = (
 /obj/machinery/door/firedoor,
@@ -375,13 +394,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/hatch{
 	name = "Bathroom";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	id_tag = "slp_bath"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "dV" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "eb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -403,16 +423,22 @@
 /obj/machinery/vending/engivend{
 	onstation = 0
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/plasteel/dark/textured/large,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "eh" = (
 /obj/structure/statue/bronze/marx{
 	pixel_x = 16;
 	pixel_y = -16
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
 	},
 /turf/open/floor/engine/vacuum,
 /area/space)
@@ -430,7 +456,10 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/rtg/advanced/fullupgrade,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "es" = (
 /obj/machinery/door/firedoor,
@@ -441,7 +470,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "et" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -458,7 +487,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "eB" = (
 /obj/machinery/light/small{
@@ -518,11 +547,11 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -541,7 +570,7 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "fi" = (
 /obj/effect/turf_decal/siding/dark,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/herringbone,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "fj" = (
 /obj/effect/turf_decal/siding/red{
@@ -591,16 +620,21 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"fC" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "fD" = (
 /obj/machinery/computer/arcade/tetris{
 	dir = 8
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
-"fN" = (
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "gk" = (
 /obj/effect/turf_decal/siding/dark{
@@ -620,6 +654,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white/smooth/small,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"gn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/red{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "gr" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -634,7 +679,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "gE" = (
 /obj/structure/pool/ladder{
@@ -673,20 +718,22 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ha" = (
-/obj/machinery/sleeper/syndie,
-/obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 1
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/sleeper/syndie/fullupgrade,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/smooth,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "hj" = (
 /obj/effect/turf_decal/siding/dark,
-/obj/effect/decal/cleanable/dirt{
-	desc = "A thin layer of dust coating the floor.";
-	name = "dust"
-	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "hq" = (
@@ -735,7 +782,9 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "hW" = (
 /obj/effect/turf_decal/siding/dark{
@@ -764,12 +813,15 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/corner,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ii" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "slp_rtgs"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -778,10 +830,17 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/structure/filingcabinet,
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/structure/filingcabinet{
+	pixel_x = -5
+	},
+/obj/item/paper/fluff/ruins/listeningstation/odd_report{
+	pixel_x = -5
+	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/filingcabinet{
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "iv" = (
 /obj/effect/turf_decal/siding/red{
@@ -830,7 +889,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "jB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -858,7 +917,7 @@
 	onstation = 0
 	},
 /obj/machinery/light/small,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "jN" = (
 /obj/machinery/light/small{
@@ -891,7 +950,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/herringbone,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "kc" = (
 /obj/effect/turf_decal/siding/dark{
@@ -916,10 +975,7 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/defibrillator/compact/combat,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plasteel/white/smooth/small,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "kp" = (
 /obj/docking_port/stationary{
@@ -966,6 +1022,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ky" = (
@@ -987,7 +1044,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "kH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -1018,12 +1075,15 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ly" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "lC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1057,6 +1117,12 @@
 /obj/item/flashlight{
 	pixel_y = 10
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "mc" = (
@@ -1064,12 +1130,23 @@
 	desc = "An advanced vendor that dispenses medical drugs, both recreational and medicinal. It's said to have been salvaged from an old decomissioned Cybersun Cruiser.";
 	name = "\improper SyndiMed ++"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark/smooth/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"mj" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/rtg/advanced/fullupgrade,
+/obj/effect/turf_decal/stripes/yellow/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "mm" = (
 /obj/machinery/light/small{
@@ -1091,7 +1168,10 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "slp_self_destruct"
+	},
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "mw" = (
 /obj/effect/turf_decal/siding/red{
@@ -1116,9 +1196,6 @@
 /obj/machinery/atmospherics/components/binary/pump/off/general/hidden/layer3{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
@@ -1130,10 +1207,7 @@
 /obj/item/broom,
 /obj/effect/turf_decal/bot/white,
 /obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/decal/cleanable/dirt{
-	desc = "A thin layer of dust coating the floor.";
-	name = "dust"
-	},
+/obj/item/lightreplacer,
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
 	},
@@ -1174,7 +1248,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ni" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -1190,7 +1264,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "nv" = (
 /turf/open/floor/plating/asteroid/airless,
@@ -1307,7 +1381,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/corner{
+	dir = 1
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "pp" = (
 /obj/structure/chair/sofa/corp/left{
@@ -1437,6 +1513,19 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"qm" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/rtg/advanced/fullupgrade,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "qu" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
@@ -1459,7 +1548,16 @@
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/button/door{
+	id = "slp_rtgs";
+	name = "Shutters control";
+	pixel_x = 22;
+	pixel_y = -11;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark/smooth/corner{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "qw" = (
 /obj/structure/fluff/railing/corner{
@@ -1481,7 +1579,6 @@
 /obj/effect/spawner/lootdrop/syndicate_present,
 /obj/effect/spawner/lootdrop/syndicate_present,
 /obj/effect/spawner/lootdrop/syndicate_present,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "qM" = (
@@ -1516,6 +1613,9 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "qW" = (
 /obj/effect/turf_decal/siding/red/corner,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rj" = (
@@ -1529,20 +1629,24 @@
 	dir = 8
 	},
 /obj/item/soap/syndie,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/white/smooth/diagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "rn" = (
 /obj/machinery/vending/cola/random{
 	extended_inventory = 1
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/corner,
+/obj/effect/turf_decal/stripes/yellow/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -1553,6 +1657,14 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "slp_dorm1";
+	name = "Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 24;
+	specialfunctions = 4
 	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -1581,7 +1693,10 @@
 	},
 /obj/effect/turf_decal/siding/red/corner,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -1614,7 +1729,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/corner,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "sp" = (
 /obj/structure/chair/office/dark{
@@ -1641,11 +1756,13 @@
 	icon_state = "box_1";
 	state = 2
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white/smooth,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "sD" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "sR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -1728,12 +1845,19 @@
 /obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"uw" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/rtg/advanced/fullupgrade,
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "uA" = (
 /obj/structure/table,
 /obj/machinery/cell_charger_multi,
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
 /obj/item/stock_parts/cell/high/plus{
 	pixel_x = 4;
 	pixel_y = -4
@@ -1743,7 +1867,10 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "uC" = (
 /obj/structure/sink{
@@ -1772,7 +1899,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"uW" = (
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "uZ" = (
 /obj/effect/turf_decal/bot,
@@ -1780,7 +1912,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "vi" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1801,8 +1933,14 @@
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/vending/wardrobe/syndie_wardrobe,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"vl" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/engine/vacuum,
+/area/space)
 "vn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -1841,7 +1979,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "vx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1864,7 +2005,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "vO" = (
 /obj/effect/turf_decal/siding/dark/corner{
@@ -1885,7 +2026,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "vR" = (
 /obj/effect/turf_decal/siding/red{
@@ -1955,7 +2096,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "wM" = (
 /obj/effect/turf_decal/siding/dark{
@@ -1998,8 +2139,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"xu" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xv" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -2013,7 +2157,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/smooth/herringbone,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xx" = (
 /obj/structure/cable{
@@ -2023,7 +2170,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/rtg/advanced/fullupgrade,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xy" = (
 /turf/closed/mineral/random,
@@ -2031,7 +2181,10 @@
 "xD" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/smooth/herringbone,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "yl" = (
 /obj/effect/turf_decal/trimline/dark_red/line,
@@ -2087,13 +2240,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 1
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "yY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2104,14 +2262,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "zh" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plasteel/white/smooth/small,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "zi" = (
 /obj/effect/turf_decal/trimline/dark_red/line,
@@ -2122,6 +2277,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/table/wood,
+/obj/machinery/light/small,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "zj" = (
@@ -2171,7 +2327,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "zH" = (
 /obj/machinery/computer/shuttle/ds_syndicate{
@@ -2181,28 +2337,34 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "zQ" = (
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/misc/bathrobe,
 /obj/item/reagent_containers/rag/towel/random,
-/turf/open/floor/plasteel/white/smooth/small,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "zR" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "slp_rtgs"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -2219,7 +2381,7 @@
 	dir = 2
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ar" = (
 /obj/effect/turf_decal/siding/dark{
@@ -2234,13 +2396,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/smooth/corner,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "AF" = (
 /obj/structure/window/reinforced/survival_pod{
@@ -2250,8 +2415,7 @@
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot/white,
-/obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "AM" = (
 /obj/effect/turf_decal/siding/white,
@@ -2276,7 +2440,7 @@
 /obj/structure/table,
 /obj/machinery/fax,
 /obj/item/paper/monitorkey,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "AR" = (
 /obj/structure/fans/tiny,
@@ -2290,8 +2454,13 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "syndie_listening_lockdown"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "AV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2320,7 +2489,7 @@
 "Bv" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Bz" = (
 /obj/effect/turf_decal/siding/red{
@@ -2491,10 +2660,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot/white,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	pixel_x = 4
+	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Da" = (
@@ -2517,7 +2687,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/blood/OMinus,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plasteel/white/smooth/small,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Dj" = (
 /obj/structure/frame/machine{
@@ -2559,6 +2729,14 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "slp_dorm2";
+	name = "Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -24;
+	specialfunctions = 4
 	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -2613,9 +2791,15 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Fc" = (
 /obj/structure/table,
-/obj/effect/turf_decal/siding/dark,
-/obj/item/pipe_dispenser,
-/turf/open/floor/mineral/plastitanium,
+/obj/item/stack/cable_coil,
+/obj/effect/spawner/lootdrop/high_tools,
+/obj/item/clothing/glasses/science{
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Fk" = (
 /obj/effect/turf_decal/trimline/dark/line{
@@ -2648,7 +2832,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/hatch{
 	name = "Private Quarters Access";
-	req_access_txt = "150"
+	req_access_txt = "150";
+	id_tag = "slp_dorm2"
 	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -2661,6 +2846,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Fv" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/closed/mineral/random,
+/area/ruin/space)
 "FF" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -2690,7 +2881,8 @@
 	},
 /obj/machinery/power/rtg/advanced/fullupgrade,
 /obj/machinery/light/small,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/yellow/line,
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "FY" = (
 /obj/effect/turf_decal/siding/red/corner,
@@ -2773,7 +2965,11 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/item/clothing/glasses/hud/health/sunglasses/aviators,
+/obj/item/clothing/glasses/hud/health/sunglasses/aviators,
+/obj/item/clothing/gloves/color/latex/nitrile/hsc,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark/smooth/edge,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "GY" = (
 /obj/effect/turf_decal/siding/dark{
@@ -2808,6 +3004,22 @@
 	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Hg" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	id = "slp_self_destruct";
+	name = "Self Dectruct Access";
+	pixel_x = -24;
+	pixel_y = 38;
+	req_access_txt = "150"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "Hm" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -2819,13 +3031,13 @@
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Hr" = (
-/obj/machinery/recharge_station/upgraded,
 /obj/effect/turf_decal/siding/red{
 	dir = 5
 	},
+/obj/machinery/recharge_station/fullupgrade,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ht" = (
@@ -2873,19 +3085,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Il" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
 /turf/open/floor/engine/vacuum,
 /area/space)
 "Ip" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	desc = "A thin layer of dust coating the floor.";
-	name = "dust"
-	},
-/obj/effect/decal/cleanable/dirt{
-	desc = "A thin layer of dust coating the floor.";
-	name = "dust"
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -2919,7 +3126,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 4
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "IO" = (
 /obj/structure/rack{
@@ -2933,24 +3142,29 @@
 /obj/item/tank/internals/doubleoxygen{
 	pixel_y = 6
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 9
+	},
 /obj/effect/turf_decal/bot/white,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "IQ" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/item/analyzer/ranged{
-	pixel_y = 10
-	},
-/obj/item/storage/part_replacer,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/item/storage/box/beakers/bluespace{
+	pixel_y = 9;
+	pixel_x = 11
+	},
+/obj/item/analyzer/ranged{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/obj/item/storage/part_replacer,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "IZ" = (
@@ -2959,7 +3173,7 @@
 	req_one_access = null
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Jd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2998,7 +3212,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ji" = (
 /obj/machinery/power/smes{
@@ -3016,7 +3230,7 @@
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Jo" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3031,12 +3245,14 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/dark/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -3046,6 +3262,17 @@
 	dir = 9
 	},
 /turf/open/floor/wood/wood_parquet,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"JT" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 4
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Kd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3073,18 +3300,17 @@
 "Ko" = (
 /obj/structure/table,
 /obj/structure/table,
-/obj/item/holosign_creator,
+/obj/item/holosign_creator{
+	pixel_y = 4;
+	pixel_x = -4
+	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 6;
-	pixel_y = -6
+	pixel_y = 6
 	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	desc = "A thin layer of dust coating the floor.";
-	name = "dust"
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 5
@@ -3123,14 +3349,16 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "KN" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/white/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "KS" = (
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 6
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -3147,15 +3375,18 @@
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Lj" = (
 /obj/structure/table/optable,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Lk" = (
 /obj/machinery/door/firedoor,
@@ -3170,7 +3401,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3181,7 +3412,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "LL" = (
 /obj/effect/turf_decal/siding/red{
@@ -3209,6 +3440,9 @@
 	req_access_txt = "150";
 	specialfunctions = 4
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ML" = (
@@ -3220,6 +3454,7 @@
 /obj/effect/turf_decal/siding/red/end{
 	dir = 1
 	},
+/obj/item/circuitboard/machine/autolathe,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "MO" = (
@@ -3228,13 +3463,20 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/airalarm/syndicate{
-	pixel_y = 24
+	pixel_y = 34
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "slp_rnd";
+	name = "Shutters control";
+	pixel_x = -6;
+	pixel_y = 22;
+	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -3262,6 +3504,18 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
+/obj/machinery/button/door{
+	id = "slp_bath";
+	name = "Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 34;
+	specialfunctions = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/white/smooth/small,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "Nn" = (
@@ -3283,17 +3537,19 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/item/storage/box/stockparts/basic{
-	pixel_x = -3;
-	pixel_y = 11
-	},
-/obj/item/storage/box/stockparts/basic{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/storage/box/stockparts/basic,
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/item/storage/box/stockparts/deluxe{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/storage/box/stockparts/deluxe{
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = -4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -3327,7 +3583,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "NW" = (
 /obj/effect/turf_decal/siding/red{
@@ -3437,6 +3693,16 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"PP" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/rtg/advanced/fullupgrade,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 5
+	},
+/turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Qa" = (
 /obj/effect/turf_decal/siding/dark,
@@ -3549,7 +3815,10 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/misc/bathrobe,
 /obj/item/reagent_containers/rag/towel/random,
-/turf/open/floor/plasteel/white/smooth/small,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "QK" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3615,7 +3884,6 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ry" = (
 /obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/general/visible/layer3{
 	dir = 9
 	},
@@ -3669,7 +3937,7 @@
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Si" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3694,6 +3962,9 @@
 	color = "#777777"
 	},
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ss" = (
@@ -3710,10 +3981,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "St" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plasteel/white/smooth/small,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "SG" = (
 /obj/effect/turf_decal/siding/yellow,
@@ -3721,7 +3989,14 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/edge,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"SM" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "slp_rnd"
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "SN" = (
 /obj/effect/turf_decal/siding/red{
@@ -3791,6 +4066,9 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Tm" = (
@@ -3827,7 +4105,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "TB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3866,13 +4144,20 @@
 	pixel_x = -27;
 	pixel_y = 1
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
-"Uk" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/turf/open/floor/plasteel/dark/smooth/corner{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"Uk" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/smooth/corner{
+	dir = 1
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ur" = (
 /obj/effect/turf_decal/siding/dark,
@@ -3903,13 +4188,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Uu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Uv" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3927,13 +4213,22 @@
 	dir = 10
 	},
 /obj/structure/railing,
-/turf/open/floor/plasteel/white/smooth/small,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "UE" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"UI" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/engine/vacuum,
+/area/space)
 "UR" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3968,7 +4263,7 @@
 	},
 /obj/structure/railing,
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "VA" = (
 /obj/effect/turf_decal/siding/red{
@@ -4015,9 +4310,6 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 32
@@ -4025,7 +4317,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/smooth/corner{
+	dir = 8
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Wo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -4054,14 +4357,14 @@
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ww" = (
 /obj/machinery/vending/snack/random{
 	extended_inventory = 1
 	},
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/smooth/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Wx" = (
 /obj/structure/chair/office/dark{
@@ -4092,17 +4395,18 @@
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "WS" = (
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/bot/white,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "WT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
@@ -4126,6 +4430,12 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation_shower)
 "Xe" = (
 /obj/effect/turf_decal/siding/red,
+/obj/effect/turf_decal/stripes/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/yellow/corner{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Xh" = (
@@ -4159,7 +4469,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Xs" = (
 /obj/structure/fluff/railing/corner,
@@ -4191,6 +4501,7 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/yellow/line,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Yd" = (
@@ -4256,7 +4567,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/plasteel/dark/smooth/edge{
+	dir = 4
+	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Za" = (
 /obj/structure/closet/firecloset/full,
@@ -4291,8 +4604,13 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "syndie_listening_lockdown"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/textured/large,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ZK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4312,7 +4630,10 @@
 "ZN" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot/white,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/smooth/herringbone,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ZX" = (
 /obj/item/kirbyplants{
@@ -4705,7 +5026,7 @@ dV
 bU
 dV
 dV
-dV
+xu
 vr
 pz
 VE
@@ -4852,7 +5173,7 @@ dV
 dV
 dV
 dV
-fN
+xu
 ky
 Ph
 Hm
@@ -4863,7 +5184,7 @@ pQ
 vk
 Si
 Qp
-dV
+SM
 Hr
 DC
 Cy
@@ -4902,7 +5223,7 @@ lC
 Jn
 Gz
 Nq
-wV
+SM
 ku
 aV
 aV
@@ -4925,7 +5246,7 @@ tP
 dV
 dV
 ij
-eo
+Hg
 sp
 BO
 PN
@@ -5023,7 +5344,7 @@ dV
 fj
 eC
 NW
-jZ
+fC
 Fc
 dV
 kH
@@ -5090,7 +5411,7 @@ zF
 YJ
 KF
 Uu
-LL
+gn
 SN
 LL
 cF
@@ -5129,7 +5450,7 @@ dV
 QL
 QM
 Bv
-pR
+QL
 GD
 pR
 Iu
@@ -5184,8 +5505,8 @@ dV
 xy
 aI
 dV
-xx
-xx
+qm
+mj
 xx
 dV
 tP
@@ -5209,7 +5530,7 @@ bV
 dV
 ha
 Az
-CT
+uW
 mc
 dV
 Qo
@@ -5224,7 +5545,7 @@ dV
 nT
 dV
 vu
-xx
+uw
 FR
 dV
 tP
@@ -5262,8 +5583,8 @@ Za
 dV
 nT
 dV
-eq
-eq
+PP
+ds
 eq
 dV
 tP
@@ -5287,7 +5608,7 @@ Rf
 dV
 dV
 Wj
-Uk
+JT
 Uk
 rV
 DH
@@ -5418,8 +5739,8 @@ dV
 tP
 tP
 tP
-Il
-Il
+vl
+UI
 tP
 tP
 tP
@@ -5457,7 +5778,7 @@ tP
 tP
 tP
 tP
-tP
+Fv
 tP
 tP
 tP


### PR DESCRIPTION
# Описание
Немного изменила внешний вид станции. (Изменение декалей и возвращение некоторых, которые пропали) Поменяла стены на обычные пластитановые, как на ДС-1. Ранее было как на ДС-2. Положила немного блюспейс деталей для машинерии, как и на ДСах, ранее были стандартные. Добавила кнопки болтирования в личные комнаты, ванную, так же кнопку на мостик, открывающую защитную дверь в отсек с бомбой самоуничтожения. 

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

1. Проблема стен, при уничтожении стены ее невозможно восстановить не повредив внешний вид станции. Стены не сливаются в одну, из-за разных видов.
2. Некоторые декали исчезли с карты, восстановила, теперь такого быть не должно.
3. Сделала небольшие правки, в дополнение к тому, что нужно было исправить. 

## Демонстрация изменений
Картинка карты:
<img width="1248" height="1184" alt="image" src="https://github.com/user-attachments/assets/c784691b-cdcd-49e0-ae7c-95f869018cf7" />

## Changelog
:cl:
map: modified map content
/:cl:
