### PR TITLE
Фикс библиотеки + небольшой ремап ботаники на боксе + фикс установки питона (да, серьёзно тут)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -29869,7 +29869,6 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "cpg" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm{
 	pixel_x = 27
 	},
@@ -29879,6 +29878,8 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/service/hydroponics)
 "cph" = (
@@ -36817,13 +36818,11 @@
 	},
 /area/security/office)
 "dKa" = (
-/obj/effect/turf_decal/tile/green/half{
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/yellow/line,
-/obj/effect/turf_decal/siding/green,
-/turf/open/floor/plasteel/textured/half{
-	dir = 8
+/turf/open/floor/plasteel/textured/edge{
+	dir = 4
 	},
 /area/service/hydroponics)
 "dKj" = (
@@ -40290,6 +40289,12 @@
 	dir = 4
 	},
 /area/medical/medbay/central)
+"fjt" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/dark/textured/large,
+/area/service/hydroponics)
 "fjE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41272,8 +41277,14 @@
 	},
 /area/security/courtroom)
 "fAQ" = (
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/dark/textured/large,
+/obj/effect/turf_decal/siding/green,
+/obj/effect/turf_decal/stripes/yellow/line,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/textured/half{
+	dir = 8
+	},
 /area/service/hydroponics)
 "fBl" = (
 /obj/structure/table/reinforced,
@@ -42714,15 +42725,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/half{
+/obj/effect/turf_decal/tile/green/anticorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/textured/edge{
-	dir = 1
-	},
+/turf/open/floor/plasteel/textured/corner,
 /area/service/hydroponics)
 "gef" = (
 /obj/machinery/light{
@@ -52574,12 +52580,6 @@
 "kck" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/yellow/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/green{
-	dir = 8
-	},
 /turf/open/floor/plasteel/textured/large,
 /area/service/hydroponics)
 "kcp" = (
@@ -57551,6 +57551,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
+"miW" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/dark/textured/large,
+/area/service/hydroponics)
 "mjy" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -61157,8 +61164,6 @@
 /turf/open/floor/plasteel/dark/textured/half,
 /area/security/prison/cells)
 "nEX" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 23
@@ -61166,6 +61171,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/service/hydroponics)
 "nEZ" = (
@@ -71516,8 +71522,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/service/hydroponics)
 "sad" = (
@@ -73968,9 +73973,7 @@
 	dir = 2
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/dark/textured/large,
 /area/service/hydroponics)
 "tcj" = (
@@ -126816,7 +126819,7 @@ gon
 foq
 kWT
 aIp
-aWd
+fjt
 gdJ
 dKa
 fAQ
@@ -127075,8 +127078,8 @@ gMN
 aIp
 tbF
 mMP
-kKE
 kck
+kKE
 vTT
 wnT
 bBs
@@ -128363,7 +128366,7 @@ aEx
 rZx
 rZx
 swE
-rrY
+miW
 cpg
 nEX
 nNf

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -239,7 +239,10 @@
 				book_w = text2num(size_parts[1])
 				book_h = text2num(size_parts[2])
 		var/datum/browser/popup = new(user, "book", title || "Book", book_w, book_h)
-		popup.set_content("<TT><I>Penned by [author].</I></TT> <BR>[dat]")
+		var/book_style = "<body style ='background-color: #dddddd'"
+		book_style += "<TT style='color: black'><I>Penned by [author].</I></TT><BR>"
+		book_style += "<uiContent style='color: black'[dat]</uiContent></body>"
+		popup.set_content("[book_style]")
 		popup.open()
 		user.visible_message("<span class='notice'>[user] opens a book titled \"[title]\" and begins reading intently.</span>")
 		// SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -239,9 +239,9 @@
 				book_w = text2num(size_parts[1])
 				book_h = text2num(size_parts[2])
 		var/datum/browser/popup = new(user, "book", title || "Book", book_w, book_h)
-		var/book_style = "<body style ='background-color: #dddddd'"
+		var/book_style = "<body style ='background-color: #dddddd'>"
 		book_style += "<TT style='color: black'><I>Penned by [author].</I></TT><BR>"
-		book_style += "<uiContent style='color: black'[dat]</uiContent></body>"
+		book_style += "<uiContent style='color: black'>[dat]</uiContent></body>"
 		popup.set_content("[book_style]")
 		popup.open()
 		user.visible_message("<span class='notice'>[user] opens a book titled \"[title]\" and begins reading intently.</span>")

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 		dat += "No data stored in memory.<BR>"
 	dat += "<a href='byond://?src=[REF(src)];scan=1'>\[Scan\]</A>"
 	if(cache)
-		dat += "       <<a href='byond://?src=[REF(src)];clear=1'>\[Clear Memory\]</A><BR><BR><A href='?src=[UID()];eject=1'>\[Remove Book\]</A>"
+		dat += "       <a href='byond://?src=[REF(src)];clear=1'>\[Clear Memory\]</A><BR><BR><A href='?src=[UID()];eject=1'>\[Remove Book\]</A>"
 	else
 		dat += "<BR>"
 	var/datum/browser/popup = new(user, "scanner", name, 300, 200)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -171,13 +171,14 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 		dat += "<FONT color=#005500>Data stored in memory.</FONT><BR>"
 	else
 		dat += "No data stored in memory.<BR>"
-	dat += "<A href='?src=[UID()];scan=1'>\[Scan\]</A>"
+	dat += "<a href='byond://?src=[REF(src)];scan=1'>\[Scan\]</A>"
 	if(cache)
-		dat += "       <A href='?src=[UID()];clear=1'>\[Clear Memory\]</A><BR><BR><A href='?src=[UID()];eject=1'>\[Remove Book\]</A>"
+		dat += "       <<a href='byond://?src=[REF(src)];clear=1'>\[Clear Memory\]</A><BR><BR><A href='?src=[UID()];eject=1'>\[Remove Book\]</A>"
 	else
 		dat += "<BR>"
-	user << browse(dat, "window=scanner")
-	onclose(user, "scanner")
+	var/datum/browser/popup = new(user, "scanner", name, 300, 200)
+	popup.set_content(dat)
+	popup.open()
 
 /obj/machinery/libraryscanner/Topic(href, href_list)
 	if(..())

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(library_section_names, list("Any", "Fiction", "Non-Fiction", "A
 		dat += "No data stored in memory.<BR>"
 	dat += "<a href='byond://?src=[REF(src)];scan=1'>\[Scan\]</A>"
 	if(cache)
-		dat += "       <a href='byond://?src=[REF(src)];clear=1'>\[Clear Memory\]</A><BR><BR><A href='?src=[UID()];eject=1'>\[Remove Book\]</A>"
+		dat += "       <a href='byond://?src=[REF(src)];clear=1'>\[Clear Memory\]</A><BR><BR><a href='byond://?src=[REF(src)];eject=1'>\[Remove Book\]</A>"
 	else
 		dat += "<BR>"
 	var/datum/browser/popup = new(user, "scanner", name, 300, 200)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -18,7 +18,7 @@ export NODE_VERSION_COMPAT=20.19.0
 export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.9.0
+export PYTHON_VERSION=3.11.0
 
 # Auxmos git tag
 export AUXMOS_VERSION=v2.5.1

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -46,7 +46,6 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 		"https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip" `
 		-OutFile $Archive `
 		-ErrorAction Stop
-		-UseBasicParsing
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
@@ -66,7 +65,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 if (!(Test-Path "$PythonDir/Scripts/pip.exe")) {
 	$host.ui.RawUI.WindowTitle = "Downloading Pip..."
 
-	Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" ` -UseBasicParsing
+	Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" `
 		-OutFile "$Cache/get-pip.py" `
 		-ErrorAction Stop
 

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -45,6 +45,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	Invoke-WebRequest `
 		"https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip" `
 		-OutFile $Archive `
+		-UseBasicParsing `
 		-ErrorAction Stop
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
@@ -67,6 +68,7 @@ if (!(Test-Path "$PythonDir/Scripts/pip.exe")) {
 
 	Invoke-WebRequest "https://bootstrap.pypa.io/get-pip.py" `
 		-OutFile "$Cache/get-pip.py" `
+		-UseBasicParsing `
 		-ErrorAction Stop
 
 	& $PythonExe "$Cache/get-pip.py" --no-warn-script-location


### PR DESCRIPTION
# Описание
до холодоса в ботанике нельзя было достать (пофикшено)
был сломан интерфейс сканера библиотеки
фон книг был слишком тёмный и не было видно текст
повышена версия питона которая скачивается (для соответсвия всем модулям которые им пользуются)
убраны 2 проверки которые ломали проход по коду установки локального питона
<img width="1431" height="133" alt="image" src="https://github.com/user-attachments/assets/b20b8885-8999-40d4-a11f-724a89c1aeaf" />

## Причина изменений
багфиксы

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popup-based library scanner for smoother in-app scanning/navigation
  * Styled book display popups with improved visual formatting

* **Updates**
  * Major Box Station map overhaul with extensive layout, object, decal, and overlay reorganizations

* **Bug Fixes**
  * Resolved display/formatting inconsistencies in the library interface

* **Chores**
  * Updated installer/tooling scripts and Python runtime handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->