### PR TITLE
Пачка фиксов и улучшения геймплея для слепых

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -77,6 +77,9 @@
 	//msg = "<b>[user]</b> " + msg //SKYRAT CHANGE
 	var/dchatmsg = "<span class='emote'><b>[user]</b> [msg]</span>" //SKYRAT CHANGE
 
+	var/blind_msg = "<span class='emote'><b>Кто-то</b> [msg]</span>"
+	if(emote_type != EMOTE_VISIBLE)
+		play_fov_effect(user, 3, "talk", ignore_self = FALSE)
 	if(user.client)
 		for(var/mob/M in GLOB.dead_mob_list)
 			if(!M.client || isnewplayer(M))
@@ -90,7 +93,7 @@
 	else if(emote_type == EMOTE_VISIBLE)
 		user.visible_message(dchatmsg, runechat_popup = chat_popup, rune_msg = msg)
 	else if(emote_type == EMOTE_BOTH)
-		user.visible_message(dchatmsg, blind_message = msg, runechat_popup = chat_popup, rune_msg = msg)
+		user.visible_message(dchatmsg, blind_message = blind_msg, runechat_popup = chat_popup, rune_msg = msg)
 	else if(emote_type == EMOTE_OMNI)
 		user.visible_message(dchatmsg, omni = TRUE, runechat_popup = chat_popup, rune_msg = msg)
 	//Skyrat change

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -418,6 +418,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		eavesrendered = compose_message(src, message_language, eavesdropping, null, spans, message_mode, FALSE, source)
 
 	var/rendered = compose_message(src, message_language, message, null, spans, message_mode, FALSE, source)
+	play_fov_effect(src, 6, "talk", ignore_self = TRUE, override_list = listening)
 	for(var/_AM in listening)
 		var/atom/movable/AM = _AM
 		// ПАТЧ ТЕШАРИ - проверяем дистанцию для чёткого слуха

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -198,7 +198,7 @@
 		if(visible_message_flags & EMOTE_MESSAGE && !M.is_blind())
 			M.create_chat_message(src, raw_message = raw_msg)
 
-		M.show_message(msg, MSG_VISUAL, blind_message, MSG_AUDIBLE) //SKYRAT CHANGE
+		M.show_message(msg, MSG_VISUAL, in_range(T,M) ? msg : blind_message, MSG_AUDIBLE) //SKYRAT CHANGE
 
 ///Adds the functionality to self_message.
 /mob/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, mob/target, target_message, omni = FALSE, runechat_popup, rune_msg, visible_message_flags)


### PR DESCRIPTION
# Описание
1) Теперь эмоуты которые кидают слепому идут с припиской "Кто-то" в ситуации когда сделавший эмоут находится далеко
2)  Визуальные эмоуты в радиусе 1 турфа и на турфе при слепоте отображаются как при наличии зрения (фиксит проблемы и с эмоутами при vore; эмоутами через панельку (нет, слепым всё ещё не показываются кидание факов им если они дальше 1 турфа)
3) Добавлено появление облачка эхолокации при эмоуте в радиусе 3 турфов от слепого
4) Добавлено появление облачка эхолокации при "говорении" в радиусе 6-ти турфов (если говорящий в прямой "видимости" от слепого)
## Причина изменений
Багфиксы и улучшение геймплея за слепых