### PR TITLE
Обновление шахтёрского вендора 

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -110,10 +110,12 @@
 
 /obj/machinery/mineral/equipment_vendor/RefreshParts()
 	var/discount_rate = 0.0 // Делаем скидку за части выше Т1
-	for(var/obj/item/stock_parts/matter_bin/bin in component_parts) // За каждый бин внутри отдельно
-		discount_rate += 0.025 * (bin.rating - 1)
+	for(var/obj/item/stock_parts/matter_bin/bin in component_parts) // За каждый бин внутри отдельно.
+		discount_rate += 0.025 * (bin.rating - 1) // По 2.5% за тир выше первого.
 
 	for (var/datum/data/mining_equipment/prize in prize_list)
+		if(ispath(prize.equipment_path, /obj/item/card/mining_point_card)) // Чтобы карточки по 50 и 500 очков не стоили меньше нужного.
+			continue
 		prize.cost = max(1, round(prize.base_cost * (1 - discount_rate)))
 
 /obj/machinery/mineral/equipment_vendor/ui_assets(mob/user)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -85,11 +85,13 @@
 	var/equipment_name = "generic"
 	var/equipment_path = null
 	var/cost = 0
+	var/base_cost = 0
 
 /datum/data/mining_equipment/New(name, path, cost)
 	src.equipment_name = name
 	src.equipment_path = path
 	src.cost = cost
+	src.base_cost = cost
 
 /obj/machinery/mineral/equipment_vendor/Initialize(mapload)
 	. = ..()
@@ -112,8 +114,7 @@
 		discount_rate += 0.025 * (bin.rating - 1)
 
 	for (var/datum/data/mining_equipment/prize in prize_list)
-		var/original_cost = prize.cost
-		prize.cost = max(1, round(original_cost * (1 - discount_rate)))
+		prize.cost = max(1, round(prize.base_cost * (1 - discount_rate)))
 
 /obj/machinery/mineral/equipment_vendor/ui_assets(mob/user)
 	return list(

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -106,6 +106,15 @@
 	else
 		icon_state = "[initial(icon_state)]-off"
 
+/obj/machinery/mineral/equipment_vendor/RefreshParts()
+	var/discount_rate = 0.0 // Делаем скидку за части выше Т1
+	for(var/obj/item/stock_parts/matter_bin/bin in component_parts) // За каждый бин внутри отдельно
+		discount_rate += 0.025 * (bin.rating - 1)
+
+	for (var/datum/data/mining_equipment/prize in prize_list)
+		var/original_cost = prize.cost
+		prize.cost = max(1, round(original_cost * (1 - discount_rate)))
+
 /obj/machinery/mineral/equipment_vendor/ui_assets(mob/user)
 	return list(
 		get_asset_datum(/datum/asset/spritesheet/vending),


### PR DESCRIPTION
# Описание
Вендор шахты можно было улучшать, а смысла от улучшения - мало. 
Влепил скидку товара за каждый бин, 2.5% за каждую градацию выше Т1. 
- 15% скидки при трёх Т3 бинах.
- 22.5% скидки при трёх Т4 бинах.
- 30%, почти треть, при Т5 бинах.

## Причина изменений
Теперь его имеет смысл улучшать. Как сказал в блоке кода:
`так будет проще новичкам, что только изучают ассортимент, и приятнее всем. "Копейка рубль бережёт" или типа того.`
Прелесть процентных величин в том, что дешёвые вещи сильно не подешевеют, а дорогие может и заставят попинать учёных, чтобы ваш вендор улучшили.

## Демонстрация изменений
Справа-налево: Т3, Т4, Т5.
![prices](https://github.com/user-attachments/assets/1b588793-46a4-47c5-b557-a8ccc0cc7074)

## Changelog
:cl:
balance: Улучшение вендоров шахты теперь даёт скидку на товары вендора.
/:cl: