### PR TITLE
бафф картриджей RCD

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -646,14 +646,14 @@ RLD
 	item_state = "rcdammo"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	custom_materials = list(/datum/material/iron=12000, /datum/material/glass=8000)
-	var/ammoamt = 40
+	custom_materials = list(/datum/material/iron=24000, /datum/material/glass=16000)
+	var/ammoamt = 80
 
 /obj/item/rcd_ammo/large
 	name = "large compressed matter cartridge"
 	desc = "Highly compressed matter for the RCD. Has four times the matter packed into the same space as a normal cartridge."
-	custom_materials = list(/datum/material/iron=48000, /datum/material/glass=32000)
-	ammoamt = 160
+	custom_materials = list(/datum/material/iron=96000, /datum/material/glass=64000)
+	ammoamt = 320 
 
 
 /obj/item/construction/rcd/combat/admin


### PR DESCRIPTION

# Описание

<!-- Удвоил стоимость в ресурсах и количество материи картриджей РСД -->

## Причина изменений
картридж СЖАТОЙ материи пополняет РСД на 160 материи, а стак не сжатого металла на 200 стоковый и на 600 индустриальный рсд, но места в рюкзаке занимают одинаково (????) при этом картридж на 3/5 из металла и состоит
Из металла можно крафтить предметы, а картридж даже в техфаб обратно не засунуть. Менее функциональный + содержит меньше материи == абсолютно невыгодный, бесполезный. Он должен иметь преимущество перед более функциональным стаком металла, или вовсе исчезнуть из техфаба.
