### PR TITLE
Хирургия QOL

### DIFF
--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -17,6 +17,7 @@
 /datum/surgery_step/fix_brain
 	name = "Восстановить Мозг"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
+	repeatable = TRUE
 	time = 120 //long and complicated
 	preop_sound = 'sound/surgery/hemostat1.ogg'
 	success_sound = 'sound/surgery/hemostat1.ogg'

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -8,14 +8,16 @@
 /datum/surgery_step/extract_implant
 	name = "Изъять Импланты"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 65)
+	repeatable = TRUE
 	time = 64
 	success_sound = 'sound/surgery/hemostat1.ogg'
 	var/obj/item/implant/I = null
 
 /datum/surgery_step/extract_implant/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/implants = list()
 	for(var/obj/item/O in target.implants)
-		I = O
-		break
+		implants[O.name] = O
+	I = show_radial_menu(user, target, implants, require_near = TRUE, tooltips = TRUE)
 	if(I)
 		display_results(user, target, "<span class='notice'>You begin to extract [I] from [target]'s [target_zone]...</span>",
 			"[user] begins to extract [I] from [target]'s [target_zone].",


### PR DESCRIPTION
# Описание
Радиальное меню при изъятии имплантов, повторение операции по восстановлению мозга.

## Причина изменений
Операция по изъятию имлантов работала очень криво, позволяя вытащить лишь последний вколотый. Операцию по восстановлению мозга нужно было проворачивать с самого начала по нескольку раз, например после лоботомии. 

## Демонстрация изменений
<img width="252" height="215" alt="image" src="https://github.com/user-attachments/assets/d538712e-2454-4dc6-b9fc-66ee6d09617a" />

## Changelog
:cl: 
qol: brain fix, implant removal. better. sosiski.
/:cl:
