### PR TITLE
Улучшение времени активации и обслуживания МОДа

### DIFF
--- a/code/__DEFINES/mod.dm
+++ b/code/__DEFINES/mod.dm
@@ -5,7 +5,7 @@
 #define DEFAULT_CHARGE_DRAIN 5
 
 /// Default time for a part to seal
-#define MOD_ACTIVATION_STEP_TIME (2 SECONDS)
+#define MOD_ACTIVATION_STEP_TIME (1 SECONDS)
 
 /// Passive module, just acts when put in naturally.
 #define MODULE_PASSIVE 0

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -255,7 +255,7 @@
 			balloon_alert(user, "no cell!")
 			return
 		balloon_alert(user, "removing cell...")
-		if(!do_after(user, 1.5 SECONDS, target = src))
+		if(!do_after(user, 1 SECONDS, target = src))
 			balloon_alert(user, "interrupted!")
 			return
 		balloon_alert(user, "cell removed")
@@ -288,7 +288,7 @@
 		return FALSE
 	balloon_alert(user, "[open ? "closing" : "opening"] panel...")
 	screwdriver.play_tool_sound(src, 100)
-	if(screwdriver.use_tool(src, user, 1 SECONDS))
+	if(screwdriver.use_tool(src, user, 0.5 SECONDS))
 		if(active || activating)
 			balloon_alert(user, "deactivate suit first!")
 		screwdriver.play_tool_sound(src, 100)
@@ -345,9 +345,17 @@
 			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 			return FALSE
 		if(cell)
-			balloon_alert(user, "cell already installed!")
-			playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-			return FALSE
+			//balloon_alert(user, "cell already installed!")
+			//playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+			//return FALSE
+			balloon_alert(user, "removing cell...")
+			if(!do_after(user, 1 SECONDS, target = src))
+				balloon_alert(user, "interrupted!")
+				return FALSE
+			balloon_alert(user, "cell removed")
+			playsound(src, 'sound/machines/click.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)
+			cell.forceMove(drop_location())
+			user.put_in_hands(cell)
 		attacking_item.forceMove(src)
 		cell = attacking_item
 		balloon_alert(user, "cell installed")


### PR DESCRIPTION
Ускорено время активации каждой части с 2х секунд до 1 (общее время активации стало 5 секунд, как на ВМ)

Ускорено время раскручивания и время извлечения батареи.

Добавлена быстрая замена батареи, работает как перезарядка оружия кликом батареи по раскрученному моу, старая выпадает на пол. По тестам ощущается в темпе бм