### PR TITLE
Фикс использования отеля

### DIFF
--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -121,7 +121,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	var/chosen_room = "Nothing"
 	if(!activeRooms["[chosenRoomNumber]"] && !storedRooms["[chosenRoomNumber]"] && chosenRoomNumber != GLOB.hhmysteryRoomNumber)
 		chosen_room = tgui_input_list(user, "Choose your desired room:", "∼♦️ Time to choose a room ♦️∼!", hotel_maps)
-		if(!chosen_room)
+		if(!chosen_room || !user.CanReach(src))
 			return FALSE
 	//SPLURT EDIT END
 


### PR DESCRIPTION
# Описание
1) Выбор типа комнаты у инфинити дормы требует нахождения около инфинити дормы чтобы в неё телепортироваться

## Причина изменений
защита от использования инфинити дормы как бесплатного тп с любой точки карты