### PR TITLE
Ещё больше полировки отображения сообщений у слепых

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -205,7 +205,7 @@
 ///Adds the functionality to self_message.
 /mob/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, mob/target, target_message, omni = FALSE, runechat_popup, rune_msg, visible_message_flags)
 	. = ..()
-	if(self_message && target && target != src)
+	if(self_message && target != src)
 		if(omni || !blind_message)
 			show_message(self_message)
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -163,7 +163,7 @@
 
 	if(target_message && target && istype(target) && (target.client || target.audiovisual_redirect))
 		hearers -= target
-		if(omni || (target_message && !blind_message))
+		if(omni || !blind_message)
 			target.show_message(target_message)
 		else
 			//This entire if/else chain could be in two lines but isn't for readibilties sake.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -154,11 +154,16 @@
 	var/list/hearers = get_hearers_in_view(vision_distance, src) //caches the hearers and then removes ignored mobs.
 	if(!length(hearers))
 		return
+
+	var/raw_msg = message
+	if(visible_message_flags & EMOTE_MESSAGE)
+		message = "<span class='emote'><b>[src]</b>[separation][message]</span>" // SKYRAT EDIT - Better emotes
+
 	hearers -= ignored_mobs
 
 	if(target_message && target && istype(target) && (target.client || target.audiovisual_redirect))
 		hearers -= target
-		if(omni)
+		if(omni || (target_message && !blind_message))
 			target.show_message(target_message)
 		else
 			//This entire if/else chain could be in two lines but isn't for readibilties sake.
@@ -169,13 +174,9 @@
 			else if(target.lighting_alpha > LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE && T.is_softly_lit() && !in_range(T,target))
 				msg = blind_message
 			if(msg)
-				target.show_message(msg, MSG_VISUAL,blind_message, MSG_AUDIBLE)
+				target.show_message(msg, MSG_VISUAL, in_range(T, target) ? msg : blind_message, MSG_AUDIBLE)
 	if(self_message)
 		hearers -= src
-
-	var/raw_msg = message
-	if(visible_message_flags & EMOTE_MESSAGE)
-		message = "<span class='emote'><b>[src]</b>[separation][message]</span>" // SKYRAT EDIT - Better emotes
 
 	for(var/mob/M in hearers)
 		if(!M.client && !M.audiovisual_redirect)
@@ -204,15 +205,13 @@
 ///Adds the functionality to self_message.
 /mob/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, mob/target, target_message, omni = FALSE, runechat_popup, rune_msg, visible_message_flags)
 	. = ..()
-	if(self_message && target != src)
-		if(!omni)
-			show_message(self_message, MSG_VISUAL, blind_message, MSG_AUDIBLE)
-			if(runechat_popup && client?.prefs.chat_on_map && client.prefs.see_chat_emotes) //SKYRAT CHANGE
-				create_chat_message(src, null, rune_msg ? rune_msg : self_message, list("emote", "italics"), null) //Skyrat change
-		else
+	if(self_message && target && target != src)
+		if(omni || !blind_message)
 			show_message(self_message)
-			if(runechat_popup && client?.prefs.chat_on_map && client.prefs.see_chat_emotes) //SKYRAT CHANGE
-				create_chat_message(src, null, rune_msg ? rune_msg : self_message, list("emote", "italics"), null) //Skyrat change
+		else
+			show_message(self_message, MSG_VISUAL, blind_message, MSG_AUDIBLE)
+		if(runechat_popup && client?.prefs.chat_on_map && client.prefs.see_chat_emotes) //SKYRAT CHANGE
+			create_chat_message(src, null, rune_msg ? rune_msg : self_message, list("emote", "italics"), null) //Skyrat change
 
 /**
   * Show a message to all mobs in earshot of this atom


### PR DESCRIPTION
# Описание
1) Если сообщение исходит от слепого, то при отсутствии сообщения для слепых тот будет видеть сообщение для себя, в ином случае получая сообщение как для слепого
2) Если целью сообщения является слепой, есть текст для него и нет сообщения для слепых, то будет отображаться текст словно он зрячий
3) Если визуальное сообщение происходит в 1 турфе от цели, то она его видит как не слепая цель
## Причина изменений
фиксы ещё пары ишшуев со слепыми (те не могли понять, что их гладят на хелпе (например)) или что они сами не видели (в чате), что кого-то обняли


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Улучшения**
  * Оптимизирована доставка сообщений с улучшенной обработкой видимости, целевых и собственных сообщений.
  * Уточнена логика показа целевых и собственных сообщений в зависимости от видимости и расстояния.
  * Форматирование эмот-сообщений стало последовательнее: исходный текст сохраняется для корректного отображения.
  * Добавлен флаг для гибкого управления поведением видимых сообщений и форматированием эмотов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->