### PR TITLE
Радиация реакторным батареям + нерф батарей.

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -269,7 +269,7 @@
 	cell = /obj/item/stock_parts/cell/high
 
 /obj/item/defibrillator/compact/loaded_ert
-	cell = /obj/item/stock_parts/cell/bluespacereactor
+	cell = /obj/item/stock_parts/cell/vortex
 
 /obj/item/defibrillator/compact/combat
 	name = "combat defibrillator"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -375,7 +375,7 @@
 		/obj/item/rcd_ammo/large=2,
 		/obj/item/construction/rcd/combat=1,
 		/obj/item/inducer=1,
-		/obj/item/stock_parts/cell/bluespacereactor=1,
+		/obj/item/stock_parts/cell/vortex=1,
 	)
 
 	cybernetic_implants = list(
@@ -402,7 +402,7 @@
 		/obj/item/rcd_ammo/large=2,
 		/obj/item/construction/rcd/combat=1,
 		/obj/item/inducer=1,
-		/obj/item/stock_parts/cell/bluespacereactor=1,
+		/obj/item/stock_parts/cell/vortex=1,
 		)
 
 	cybernetic_implants = list(
@@ -433,7 +433,7 @@
 		/obj/item/storage/firstaid/regular=1,\
 		/obj/item/construction/rcd/combat=1,
 		/obj/item/inducer/sci/combat=1,
-		/obj/item/stock_parts/cell/bluespacereactor=1,
+		/obj/item/stock_parts/cell/vortex=1,
 		)
 
 	cybernetic_implants = list(
@@ -455,7 +455,7 @@
 		/obj/item/storage/firstaid/regular=1,\
 		/obj/item/construction/rcd/combat=1,
 		/obj/item/inducer/sci/combat=1,
-		/obj/item/stock_parts/cell/bluespacereactor=1,
+		/obj/item/stock_parts/cell/vortex=1,
 		)
 
 	cybernetic_implants = list(

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -28,6 +28,11 @@
 	var/has_charge_overlay = TRUE
 	rad_flags = RAD_NO_CONTAMINATE // Prevent the same cheese as with the stock parts
 
+	/// If a cell emits any radiation
+	var/cell_is_radioactive = FALSE
+	/// The strength of emmited radiation
+	var/rad_strength = 0
+
 /obj/item/stock_parts/cell/get_cell()
 	return src
 
@@ -60,8 +65,18 @@
 /obj/item/stock_parts/cell/process()
 	if(self_recharge)
 		give(chargerate * 0.25)
+		if(cell_is_radioactive)
+			irradiate()
 	else
 		return PROCESS_KILL
+
+/// Proc for radioactive cells made with uranium and considered as contaminating its surroundings
+/obj/item/stock_parts/cell/proc/irradiate(obj/item/stock_parts/cell/C)
+	if(charge < maxcharge)
+		radiation_pulse(get_turf(src), rad_strength, 1.5)
+		AddComponent(/datum/component/radioactive, 1.1, src)
+	else
+		radiation_pulse(get_turf(src), 15, 1.5)
 
 /obj/item/stock_parts/cell/update_overlays()
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -132,6 +132,12 @@
 			use_power(250*recharge_amount)
 		recharge_counter = 0
 		return
+	if(cell.cell_is_radioactive)
+		if(cell.charge < cell.maxcharge)
+			radiation_pulse(get_turf(src), cell.rad_strength, 1.5)
+			AddComponent(/datum/component/radioactive, 1.1, src)
+		else
+			radiation_pulse(get_turf(src), 15, 1.5)
 	recharge_counter++
 
 /obj/machinery/chem_dispenser/proc/display_beaker()

--- a/modular_sand/code/modules/power/cell.dm
+++ b/modular_sand/code/modules/power/cell.dm
@@ -5,7 +5,7 @@
 	icon_state = "vortexcell"
 	maxcharge = 60000
 	custom_materials = list(/datum/material/glass=600)
-	chargerate = 3000 //Recharges slowly.
+	chargerate = 800 //Recharges slowly.
 	self_recharge = 1
 	rating = 6
 

--- a/modular_sand/code/modules/research/designs/power_designs.dm
+++ b/modular_sand/code/modules/research/designs/power_designs.dm
@@ -3,9 +3,9 @@
 	desc = "A power cell that holds 60 MJ of energy and slowly recharge itself."
 	id = "vortex_cell"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 800, /datum/material/gold = 120, /datum/material/glass = 160, /datum/material/diamond = 160, /datum/material/titanium = 300, /datum/material/bluespace = 300)
+	materials = list(/datum/material/iron = 800, /datum/material/gold = 3200, /datum/material/glass = 160, /datum/material/diamond = 1600, /datum/material/titanium = 300, /datum/material/bluespace = 750)
 	construction_time=180
 	build_path = /obj/item/stock_parts/cell/vortex/empty
-	reagents_list = list(/datum/reagent/liquid_dark_matter = 5, /datum/reagent/bluespace = 5, /datum/reagent/teslium/energized_jelly = 10)
+	reagents_list = list(/datum/reagent/liquid_dark_matter = 15, /datum/reagent/bluespace = 15, /datum/reagent/teslium/energized_jelly = 30)
 	category = list("Misc","Power Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING

--- a/modular_sand/code/modules/research/techweb/nodes/alien_nodes.dm
+++ b/modular_sand/code/modules/research/techweb/nodes/alien_nodes.dm
@@ -2,6 +2,6 @@
 	id = "alien_stockparts"
 	display_name = "Theoretical Engineering"
 	description = "A merging of unknown alien designs, bluespace mannagement, and xenobiology."
-	prereq_ids = list("alientech", "emp_super", "alien_engi", "bluespace_power")
+	prereq_ids = list("alientech", "emp_super", "alien_engi", "bluespace_power_reactor")
 	design_ids = list("super_quadultra_micro_laser", "dark_matter_bin", "vortex_cell", "atto_mani", "unilatera_triphasic_scanning", "giga_capacitor", "ultimatebeaker")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 25000)

--- a/modular_splurt/code/modules/power/cell.dm
+++ b/modular_splurt/code/modules/power/cell.dm
@@ -1,9 +1,11 @@
 /obj/item/stock_parts/cell/bluespacereactor
 	name = "bluespace reactor power cell"
-	desc = "A self charging transdimensional power cell, houses a miniature reactor within its bluespace power pocket. Suffers in terms of capacity as a result."
+	desc = "A self charging transdimensional power cell, houses a miniature reactor within its bluespace power pocket. Suffers in terms of capacity as a result and radiates while working."
 	icon_state = "bsreactorcell"
 	maxcharge = 10000
 	custom_materials = list(/datum/material/glass=600)
-	chargerate = 400
+	chargerate = 200
 	rating = 5
 	self_recharge = 1
+	cell_is_radioactive = TRUE
+	rad_strength = 50

--- a/modular_splurt/code/modules/research/designs/power_designs.dm
+++ b/modular_splurt/code/modules/research/designs/power_designs.dm
@@ -1,10 +1,11 @@
 //Jessie Added this
 /datum/design/bluespace_cell_reactor
 	name = "Bluespace Reactor Power Cell"
-	desc = "A power cell that holds 5 MJ of energy."
+	desc = "A power cell that holds 10 MJ of energy."
 	id = "bluespace_cell_reactor"
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = 1200, /datum/material/gold = 260, /datum/material/glass = 360, /datum/material/diamond = 560, /datum/material/titanium = 600, /datum/material/bluespace = 1200, /datum/material/uranium = 2600)
+	reagents_list = list(/datum/reagent/bluespace = 10)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/bluespacereactor
 	category = list("Misc","Power Designs")

--- a/modular_splurt/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/modular_splurt/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -3,6 +3,6 @@
 	id = "bluespace_power_reactor"
 	display_name = "Bluespace Power Reactor Technology"
 	description = "Even more powerful.. POWA!!!"
-	prereq_ids = list("adv_power", "adv_bluespace","bluespace_power")
+	prereq_ids = list("adv_power", "adv_bluespace","bluespace_power", "bluespace_holding")
 	design_ids = list("bluespace_cell_reactor")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12000)


### PR DESCRIPTION
# Описание
1. Реакторки внутри диспенсеров, мехов, киборгов и предметов, а также сами по себе излучают радиацию.
2. Батареи стали меньше регенерировать энергии:
   - Реакторки регенерируют в 2 раза меньше энергии.
   - Вортекс регенерируют в ~3.5 раза меньше энергии.
3. Реакторки требуют блюспейс-пыль для крафта. Вортексы требуют в три раза больше реагентных компонентов для крафта.
4. Ноды исследования реакторных и вортекс батарей стали сильно дороже.
   - Вортекс батареи требуют исследования реакторных батарей, а не обычных.
   - Реакторные батареи теперь требуют Bluespace Pockets исследования.
5. Реакторки у инженеров ОБР были заменены на вортекс. Также у дефибов медиков 

## Причина изменений
1. Устранение меты реакторной батареи не все случаи трат энергии.
2. Подсрачник использовать зарядники, а не забывать о их существовании как явлении.
3. Отсрочка получения вечной батарейки на смене.
4. Ditto предыдущего пункта + коррекция под описание батарей и логику нод.
5. ОБР оснащены наилучшим и не должны облучаться радиацией.

## Демонстрация изменений
Вряд ли нужны. Тут нечего показывать.

## Changelog
:cl:
add: Реакторные батареи излучают радиацию когда не заряжены и заряжены, в разной пропорции.
balance: Реакторные и вортексные батареи регенерируют меньше энергии.
balance: Реакторные и вортексные батареи теперь усложнены в крафте.
balance: Реакторные и вортексные батареи теперь усложнены в изучении.
balance: Реакторные батареи инженеров ОБР заменены на вортексные.
/:cl: