### PR TITLE
Полировка обновления реакторок + обновление радиации

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -59,3 +59,22 @@
 	if(log)
 		log_game("Radiation pulse with intensity: [intensity] and range modifier: [range_modifier] in [loc_name(PL)][spawn_waves ? "" : " (contained by [nested_loc.name])"]")
 	return TRUE
+
+/// Bluemoon add.
+/// Если какой-либо нужный нам item фонит радиацией - этот прок используется для проверок на изоляцию.
+/// Это нужно для того, чтобы предметы в инвентаре, РПЕД и т.д. могли фонить, но не в радмешке для тел или радящике.
+/proc/is_radiation_blocked(atom/A)
+	if(!A)
+		return FALSE
+
+	for(var/atom/X = A; X; X = X.loc)
+		if(istype(X, /turf)) // "голые" турфы не защищают
+			break
+		// если у контейнера задан флаг защиты, радейка заблокируется
+		if(istype(X, /obj/structure/closet) && (X.rad_flags & RAD_PROTECT_CONTENTS))
+			return TRUE
+
+	if(A.rad_flags & RAD_PROTECT_CONTENTS)
+		return TRUE
+
+	return FALSE

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -68,9 +68,9 @@
 		return FALSE
 
 	for(var/atom/X = A; X; X = X.loc)
-		if(istype(X, /turf)) // "голые" турфы не защищают
+		if(istype(X, /turf)) // "Голые" турфы не защищают
 			break
-		// если у контейнера задан флаг защиты, радейка заблокируется
+		// Если у контейнера задан флаг защиты, радейка заблокируется
 		if(istype(X, /obj/structure/closet) && (X.rad_flags & RAD_PROTECT_CONTENTS))
 			return TRUE
 

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -46,7 +46,7 @@
 /datum/component/radioactive/process()
 	if(!prob(50))
 		return
-	radiation_pulse(get_turf(parent), strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
+	radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 
 	if(!hl3_release_date)
 		return
@@ -97,7 +97,7 @@
 	examine_list += out.Join()
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)
-	radiation_pulse(get_turf(parent), strength/20)
+	radiation_pulse(parent, strength/20)
 	target.rad_act(strength/2)
 	if(!hl3_release_date)
 		return

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -44,9 +44,10 @@
 	return ..()
 
 /datum/component/radioactive/process()
-	if(!prob(50))
+	var/turf/T = get_turf(parent)
+	if(!prob(50) || is_radiation_blocked(parent) || !T) // Кроме 50%-ного шанса, проверяем или есть защита на радиацию
 		return
-	radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
+	radiation_pulse(T, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 
 	if(!hl3_release_date)
 		return
@@ -97,7 +98,10 @@
 	examine_list += out.Join()
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)
-	radiation_pulse(parent, strength/20)
+	var/turf/T = get_turf(parent)
+	if(is_radiation_blocked(parent || !T)) // Проверяем или есть защита на радиацию
+		return
+	radiation_pulse(T, strength/20)
 	target.rad_act(strength/2)
 	if(!hl3_release_date)
 		return

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -51,7 +51,7 @@
 		recharge_speed *= C.maxcharge / 10000
 		// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 		if(C.cell_is_radioactive)
-			AddComponent(/datum/component/radioactive, C.rad_strength/2.5, src, 0)
+			AddComponent(/datum/component/radioactive, round(C.rad_strength/1.5, 0.5), src, 0)
 		else
 			qdel(GetComponent(/datum/component/radioactive))
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -51,7 +51,7 @@
 		recharge_speed *= C.maxcharge / 10000
 		// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 		if(C.cell_is_radioactive)
-			AddComponent(/datum/component/radioactive, round(C.rad_strength/1.5, 0.5), src, 0)
+			AddComponent(/datum/component/radioactive, 0, src, 0)
 		else
 			qdel(GetComponent(/datum/component/radioactive))
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -197,7 +197,7 @@
 		return PROCESS_KILL
 	// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 	if(cell.cell_is_radioactive)
-		AddComponent(/datum/component/radioactive, 1, src)
+		AddComponent(/datum/component/radioactive, 0, src)
 	var/malfunctioning_charge_drain = 0
 	if(malfunctioning)
 		malfunctioning_charge_drain = rand(1,20)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -73,13 +73,10 @@
 		return PROCESS_KILL
 
 /// Proc for radioactive cells made with uranium and considered as contaminating its surroundings
-/obj/item/stock_parts/cell/proc/irradiate(datum/component/radioactive/Comp)
+/obj/item/stock_parts/cell/proc/irradiate()
 	AddComponent(/datum/component/radioactive, 0, src, 0)
-	Comp = GetComponent(/datum/component/radioactive)
-	if(charge < maxcharge)
-		Comp.strength = rad_strength
-	else
-		Comp.strength = rad_strength/3.1
+	if(prob(75))
+		radiation_pulse(get_turf(src), rad_strength*(charge < maxcharge ? 1 : 0.5), RAD_DISTANCE_COEFFICIENT*2)
 
 /obj/item/stock_parts/cell/update_overlays()
 	. = ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -73,10 +73,10 @@
 		return PROCESS_KILL
 
 /// Proc for radioactive cells made with uranium and considered as contaminating its surroundings
-/obj/item/stock_parts/cell/proc/irradiate()
+/obj/item/stock_parts/cell/proc/irradiate(datum/component/radioactive/Comp)
 	AddComponent(/datum/component/radioactive, 0, src, 0)
-	if(prob(75))
-		radiation_pulse(get_turf(src), rad_strength*(charge < maxcharge ? 1 : 0.5), RAD_DISTANCE_COEFFICIENT*2)
+	Comp = GetComponent(/datum/component/radioactive)
+	Comp.strength = round(rad_strength*(charge < maxcharge ? 1 : 0.5), 0.5) // Округляем к ближайшей целой половине
 
 /obj/item/stock_parts/cell/update_overlays()
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -474,7 +474,7 @@
 		cell = P
 		// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 		if(P.cell_is_radioactive)
-			AddComponent(/datum/component/radioactive, P.rad_strength/2.5, src, 0)
+			AddComponent(/datum/component/radioactive, round(P.rad_strength/1.5, 0.5), src, 0)
 		else
 			qdel(GetComponent(/datum/component/radioactive))
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -474,7 +474,7 @@
 		cell = P
 		// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 		if(P.cell_is_radioactive)
-			AddComponent(/datum/component/radioactive, round(P.rad_strength/1.5, 0.5), src, 0)
+			AddComponent(/datum/component/radioactive, 0, src, 0)
 		else
 			qdel(GetComponent(/datum/component/radioactive))
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -468,7 +468,7 @@
 
 	// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 	if(cell.cell_is_radioactive)
-		AddComponent(/datum/component/radioactive, 1, src, 0)
+		AddComponent(/datum/component/radioactive, 0, src, 0)
 	else
 		qdel(GetComponent(/datum/component/radioactive))
 

--- a/modular_splurt/code/modules/power/cell.dm
+++ b/modular_splurt/code/modules/power/cell.dm
@@ -8,4 +8,4 @@
 	rating = 5
 	self_recharge = 1
 	cell_is_radioactive = TRUE
-	rad_strength = 45
+	rad_strength = 29


### PR DESCRIPTION
# Описание
1. Изменения датум/компонентов.
   - Добавлен новый прок `is_radiation_blocked()` для проверок на структуру с `RAD_PROTECT_CONTENTS`.
   - Теперь радиация останавливается, если есть защита от радиации от таких структур как: `contamination bodybag`, crate от радиации и т.д.
2. Рефакторнут код радиации батареек. Код теперь сделан более компактным.
3. Реакторная батарея будет фонить меньше.

## Причина изменений
1. Это глобальное изменение, которое теперь позволит надетой одежде и лежащим в инвентаре вещам - корректно фонить, если они сильно облучены.
2. GIIIIT GUUUD (C) Hornet
3. Балансная полировка.

## Демонстрация изменений
Не думаю, что нужно.

## Changelog
:cl:
balance: Реакторная батарея теперь фонит меньше.
code: Ревертнуты изменения компонента радиации.
code: Добавлен новый прок is_radiation_blocked()
refactor: Код irradiate батареек сделан более компактным.
/:cl: