### PR TITLE
Кроциновая ядовитость

### DIFF
--- a/code/__BLUEMOONCODE/_DEFINES/traits.dm
+++ b/code/__BLUEMOONCODE/_DEFINES/traits.dm
@@ -13,6 +13,7 @@
 #define TRAIT_BLUEMOON_COOLANT_GENERATOR	"coolant_generator"
 #define TRAIT_BLUEMOON_WATER_VULNERABILITY	"robotic_water_vulnerability"
 #define TRAIT_BLUEMOON_EMP_VULNERABILITY	"robotic_emp_vulnerability"
+#define TRAIT_BLUEMOON_CROCIN_POISONOUS		"crocin_poisonous"
 #define TRAIT_LEWD_JOB						"lewd_job"
 #define TRAIT_LEWD_SUMMON					"Призываемый"
 #define TRAIT_LEWD_SUMMONED					"lewd_summoned"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -846,3 +846,7 @@
 // BLUEMOON ADD — pregnancy signals
 #define COMSIG_PREGNANCY_STARTED "pregnancy_started"
 #define COMSIG_PREGNANCY_ENDED "pregnancy_ended"
+
+// interaction signals
+#define COMSIG_INTERACTION_ADJACENT "interaction_adjacent"
+#define COMSIG_INTERACTION_KISS		"interaction_kiss"

--- a/modular_bluemoon/code/datums/traits/neutral/crocin_poisonous.dm
+++ b/modular_bluemoon/code/datums/traits/neutral/crocin_poisonous.dm
@@ -1,0 +1,28 @@
+
+/datum/quirk/crocin_poisonous
+	name = "Кроциновая токсичность"
+	desc = "Ваше тело выделяет кроцин, легко проникающий в чужой организм при близком контакте. Особую эффективность имеют в этом поцелуи."
+	value = 0
+	medical_record_text = "Пациент имеет токсичность с выделением кроцина на своём теле."
+	mob_trait = TRAIT_BLUEMOON_CROCIN_POISONOUS
+	gain_text = span_notice("Вы ощущаете свою токсичность")
+	lose_text = span_notice("Вы стали менее токсичны. Как минимум физически.")
+
+/datum/quirk/crocin_poisonous/add()
+	RegisterSignal(quirk_holder, COMSIG_INTERACTION_ADJACENT, PROC_REF(pois), TRUE)
+	RegisterSignal(quirk_holder, COMSIG_INTERACTION_KISS, PROC_REF(kiss_pois), TRUE)
+
+/datum/quirk/crocin_poisonous/remove()
+	UnregisterSignal(quirk_holder, list(COMSIG_INTERACTION_ADJACENT, COMSIG_INTERACTION_KISS))
+
+/datum/quirk/crocin_poisonous/proc/kiss_pois(mob/living/user, mob/living/target)
+	SIGNAL_HANDLER
+	pois(user, target, /datum/reagent/drug/aphrodisiacplus)
+
+/datum/quirk/crocin_poisonous/proc/pois(mob/living/user, mob/living/target, datum/reagent/used_reagent = /datum/reagent/drug/aphrodisiac)
+	SIGNAL_HANDLER
+	if(!target.reagents)
+		return
+	var/reagent_amount = target.reagents.get_reagent_amount(used_reagent)
+	if(reagent_amount < 2)
+		target.reagents.add_reagent(used_reagent, 2 - reagent_amount)

--- a/modular_bluemoon/code/modules/plug13_integration/bluemoon_interaction.dm
+++ b/modular_bluemoon/code/modules/plug13_integration/bluemoon_interaction.dm
@@ -42,6 +42,9 @@
 			p13target_duration
 		)
 
+	if(interaction_flags & INTERACTION_FLAG_ADJACENT && user != target)
+		SEND_SIGNAL(user, COMSIG_INTERACTION_ADJACENT, target)
+		SEND_SIGNAL(target, COMSIG_INTERACTION_ADJACENT, user)
 
 /datum/interaction/proc/get_lust_modifier(mob/living/user)
 	return (20 * (user.get_lust() / user.get_lust_tolerance())) - 10

--- a/modular_splurt/code/datums/interactions/lewd/lewd_datums.dm
+++ b/modular_splurt/code/datums/interactions/lewd/lewd_datums.dm
@@ -510,6 +510,9 @@
 /datum/interaction/lewd/kiss/post_interaction(mob/living/user, mob/living/partner)
 	. = ..()
 
+	SEND_SIGNAL(user, COMSIG_INTERACTION_KISS, partner)
+	SEND_SIGNAL(partner, COMSIG_INTERACTION_KISS, user)
+
 	//SPLURT EDIT START:
 	// Check if user has TRAIT_KISS_SLUT and increase their lust
 	if(HAS_TRAIT(user, TRAIT_KISS_SLUT))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4297,6 +4297,7 @@
 #include "modular_bluemoon\code\datums\traits\negative\shower_trait.dm"
 #include "modular_bluemoon\code\datums\traits\negative\water_vulnerability.dm"
 #include "modular_bluemoon\code\datums\traits\neutral\criminal_quirk.dm"
+#include "modular_bluemoon\code\datums\traits\neutral\crocin_poisonous.dm"
 #include "modular_bluemoon\code\datums\traits\neutral\lewd_bite.dm"
 #include "modular_bluemoon\code\datums\traits\neutral\lewdsummon.dm"
 #include "modular_bluemoon\code\datums\traits\neutral\pheromones.dm"


### PR DESCRIPTION
# Описание
1) Квирк кроциновой ядовитости - при любых прикосновениях через панельку накладывает на цель до 2 кубов кроцина (тоесть если в теле больше 2 кубов, то не даёт больше), что дополняется ещё 2-мя кубами гексы при поцелуях в губы (так-же до 2-ух кубов, тоесть в безопасном количестве)

## Причина изменений
забавный новый квирк для отыгрыша токсичных слаймов и тд 