### PR TITLE
Fixes edge-case runtimes across gameplay systems

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -169,12 +169,12 @@
 		else
 			var/turned_adjacency = turn(adjacencies, 180)
 			var/turf/T = get_step(src, turned_adjacency)
-			if(!T.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
+			if(!T?.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 				T = get_step(src, turn(adjacencies, 135))
-				if(!T.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
+				if(!T?.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 					T = get_step(src, turn(adjacencies, 225))
 			//if all else fails, ask our own turf
-			if(!T.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency) && !get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
+			if(!T?.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency) && !get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 				underlay_appearance.icon = DEFAULT_UNDERLAY_ICON
 				underlay_appearance.icon_state = DEFAULT_UNDERLAY_ICON_STATE
 		underlays = U

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -6390,6 +6390,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(!length(user_gear[LOADOUT_COLOR]))
 					user_gear[LOADOUT_COLOR] = list("#FFFFFF")
 				var/current_color = user_gear[LOADOUT_COLOR][1]
+				if(!istext(current_color))
+					current_color = "#FFFFFF"
 				var/new_color = input(user, "Polychromic options", "Choose Color", current_color) as color|null
 				user_gear[LOADOUT_COLOR][1] = sanitize_hexcolor(new_color, 6, TRUE, current_color)
 
@@ -6413,6 +6415,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(color_to_change)
 					var/color_index = text2num(copytext(color_to_change, 7))
 					var/current_color = user_gear[LOADOUT_COLOR][color_index]
+					if(!istext(current_color))
+						current_color = "#FFFFFF"
 					var/new_color = input(user, "Polychromic options", "Choose [color_to_change] Color", current_color) as color|null
 					if(new_color)
 						user_gear[LOADOUT_COLOR][color_index] = sanitize_hexcolor(new_color, 6, TRUE, current_color)

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -50,7 +50,7 @@
 
 /datum/round_event/aurora_caelus/tick()
 	if(activeFor % 5 == 0)
-		aurora_progress++
+		aurora_progress = (aurora_progress % aurora_colors.len) + 1
 		var/aurora_color = aurora_colors[aurora_progress]
 		for(var/area in GLOB.sortedAreas)
 			var/area/A = area

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -79,7 +79,7 @@
 //Second link in a breath chain, calls check_breath()
 /mob/living/carbon/proc/breathe()
 	var/obj/item/organ/lungs = getorganslot(ORGAN_SLOT_LUNGS)
-	if(reagents.has_reagent(/datum/reagent/toxin/lexorin))
+	if(reagents?.has_reagent(/datum/reagent/toxin/lexorin))
 		return
 	if(istype(loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
 		return
@@ -160,7 +160,7 @@
 
 	//CRIT
 	if(!breath || (breath.total_moles() == 0) || !lungs)
-		if(reagents.has_reagent(/datum/reagent/medicine/epinephrine) && lungs)
+		if(reagents?.has_reagent(/datum/reagent/medicine/epinephrine) && lungs)
 			return
 		adjustOxyLoss(1)
 
@@ -399,7 +399,7 @@
 			if(O)
 				O.on_life(seconds, times_fired)
 	else if(!QDELETED(src))
-		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/preservahyde, 1)) // No organ decay if the body contains formaldehyde. Or preservahyde.
+		if(reagents?.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents?.has_reagent(/datum/reagent/preservahyde, 1)) // No organ decay if the body contains formaldehyde. Or preservahyde.
 			return
 		for(var/V in internal_organs)
 			var/obj/item/organ/O = V

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -847,8 +847,9 @@ BLUEMOON REMOVAL END */
 		liver_failure(seconds, times_fired)
 
 /mob/living/carbon/proc/liver_failure(seconds, times_fired)
-	reagents.end_metabolization(src, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
-	reagents.metabolize(src, seconds, times_fired, can_overdose=FALSE, liverless = TRUE)
+	if(reagents)
+		reagents.end_metabolization(src, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
+		reagents.metabolize(src, seconds, times_fired, can_overdose=FALSE, liverless = TRUE)
 	if(HAS_TRAIT(src, TRAIT_STABLELIVER))
 		return
 	adjustToxLoss(4, TRUE,  TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -585,6 +585,8 @@
 //These two procs handle losing our target if we've failed to attack them for
 //more than lose_patience_timeout deciseconds, which probably means we're stuck
 /mob/living/simple_animal/hostile/proc/GainPatience()
+	if(QDELETED(src))
+		return
 	if(lose_patience_timeout)
 		LosePatience()
 		lose_patience_timer_id = addtimer(CALLBACK(src, PROC_REF(LoseTarget)), lose_patience_timeout, TIMER_STOPPABLE)
@@ -596,6 +598,8 @@
 
 //These two procs handle losing and regaining search_objects when attacked by a mob
 /mob/living/simple_animal/hostile/proc/LoseSearchObjects()
+	if(QDELETED(src))
+		return
 	search_objects = 0
 	deltimer(search_objects_timer_id)
 	search_objects_timer_id = addtimer(CALLBACK(src, PROC_REF(RegainSearchObjects)), search_objects_regain_time, TIMER_STOPPABLE)

--- a/code/modules/modular_computers/file_system/programs/minesweeper.dm
+++ b/code/modules/modular_computers/file_system/programs/minesweeper.dm
@@ -211,6 +211,9 @@
 		data["elapsed"] = 0
 
 	// Сериализуем поле — отправляем только видимое
+	if(!length(cell_state))
+		data["grid"] = list()
+		return data
 	var/list/rows = list()
 	for(var/y in 1 to grid_h)
 		var/list/row = list()

--- a/modular_bluemoon/code/datums/mutations/mutation_traits.dm
+++ b/modular_bluemoon/code/datums/mutations/mutation_traits.dm
@@ -5,7 +5,7 @@
 
 /datum/mutation/human/bm/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
-		return
+		return TRUE
 	if(mob_trait)
 		if(HAS_TRAIT(owner, mob_trait))
 			instability = 0
@@ -1140,8 +1140,8 @@
 	text_lose_indication = "<span class='danger'>Жор идёт на спад.</span>"
 
 /datum/mutation/human/bm/hungry/on_acquiring(mob/living/carbon/human/owner)
-	. = ..()
-
+	if(..())
+		return TRUE
 	var/datum/physiology/P = owner.physiology
 	P.hunger_mod *= 2
 
@@ -1163,8 +1163,8 @@
 	text_lose_indication = "<span class='danger'>Ваша повышенная тяга к воде начинает угасать.</span>"
 
 /datum/mutation/human/bm/thirsty/on_acquiring(mob/living/carbon/human/owner)
-	. = ..()
-
+	if(..())
+		return TRUE
 	var/datum/physiology/P = owner.physiology
 	P.thirst_mod *= 2
 

--- a/modular_bluemoon/code/datums/traits/good/restorative_nanobots_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/good/restorative_nanobots_quirk.dm
@@ -79,11 +79,14 @@
 	if (!consumed_damage)
 		if(healing_in_progress)
 			REMOVE_TRAIT(H, TRAIT_NANOBOT_REPAIR_IN_PROGRESS, QUIRK_TRAIT)
-			H.physiology.hunger_mod /= 1.8
+			if(H.physiology)
+				H.physiology.hunger_mod /= 1.8
 			healing_in_progress = FALSE
 		return
 
 	if(!healing_in_progress)
+		if(!H.physiology)
+			return
 		ADD_TRAIT(H, TRAIT_NANOBOT_REPAIR_IN_PROGRESS, QUIRK_TRAIT)
 		H.physiology.hunger_mod *= 1.8
 		healing_in_progress = TRUE
@@ -98,7 +101,8 @@
 
 /datum/quirk/restorative_nanobots/remove()
 	var/mob/living/carbon/human/H = quirk_holder
-	if (!istype(H) || !H.physiology || !healing_in_progress)
+	if (!istype(H) || !healing_in_progress)
 		return
-	H.physiology.hunger_mod /= 1.8
-	REMOVE_TRAIT(quirk_holder, TRAIT_NANOBOT_REPAIR_IN_PROGRESS, QUIRK_TRAIT)
+	REMOVE_TRAIT(H, TRAIT_NANOBOT_REPAIR_IN_PROGRESS, QUIRK_TRAIT)
+	if(H.physiology)
+		H.physiology.hunger_mod /= 1.8

--- a/modular_bluemoon/code/datums/traits/good/restorative_nanobots_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/good/restorative_nanobots_quirk.dm
@@ -98,7 +98,7 @@
 
 /datum/quirk/restorative_nanobots/remove()
 	var/mob/living/carbon/human/H = quirk_holder
-	if (!istype(H) || !healing_in_progress)
+	if (!istype(H) || !H.physiology || !healing_in_progress)
 		return
 	H.physiology.hunger_mod /= 1.8
 	REMOVE_TRAIT(quirk_holder, TRAIT_NANOBOT_REPAIR_IN_PROGRESS, QUIRK_TRAIT)

--- a/modular_bluemoon/code/datums/traits/good/syscleaner_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/good/syscleaner_quirk.dm
@@ -22,18 +22,21 @@
 /datum/quirk/syscleaner/on_process()
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
-	if (!istype(H) || !H.physiology)
+	if (!istype(H))
 		return
 
 	var/consumed_damage = H.getToxLoss(TOX_SYSCORRUPT)
 	if (!consumed_damage)
 		if(syscleaning_in_progress)
 			REMOVE_TRAIT(H, TRAIT_SYSCLEANER_IN_PROGRESS, QUIRK_TRAIT)
-			H.physiology.hunger_mod /= 1.6
+			if(H.physiology)
+				H.physiology.hunger_mod /= 1.6
 			syscleaning_in_progress = FALSE
 		return
 
 	if(!syscleaning_in_progress)
+		if(!H.physiology)
+			return
 		ADD_TRAIT(H, TRAIT_SYSCLEANER_IN_PROGRESS, QUIRK_TRAIT)
 		H.physiology.hunger_mod *= 1.6
 		syscleaning_in_progress = TRUE
@@ -47,7 +50,8 @@
 
 /datum/quirk/syscleaner/remove()
 	var/mob/living/carbon/human/H = quirk_holder
-	if (!istype(H) || !syscleaning_in_progress || !H.physiology)
+	if (!istype(H) || !syscleaning_in_progress)
 		return
-	H.physiology.hunger_mod /= 1.6
+	if(H.physiology)
+		H.physiology.hunger_mod /= 1.6
 	REMOVE_TRAIT(quirk_holder, TRAIT_SYSCLEANER_IN_PROGRESS, QUIRK_TRAIT)

--- a/modular_bluemoon/code/datums/traits/good/syscleaner_quirk.dm
+++ b/modular_bluemoon/code/datums/traits/good/syscleaner_quirk.dm
@@ -22,7 +22,7 @@
 /datum/quirk/syscleaner/on_process()
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
-	if (!istype(H))
+	if (!istype(H) || !H.physiology)
 		return
 
 	var/consumed_damage = H.getToxLoss(TOX_SYSCORRUPT)
@@ -47,7 +47,7 @@
 
 /datum/quirk/syscleaner/remove()
 	var/mob/living/carbon/human/H = quirk_holder
-	if (!istype(H) || !syscleaning_in_progress)
+	if (!istype(H) || !syscleaning_in_progress || !H.physiology)
 		return
 	H.physiology.hunger_mod /= 1.6
 	REMOVE_TRAIT(quirk_holder, TRAIT_SYSCLEANER_IN_PROGRESS, QUIRK_TRAIT)

--- a/modular_bluemoon/code/modules/mob/living/simple_animal/tentacles/tentacles.dm
+++ b/modular_bluemoon/code/modules/mob/living/simple_animal/tentacles/tentacles.dm
@@ -246,18 +246,21 @@
 		if(CUM_TARGET_VAGINA)
 			message = "вгоняют свои тентакли в дырочки \the [M] и заполняют их спермой!"
 			target_gen = M.getorganslot(ORGAN_SLOT_WOMB)
-			target_gen.reagents.add_reagent(/datum/reagent/consumable/semen, 100)
-			M.impregnate(src, M.getorganslot(ORGAN_SLOT_WOMB), src.type)
+			if(target_gen)
+				target_gen.reagents.add_reagent(/datum/reagent/consumable/semen, 100)
+				M.impregnate(src, target_gen, src.type)
 
 		if(CUM_TARGET_PENIS)
 			message = "обхватывают член \the [M] и обливают спермой!"
 			target_gen = M.getorganslot(ORGAN_SLOT_PENIS)
-			target_gen.reagents.add_reagent(/datum/reagent/consumable/semen, 100)
+			if(target_gen)
+				target_gen.reagents.add_reagent(/datum/reagent/consumable/semen, 100)
 
 		if(CUM_TARGET_ANUS)
 			message = "вгоняют свои тентакли в задницу \the [M] и заполняют её спермой!"
 			target_gen = M.getorganslot(ORGAN_SLOT_ANUS)
-			target_gen.reagents.add_reagent(/datum/reagent/consumable/semen, 100)
+			if(target_gen)
+				target_gen.reagents.add_reagent(/datum/reagent/consumable/semen, 100)
 
 	if(istype(M, /mob/living/carbon))
 		M.reagents.add_reagent(/datum/reagent/drug/aphrodisiacplus, 5) //Cum contains hexocrocin

--- a/modular_sand/code/datums/traits/negative.dm
+++ b/modular_sand/code/datums/traits/negative.dm
@@ -16,7 +16,7 @@
 /datum/quirk/sheltered/remove() //i mean, the lose text explains it, so i'm making it actually work
 	var/mob/living/carbon/human/H = quirk_holder
 	// BLUEMOON EDIT START - sanity check
-	if(!H)
+	if(!H || QDELING(H))
 		return
 	// BLUEMOON EDIT END
 	H.grant_language(/datum/language/common)


### PR DESCRIPTION
Пачка мелких, но нужных фиксов по рантаймам, которые вылезали в edge-case ситуациях:

- Дыхание и органика: добавлены ?. проверки на reagents у карбонов - крашило, если реагенты ещё не инициализированы (life.dm)
- Сглаживание иконок: get_step() мог вернуть null на краю карты - добавлен ?. оператор
- Мутации: on_acquiring() теперь корректно возвращает TRUE при неудаче родителя, а не молча продолжает - из-за этого пропускались эффекты голода/жажды и крашило на обращении к physiology
- Квирки (наноботы, syscleaner, sheltered): проверки на physiology и QDELING - без них крашило при удалении квирка, если моб уже в процессе удаления
- Тентакли: null-чеки на органы перед обращением к reagents - не у всех мобов есть нужные слоты
- Hostile AI: QDELETED(src) в GainPatience/LoseSearchObjects - таймеры могли стрельнуть по удалённому мобу
- Сапёр: пустое поле cell_state крашило сериализацию - теперь возвращает пустой грид
- Preferences: невалидный цвет в loadout больше не крашит color picker
- Aurora Caelus: прогресс цвета теперь корректно зацикливается вместо выхода за границы массива

В общем, ничего геймплейного не меняется - просто убраны краши в местах, где не хватало проверок на null/deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Повышена надёжность визуальных эффектов и цикла смены цветов (исправление обхода индекса цветов).
  * Устранены сбои при отсутствии данных: безопасная обработка пустых полей в играх и сохранениях сеток.
  * Стабильность при работе с предметными/биологическими системами и чертами улучшена — добавлены проверки перед изменением состояния.
  * Исправлена обработка пользовательских настроек цвета — добавлен безопасный возврат к значению по умолчанию.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->