### PR TITLE
Прозрачность иконок для сб худов.

### DIFF
--- a/code/datums/elements/tactical.dm
+++ b/code/datums/elements/tactical.dm
@@ -2,6 +2,16 @@
 	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
 	id_arg_index = 2
 	var/allowed_slot
+	var/static/list/hud_to_hide = list(
+		HEALTH_HUD,
+		STATUS_HUD,
+		ID_HUD,
+        WANTED_HUD,
+        IMPLOYAL_HUD,
+        IMPCHEM_HUD,
+        IMPTRACK_HUD,
+        RAD_HUD,
+    )
 
 /datum/element/tactical/Attach(datum/target, allowed_slot)
 	. = ..()
@@ -28,6 +38,8 @@
 	source.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "sneaking_mission", I)
 	I.layer = ABOVE_MOB_LAYER
 
+	set_hud_alpha(user, 100)
+
 /datum/element/tactical/proc/unmodify(obj/item/source, mob/user)
 	if(!user)
 		if(!ismob(source.loc))
@@ -35,3 +47,10 @@
 		user = source.loc
 
 	user.remove_alt_appearance("sneaking_mission")
+
+	set_hud_alpha(user, 255)
+
+/datum/element/tactical/proc/set_hud_alpha(mob/user, alpha = 255)
+    for(var/hud_id in hud_to_hide)
+        var/image/hud_image = user.hud_list[hud_id]
+        hud_image?.alpha = alpha


### PR DESCRIPTION
прозрачность иконок профы в кустах

- [x ] Изменения были проверены на локальном сервере

## Демонстрация изменений
<img width="413" height="271" alt="Без имени" src="https://github.com/user-attachments/assets/b1ca8601-1888-4721-ba44-8879ac2e5b20" />

:cl:
qol: Security hud bush
/:cl:
