### PR TITLE
[BLUEMOON] Station goals update

### DIFF
--- a/_maps/archive/IceTaxi/Smexistation/bluemoonsmexistation.json
+++ b/_maps/archive/IceTaxi/Smexistation/bluemoonsmexistation.json
@@ -9,6 +9,7 @@
 	"station_ruin_budget": 0,
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
+	"planetary": true,
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/_maps/archive/IceTaxi/Smexistation/smexistation.json
+++ b/_maps/archive/IceTaxi/Smexistation/smexistation.json
@@ -7,6 +7,7 @@
    "station_ruin_budget":0,
    "space_ruin_levels":0,
    "space_empty_levels":0,
+   "planetary": true,
    "shuttles":{
       "cargo":"cargo_box",
       "ferry":"ferry_fancy",

--- a/_maps/icemoonstation.json
+++ b/_maps/icemoonstation.json
@@ -5,6 +5,7 @@
 	"station_ruin_budget": 0,
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
+	"planetary": true,
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1323,8 +1323,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Tip")
 
 /client/proc/modify_goals()
-	set category = "Debug"
-	set name = "Modify goals"
+	set name = "Station Goals"
+	set category = "Admin.Events"
 
 	if(!check_rights(R_ADMIN))
 		return
@@ -1333,8 +1333,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /datum/admins/proc/modify_goals()
 	var/dat = ""
-	for(var/datum/station_goal/S in SSticker.mode.station_goals)
-		dat += "[S.name] - <a href='?src=[REF(S)];[HrefToken()];announce=1'>Announce</a> | <a href='?src=[REF(S)];[HrefToken()];remove=1'>Remove</a> | <a href='?src=[REF(S)];[HrefToken()];complete=1'>Complete</a><br>"
+	for(var/datum/station_goal/S in SSticker.mode?.station_goals)
+		dat += "[S.check_completion() ? "<font color='green'><b>[S.name]</b></font>" : "<font color='red'>[S.name]</font>"] - \
+		<a href='?src=[REF(S)];[HrefToken()];announce=1'>Announce</a> | \
+		<a href='?src=[REF(S)];[HrefToken()];remove=1'>Remove</a> | \
+		<a href='?src=[REF(S)];[HrefToken()];complete=1'>Toggle completion flag</a><br>"
 	dat += "<br><a href='?src=[REF(src)];[HrefToken()];add_station_goal=1'>Add New Goal</a>"
 	usr << browse(dat, "window=goals;size=400x400")
 

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -21,7 +21,7 @@
 
 /datum/station_goal/bluespace_cannon/check_completion()
 	if(!..())
-		return
+		return FALSE
 	for(var/obj/machinery/bsa/full/B in SSmachines.get_machines_by_type(/obj/machinery/bsa/full))
 		if(B && !B.machine_stat && (is_station_level(B.z) || is_mining_level(B.z)))
 			return TRUE

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -8,6 +8,7 @@
 /datum/station_goal/bluespace_cannon/get_report()
 	return {" <b>Наше военное присутствие в вашем секторе недостаточно.</b><br>
 	Нам нужно, чтобы вы построили артиллерийскую установку BSA-[rand(1,99)] на борту вашей станции.
+	После постройки необходимо проверить работоспособность, выстрелив по любой цели.
 	<br><br>
 	Основа для артиллерии доступна к заказу в карго.
 	<br>
@@ -19,11 +20,11 @@
 	P.special_enabled = TRUE
 
 /datum/station_goal/bluespace_cannon/check_completion()
-	if(..())
-		return TRUE
-	var/obj/machinery/bsa/full/B = locate()
-	if(B && !B.machine_stat)
-		return TRUE
+	if(!..())
+		return
+	for(var/obj/machinery/bsa/full/B in SSmachines.get_machines_by_type(/obj/machinery/bsa/full))
+		if(B && !B.machine_stat && (is_station_level(B.z) || is_mining_level(B.z)))
+			return TRUE
 	return FALSE
 
 /obj/machinery/bsa
@@ -207,6 +208,9 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] has launched an artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)].")
 		log_game("[key_name(user)] has launched an artillery strike targeting [AREACOORD(bullseye)].")
 		explosion(bullseye, ex_power, ex_power*2, ex_power*4)
+		if(is_station_level(z) || is_mining_level(z))
+			var/datum/station_goal/bluespace_cannon/B = locate() in SSticker.mode?.station_goals
+			B?.completed = TRUE
 	else
 		message_admins("[ADMIN_LOOKUPFLW(user)] has launched an artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)] but it was blocked by [blocker] at [ADMIN_VERBOSEJMP(target)].")
 		log_game("[key_name(user)] has launched an artillery strike targeting [AREACOORD(bullseye)] but it was blocked by [blocker] at [AREACOORD(target)].")

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -5,7 +5,12 @@ GLOBAL_LIST_EMPTY(meteor_satellites) // BLUEMOON ADD - список всех п�
 // Satellites be actived to generate a shield that will block unorganic matter from passing it.
 /datum/station_goal/station_shield
 	name = "Station Shield"
-	var/coverage_goal = 500
+	var/coverage_goal = 5000 // один средне расположенный спутник покрывает больше 1000 тайлов.
+
+/datum/station_goal/station_shield/can_be_selected()
+	. = ..()
+	if(SSmapping.config.planetary)
+		return FALSE
 
 /datum/station_goal/station_shield/get_report()
 	return {" <b>Сооружение щитов станции</b><br>
@@ -36,7 +41,10 @@ GLOBAL_LIST_EMPTY(meteor_satellites) // BLUEMOON ADD - список всех п�
 		if(!A.active || !is_station_level(A.z))
 			continue
 		coverage |= view(A.kill_range,A)
-	return coverage.len
+	var/counter = 0
+	counter += count_by_type(coverage, /turf/open/space)
+	counter += count_by_type(coverage, /turf/open/openspace)
+	return counter
 
 /obj/machinery/computer/sat_control
 	name = "satellite control"

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_EMPTY(meteor_satellites) // BLUEMOON ADD - список всех п�
 		coverage |= view(A.kill_range,A)
 	var/counter = 0
 	counter += count_by_type(coverage, /turf/open/space)
-	counter += count_by_type(coverage, /turf/open/openspace)
+	counter += count_by_type(coverage, /turf/open/openspace) // for multi-z stations
 	return counter
 
 /obj/machinery/computer/sat_control

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -49,7 +49,7 @@
 	else if(href_list["remove"])
 		qdel(src)
 	else if(href_list["complete"])
-		completed = TRUE
+		completed = !completed
 
 /datum/station_goal/proc/can_be_selected()
 	return TRUE

--- a/modular_bluemoon/code/modules/station_goals/bfl.dm
+++ b/modular_bluemoon/code/modules/station_goals/bfl.dm
@@ -10,7 +10,7 @@
 		return FALSE
 	var/lava_z = pick(L)
 	var/station_z = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
-	if(is_mining_level(station_z) || station_z == lava_z || SSmapping.config.minetype == "none")
+	if(is_mining_level(station_z) || station_z == lava_z || SSmapping.config.minetype == "none" || SSmapping.config.planetary)
 		return FALSE
 
 /datum/station_goal/bfl/get_report()


### PR DESCRIPTION
- Админ панелька для станционных целей переехала во вкладку Admin-Events (называется Station Goals) и отображает цветовой индикацией какие цели действительно выполнены.
- Цель Щиты: выявлена и устранена проблема нереальных процентов покрытия от каждого отдельного саттелита. Повышен порог для выполнения цели. Не должна выдаваться на планетарных картах.
- Цель БСА: устранена проблема, что любая существующая бса в мире засчитывала выполнение цели. Теперь для выполнения цели необходимо сделать хотя бы один выстрел из построенной БСА.