### PR TITLE
Крю манитор на лаваленд + ремап декалей дерева на боксе и ремап офиса СМО на боксе

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -203,6 +203,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white/textured/edge,
 /area/medical/medbay/central)
 "acN" = (
@@ -946,6 +947,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/textured/large,
@@ -3511,8 +3515,7 @@
 /turf/open/floor/grass/grass0,
 /area/service/chapel/main)
 "axK" = (
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/Runtime,
+/obj/machinery/photocopier,
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/cmo)
 "axP" = (
@@ -16532,13 +16535,10 @@
 "bvm" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-28";
-	pixel_y = 6
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/cmo)
 "bvx" = (
@@ -25226,6 +25226,10 @@
 /obj/item/toy/figure/cmo{
 	pixel_y = 9;
 	pixel_x = 8
+	},
+/obj/machinery/computer/security/telescreen/cmo{
+	pixel_x = 0;
+	pixel_y = 29
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/cmo)
@@ -38190,6 +38194,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/medical/medbay/central)
 "eqD" = (
@@ -39609,6 +39614,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/medical/medbay/central)
 "eVc" = (
@@ -40343,6 +40351,9 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-33";
 	pixel_y = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/cmo)
@@ -53428,10 +53439,8 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
-	},
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/cmo)
 "kyS" = (
@@ -58476,12 +58485,15 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "mFJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/cmo)
@@ -60809,6 +60821,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/medical/medbay/central)
 "nzV" = (
@@ -62753,6 +62768,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white/textured/edge{
 	dir = 1
 	},
@@ -68154,6 +68170,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white/textured/large,
 /area/medical/medbay/central)
 "qHr" = (
@@ -69772,6 +69789,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/medical/medbay/central)
 "rrA" = (
@@ -70002,6 +70022,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/command/heads_quarters/cmo)
 "rva" = (
@@ -70601,9 +70622,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "rIz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -70612,6 +70630,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/medical/medbay/central)
@@ -70841,6 +70862,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white/textured/large,
@@ -81249,6 +81273,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/textured/large,
 /area/medical/medbay/central)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -80208,11 +80208,11 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/thin{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/textured/edge{
 	dir = 8

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -101,7 +101,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/wood,
@@ -214,8 +214,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin,
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_large,
@@ -593,10 +593,10 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "agq" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/flora/tree/jungle/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/service/park)
 "agz" = (
@@ -1121,7 +1121,7 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/command/teleporter)
 "amc" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -1631,7 +1631,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "apc" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/carpet/red,
@@ -1963,7 +1963,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/textured/edge{
@@ -2100,7 +2100,7 @@
 	},
 /area/hallway/primary/fore)
 "aqH" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_parquet,
 /area/medical/psychology)
 "aqP" = (
@@ -2327,9 +2327,6 @@
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/textured/half,
 /area/commons/dorms)
 "ash" = (
@@ -2510,7 +2507,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/textured/large,
@@ -2733,12 +2730,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aux" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/textured/large,
-/area/commons/dorms)
 "auD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -2898,9 +2889,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/commons/dorms)
 "avC" = (
@@ -2970,18 +2958,6 @@
 /obj/structure/sign/warning/pods,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"avR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/textured/large,
-/area/commons/dorms)
 "avS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3060,6 +3036,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 4
+	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "awn" = (
@@ -3069,18 +3048,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/maintenance/central)
-"awp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/textured/large,
-/area/commons/dorms)
 "awq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -3092,9 +3059,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/textured/half{
@@ -4446,7 +4410,7 @@
 	pixel_x = 13;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -4866,7 +4830,7 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/commons/fitness)
 "aDR" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/table/wood,
@@ -5165,13 +5129,13 @@
 /area/service/chapel/main)
 "aFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/main)
 "aFG" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -5676,7 +5640,7 @@
 /turf/open/floor/wood/wood_large,
 /area/service/library)
 "aIC" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green/half,
@@ -5840,6 +5804,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 6
+	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "aIY" = (
@@ -5851,6 +5818,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
@@ -6014,6 +5984,7 @@
 "aJy" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
 "aJz" = (
@@ -6280,7 +6251,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -6487,7 +6458,6 @@
 	},
 /area/command/bridge)
 "aLM" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -6495,6 +6465,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/wood_diagonal,
 /area/service/hydroponics/garden)
 "aLP" = (
@@ -6625,7 +6596,7 @@
 /area/service/kitchen)
 "aMM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/wood/wood_large,
@@ -7635,7 +7606,7 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "aQn" = (
@@ -8572,7 +8543,7 @@
 /turf/open/floor/plasteel/textured/large,
 /area/ai_monitored/command/storage/eva)
 "aUf" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/machinery/door/window{
@@ -9441,7 +9412,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet,
 /area/service/library)
 "aXX" = (
@@ -9727,7 +9698,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet,
 /area/service/library)
 "aZa" = (
@@ -9817,7 +9788,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/carpet/royalblack,
@@ -10425,6 +10396,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 1
+	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "bbo" = (
@@ -10504,10 +10478,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -10562,7 +10536,7 @@
 /area/service/theater)
 "bbT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_large,
@@ -10653,7 +10627,7 @@
 	},
 /area/command/bridge)
 "bcd" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
@@ -10692,10 +10666,10 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/captain,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/wood/wood_large,
 /area/command/heads_quarters/captain)
 "bci" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -10953,7 +10927,7 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/security/courtroom)
 "bcN" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -11105,7 +11079,7 @@
 	},
 /area/command/bridge)
 "bdi" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/structure/table/wood,
@@ -11318,12 +11292,12 @@
 /turf/open/floor/wood,
 /area/command/blueshieldoffice)
 "bdI" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/effect/landmark/navigate_destination/hop,
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/hop)
 "bdK" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -11483,7 +11457,7 @@
 	dir = 1;
 	color = "#777777"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -11728,7 +11702,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfk" = (
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /turf/open/floor/wood,
 /area/service/bar)
 "bfo" = (
@@ -11799,7 +11773,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/structure/chair/comfy/black{
@@ -11928,7 +11902,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/wood,
@@ -13007,7 +12981,7 @@
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/hop)
 "bjF" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -13029,7 +13003,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "bjG" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -13050,7 +13024,7 @@
 /turf/open/floor/wood/wood_parquet,
 /area/command/heads_quarters/captain)
 "bjI" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /obj/structure/window/reinforced{
@@ -13870,7 +13844,7 @@
 	pixel_x = 26;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
@@ -14085,7 +14059,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bnu" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /obj/structure/table/wood,
@@ -14488,6 +14462,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 9
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
@@ -18339,7 +18316,7 @@
 /turf/open/floor/plasteel/textured/half,
 /area/commons/storage/primary)
 "bDu" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -19450,7 +19427,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -21971,7 +21948,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -23832,6 +23809,9 @@
 /obj/structure/displaycase/captain,
 /obj/machinery/light_switch{
 	pixel_y = 24
+	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 5
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
@@ -26583,7 +26563,7 @@
 /obj/structure/chair/stool/bar{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/wood,
@@ -33287,9 +33267,6 @@
 /obj/machinery/camera{
 	c_tag = "Chapel North"
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
 /turf/open/floor/carpet/black,
 /area/service/chapel/main)
 "cCP" = (
@@ -33469,7 +33446,7 @@
 	},
 /area/cargo/sorting)
 "cFn" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -33887,7 +33864,7 @@
 /turf/open/floor/plasteel/textured/corner,
 /area/security/prison/workout)
 "cKS" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -35293,7 +35270,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -35351,7 +35328,7 @@
 /turf/open/floor/grass/grass0,
 /area/service/chapel/main)
 "dgK" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -35433,6 +35410,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/service/library)
+"diH" = (
+/obj/effect/turf_decal/siding/wood/thin,
+/turf/open/floor/carpet/green,
+/area/commons/dorms)
 "diL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -36271,7 +36252,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/wood,
@@ -36839,7 +36820,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -36984,7 +36965,7 @@
 "dOk" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/splurt_space_law,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/item/folder/blue,
 /obj/item/stamp/law,
 /turf/open/floor/wood/wood_large,
@@ -37384,14 +37365,14 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_parquet,
 /area/medical/psychology)
 "dYB" = (
 /obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -37675,7 +37656,7 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/ntr)
 "eev" = (
@@ -37755,13 +37736,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "egM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -38545,7 +38526,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -38771,10 +38752,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eDt" = (
+/obj/structure/flora/junglebush/large,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
 /area/service/park)
 "eDu" = (
@@ -38956,10 +38937,10 @@
 "eIF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /turf/open/floor/wood,
 /area/service/bar)
 "eIG" = (
@@ -39063,10 +39044,10 @@
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -39162,7 +39143,7 @@
 /area/maintenance/fore/secondary)
 "eMI" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/hallway/primary/fore)
 "eNc" = (
@@ -39298,12 +39279,6 @@
 	dir = 8
 	},
 /area/security/prison/garden)
-"ePT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/textured/large,
-/area/commons/fitness)
 "ePV" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -39356,7 +39331,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/item/kirbyplants/hedge{
@@ -39632,7 +39607,7 @@
 	req_access_txt = "76"
 	},
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -40088,9 +40063,10 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "fgp" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/wood_large,
 /area/service/bar)
 "fgu" = (
@@ -40447,12 +40423,12 @@
 	},
 /area/hallway/primary/aft)
 "fns" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /obj/machinery/light/floor{
 	pixel_x = 7;
 	pixel_y = -7
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
 /turf/open/floor/plasteel/smooth/corner,
 /area/service/park)
@@ -40540,7 +40516,7 @@
 	pixel_x = -9;
 	pixel_y = 9
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_large,
@@ -40637,7 +40613,7 @@
 	specialfunctions = 4;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/security/brig)
 "frk" = (
@@ -40691,7 +40667,7 @@
 "fsz" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
@@ -40775,7 +40751,7 @@
 /obj/item/pen/fountain{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/main)
 "fty" = (
@@ -40887,7 +40863,7 @@
 /obj/item/pet_carrier{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -41390,7 +41366,7 @@
 /area/hallway/primary/central)
 "fEG" = (
 /obj/effect/landmark/navigate_destination/bar,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -42046,7 +42022,7 @@
 "fSK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -42249,7 +42225,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/wood,
@@ -42360,7 +42336,7 @@
 "fYM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -42558,15 +42534,15 @@
 /turf/open/floor/carpet/royalblue,
 /area/maintenance/starboard/aft)
 "gcA" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
 /obj/structure/flora/grass/jungle,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -42601,7 +42577,7 @@
 	pixel_x = 6;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /obj/structure/sign/poster/contraband/vulp1{
@@ -43127,7 +43103,7 @@
 /obj/structure/chair/sofa/left/maroon{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -43137,7 +43113,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_tiled,
 /area/commons/fitness/recreation)
 "gpk" = (
@@ -43428,7 +43404,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -43459,7 +43435,7 @@
 	},
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/head_of_security,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -43541,6 +43517,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet)
+"gxQ" = (
+/obj/effect/turf_decal/siding/wood/thin,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/captain)
 "gxT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43864,7 +43844,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/carpet/green,
@@ -43994,7 +43974,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
@@ -44233,13 +44213,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/commons/fitness)
 "gKO" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
@@ -45601,7 +45578,7 @@
 /turf/open/floor/plasteel/dark/textured/edge,
 /area/security/brig)
 "hjQ" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_tiled,
 /area/commons/fitness/recreation)
 "hke" = (
@@ -46108,7 +46085,7 @@
 	light_color = "#d1dfff"
 	},
 /obj/structure/chair/sofa/right/brown,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -46383,7 +46360,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -46421,7 +46398,7 @@
 	pixel_x = -24
 	},
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -46473,7 +46450,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -46663,7 +46640,6 @@
 	light_range = 4;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/flora/rock/pile,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -46671,13 +46647,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/grass,
 /area/service/park)
 "hHw" = (
 /turf/closed/wall,
 /area/hallway/secondary/construction)
 "hHM" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /obj/machinery/light/small,
@@ -46740,7 +46717,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -46973,7 +46950,7 @@
 "hMS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
@@ -47020,7 +46997,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -47506,7 +47483,7 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "iak" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -47537,10 +47514,10 @@
 /turf/open/floor/plasteel/textured,
 /area/hallway/secondary/exit)
 "iaw" = (
+/obj/structure/flora/tree/jungle/small,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
 /area/service/park)
 "iaF" = (
@@ -47614,7 +47591,7 @@
 /turf/open/floor/plasteel/white/textured/corner,
 /area/medical/medbay/zone2)
 "ibO" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -47724,7 +47701,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/psychologist,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_parquet,
 /area/medical/psychology)
 "idT" = (
@@ -48127,7 +48104,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "inW" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /turf/open/floor/wood/wood_large,
@@ -48148,7 +48125,7 @@
 	layer = 2.79;
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -48543,7 +48520,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "izk" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /obj/structure/sign/poster/contraband/yes_erp{
@@ -48622,7 +48599,7 @@
 /obj/item/folder/blue,
 /obj/item/stamp/law,
 /obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_large,
@@ -48763,7 +48740,7 @@
 /turf/open/floor/wood/wood_tiled,
 /area/command/heads_quarters/ntr)
 "iFx" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -48772,7 +48749,7 @@
 /obj/structure/bed/double{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/item/bedsheet/brown/double{
@@ -49191,7 +49168,7 @@
 "iMz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /turf/open/floor/wood,
@@ -49215,7 +49192,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/item/kirbyplants/hedge{
@@ -49245,7 +49222,7 @@
 /turf/open/floor/plasteel/dark/textured/half,
 /area/security/prison)
 "iNA" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -49621,10 +49598,10 @@
 /obj/machinery/camera{
 	c_tag = "Park2"
 	},
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/grass,
 /area/service/park)
 "iWE" = (
@@ -50020,7 +49997,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_large,
@@ -50231,7 +50208,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -50546,7 +50523,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_tiled,
 /area/commons/fitness/recreation)
 "jpO" = (
@@ -50683,7 +50660,7 @@
 	pixel_y = 9;
 	layer = 2.78
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /obj/item/paper/fluff/ruins/security_arsenal{
@@ -50882,7 +50859,7 @@
 	},
 /area/medical/medbay/zone2)
 "jxo" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/structure/chair/sofa/left/brown{
@@ -51014,13 +50991,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "jBd" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/service/park)
 "jBf" = (
@@ -51303,6 +51280,9 @@
 /area/engineering/atmos)
 "jGZ" = (
 /obj/machinery/suit_storage_unit/captain,
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 10
+	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "jHc" = (
@@ -51690,7 +51670,7 @@
 	},
 /area/commons/fitness)
 "jLJ" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/main)
 "jLO" = (
@@ -51881,10 +51861,10 @@
 /turf/open/floor/plasteel/textured/half,
 /area/security/courtroom)
 "jPj" = (
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/service/park)
 "jPz" = (
@@ -51961,7 +51941,7 @@
 /turf/open/floor/plasteel/textured/large,
 /area/commons/storage/tools)
 "jRE" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -52117,7 +52097,7 @@
 	},
 /area/science/robotics/lab)
 "jVS" = (
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -52176,10 +52156,10 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "jWZ" = (
@@ -52191,9 +52171,6 @@
 	},
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark/textured/half{
 	dir = 4
@@ -52409,7 +52386,7 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -52584,7 +52561,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/wood,
@@ -52613,6 +52590,11 @@
 	},
 /turf/open/floor/plasteel/textured/half,
 /area/hallway/secondary/entry)
+"khh" = (
+/obj/structure/table/wood/poker,
+/obj/effect/turf_decal/siding/wood/thin,
+/turf/open/floor/carpet/green,
+/area/commons/dorms)
 "khZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/blue/half,
@@ -52811,7 +52793,7 @@
 /area/maintenance/central)
 "kmD" = (
 /obj/machinery/vending/kink,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /obj/structure/cable{
@@ -53039,7 +53021,7 @@
 /turf/open/floor/wood/wood_large,
 /area/security/prison/rec)
 "kpl" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -53109,7 +53091,7 @@
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -53499,7 +53481,7 @@
 /turf/open/floor/plasteel/textured/corner,
 /area/cargo/office)
 "kzR" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -53878,7 +53860,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "kHs" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -54260,7 +54242,7 @@
 	},
 /area/medical/surgery)
 "kPu" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -54718,11 +54700,11 @@
 /area/medical/medbay/zone2)
 "laC" = (
 /obj/structure/flora/rock/pile,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -54741,7 +54723,7 @@
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/office)
 "lbV" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/machinery/vending/cart,
@@ -54946,7 +54928,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /turf/open/floor/wood/wood_large,
@@ -55055,11 +55037,11 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/textured/edge{
 	dir = 4
@@ -56075,7 +56057,7 @@
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /turf/open/floor/wood/wood_parquet,
 /area/medical/psychology)
 "lIl" = (
@@ -56435,7 +56417,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
@@ -56874,7 +56856,7 @@
 	dir = 1
 	},
 /obj/structure/dresser,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -56933,7 +56915,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -57136,10 +57118,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -57197,9 +57179,6 @@
 	dir = 8
 	},
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark/textured/half{
 	dir = 1
 	},
@@ -57271,7 +57250,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/captain)
 "mhs" = (
@@ -57516,7 +57495,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mnv" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/hallway/primary/fore)
 "mny" = (
@@ -58045,8 +58024,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -58415,10 +58394,10 @@
 /turf/open/floor/plasteel/textured/large,
 /area/hallway/primary/central)
 "mDX" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_large,
@@ -58887,7 +58866,7 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "mPk" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -59142,10 +59121,10 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "mSi" = (
+/obj/structure/flora/grass/jungle,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/service/park)
 "mSm" = (
@@ -59438,7 +59417,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/commons/cryopod)
 "mXE" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/effect/landmark/start/bouncer,
@@ -59578,13 +59557,13 @@
 	},
 /area/science)
 "nbx" = (
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/grass,
 /area/service/park)
 "nbF" = (
@@ -60033,7 +60012,7 @@
 	},
 /area/commons/fitness/recreation)
 "nly" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/vending/coffee,
@@ -60604,7 +60583,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nuy" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_large,
@@ -60715,6 +60694,9 @@
 "nxu" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 10
 	},
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
@@ -60968,7 +60950,7 @@
 "nDw" = (
 /obj/structure/dresser,
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/ntr)
 "nDz" = (
@@ -61233,7 +61215,7 @@
 	req_access_txt = "76"
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -61776,7 +61758,7 @@
 /area/security/brig/brig_medical)
 "nVL" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/white/corner{
@@ -61917,7 +61899,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/table/wood,
@@ -62094,7 +62076,7 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/commons/locker)
 "odq" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -62289,7 +62271,7 @@
 	},
 /area/medical/medbay/central)
 "ohQ" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -62538,7 +62520,7 @@
 /obj/structure/table,
 /obj/item/clothing/mask/muzzle/ballgag,
 /obj/item/clothing/neck/petcollar/locked/holo,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -62756,7 +62738,7 @@
 	name = "Captain's Desk Door";
 	req_access_txt = "20"
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
@@ -63128,13 +63110,13 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "oyc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "oyl" = (
@@ -63853,7 +63835,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oNt" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
@@ -63890,7 +63872,7 @@
 /turf/open/floor/grass,
 /area/service/park)
 "oOg" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -64047,12 +64029,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/grass,
 /area/command/bridge)
-"oUa" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/textured/large,
-/area/commons/fitness)
 "oUe" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -64138,10 +64114,10 @@
 /area/space/nearstation)
 "oUN" = (
 /obj/item/kirbyplants/hedge,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -64280,6 +64256,9 @@
 	},
 /area/science/xenobiology)
 "oXz" = (
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 6
+	},
 /turf/open/floor/carpet,
 /area/commons/fitness)
 "oXP" = (
@@ -64961,7 +64940,7 @@
 /area/ai_monitored/security/armory)
 "pph" = (
 /obj/structure/chair/sofa/left/brown,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /obj/machinery/light{
@@ -65026,7 +65005,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/service/library)
@@ -65172,6 +65151,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
 "ptF" = (
@@ -65190,7 +65170,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -65582,7 +65562,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/captain)
 "pCP" = (
@@ -66011,8 +65991,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin,
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_large,
@@ -66073,11 +66053,11 @@
 /turf/open/floor/plasteel/white/textured/half,
 /area/security/brig/brig_medical)
 "pNN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/flora/grass/jungle/b{
 	icon_state = "grassa5"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -66292,7 +66272,7 @@
 	},
 /area/security/warden)
 "pTa" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green/half,
@@ -66581,13 +66561,13 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "pZw" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -66751,12 +66731,12 @@
 /area/medical/genetics)
 "qeb" = (
 /obj/structure/flora/junglebush/large,
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/grass,
 /area/service/park)
 "qei" = (
@@ -66816,7 +66796,7 @@
 /area/security/office)
 "qfa" = (
 /obj/structure/chair/sofa/right/maroon,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -67159,7 +67139,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
@@ -67316,12 +67296,12 @@
 	},
 /area/security/courtroom)
 "qoz" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "qoC" = (
@@ -67367,7 +67347,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "qpe" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
@@ -67593,9 +67573,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark/textured/large,
 /area/commons/dorms)
 "qsc" = (
@@ -67648,7 +67625,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/carpet/red,
@@ -67919,10 +67896,10 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green/half,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/plasteel/dark/textured/half{
 	dir = 4
 	},
@@ -68073,10 +68050,10 @@
 /turf/open/floor/plasteel/textured/large,
 /area/cargo/sorting)
 "qEz" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -68470,9 +68447,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -68502,15 +68476,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "qOZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/camera{
 	c_tag = "Garden"
 	},
 /obj/structure/sink{
 	pixel_y = 30
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/service/hydroponics/garden)
@@ -68759,7 +68733,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -68888,7 +68862,7 @@
 /area/hallway/secondary/entry)
 "qXm" = (
 /obj/machinery/jukebox,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -68987,7 +68961,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white/corner,
@@ -69418,7 +69392,7 @@
 /area/solars/starboard/fore)
 "rjb" = (
 /obj/structure/chair/sofa/left/brown,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/dymai{
@@ -69533,7 +69507,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/textured/edge,
@@ -69673,7 +69647,7 @@
 /turf/open/floor/carpet/red,
 /area/security/prison/rec)
 "roC" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/carpet/red,
@@ -69689,7 +69663,7 @@
 /turf/open/floor/plasteel/white/textured/half,
 /area/security/brig/brig_medical)
 "rpG" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
@@ -69737,7 +69711,7 @@
 /obj/structure/bed{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/wood/wood_large,
@@ -70196,7 +70170,7 @@
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -70271,9 +70245,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rCw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/structure/flora/ausbushes/brflowers,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -70281,11 +70252,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/grass,
 /area/service/park)
 "rCy" = (
 /obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -70359,7 +70333,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /obj/item/kirbyplants/hedge{
@@ -70521,7 +70495,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/carpet,
@@ -70540,7 +70514,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet/green,
@@ -70893,7 +70867,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/wood/wood_large,
@@ -71228,7 +71202,7 @@
 /area/service/park)
 "rWK" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -72020,7 +71994,7 @@
 /turf/open/floor/wood/wood_diagonal,
 /area/maintenance/port/fore)
 "spT" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_tiled,
@@ -73190,7 +73164,7 @@
 /turf/open/floor/plasteel/textured/large,
 /area/security/prison/rec)
 "sPd" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/noticeboard{
@@ -73253,7 +73227,7 @@
 /area/cargo/storage)
 "sPz" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/security/brig)
 "sPT" = (
@@ -73617,7 +73591,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -73654,7 +73628,7 @@
 	pixel_x = 4;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/main)
 "sZu" = (
@@ -74088,7 +74062,7 @@
 /turf/template_noop,
 /area/template_noop)
 "tjq" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/machinery/button/door{
@@ -74830,7 +74804,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /turf/open/floor/wood/wood_large,
@@ -75217,7 +75191,7 @@
 /obj/structure/table,
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -75798,7 +75772,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "tRE" = (
@@ -76125,7 +76099,7 @@
 	pixel_y = 9;
 	layer = 2.78
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -76423,10 +76397,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark/textured/edge{
 	dir = 1
 	},
@@ -76887,6 +76861,15 @@
 	dir = 4
 	},
 /area/security/detectives_office/private_investigators_office/investigators_room)
+"umz" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/commons/dorms)
 "umW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -76946,7 +76929,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/structure/chair/wood{
@@ -77204,7 +77187,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uvi" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_large,
@@ -77346,7 +77329,7 @@
 /area/maintenance/starboard/aft)
 "uwO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/wood/wood_large,
@@ -77843,7 +77826,7 @@
 /area/hallway/secondary/entry)
 "uHA" = (
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
@@ -78020,7 +78003,7 @@
 	},
 /area/maintenance/starboard/aft)
 "uMb" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -78071,7 +78054,7 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/cargo/sorting)
 "uNs" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/structure/chair/wood{
@@ -78374,10 +78357,10 @@
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_large,
@@ -78673,7 +78656,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_large,
@@ -78785,7 +78768,7 @@
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -78811,7 +78794,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/navigate_destination/library,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -79456,11 +79439,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vqV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -79805,12 +79788,12 @@
 /turf/open/floor/grass,
 /area/service/park)
 "vyE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
 /obj/machinery/light/floor{
 	pixel_x = -8;
 	pixel_y = -7
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
 /turf/open/floor/plasteel/smooth/corner{
 	dir = 8
@@ -79875,7 +79858,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/service/bar)
 "vzx" = (
@@ -80225,7 +80208,7 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
@@ -80240,10 +80223,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /turf/open/floor/wood/wood_large,
 /area/service/bar)
 "vDX" = (
@@ -80313,7 +80296,7 @@
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/hop)
 "vFk" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -80650,18 +80633,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "vJU" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/service/bar)
 "vJX" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/service/park)
@@ -80696,7 +80679,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_parquet,
@@ -80726,7 +80709,7 @@
 	},
 /area/hallway/secondary/exit)
 "vKW" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 5
 	},
 /turf/open/floor/carpet/red,
@@ -80889,7 +80872,7 @@
 /area/medical/medbay/central)
 "vOf" = (
 /obj/structure/chair/sofa/right/brown,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/security/brig)
 "vOj" = (
@@ -81118,7 +81101,7 @@
 /turf/open/floor/plasteel/textured/large,
 /area/security/office)
 "vTQ" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/wood/wood_large,
@@ -81196,7 +81179,7 @@
 /obj/structure/chair/stool/bar{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -81324,17 +81307,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/service/library)
 "vYh" = (
+/obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/service/park)
 "vYx" = (
@@ -81711,7 +81694,7 @@
 /turf/open/floor/plasteel/white/textured/corner,
 /area/science/robotics/lab)
 "wgU" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -81790,7 +81773,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wjh" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/carpet/red,
@@ -82414,6 +82397,13 @@
 	},
 /turf/open/floor/plasteel/textured/half,
 /area/security/office)
+"wuF" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/thin,
+/turf/open/floor/carpet,
+/area/commons/fitness)
 "wuO" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -82519,7 +82509,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/structure/chair/comfy/black{
@@ -82685,7 +82675,6 @@
 /turf/open/floor/plasteel/textured,
 /area/hallway/secondary/exit)
 "wAN" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -82693,6 +82682,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/service/park)
 "wAP" = (
@@ -82736,7 +82726,7 @@
 /turf/open/floor/plasteel/white/textured/half,
 /area/science)
 "wBz" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 6
 	},
 /turf/open/floor/wood,
@@ -83059,7 +83049,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -83254,7 +83244,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/cargo/storage)
 "wKZ" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/south,
@@ -83311,10 +83301,10 @@
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/service/park)
 "wMH" = (
@@ -83486,7 +83476,7 @@
 	pixel_y = 4
 	},
 /obj/item/book/manual/splurt_space_law,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -83503,7 +83493,7 @@
 /area/command/bridge)
 "wRY" = (
 /obj/item/kirbyplants/hedge,
-/obj/effect/turf_decal/siding/wood/end{
+/obj/effect/turf_decal/siding/wood/thin/end{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -83812,7 +83802,7 @@
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/shoes/sandal,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -83910,11 +83900,11 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/command/heads_quarters/hos)
 "wYP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/service/hydroponics/garden)
@@ -84064,10 +84054,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/wood_large,
 /area/service/bar)
 "xfe" = (
@@ -84107,7 +84097,7 @@
 /turf/open/floor/plasteel/dark/textured/large,
 /area/medical/morgue)
 "xfN" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
@@ -84173,7 +84163,7 @@
 /area/maintenance/starboard/aft)
 "xgu" = (
 /obj/structure/dresser,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -84533,7 +84523,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "xng" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
@@ -84652,12 +84642,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"xrJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/textured/large,
-/area/commons/fitness)
 "xsc" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
@@ -84980,7 +84964,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/carpet/red,
@@ -84994,7 +84978,7 @@
 	specialfunctions = 4;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/thin/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -85003,7 +84987,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/thin/corner,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -85234,7 +85218,7 @@
 /turf/open/floor/plasteel/textured/half,
 /area/security/range)
 "xGZ" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /obj/machinery/vending/games{
 	onstation = 0
 	},
@@ -85370,6 +85354,12 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/textured/large,
 /area/security/office)
+"xLo" = (
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/commons/fitness)
 "xLB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -85528,7 +85518,7 @@
 /obj/structure/transmitter/command{
 	pixel_x = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
@@ -85542,7 +85532,7 @@
 	},
 /area/security/office)
 "xOR" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 10
 	},
 /turf/open/floor/wood,
@@ -85702,7 +85692,7 @@
 /turf/open/floor/plasteel/textured/large,
 /area/cargo/sorting)
 "xTm" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /obj/structure/table/wood,
@@ -86295,7 +86285,7 @@
 "ydV" = (
 /obj/structure/table,
 /obj/item/clothing/head/hardhat/cakehat,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -86420,6 +86410,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/cargo/storage)
+"yjf" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/thin,
+/turf/open/floor/carpet,
+/area/commons/fitness)
 "yjD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -116479,7 +116476,7 @@ aZV
 ugG
 bbn
 bcg
-bcP
+gxQ
 beg
 aZV
 aDl
@@ -117993,9 +117990,9 @@ cjo
 aqg
 arf
 asf
-aux
-aux
-aux
+nxf
+nxf
+nxf
 avt
 vzy
 oxf
@@ -118249,11 +118246,11 @@ ajy
 ajy
 aqe
 arf
+umz
+umz
+umz
 nxu
-nxu
-nxu
-nxu
-awp
+avt
 jlG
 uyk
 uyk
@@ -118509,7 +118506,7 @@ arf
 phF
 aqo
 rgL
-aqo
+khh
 qrT
 sex
 uyk
@@ -118767,7 +118764,7 @@ asm
 blU
 blU
 ptE
-awp
+avt
 vQl
 uyk
 gva
@@ -119023,8 +119020,8 @@ arf
 ari
 ari
 ari
-ari
-avR
+diH
+xoY
 jlG
 uyk
 xsX
@@ -125948,7 +125945,7 @@ axR
 ceV
 lcm
 axR
-ceV
+wuF
 mfl
 wQW
 jgV
@@ -126205,8 +126202,8 @@ oRS
 azz
 avb
 axR
-azz
-xrJ
+yjf
+ghD
 tcx
 avC
 weU
@@ -126457,13 +126454,13 @@ wet
 wet
 wet
 wet
+xLo
+xLo
+xLo
+xLo
+xLo
 oXz
-oXz
-oXz
-oXz
-oXz
-oXz
-xrJ
+ghD
 ghD
 ghD
 czS
@@ -126715,12 +126712,12 @@ iEr
 bym
 wet
 jWZ
-ePT
-ePT
-ePT
+ghD
+ghD
+ghD
 gKr
-ePT
-oUa
+ghD
+ghD
 ghD
 ghD
 czS

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -11469,13 +11469,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "jxk" = (
-/obj/machinery/camera{
-	c_tag = "Sleeper Room";
-	dir = 8;
-	network = list("mine")
-	},
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "jxE" = (
@@ -17609,6 +17603,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/lavaland/unpowered/deepspaceone/security)
+"nVU" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/white,
+/area/mine/living_quarters)
 "nWq" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -18262,6 +18261,12 @@
 /obj/item/clothing/shoes/clockwork,
 /turf/open/indestructible/boss,
 /area/lavaland/necropolis)
+"ovd" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/living_quarters)
 "ovQ" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/yellow/line{
@@ -133508,7 +133513,7 @@ fAr
 cLH
 hAO
 jxk
-gqn
+ovd
 rIe
 vUy
 abn
@@ -133765,8 +133770,8 @@ hGR
 okz
 abn
 abn
-abn
-abn
+nVU
+gqn
 abn
 abn
 llq
@@ -134022,9 +134027,9 @@ fAr
 cLH
 xTx
 abn
-llq
-llq
-llq
+abn
+abn
+abn
 llq
 llq
 gIl


### PR DESCRIPTION
# Описание
1) добавлен крю монитор на лаваленде чтобы работала систем hero998 с подвязкой датчиков на крю мониторы
2) добавлен телеэкран в офис смо, мусорка и принтер
3) заменены декали дерева на боксе

## Причина изменений
улучшение игры при помощи маппинга