### PR TITLE
Обновление писанины книг в библеотеке

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -120507,7 +120507,6 @@
 /turf/closed/wall/r_wall,
 /area/security/brig_cells)
 "uJd" = (
-/obj/item/kirbyplants/random,
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_y = -26
@@ -120525,6 +120524,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/bookbinder,
 /turf/open/floor/plasteel/dark,
 /area/service/library)
 "uJu" = (

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -456,9 +456,8 @@
 			for(var/mob/V in hearers(src))
 				V.show_message("<b>[src]</b>'s monitor flashes, \"Printer unavailable. Please allow a short time before attempting to print.\"")
 		else
-			bibledelay = 1
-			spawn(60)
-				bibledelay = 0
+			bibledelay = TRUE
+			addtimer(VARSET_CALLBACK(src, bibledelay, FALSE), 2 SECONDS)
 			make_external_book(newbook)
 
 	src.add_fingerprint(usr)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -256,36 +256,38 @@
 			return
 		switch(choice)
 			if("Title")
-				var/newtitle = reject_bad_text(stripped_input(user, "Write a new title:"))
+				var/newtitle = tgui_input_text(usr, "Write a new title:", "Book Labelling", max_length = MAX_NAME_LEN, encode = TRUE)
 				if(!user.canUseTopic(src, BE_CLOSE, literate))
-					return
-				if (length(newtitle) > 30)
-					to_chat(user, "<span class='warning'>That title won't fit on the cover!</span>")
 					return
 				if(!newtitle)
 					to_chat(user, "<span class='warning'>That title is invalid.</span>")
 					return
-				else
-					name = newtitle
-					title = newtitle
+
+				name = newtitle
+				title = newtitle
+				return
+
 			if("Contents")
-				var/content = stripped_input(user, "Write your book's contents (HTML NOT allowed):","","",8192)
+				var/content = tgui_input_text(usr, "Write your book's contents:", "Book contents", max_length = MAX_PAPER_LENGTH, multiline = TRUE, encode = TRUE, prevent_enter = TRUE)
 				if(!user.canUseTopic(src, BE_CLOSE, literate))
 					return
 				if(!content)
 					to_chat(user, "<span class='warning'>The content is invalid.</span>")
 					return
-				else
-					dat += content
+
+				dat += replacetext(content, "\n", "<BR>") + "<br>"
+				return
+
 			if("Author")
-				var/newauthor = stripped_input(user, "Write the author's name:")
+				var/newauthor = tgui_input_text(usr, "Write the author's name:", "Book Author", max_length = MAX_NAME_LEN, encode = TRUE)
 				if(!user.canUseTopic(src, BE_CLOSE, literate))
 					return
 				if(!newauthor)
 					to_chat(user, "<span class='warning'>The name is invalid.</span>")
 					return
-				else
-					author = newauthor
+
+				author = newauthor
+				return
 			else
 				return
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -208,6 +208,7 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 	icon_state = "binder"
 	anchored = 1
 	density = 1
+	var/checking_var = TRUE
 
 /obj/machinery/bookbinder/attackby(obj/item/I, mob/user)
 	var/obj/item/paper/P = I
@@ -226,7 +227,7 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 		src.visible_message("[src] whirs as it prints and binds a new book.")
 		var/obj/item/book/b = new(loc)
 		for(var/datum/paper_input/line in P.raw_text_inputs)
-			b.dat += line.to_raw_html() + "\n"
+			b.dat += replacetext(line.to_raw_html(), "\n", "<BR>") + "<br>"
 		b.name = "Print Job #[rand(100, 999)]"
 		b.icon_state = "book[rand(1,16)]"
 		qdel(P)

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -50,7 +50,7 @@ export const TextInputModal = (_, context) => {
       <Window.Content
         onKeyDown={(event) => {
           const keyCode = window.event ? event.which : event.keyCode;
-          if (keyCode === KEY_ENTER) {
+          if (keyCode === KEY_ENTER && (!multiline || !event.shiftKey)) {
             act('submit', { entry: input });
           }
           if (keyCode === KEY_ESCAPE) {


### PR DESCRIPTION
# Описание
1) Добавлен bookbinder на delta station
2) Делей печати книг теперь 2 секунды вместо 6-ти
3) Все меню выбора в добавлении у книги переделаны по ТГуи
3.1) Предел названия у книги увеличен до 42 символов
3.2) Предел добавления текста за один раз в книгу увеличен до 5000
3.3) Добавлен предел для имени автора в 42 символа
5) Пофикшен перенос текста с листа бумаги в книгу
6) Добавлена возможность удобно делать перенос строки в книгу
7) Шифт-энтер в многострочном меню ввода ТГуи теперь делает перенос строки (ранее любое нажатие enter приводило к submit текста)

## Причина изменений
Улучшения писанины книг
## Демонстрация изменений
<img width="358" height="293" alt="image" src="https://github.com/user-attachments/assets/e134575d-6646-4e01-a678-98226e2538ed" />
<img width="1919" height="1027" alt="image" src="https://github.com/user-attachments/assets/eb9bf668-7dae-4603-a03f-f5ae1a794db4" />

## Changelog
:cl: Winter Schock
qol: улучшено меню взаимодействия с книгами из библиотеки 
map: Добавлен bookbinder на delta station
/:cl:
