### PR TITLE
Batches auto-cryo and ghost cleanup

### DIFF
--- a/modular_splurt/code/controllers/subsystem/afk.dm
+++ b/modular_splurt/code/controllers/subsystem/afk.dm
@@ -36,7 +36,6 @@ SUBSYSTEM_DEF(auto_cryo)
 			if(afk_time < SUBSYSTEM_CRYO_TIME)
 				continue
 			cryoMob(cryo_mob, is_teleporter = TRUE, effects = TRUE) //BLUEMOON CHANGE было is_teleporter = FALSE (нужно для правильного описания коробки в некоторых ситуациях)
-			GLOB.ssd_mob_list -= cryo_mob
 			log_game("[cryo_mob] was sent to cryo after being SSD for [afk_time] ticks.")
 			if(MC_TICK_CHECK)
 				return

--- a/modular_splurt/code/controllers/subsystem/afk.dm
+++ b/modular_splurt/code/controllers/subsystem/afk.dm
@@ -8,6 +8,10 @@ SUBSYSTEM_DEF(auto_cryo)
 	name = "Automated Cryogenics"
 	flags = SS_BACKGROUND
 	wait = 5 MINUTES
+	/// Current batch of SSD mobs being processed
+	var/list/currentrun_cryo = list()
+	/// Current batch of ghosts being processed
+	var/list/currentrun_ghosts = list()
 
 /datum/controller/subsystem/auto_cryo/Initialize()
 	// Check config before running
@@ -17,61 +21,45 @@ SUBSYSTEM_DEF(auto_cryo)
 	return ..()
 
 /datum/controller/subsystem/auto_cryo/fire()
+	// Process cryo mobs
 	if(SUBSYSTEM_CRYO_CAN_RUN)
-		cryo_mobs()
-	if(SUBSYSTEM_CRYO_CHECK_GHOSTS) //BLUEMOON REWORKED real this time
-		cull_ghosts()
+		if(!currentrun_cryo.len)
+			currentrun_cryo = GLOB.ssd_mob_list.Copy()
+		while(currentrun_cryo.len)
+			var/mob/living/cryo_mob = currentrun_cryo[currentrun_cryo.len]
+			currentrun_cryo.len--
+			if(QDELETED(cryo_mob) || !isliving(cryo_mob))
+				continue
+			if(!(cryo_mob in GLOB.ssd_mob_list))
+				continue
+			var/afk_time = world.time - cryo_mob.lastclienttime
+			if(afk_time < SUBSYSTEM_CRYO_TIME)
+				continue
+			cryoMob(cryo_mob, is_teleporter = TRUE, effects = TRUE) //BLUEMOON CHANGE было is_teleporter = FALSE (нужно для правильного описания коробки в некоторых ситуациях)
+			GLOB.ssd_mob_list -= cryo_mob
+			log_game("[cryo_mob] was sent to cryo after being SSD for [afk_time] ticks.")
+			if(MC_TICK_CHECK)
+				return
 
-/datum/controller/subsystem/auto_cryo/proc/cryo_mobs()
-	// Check for any targets
-	if(!LAZYLEN(GLOB.ssd_mob_list))
-		// No SSD mobs exist
-		return
-
-	// Check possible targets
-	var/afk_time
-	for(var/mob/living/cryo_mob in GLOB.ssd_mob_list)
-
-		// Get SSD time
-		// This is set when disconnecting
-		afk_time = world.time - cryo_mob.lastclienttime
-
-		// Check if client meets the time requirement
-		if(afk_time < SUBSYSTEM_CRYO_TIME)
-			continue
-
-		// Send to cryo
-		cryoMob(cryo_mob, is_teleporter = TRUE, effects = TRUE) //BLUEMOON CHANGE было is_teleporter = FALSE (нужно для правильного описания коробки в некоторых ситуациях)
-
-		// Remove from SSD list
-		GLOB.ssd_mob_list -= cryo_mob
-
-		// Log cryo interaction
-		log_game("[cryo_mob] was sent to cryo after being SSD for [afk_time] ticks.")
-
-//BLUEMOON REWORKED теперь реально удаляем гостов
-/datum/controller/subsystem/auto_cryo/proc/cull_ghosts()
-	// Check for any targets
-	if(!LAZYLEN(GLOB.dead_mob_list))
-		return
-
-	// Check possible targets
-	var/afk_time = 0
-	for(var/mob/dead/observer/ghost_mob in GLOB.dead_mob_list)
-		// Get SSD time
-		// This is set when disconnecting
-		afk_time = world.time - ghost_mob.lastclienttime
-
-		// Check if client meets the time requirement
-		if(ghost_mob.client || afk_time < SUBSYSTEM_CRYO_GHOST_PERIOD)
-			continue
-
-		// Log del interaction
-		log_game("[ghost_mob] was deleted after being SSD for [afk_time] ticks.")
-
-		// Send to valhalla
-		qdel(ghost_mob)
-//BLUEMOON REWORKED END
+	//BLUEMOON REWORKED теперь реально удаляем гостов
+	if(SUBSYSTEM_CRYO_CHECK_GHOSTS)
+		if(!currentrun_ghosts.len)
+			currentrun_ghosts = GLOB.dead_mob_list.Copy()
+		while(currentrun_ghosts.len)
+			var/mob/dead/observer/ghost_mob = currentrun_ghosts[currentrun_ghosts.len]
+			currentrun_ghosts.len--
+			if(QDELETED(ghost_mob) || !istype(ghost_mob))
+				continue
+			if(ghost_mob.client)
+				continue
+			var/afk_time = world.time - ghost_mob.lastclienttime
+			if(afk_time < SUBSYSTEM_CRYO_GHOST_PERIOD)
+				continue
+			log_game("[ghost_mob] was deleted after being SSD for [afk_time] ticks.")
+			qdel(ghost_mob)
+			if(MC_TICK_CHECK)
+				return
+	//BLUEMOON REWORKED END
 
 // Remove defines
 #undef SUBSYSTEM_CRYO_CAN_RUN

--- a/modular_splurt/code/controllers/subsystem/afk.dm
+++ b/modular_splurt/code/controllers/subsystem/afk.dm
@@ -28,15 +28,11 @@ SUBSYSTEM_DEF(auto_cryo)
 		while(currentrun_cryo.len)
 			var/mob/living/cryo_mob = currentrun_cryo[currentrun_cryo.len]
 			currentrun_cryo.len--
-			if(QDELETED(cryo_mob) || !isliving(cryo_mob))
-				continue
-			if(!(cryo_mob in GLOB.ssd_mob_list))
-				continue
-			var/afk_time = world.time - cryo_mob.lastclienttime
-			if(afk_time < SUBSYSTEM_CRYO_TIME)
-				continue
-			cryoMob(cryo_mob, is_teleporter = TRUE, effects = TRUE) //BLUEMOON CHANGE было is_teleporter = FALSE (нужно для правильного описания коробки в некоторых ситуациях)
-			log_game("[cryo_mob] was sent to cryo after being SSD for [afk_time] ticks.")
+			if(!QDELETED(cryo_mob) && isliving(cryo_mob) && (cryo_mob in GLOB.ssd_mob_list))
+				var/afk_time = world.time - cryo_mob.lastclienttime
+				if(afk_time >= SUBSYSTEM_CRYO_TIME)
+					cryoMob(cryo_mob, is_teleporter = TRUE, effects = TRUE) //BLUEMOON CHANGE было is_teleporter = FALSE (нужно для правильного описания коробки в некоторых ситуациях)
+					log_game("[cryo_mob] was sent to cryo after being SSD for [afk_time] ticks.")
 			if(MC_TICK_CHECK)
 				return
 
@@ -47,15 +43,11 @@ SUBSYSTEM_DEF(auto_cryo)
 		while(currentrun_ghosts.len)
 			var/mob/dead/observer/ghost_mob = currentrun_ghosts[currentrun_ghosts.len]
 			currentrun_ghosts.len--
-			if(QDELETED(ghost_mob) || !istype(ghost_mob))
-				continue
-			if(ghost_mob.client)
-				continue
-			var/afk_time = world.time - ghost_mob.lastclienttime
-			if(afk_time < SUBSYSTEM_CRYO_GHOST_PERIOD)
-				continue
-			log_game("[ghost_mob] was deleted after being SSD for [afk_time] ticks.")
-			qdel(ghost_mob)
+			if(!QDELETED(ghost_mob) && istype(ghost_mob) && !ghost_mob.client)
+				var/afk_time = world.time - ghost_mob.lastclienttime
+				if(afk_time >= SUBSYSTEM_CRYO_GHOST_PERIOD)
+					log_game("[ghost_mob] was deleted after being SSD for [afk_time] ticks.")
+					qdel(ghost_mob)
 			if(MC_TICK_CHECK)
 				return
 	//BLUEMOON REWORKED END


### PR DESCRIPTION
## Батчинг авто-крио и удаления призраков

Переписал `SSauto_cryo`, чтобы он не съедал весь тик за раз.

### Проблема

Раньше подсистема при каждом `fire()` проходила по всему `GLOB.ssd_mob_list` и `GLOB.dead_mob_list` целиком - при большом количестве SSD-мобов или призраков это могло залочить тик и вызвать подвисания

### Что изменилось

- Оба цикла (крио-отправка и удаление призраков) теперь работают через батчи с `MC_TICK_CHECK` - если тик заканчивается, обработка прерывается и продолжается в следующем `fire()`
- Списки `currentrun_cryo` и `currentrun_ghosts` сохраняются между вызовами, так что ничего не теряется
- Добавлены проверки на `QDELETED()` и `istype()`/`isliving()` - на случай если моб удалился или изменился между циклами

### Что не затронуто

Логика таймингов и логирования не изменилась, всё работает как раньше - только теперь не тормозит

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Рефакторинг**
  * Переведена обработка неактивных игроков и призраков на поэтапную пакетную обработку в рамках одного цикла для снижения пиковых нагрузок.
  * Добавлена явная очередность и защита от повторной или некорректной обработки объектов, улучшена фильтрация перед выполнением действий.
* **Исправления**
  * Стабилизирована логика крио и удаления призраков: корректные тайминги, логирование и своевременный выход по таймеру цикла.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->