### PR TITLE
ТГ инпут в переименовывание карты синдиката

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -599,8 +599,8 @@
 		if(!user.canUseTopic(src, BE_CLOSE, FALSE))
 			return
 		if(popup_input == "Forge/Reset" && !forged)
-			var/input_name = stripped_input(user, "Какое имя вы хотите присвоить карте? Оставьте пустым для случайной генерации.", "Имя агентской карточки", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN)
-			input_name = reject_bad_name(input_name)
+			var/input_name = tgui_input_text(user, "Какое имя вы хотите присвоить карте? Оставьте пустым для случайной генерации.", "Имя агентской карточки", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN)
+			input_name = reject_bad_name(input_name, TRUE)
 			if(!input_name)
 				// Invalid/blank names give a randomly generated one.
 				if(user.gender == MALE)
@@ -610,7 +610,7 @@
 				else
 					input_name = "[pick(GLOB.first_names)] [pick(GLOB.last_names)]"
 
-			var/target_occupation = stripped_input(user, "Какую должность вы хотите присвоить карте?\nИмейте ввиду: это не даст соответствующих доступов.", "Должность агентской карточки", assignment ? assignment : "Assistant", MAX_MESSAGE_LEN)
+			var/target_occupation = tgui_input_text(user, "Какую должность вы хотите присвоить карте?\nИмейте ввиду: это не даст соответствующих доступов.", "Должность агентской карточки", assignment ? assignment : "Assistant", MAX_MESSAGE_LEN, encode = TRUE)
 			if(!target_occupation)
 				return
 			registered_name = input_name


### PR DESCRIPTION
# Описание
1) добавил переименовывание в карту синдиката tg инпут и чуток сбавил количество лишних проверок, позволяет теперь сделать через карту имена с ' и другими такими символами (не считая " и подобного запрещённого)
## Причина изменений
фиксы
## Демонстрация изменений
<img width="370" height="31" alt="image" src="https://github.com/user-attachments/assets/96101f7b-5416-4080-88b2-9ef254f66002" />