### PR TITLE
maebari fix

### DIFF
--- a/modular_splurt/code/modules/clothing/underwear/boxers.dm
+++ b/modular_splurt/code/modules/clothing/underwear/boxers.dm
@@ -13,7 +13,6 @@
 	icon = 'modular_splurt/icons/obj/clothing/underwear.dmi'
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/underwear.dmi'
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
-	body_parts_covered = NONE
 
 /obj/item/clothing/underwear/briefs/panties/maebari/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
# Описание
Все maebari (трусы - наклейки, ХЗ как назвать, для женских персонажей) теперь собственно, закрывают органы.

Проверено на локалке.
## Причина изменений
Не знаю по какой причине, у всего подтипа был вырезан этот флаг, но с моей точки зрения, это не логично. Накладки и прочее, по оверлею перекрывают органы, некоторые с сильным запасом, но при этом почему-то в описании или при возбуждении (когда меняется спрайт) органы вдруг видны, что втройне кринжево, т.к. оверлеи накладываются друг на друга.