### PR TITLE
Фикст атаки вендоматов и их поднятия

### DIFF
--- a/modular_bluemoon/code/modules/vending/_vending.dm
+++ b/modular_bluemoon/code/modules/vending/_vending.dm
@@ -619,7 +619,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 				else
 					to_chat(user, span_warning("Нечего пополнять!"))
 			return
-	if(compartmentLoadAccessCheck(user) && !user.combat_mode)
+	if(compartmentLoadAccessCheck(user) && !SEND_SIGNAL(user, COMSIG_COMBAT_MODE_CHECK, COMBAT_MODE_ACTIVE))
 		if(canLoadItem(I))
 			loadingAttempt(I,user)
 
@@ -802,8 +802,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 	unbuckle_all_mobs(TRUE)
 
 	tilted = FALSE
-	panel_open = FALSE
-	set_anchored(TRUE)
 	layer = initial(layer)
 
 	var/matrix/M = matrix()


### PR DESCRIPTION
# Описание
1) вендоматы не прикручивают себя к полу после падения
2) вендоматы теперь можно атаковать в комбат моде

## Причина изменений
фиксы