### PR TITLE
capasitor dispenser up

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -26,7 +26,7 @@
 	var/powerefficiency = 0.0666666
 	var/dispenceUnit = 5
 	var/amount = 30
-	var/recharge_amount = 100 // BLUEMOON EDIT
+	var/recharge_amount = 300 // BLUEMOON EDIT
 	var/recharge_counter = 0
 	var/canStore = TRUE//If this can hold reagents or not
 	var/mutable_appearance/beaker_overlay


### PR DESCRIPTION
# Описание
- Скопировал циферки зарядки батарей в диспенсерах с ВМа _(30 раз в 10 секунд, только там тики работы быстрее, поэтому это уже адаптированная версия, а так там 6 в тик на Т1)_

## Причина изменений
Нерф _(убийство реакторок, ибо никто не будет пихать в раздатчики радиактивную шляпу)_. Прошлый мой ап этих циферок делался с учтом наличия реакторок, что бы не было овербыстрой зарядки. Сейчас, я просто взял баланс с ВМа. Энергии если, что тоже будут жрать больше.