### PR TITLE
Фикс сушки (я забыл про переменную)

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -484,9 +484,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown))
-		var/obj/item/reagent_containers/food/snacks/grown/G = O
 		if(!packeditem)
-			if(G.dry == 1)
+			if(HAS_TRAIT(O, TRAIT_DRIED))
 				to_chat(user, "<span class='notice'>You stuff [O] into [src].</span>")
 				smoketime = 400
 				packeditem = 1
@@ -886,8 +885,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!proximity)
 		return
 	if(istype(target, /obj/item/reagent_containers/food/snacks/grown))
-		var/obj/item/reagent_containers/food/snacks/grown/O = target
-		if(O.dry)
+		if(HAS_TRAIT(target, TRAIT_DRIED))
 			var/obj/item/clothing/mask/cigarette/rollie/R = new /obj/item/clothing/mask/cigarette/rollie(user.loc)
 			R.chem_volume = target.reagents.total_volume
 			target.reagents.trans_to(R, R.chem_volume, log = "cigar fill: rolling paper afterattack")
@@ -1099,20 +1097,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	. = ..()
 	//If we're using a dried plant..
 	if(istype(O,/obj/item/reagent_containers/food/snacks))
-		var/obj/item/reagent_containers/food/snacks/DP = O
-		if (DP.dry)
+		if(HAS_TRAIT(O, TRAIT_DRIED))
 			//Nothing if our bong is full
 			if (reagents.holder_full())
 				user.show_message("<span class='notice'>The bowl is full!</span>", MSG_VISUAL)
 				return
 
 			//Transfer reagents and remove the plant
-			user.show_message("<span class='notice'>You stuff the [DP] into the [src]'s bowl.</span>", MSG_VISUAL)
-			DP.reagents.trans_to(src, 100, log = "cigar fill: bong")
-			qdel(DP)
+			user.show_message("<span class='notice'>You stuff the [O] into the [src]'s bowl.</span>", MSG_VISUAL)
+			O.reagents.trans_to(src, 100, log = "cigar fill: bong")
+			qdel(O)
 			return
 		else
-			user.show_message("<span class='warning'>[DP] must be dried first!</span>", MSG_VISUAL)
+			user.show_message("<span class='warning'>[O] must be dried first!</span>", MSG_VISUAL)
 			return
 
 	if (O.get_temperature() <= 500)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -59,7 +59,6 @@ All foods are distributed among various categories. Use common sense.
 	var/slice_path    // for sliceable food. path of the item resulting from the slicing
 	var/slices_num
 	var/eatverb
-	var/dry = 0
 	var/cooked_type = null  //for microwave cooking. path of the resulting item after microwaving
 	var/filling_color = "#FFFFFF" //color to use when added to custom food.
 	var/custom_food_type = null  //for food customizing. path of the custom food to create

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -141,7 +141,7 @@
 		. = new trash(get_turf(src), seed)
 
 /obj/item/reagent_containers/food/snacks/grown/grind_requirements()
-	if(dry_grind && HAS_TRAIT(src, TRAIT_DRIED))
+	if(dry_grind && !HAS_TRAIT(src, TRAIT_DRIED))
 		to_chat(usr, "<span class='warning'>[src] needs to be dry before it can be ground up!</span>")
 		return
 	return TRUE

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -141,7 +141,7 @@
 		. = new trash(get_turf(src), seed)
 
 /obj/item/reagent_containers/food/snacks/grown/grind_requirements()
-	if(dry_grind && !dry)
+	if(dry_grind && HAS_TRAIT(src, TRAIT_DRIED))
 		to_chat(usr, "<span class='warning'>[src] needs to be dry before it can be ground up!</span>")
 		return
 	return TRUE

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -65,7 +65,7 @@
 
 	if(CheckAccepted(W))
 		var/obj/item/reagent_containers/food/snacks/grown/leaf = W
-		if(leaf.dry)
+		if(HAS_TRAIT(leaf, TRAIT_DRIED))
 			user.show_message("<span class='notice'>You wrap \the [W] around the log, turning it into a torch!</span>")
 			var/obj/item/flashlight/flare/torch/T = new /obj/item/flashlight/flare/torch(user.loc)
 			usr.dropItemToGround(W)


### PR DESCRIPTION
# Описание
пофикшены крафты из сушеных штук (бонг, самокрутки, ФАКЕЛА)

## Причина изменений
багфиксы

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how the game determines whether items are "dried", streamlining interactions for cigarettes, pipes, rolling papers, bongs, snacks, grinding, and log wrapping.
  * Updated in‑game messages and warnings to reference the actual item being used and to clearly indicate when an item must be dried before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->