### PR TITLE
rad bold fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1758,7 +1758,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	if(radiation > RAD_MOB_HAIRLOSS)
 		if(prob(15) && !(H.hair_style == "Bald") && (HAIR in species_traits))
 			to_chat(H, "<span class='danger'>Your hair starts to fall out in clumps...</span>")
-			addtimer(CALLBACK(src, PROC_REF(go_bald), H), 50)
+			go_bald(H)
 
 /datum/species/proc/go_bald(mob/living/carbon/human/H)
 	if(QDELETED(H))	//may be called from a timer


### PR DESCRIPTION
# Описание
Багфикс. Радиация после 800 рады с шансом 15 процентов **спавнит таймер** в кукле. При этом не проверяет есть ли он там или нету. Т.Е. **радейка может сделать 50 таймеров и ты будешь лысеть, пока они не пройдут**, даже если у тебя **нету радиации** уже.
Не очень понимаю, какой там смысл таймера в принципе, так, что убрал его, что бы не делать новую лишнюю переменную.

Проверено на локалке