### PR TITLE
Radiation safety: processing cap, set_strength setter, contamination chain fix

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -49,7 +49,9 @@ Ask ninjanomnom if they're around
 // contamination_strength = 	(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
 #define RAD_MINIMUM_CONTAMINATION 300				// How strong does a radiation wave have to be to contaminate objects
 #define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.005	// Higher means higher strength scaling contamination chance
-#define RAD_CONTAMINATION_STR_COEFFICIENT 0.99		// Higher means higher strength scaling contamination strength
+#define RAD_CONTAMINATION_STR_COEFFICIENT 0.35		// Higher means higher strength scaling contamination strength. Lowered from 0.99 to break self-sustaining contamination chain reactions
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
 #define RAD_HALF_LIFE 90							// The half-life of contaminated objects
+
+#define RAD_MAX_PROCESSING 200						// Safety cap on SSradiation processing list size. Wave creation is suppressed when exceeded

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -8,6 +8,7 @@
 		/obj/effect,
 		/obj/docking_port,
 		/obj/item/projectile,
+		/atom/movable/lighting_object,
 		))
 	var/list/processing_list = list(location)
 	. = list()
@@ -24,15 +25,15 @@
 		lim = processing_list.len
 
 /proc/radiation_pulse(mob/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
-	if(!SSradiation.can_fire)
+	if(!SSradiation.can_fire || !source)
 		return
 	var/turf/open/pool/PL = get_turf(source)
 	if(istype(PL))
 		if(PL.filled == TRUE)
 			intensity *= 0.15
-	var/area/A = get_area(source)
-	if(source == null)
+	if(intensity <= RAD_BACKGROUND_RADIATION)
 		return
+	var/area/A = get_area(source)
 	var/atom/nested_loc = source.loc
 	var/spawn_waves = TRUE
 	while(nested_loc != A)
@@ -40,7 +41,7 @@
 			spawn_waves = FALSE
 			break
 		nested_loc = nested_loc.loc
-	if(spawn_waves)
+	if(spawn_waves && intensity >= RAD_MINIMUM_CONTAMINATION && SSradiation.processing.len < RAD_MAX_PROCESSING)
 		for(var/dir in GLOB.cardinals)
 			new /datum/radiation_wave(source, dir, intensity, range_modifier, can_contaminate)
 

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -13,7 +13,6 @@
 	var/can_contaminate
 
 /datum/component/radioactive/Initialize(_strength=0, _source, _half_life=RAD_HALF_LIFE, _can_contaminate=TRUE)
-	strength = _strength
 	source = _source
 	hl3_release_date = _half_life
 	can_contaminate = _can_contaminate
@@ -26,16 +25,13 @@
 	else
 		CRASH("Something that wasn't an atom was given /datum/component/radioactive")
 
-	if(strength > RAD_MINIMUM_CONTAMINATION)
-		SSradiation.warn(src)
-
 	//Let's make er glow
 	//This relies on parent not being a turf or something. IF YOU CHANGE THAT, CHANGE THIS
 	var/atom/movable/master = parent
 	master.add_filter("rad_glow", 2, list("type" = "outline", "color" = "#39ff1430", "size" = 2))
 	addtimer(CALLBACK(src, PROC_REF(glow_loop), master), rand(1,19))//Things should look uneven
 
-	START_PROCESSING(SSradiation, src)
+	set_strength(_strength)
 
 /datum/component/radioactive/Destroy()
 	STOP_PROCESSING(SSradiation, src)
@@ -43,9 +39,32 @@
 	master.remove_filter("rad_glow")
 	return ..()
 
+/datum/component/radioactive/proc/set_strength(new_strength)
+	var/old_strength = strength
+	if(isnull(new_strength))
+		new_strength = 0
+	strength = max(new_strength, 0)
+
+	if(strength > RAD_MINIMUM_CONTAMINATION)
+		SSradiation.warn(src)
+
+	if(strength > RAD_BACKGROUND_RADIATION)
+		if(!(datum_flags & DF_ISPROCESSING))
+			START_PROCESSING(SSradiation, src)
+		return
+
+	if(hl3_release_date && (isnull(old_strength) || old_strength > RAD_BACKGROUND_RADIATION))
+		addtimer(CALLBACK(src, PROC_REF(check_dissipate)), 5 SECONDS)
+	if(datum_flags & DF_ISPROCESSING)
+		STOP_PROCESSING(SSradiation, src)
+
 /datum/component/radioactive/process()
+	if(strength <= RAD_BACKGROUND_RADIATION)
+		if(hl3_release_date)
+			addtimer(CALLBACK(src, PROC_REF(check_dissipate)), 5 SECONDS)
+		return PROCESS_KILL
 	var/turf/T = get_turf(parent)
-	if(!prob(50) || is_radiation_blocked(parent) || !T) // Кроме 50%-ного шанса, проверяем или есть защита на радиацию
+	if(!prob(20) || is_radiation_blocked(parent) || !T) // Кроме 20%-ного шанса, проверяем или есть защита на радиацию
 		return
 	radiation_pulse(T, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 
@@ -76,9 +95,9 @@
 		return
 	if(C)
 		var/datum/component/radioactive/other = C
-		strength = max(strength, other.strength)
+		set_strength(max(strength, other.strength))
 	else
-		strength = max(strength, _strength)
+		set_strength(max(strength, _strength))
 
 /datum/component/radioactive/proc/rad_examine(datum/source, mob/user, list/examine_list)
 	var/atom/master = parent
@@ -99,13 +118,13 @@
 
 /datum/component/radioactive/proc/rad_attack(datum/source, atom/movable/target, mob/living/user)
 	var/turf/T = get_turf(parent)
-	if(is_radiation_blocked(parent || !T)) // Проверяем или есть защита на радиацию
+	if(!T || is_radiation_blocked(parent)) // Проверяем или есть защита на радиацию
 		return
 	radiation_pulse(T, strength/20)
 	target.rad_act(strength/2)
 	if(!hl3_release_date)
 		return
-	strength -= strength / hl3_release_date
+	set_strength(strength - (strength / hl3_release_date))
 
 #undef RAD_AMOUNT_LOW
 #undef RAD_AMOUNT_MEDIUM

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -63,17 +63,16 @@
 		if(hl3_release_date)
 			addtimer(CALLBACK(src, PROC_REF(check_dissipate)), 5 SECONDS)
 		return PROCESS_KILL
+	if(hl3_release_date)
+		strength -= strength / hl3_release_date
+		if(strength <= RAD_BACKGROUND_RADIATION)
+			addtimer(CALLBACK(src, PROC_REF(check_dissipate)), 5 SECONDS)
+			return PROCESS_KILL
+
 	var/turf/T = get_turf(parent)
 	if(!prob(20) || is_radiation_blocked(parent) || !T) // Кроме 20%-ного шанса, проверяем или есть защита на радиацию
 		return
 	radiation_pulse(T, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
-
-	if(!hl3_release_date)
-		return
-	strength -= strength / hl3_release_date
-	if(strength <= RAD_BACKGROUND_RADIATION)
-		addtimer(CALLBACK(src, PROC_REF(check_dissipate)), 5 SECONDS)
-		return PROCESS_KILL
 
 /datum/component/radioactive/proc/check_dissipate()
 	if(strength <= RAD_BACKGROUND_RADIATION)

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -114,6 +114,10 @@
 			continue
 		if((thing.rad_flags & RAD_NO_CONTAMINATE) || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
 			continue
+		// Skip objects already contaminated at equal or higher strength
+		var/datum/component/radioactive/existing = thing.GetComponent(/datum/component/radioactive)
+		if(existing?.strength >= strength)
+			continue
 		contam_atoms += thing
 	var/did_contam = 0
 	if(can_contam && contam_atoms.len)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -528,7 +528,7 @@
 	if(strength <= RAD_BACKGROUND_RADIATION + 20) //BLUEMOON CHANGES
 		qdel(healthy_green_glow)
 		return
-	healthy_green_glow.strength = max(strength-9, 0) //BLUEMOON CHANGES
+	healthy_green_glow.set_strength(max(strength-9, 0)) //BLUEMOON CHANGES
 
 /obj/machinery/shower/process()
 	if(on)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -197,7 +197,7 @@
 		return PROCESS_KILL
 	// Добавляем минорное облучение, если батарея радиоактивна. Большей частью ради свечения.
 	if(cell.cell_is_radioactive)
-		AddComponent(/datum/component/radioactive, 0, src)
+		AddComponent(/datum/component/radioactive, 0, src, 0)
 	var/malfunctioning_charge_drain = 0
 	if(malfunctioning)
 		malfunctioning_charge_drain = rand(1,20)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -76,7 +76,7 @@
 /obj/item/stock_parts/cell/proc/irradiate(datum/component/radioactive/Comp)
 	AddComponent(/datum/component/radioactive, 0, src, 0)
 	Comp = GetComponent(/datum/component/radioactive)
-	Comp.strength = round(rad_strength*(charge < maxcharge ? 1 : 0.5), 0.5) // Округляем к ближайшей целой половине
+	Comp.set_strength(round(rad_strength*(charge < maxcharge ? 1 : 0.5), 0.5)) // Округляем к ближайшей целой половине
 
 /obj/item/stock_parts/cell/update_overlays()
 	. = ..()
@@ -399,7 +399,7 @@
 /obj/item/stock_parts/cell/emergency_light
 	name = "miniature power cell"
 	desc = "A tiny power cell with a very low power capacity. Used in light fixtures to power them in the event of an outage."
-	maxcharge = 120 //Emergency lights use 0.2 W per tick, meaning ~10 minutes of emergency power from a cell
+	maxcharge = 120 //Emergency lights drain 5 W per process tick, meaning ~30 seconds of emergency power from a cell
 	custom_materials = list(/datum/material/glass = 20)
 	w_class = WEIGHT_CLASS_TINY
 


### PR DESCRIPTION
Раньше заражённые объекты могли порождать новые волны, которые заражали ещё больше объектов — и это уходило в цепную реакцию, забивая SSradiation и лагая сервер

### Основные изменения

- **Кап на обработку** - добавлен лимит `RAD_MAX_PROCESSING` (200), при превышении которого новые волны не спавнятся
- **Снижен коэффициент заражения** с 0.99 до 0.35, чтобы цепочка затухала, а не разрасталась
- **`set_strength` сеттер** - теперь сила радиации меняется через проп, который сам управляет стартом/остановкой процессинга (не крутится впустую на нулевой силе)
- **Пропуск уже заражённых** - волна не перезаражает объекты, у которых сила уже >= текущей волны
- **Шанс пульса снижен** с 50% до 20% на тик у заражённых объектов
- **Мелкие багфиксы:** null-чек source в `radiation_pulse`, исправлен порядок проверок в `rad_attack`, `lighting_object` добавлен в исключения сбора атомов

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Балансировка игры**
  * Снижена интенсивность распространения радиации.
  * Введён лимит на одновременную обработку радиационных волн для предотвращения перегрузок.

* **Улучшения**
  * Обработка радиации стала жёстче фильтровать фоновые и отсутствующие источники.
  * Объекты больше не будут повторно заражаться, если у них уже равная или большая степень загрязнения.
  * Централизовано управление силой заражения для более предсказуемого поведения.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->