### PR TITLE
Сидушки диванов и скамеек теперь лучше работают для больших персонажей

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -15,6 +15,7 @@
 	var/buildstackamount = 1
 	var/item_chair = /obj/item/chair // if null it can't be picked up
 	var/bolts = TRUE
+	var/lone_standing = TRUE // FALSE for sofa and pews. Used in handle_layer()
 
 /obj/structure/chair/examine(mob/user)
 	. = ..()
@@ -133,11 +134,27 @@
 			var/mob/living/buckled_mob = m
 			buckled_mob.setDir(direction)
 
-/obj/structure/chair/proc/handle_layer()
-	if(has_buckled_mobs() && dir == NORTH)
+/obj/structure/chair/proc/handle_layer(activate_adjacent = TRUE)
+	if(dir != NORTH)
+		layer = OBJ_LAYER
+
+	else if((has_buckled_mobs()))
+		layer = ABOVE_MOB_LAYER
+	else if(check_adjacent())
 		layer = ABOVE_MOB_LAYER
 	else
 		layer = OBJ_LAYER
+
+	if(activate_adjacent && !lone_standing)
+		for(var/obj/structure/chair/chair in orange("3x1", src))
+			if(chair.lone_standing || chair.dir != NORTH)
+				continue
+			chair.handle_layer(FALSE)
+
+/obj/structure/chair/proc/check_adjacent()
+	for(var/obj/structure/chair/chair in orange("3x1", src))
+		if(!lone_standing && chair.dir == NORTH && chair.has_buckled_mobs())
+			return TRUE
 
 /obj/structure/chair/post_buckle_mob(mob/living/M)
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -8,6 +8,7 @@
 	buildstacktype = /obj/item/stack/sheet/mineral/wood
 	buildstackamount = 3
 	item_chair = null
+	lone_standing = FALSE
 
 /obj/structure/chair/pew/left
 	name = "wooden pew end"

--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -19,6 +19,7 @@ path/corner/color_name {\
 	icon = 'icons/obj/sofa.dmi'
 	buildstackamount = 1
 	item_chair = null
+	lone_standing = FALSE
 	var/mutable_appearance/armrest
 
 /obj/structure/chair/sofa/Initialize(mapload)


### PR DESCRIPTION
# Описание
При усаживании на скамейку или диван повернутого на север дополнительно активируются сидушки справа и слева, позволяя большим персонажам поместиться на скамейку целиком, а в дополнение с этим улучшить ситуации когда персонаж сидит рядом с другим персонажем и тот не вылезал из под дивана.

## Причина изменений
улучшение визуального отображения
## Демонстрация изменений
<img width="319" height="212" alt="image" src="https://github.com/user-attachments/assets/7d5b8b8d-3fb2-4494-a9c9-fe7e574ce59b" />
