### PR TITLE
NPC performance: skip distant mob AI, cache bot view(), remove salute check

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -226,6 +226,9 @@
 #define AI_OFF		3
 #define AI_Z_OFF	4
 
+/// Distance within which a player must be for NPC AI to remain active
+#define NEARBY_PLAYER_DISTANCE 15
+
 // determines if a mob can smash through it
 #define ENVIRONMENT_SMASH_NONE		  0
 #define ENVIRONMENT_SMASH_STRUCTURES (1<<0)	// crates, lockers, ect

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(available_ai_shells)
 GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list(),list())) // One for each AI_* status define
 GLOBAL_LIST_EMPTY(spidermobs)				//all sentient spider mobs
 GLOBAL_LIST_EMPTY(bots_list)
+GLOBAL_LIST_EMPTY(commissioned_bots)
 GLOBAL_LIST_EMPTY(aiEyes)
 GLOBAL_LIST_EMPTY(suit_sensors_list) //all people with suit sensors on
 

--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -29,6 +29,7 @@ SUBSYSTEM_DEF(idlenpcpool)
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
+	var/list/clients_by_z = SSmobs.clients_by_zlevel
 
 	while(currentrun.len)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
@@ -38,10 +39,27 @@ SUBSYSTEM_DEF(idlenpcpool)
 			log_world("Found a null in simple_animals list!")
 			continue
 
-		if(!SA.ckey)
-			if(SA.stat != DEAD)
-				SA.handle_automated_movement()
-			if(SA.stat != DEAD)
-				SA.consider_wakeup()
+		if(SA.ckey)
+			continue
+
+		// Layer 1: Z-level check — no players on this z-level, deep sleep
+		var/turf/mob_turf = get_turf(SA)
+		if(!mob_turf)
+			continue
+		if(!length(clients_by_z[mob_turf.z]))
+			SA.toggle_ai(AI_Z_OFF)
+			continue
+
+		// Layer 2: Proximity check — no player within range, skip entirely
+		if(!SA.has_nearby_player())
+			continue
+
+		// Layer 3: Dead mob skip
+		if(SA.stat == DEAD)
+			continue
+
+		SA.handle_automated_movement()
+		SA.consider_wakeup()
+
 		if (MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -57,6 +57,7 @@ SUBSYSTEM_DEF(npcpool)
 					invoking = FALSE
 					return
 			else
+				SA.toggle_ai(AI_IDLE)
 				invoking = FALSE
 				return
 		if(SA.stat != DEAD)

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -44,6 +44,19 @@ SUBSYSTEM_DEF(npcpool)
 
 /datum/controller/subsystem/npcpool/proc/invoke_process(mob/living/simple_animal/SA)
 	if(!SA.ckey && !SA.mob_transforming)
+		if(!SA.has_nearby_player())
+			if(istype(SA, /mob/living/simple_animal/hostile))
+				var/mob/living/simple_animal/hostile/hostile_mob = SA
+				hostile_mob.LoseTarget()
+				SA.toggle_ai(AI_IDLE)
+			else if(istype(SA, /mob/living/simple_animal/bot))
+				var/mob/living/simple_animal/bot/bot_mob = SA
+				if(bot_mob.mode == BOT_IDLE)
+					invoking = FALSE
+					return
+			else
+				invoking = FALSE
+				return
 		if(SA.stat != DEAD)
 			SA.handle_automated_movement()
 			if(QDELETED(SA))

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -49,6 +49,8 @@ SUBSYSTEM_DEF(npcpool)
 				var/mob/living/simple_animal/hostile/hostile_mob = SA
 				hostile_mob.LoseTarget()
 				SA.toggle_ai(AI_IDLE)
+				invoking = FALSE
+				return
 			else if(istype(SA, /mob/living/simple_animal/bot))
 				var/mob/living/simple_animal/bot/bot_mob = SA
 				if(bot_mob.mode == BOT_IDLE)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -271,14 +271,6 @@
 	if(!on || client)
 		return
 
-	if(!commissioned && can_salute)
-		for(var/mob/living/simple_animal/bot/B in get_hearers_in_view(5, get_turf(src)))
-			if(B.commissioned)
-				visible_message("<b>[src]</b> performs an elaborate salute for [B]!")
-				can_salute = FALSE
-				addtimer(VARSET_CALLBACK(src, can_salute, TRUE), salute_delay)
-				break
-
 	switch(mode) //High-priority overrides are processed first. Bots can do nothing else while under direct command.
 		if(BOT_RESPONDING)	//Called by the AI.
 			call_mode()
@@ -440,7 +432,7 @@ Example usage: patient = scan(/mob/living/carbon/human, oldpatient, 1)
 The proc would return a human next to the bot to be set to the patient var.
 Pass the desired type path itself, declaring a temporary var beforehand is not required.
 */
-/mob/living/simple_animal/bot/proc/scan(scan_type, old_target, scan_range = DEFAULT_SCAN_RANGE)
+/mob/living/simple_animal/bot/proc/scan(scan_type, old_target, scan_range = DEFAULT_SCAN_RANGE, list/cached_view)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
@@ -461,7 +453,9 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 				var/final_result = checkscan(deepscan,scan_type,old_target)
 				if(final_result)
 					return final_result
-	for (var/scan in shuffle(view(scan_range, src))-adjacent) //Search for something in range!
+	if(!cached_view)
+		cached_view = shuffle(view(scan_range, src))
+	for(var/scan in cached_view - adjacent) //Search for something in range!
 		var/final_result = checkscan(scan,scan_type,old_target)
 		if(final_result)
 			return final_result

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -101,10 +101,17 @@
 	var/commissioned = FALSE // Will other (noncommissioned) bots salute this bot?
 	var/can_salute = TRUE
 	var/salute_delay = 60 SECONDS
-
-	//emotes/speech stuff
 	var/patrol_emote = "Включение режима патруля."
 	var/patrol_fail_emote = "Невозможно начать патруль."
+
+/mob/living/simple_animal/bot/proc/set_commissioned(new_value)
+	if(commissioned == new_value)
+		return
+	commissioned = new_value
+	if(commissioned)
+		GLOB.commissioned_bots += src
+	else
+		GLOB.commissioned_bots -= src
 
 /mob/living/simple_animal/bot/proc/get_mode()
 	if(client) //Player bots do not have modes, thus the override. Also an easy way for PDA users/AI to know when a bot is a player.
@@ -192,6 +199,7 @@
 		QDEL_NULL(path_hud)
 		path_hud = null
 	GLOB.bots_list -= src
+	GLOB.commissioned_bots -= src
 	if(paicard)
 		ejectpai()
 	QDEL_NULL(Radio)
@@ -270,6 +278,16 @@
 
 	if(!on || client)
 		return
+
+	if(!commissioned && can_salute && GLOB.commissioned_bots.len)
+		for(var/mob/living/simple_animal/bot/commissioned_bot as anything in GLOB.commissioned_bots)
+			if(commissioned_bot.z != z)
+				continue
+			if(get_dist(src, commissioned_bot) <= 5)
+				visible_message("<b>[src]</b> performs an elaborate salute for [commissioned_bot]!")
+				can_salute = FALSE
+				addtimer(VARSET_CALLBACK(src, can_salute, TRUE), salute_delay)
+				break
 
 	switch(mode) //High-priority overrides are processed first. Bots can do nothing else while under direct command.
 		if(BOT_RESPONDING)	//Called by the AI.

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -274,26 +274,28 @@
 	else if(prob(5))
 		audible_message("[src] делает радостный жужжаще-пищащий звук!")
 
+	var/list/cached_view_result = shuffle(view(DEFAULT_SCAN_RANGE, src))
+
 	if(ismob(target))
-		if(!(target in view(DEFAULT_SCAN_RANGE, src)))
+		if(!(target in cached_view_result))
 			target = null
 		if(!process_scan(target))
 			target = null
 
 	if(!target && emagged == 2) // When emagged, target humans who slipped on the water and melt their faces off
-		target = scan(/mob/living/carbon)
+		target = scan(/mob/living/carbon, null, DEFAULT_SCAN_RANGE, cached_view_result)
 
 	if(!target && pests) //Search for pests to exterminate first.
-		target = scan(/mob/living/simple_animal)
+		target = scan(/mob/living/simple_animal, null, DEFAULT_SCAN_RANGE, cached_view_result)
 
 	if(!target) //Search for decals then.
-		target = scan(/obj/effect/decal/cleanable)
+		target = scan(/obj/effect/decal/cleanable, null, DEFAULT_SCAN_RANGE, cached_view_result)
 
 	if(!target) //Checks for remains
-		target = scan(/obj/effect/decal/remains)
+		target = scan(/obj/effect/decal/remains, null, DEFAULT_SCAN_RANGE, cached_view_result)
 
 	if(!target && trash) //Then for trash.
-		target = scan(/obj/item/trash)
+		target = scan(/obj/item/trash, null, DEFAULT_SCAN_RANGE, cached_view_result)
 
 	// if(!target && trash) //Search for dead mices.
 	// 	target = scan(/obj/item/food/deadmouse)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -79,7 +79,7 @@
 			if(title in stolen_valor)
 				working_title += pref[title] + " "
 				if(title in officers)
-					commissioned = TRUE
+					set_commissioned(TRUE)
 				break
 			else
 				ascended = FALSE // we didn't have the first entry in the list if we got here, so we're not achievement worthy yet

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -618,6 +618,9 @@
 		toggle_ai(AI_Z_OFF)
 		return
 
+	if(!has_nearby_player())
+		return
+
 	var/cheap_search = isturf(T) && !is_station_level(T.z)
 	if (cheap_search)
 		tlist = ListTargetsLazy(T.z)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -678,7 +678,7 @@
 /mob/living/simple_animal/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
 	if(!ckey && !stat)//Not unconscious
-		if(AIStatus == AI_IDLE)
+		if(AIStatus == AI_IDLE || AIStatus == AI_Z_OFF)
 			toggle_ai(AI_ON)
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -658,6 +658,19 @@
 		else
 			stack_trace("Something attempted to set simple animals AI to an invalid state: [togglestatus]")
 
+/// Returns TRUE if any player is within given distance on the same z-level.
+/mob/living/simple_animal/proc/has_nearby_player(distance = 15)
+	var/turf/our_turf = get_turf(src)
+	if(!our_turf)
+		return FALSE
+	var/our_z = our_turf.z
+	if(!islist(SSmobs.clients_by_zlevel) || our_z > SSmobs.clients_by_zlevel.len)
+		return FALSE
+	for(var/mob/player as anything in SSmobs.clients_by_zlevel[our_z])
+		if(get_dist(our_turf, player) <= distance)
+			return TRUE
+	return FALSE
+
 /mob/living/simple_animal/proc/consider_wakeup()
 	if (pulledby || shouldwakeup)
 		toggle_ai(AI_ON)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -659,7 +659,7 @@
 			stack_trace("Something attempted to set simple animals AI to an invalid state: [togglestatus]")
 
 /// Returns TRUE if any player is within given distance on the same z-level.
-/mob/living/simple_animal/proc/has_nearby_player(distance = 15)
+/mob/living/simple_animal/proc/has_nearby_player(distance = NEARBY_PLAYER_DISTANCE)
 	var/turf/our_turf = get_turf(src)
 	if(!our_turf)
 		return FALSE

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -410,12 +410,13 @@
 
 /mob/Moved(atom/old_loc, Dir, Forced = FALSE)
 	. = ..()
-	if(!client?.parallax_holder)
+	if(!client)
 		return
-	var/anim_time = world.tick_lag
-	if(isliving(src) && glide_size > 0)
-		anim_time = world.icon_size / glide_size * world.tick_lag
-	client.parallax_holder.Update(anim_time = anim_time)
+	if(client.parallax_holder)
+		var/anim_time = world.tick_lag
+		if(isliving(src) && glide_size > 0)
+			anim_time = world.icon_size / glide_size * world.tick_lag
+		client.parallax_holder.Update(anim_time = anim_time)
 
 /mob/onTransitZ(old_z, new_z)
 	. = ..()


### PR DESCRIPTION
Небольшая оптимизация NPC-шек. Основная идея - не тратить ресурсы на AI мобов, рядом с которыми нет игроков.

### Изменения

- **Проверка `has_nearby_player()`** - если в радиусе 15 тайлов на том же z-уровне нет ни одного клиента, моб пропускает свой тик AI. Хостильные мобы при этом теряют цель и переходят в idle, боты в idle просто скипаются, остальные `simple_animal` тоже не обрабатываются.
- **Кэширование `view()` у клинботов** - раньше он вызывался до 5 раз за тик (на каждый `scan()`), теперь один раз.
- **Убрана проверка салюта у ботов** - она дёргала `get_hearers_in_view()` каждый тик для каждого бота, а толку от неё мало.
- **Рефактор `mob/Moved()`** - ранний return если нет клиента, чтобы не лезть в parallax-логику для NPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Исправлено поведение при перемещении — параллакс-анимации корректно применяются и не вызывают ошибок.
  * Враждебные сущности и NPC теперь не выполняют лишних действий при отсутствии игроков поблизости.

* **Улучшения производительности**
  * Сканирование окружения оптимизировано с кешированием обзора, реже пересчитывается видимость.
  * Боты сократили фоновую активность и автоматические приветствия для снижения нагрузки.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->