### PR TITLE
Доп поинты лодаута для донатеров

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -301,6 +301,10 @@
 /datum/config_entry/number/initial_gear_points
 	default = 16
 
+///Sponsor extra loadout points
+/datum/config_entry/number/sponsor_extra_gear_points
+	default = 4
+
 /**
   * Enables the FoV component, which hides objects and mobs behind the parent from their sight, unless they turn around, duh.
   * Camera mobs, AIs, ghosts and some other are of course exempt from this. This also doesn't influence simplemob AI, for the best.

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "</td>"
 			if(character_settings_tab == LOADOUT_CHAR_TAB) //if loadout
 				//calculate your gear points from the chosen item
-				gear_points = CONFIG_GET(number/initial_gear_points)
+				gear_points = CONFIG_GET(number/initial_gear_points) + (IS_CKEY_DONATOR_GROUP(user.ckey, DONATOR_GROUP_TIER_3) ? CONFIG_GET(number/sponsor_extra_gear_points) : 0)
 				var/list/chosen_gear = loadout_data["SAVE_[loadout_slot]"]
 				if(islist(chosen_gear))
 					loadout_errors = 0

--- a/config/entries/general.txt
+++ b/config/entries/general.txt
@@ -535,6 +535,7 @@ PAI_CUSTOM_HOLOFORMS
 STATION_NAME_NEEDS_APPROVAL
 
 INITIAL_GEAR_POINTS 16
+SPONSOR_EXTRA_GEAR_POINTS 4
 
 ## Strings for the station trait "Randomizing station name"
 RANDOMIZING_STATION_NAME_MESSAGE Due to internal affairs, the station is now named %NEW_STATION_NAME%.

--- a/modular_splurt/code/modules/client/preferences.dm
+++ b/modular_splurt/code/modules/client/preferences.dm
@@ -959,7 +959,7 @@
 
 		if(LOADOUT_TAB)
 			//calculate your gear points from the chosen item
-			gear_points = CONFIG_GET(number/initial_gear_points)
+			gear_points = CONFIG_GET(number/initial_gear_points) + (IS_CKEY_DONATOR_GROUP(user.ckey, DONATOR_GROUP_TIER_3) ? CONFIG_GET(number/sponsor_extra_gear_points) : 0)
 			var/list/chosen_gear = loadout_data["SAVE_[loadout_slot]"]
 			if(chosen_gear)
 				for(var/loadout_item in chosen_gear)


### PR DESCRIPTION
# Описание
1) донатеры 3 тира и выше получают 4 очка лодаута (настраиваемое через конфиг)

## Причина изменений
хе-хе, донат
<img width="626" height="626" alt="image" src="https://github.com/user-attachments/assets/e686f047-c8d4-4dd0-9b4f-e2188ecceafc" />