### PR TITLE
femclaw fix

### DIFF
--- a/modular_splurt/code/modules/mob/femclaw.dm
+++ b/modular_splurt/code/modules/mob/femclaw.dm
@@ -71,6 +71,11 @@
 	gib()
 
 /mob/living/simple_animal/hostile/deathclaw/funclaw/femclaw/AttackingTarget()
+
+	if(!CanRape(target))
+		..() // Attack target to death
+		return
+
 	var/mob/living/M = target
 
 	var/onLewdCooldown = FALSE
@@ -81,6 +86,10 @@
 	if(onLewdCooldown)
 		LosePatience()
 		return // Do nothing
+
+	if((target in enemies) && M.health > M.maxHealth * 0.4)
+		..() // Attack target
+		return
 
 	if(!M.pulledby)
 		if(!M.buckled && !M.density)


### PR DESCRIPTION
# Описание
Фикс к [этому](https://github.com/BlueMoon-Labs/MOLOT-BlueMoon-Station/pull/2186) ПРу. У маммиклавов был переписан один прок, поэтому они класть хотели на префы _(но только, если им заехать по морде)_

Проверил на локалке, всех дочерних фан, фем и прочих клавов, включая питомцев