### PR TITLE
Отображение звуков у близоруких теперь не появляется

### DIFF
--- a/code/__DEFINES/fov.dm
+++ b/code/__DEFINES/fov.dm
@@ -2,9 +2,6 @@
 #define BASE_FOV_MASK_X_DIMENSION 15
 #define BASE_FOV_MASK_Y_DIMENSION 15
 
-/// Range at which FOV effects treat nearsightness as blind and play
-#define NEARSIGHTNESS_FOV_BLINDNESS 3
-
 /// Range in tiles that a mob can see in the dark (used to determine if a mob has night_vision)
 #define NIGHTVISION_FOV_RANGE 8
 

--- a/code/modules/mob/living/living_fov.dm
+++ b/code/modules/mob/living/living_fov.dm
@@ -1,4 +1,4 @@
-/// Is `observed_atom` in a mob's field of view? This takes blindness, nearsightness and FOV into consideration
+/// Is `observed_atom` in a mob's field of view? This takes blindness and FOV into consideration
 /mob/living/proc/in_fov(atom/observed_atom, ignore_self = FALSE)
 	if(ignore_self && observed_atom == src)
 		return TRUE
@@ -41,11 +41,6 @@
 			. = TRUE
 	else
 		. = TRUE
-
-	// Handling nearsightnedness
-	if(. && is_nearsighted())
-		if((rel_x >= NEARSIGHTNESS_FOV_BLINDNESS || rel_x <= -NEARSIGHTNESS_FOV_BLINDNESS) || (rel_y >= NEARSIGHTNESS_FOV_BLINDNESS || rel_y <= -NEARSIGHTNESS_FOV_BLINDNESS))
-			return FALSE
 
 
 /mob/living/proc/update_fov()


### PR DESCRIPTION
# Описание
Убраны лишние проверки, близорукие у нас работают по другой системе и иконки звуков у них не имеют смысла, сколько эффект звуков срабатывается только в радиусе 3-6 тайлов которые близорукий и так видит, а уже в радиусе где появляется рябь нет эффекта из-за ухода вне радиуса где показывается это.

## Причина изменений
Багфиксы