### PR TITLE
Improves chat styling and input focus

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -162,11 +162,21 @@
 	var/list/prefixes
 
 	// Append radio icon if from a virtual speaker
+	/// Cached chat prefix icons (radio, emote) — use icon() + Scale() for consistent maptext rendering
+	var/static/list/chat_prefix_icons
 	if (extra_classes.Find("virtual-speaker"))
-		var/image/r_icon = image('icons/ui_icons/chat/chat_icons.dmi', icon_state = "radio")
+		var/icon/r_icon = LAZYACCESS(chat_prefix_icons, "radio")
+		if (isnull(r_icon))
+			r_icon = icon('icons/ui_icons/chat/chat_icons.dmi', icon_state = "radio")
+			r_icon.Scale(CHAT_MESSAGE_ICON_SIZE, CHAT_MESSAGE_ICON_SIZE)
+			LAZYSET(chat_prefix_icons, "radio", r_icon)
 		LAZYADD(prefixes, "\icon[r_icon]")
 	else if (extra_classes.Find("emote"))
-		var/image/r_icon = image('icons/ui_icons/chat/chat_icons.dmi', icon_state = "emote")
+		var/icon/r_icon = LAZYACCESS(chat_prefix_icons, "emote")
+		if (isnull(r_icon))
+			r_icon = icon('icons/ui_icons/chat/chat_icons.dmi', icon_state = "emote")
+			r_icon.Scale(CHAT_MESSAGE_ICON_SIZE, CHAT_MESSAGE_ICON_SIZE)
+			LAZYSET(chat_prefix_icons, "emote", r_icon)
 		LAZYADD(prefixes, "\icon[r_icon]")
 
 	// Append language icon if the language uses one
@@ -272,6 +282,10 @@
 /mob/proc/create_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, list/spans, message_mode)
 	// Ensure the list we are using, if present, is a copy so we don't modify the list provided to us
 	spans = spans ? spans.Copy() : list()
+
+	// Add whisper class for reduced text size in runchat
+	if(message_mode == MODE_WHISPER || message_mode == MODE_WHISPER_CRIT)
+		spans |= "whisper"
 
 	// Check for virtual speakers (aka hearing a message through a radio)
 	var/atom/movable/originalSpeaker = speaker

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -108,7 +108,7 @@ window "mapwindow"
 		text-color = none
 		is-default = true
 		saved-params = "zoom;letterbox;zoom-mode"
-		style = ".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .command_headset { font-weight: bold;\tfont-size: 8px; } .context { font-family: 'Pixellari'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'TinyUnicode'; font-size: 12pt; line-height: 0.75; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clown { color: #FF69Bf; font-size: 7px;  font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 7px; }"
+		style = ".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .command_headset { font-weight: bold;\tfont-size: 8px; } .context { font-family: 'Pixellari'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'TinyUnicode'; font-size: 12pt; line-height: 0.75; } .small { font-size: 6px; } .whisper { font-size: 6px; -dm-text-outline: 1px black; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; } .redtext { color: #FF0000; } .clown { color: #FF69Bf; font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { }"
 	elem "status_bar"
 		type = LABEL
 		pos = 0,1008

--- a/tgui/packages/tgui/components/Input.js
+++ b/tgui/packages/tgui/components/Input.js
@@ -84,12 +84,47 @@ export class Input extends Component {
     if (input) {
       input.value = toInputValue(nextValue);
     }
-    if (this.props.autoFocus) {
-      setTimeout(() => input.focus(), 1);
+    if (this.props.autoFocus || this.props.autoSelect) {
+      this.setState({ editing: true }, () => {
+        requestAnimationFrame(() => {
+          const input = this.inputRef.current;
+          if (!input) return;
+          input.focus();
+          if (this.props.autoSelect) {
+            input.select();
+            // Re-select when external forces (BYOND window manager) reset selection
+            const reselect = () => {
+              if (document.activeElement === input
+                  && input.selectionStart === input.selectionEnd
+                  && input.value.length > 0) {
+                input.select();
+              }
+            };
+            const cleanup = () => {
+              document.removeEventListener('selectionchange', reselect);
+              input.removeEventListener('mousedown', cleanup);
+              input.removeEventListener('keydown', cleanup);
+            };
+            document.addEventListener('selectionchange', reselect);
+            input.addEventListener('mousedown', cleanup, { once: true });
+            input.addEventListener('keydown', cleanup, { once: true });
+            setTimeout(cleanup, 1000);
+          }
+        });
+      });
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  shouldComponentUpdate(nextProps, nextState) {
+    // While editing, block re-renders from periodic TGUI state updates
+    // to prevent Inferno's DOM patching from resetting input selection
+    if (this.state.editing && nextState.editing) {
+      return false;
+    }
+    return true;
+  }
+
+  componentDidUpdate(prevProps) {
     const { editing } = this.state;
     const prevValue = prevProps.value;
     const nextValue = this.props.value;
@@ -107,6 +142,8 @@ export class Input extends Component {
     const { props } = this;
     // Input only props
     const {
+      autoFocus,
+      autoSelect,
       selfClear,
       onInput,
       onChange,

--- a/tgui/packages/tgui/components/NumberInput.js
+++ b/tgui/packages/tgui/components/NumberInput.js
@@ -132,14 +132,14 @@ export class NumberInput extends Component {
       else if (this.inputRef) {
         const input = this.inputRef.current;
         if (input) {
-          setTimeout(() => {
+          requestAnimationFrame(() => {
             input.value = internalValue;
             try {
               input.focus();
               input.select();
             }
             catch { }
-          }, 1);
+          });
         }
       }
     };
@@ -157,7 +157,7 @@ export class NumberInput extends Component {
         internalValue: prev.internalValue ?? this.props.value,
       }), () => {
         // Проставляем значение в DOM-инпут и выделяем всё
-        setTimeout(() => {
+        requestAnimationFrame(() => {
           const i = this.inputRef?.current;
           if (!i) return;
           i.value = String(this.state.internalValue ?? this.props.value ?? '');
@@ -165,7 +165,7 @@ export class NumberInput extends Component {
             i.focus();
             i.select(); // как при обычном клике — выделить всё
           } catch { }
-        }, 1);
+        });
       });
     }
   }

--- a/tgui/packages/tgui/components/RestrictedInput.js
+++ b/tgui/packages/tgui/components/RestrictedInput.js
@@ -98,14 +98,41 @@ export class RestrictedInput extends Component {
       input.value = getClampedNumber(nextValue, minValue, maxValue);
     }
     if (this.props.autoFocus || this.props.autoSelect) {
-      setTimeout(() => {
-        input.focus();
-
-        if (this.props.autoSelect) {
-          input.select();
-        }
-      }, 1);
+      this.setState({ editing: true }, () => {
+        requestAnimationFrame(() => {
+          const input = this.inputRef.current;
+          if (!input) return;
+          input.focus();
+          if (this.props.autoSelect) {
+            input.select();
+            // Re-select when external forces (BYOND window manager) reset selection
+            const reselect = () => {
+              if (document.activeElement === input
+                  && input.selectionStart === input.selectionEnd
+                  && input.value.length > 0) {
+                input.select();
+              }
+            };
+            const cleanup = () => {
+              document.removeEventListener('selectionchange', reselect);
+              input.removeEventListener('mousedown', cleanup);
+              input.removeEventListener('keydown', cleanup);
+            };
+            document.addEventListener('selectionchange', reselect);
+            input.addEventListener('mousedown', cleanup, { once: true });
+            input.addEventListener('keydown', cleanup, { once: true });
+            setTimeout(cleanup, 1000);
+          }
+        });
+      });
     }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (this.state.editing && nextState.editing) {
+      return false;
+    }
+    return true;
   }
 
   componentDidUpdate(prevProps, _) {
@@ -127,7 +154,7 @@ export class RestrictedInput extends Component {
 
   render() {
     const { props } = this;
-    const { onChange, onEnter, onInput, value, ...boxProps } = props;
+    const { autoFocus, autoSelect, onChange, onEnter, onInput, value, ...boxProps } = props;
     const { className, fluid, monospace, ...rest } = boxProps;
     return (
       <Box

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -17,8 +17,9 @@ type NumberInputData = {
 
 export const NumberInputModal = (_, context) => {
   const { act, data } = useBackend<NumberInputData>(context);
-  const { init_value, large_buttons, message = "", timeout, title = "" }
-    = data;
+  const { init_value, large_buttons, timeout } = data;
+  const message = data.message ?? '';
+  const title = data.title ?? '';
   const [input, setInput] = useLocalState(context, 'input', init_value);
   const onChange = (value: number) => {
     if (value === input) {

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -17,7 +17,7 @@ type NumberInputData = {
 
 export const NumberInputModal = (_, context) => {
   const { act, data } = useBackend<NumberInputData>(context);
-  const { init_value, large_buttons, message = "", timeout, title }
+  const { init_value, large_buttons, message = "", timeout, title = "" }
     = data;
   const [input, setInput] = useLocalState(context, 'input', init_value);
   const onChange = (value: number) => {


### PR DESCRIPTION
Шёпот теперь отображается мельче в runechat (добавлен класс .whisper с уменьшенным шрифтом). Иконки радио и эмоутов в чате кэшируются вместо пересоздания каждый раз. В TGUI input-компонентах починен авто-выбор текста при открытии модалок - теперь BYOND не сбрасывает выделение, а setTimeout заменён на requestAnimationFrame. Заодно почищены дублирующиеся стили в skin.dmf и добавлен дефолт для title в NumberInputModal, чтобы не рантаймило при пустом заголовке

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлена стилизация шёпота (меньший шрифт) для сообщений в чате.

* **Улучшения**
  * Ленивая загрузка и кэширование иконок префиксов в чате.
  * Улучшено поведение фокусировки и автоматического выделения в полях ввода (новые авто-фокус/авто-выделение).
  * Перешли на более предсказуемое расписание обновлений для числовых полей (вызовы через requestAnimationFrame).
  * Мелкие изменения в отображении статусной панели и текстовых стилей.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->