### PR TITLE
кд на сообщение об ошибке от машинерии и звука у джукбокса

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -152,7 +152,8 @@ Class Procs:
 	var/is_operational = TRUE
 	///Boolean on whether this machines interact with atmos
 	var/atmos_processing = FALSE
-
+	///Machinery error message cooldown
+	COOLDOWN_DECLARE(error_message_cooldown)
 
 /obj/machinery/Initialize(mapload)
 	if(!armor)
@@ -369,11 +370,13 @@ Class Procs:
 
 /obj/machinery/proc/can_transact(obj/item/card/id/thecard, allowdepartment, silent)
 	if(!istype(thecard))
-		if(!silent)
+		if(!silent && COOLDOWN_FINISHED(src, error_message_cooldown))
+			COOLDOWN_START(src, error_message_cooldown, 6 SECONDS)
 			say("Карта не найдена.")
 		return FALSE
 	else if (!thecard.registered_account)
-		if(!silent)
+		if(!silent && COOLDOWN_FINISHED(src, error_message_cooldown))
+			COOLDOWN_START(src, error_message_cooldown, 6 SECONDS)
 			say("Аккаунт не найден.")
 		return FALSE
 //	else if(!allowdepartment && !thecard.registered_account.account_job)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -210,13 +210,15 @@
 					var/mob/living/L = usr
 					C = L.get_idcard(TRUE)
 				if(!can_transact(C))
+					if(COOLDOWN_FINISHED(src, error_message_cooldown))
+						playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 					queuecooldown = world.time + (1 SECONDS)
-					playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 					return
 				if(!attempt_transact(C, queuecost))
-					say("Insufficient funds.")
+					if(COOLDOWN_FINISHED(src, error_message_cooldown))
+						say("Insufficient funds.")
+						playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 					queuecooldown = world.time + (1 SECONDS)
-					playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 					return
 				to_chat(usr, "<span class='notice'>You spend [queuecost] credits to queue [selectedtrack.song_name].</span>")
 				log_econ("[queuecost] credits were inserted into [src] by [key_name(usr)] (ID: [C.registered_name]) to queue [selectedtrack.song_name].")

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -218,6 +218,7 @@
 					if(COOLDOWN_FINISHED(src, error_message_cooldown))
 						say("Insufficient funds.")
 						playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
+						COOLDOWN_START(src, error_message_cooldown, 6 SECONDS)
 					queuecooldown = world.time + (1 SECONDS)
 					return
 				to_chat(usr, "<span class='notice'>You spend [queuecost] credits to queue [selectedtrack.song_name].</span>")


### PR DESCRIPTION
# Описание
1) сообщение об невозможности выполнить операцию теперь имеет кд в 6 секунд (тоесть 10 раз в минуту появляется если прям спамить)
2) звуковое сообщение от джукбокса подвластно этой-же схеме кд в 6 секунд
## Причина изменений
запрет на спам достаточно громким звуком 60 раз в минуту сопровождаемым сообщениями от машинерии добавляющего шума ко всему барками и спамом в чат