### PR TITLE
Починил потерянный мапером тайл, положил гардероб кэпа 

### DIFF
--- a/_maps/RandomZLevels/away_mission/spacebattle.dmm
+++ b/_maps/RandomZLevels/away_mission/spacebattle.dmm
@@ -2323,6 +2323,7 @@
 /obj/item/clothing/under/trek/command/orv/captain,
 /obj/item/pen/fountain/captain,
 /obj/item/tank/jetpack/oxygen/captain,
+/obj/item/storage/garment_case/captain,
 /turf/open/floor/wood,
 /area/awaymission/spacebattle/cruiser)
 "hL" = (
@@ -6492,7 +6493,11 @@
 /area/awaymission/spacebattle/cruiser)
 "IC" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/space/basic,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "IJ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,


### PR DESCRIPTION
В гейте, на одной из точек спавна, в баре под раздатчиком бухла не было тайла. 

Положил гардероб капитана в ящик, что раньше был ящиком капитана. 