### PR TITLE
Фикс падения CI тестов: runtime в lighting и flaky nightshift_relight_resync

### DIFF
--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -84,6 +84,8 @@
 /// Computes blended area lighting profile by averaging this turf's area with 4 cardinal neighbors.
 /// Produces soft transitions at zone boundaries instead of hard color jumps.
 /atom/movable/lighting_object/proc/calculate_area_blend()
+	if(!affected_turf)
+		return
 	prev_was_dark = FALSE
 	var/area/center_area = affected_turf.loc
 	var/turf/n_turf = get_step(affected_turf, NORTH)

--- a/code/modules/unit_tests/nightshift.dm
+++ b/code/modules/unit_tests/nightshift.dm
@@ -302,6 +302,7 @@
 	test_area.power_light = TRUE
 	test_area.lightswitch = TRUE
 	test_light = allocate(/obj/machinery/light, light_turf)
+	sleep(4) // Wait for Initialize's spawn(2) { prob(2) break_light_tube; spawn(1) { update(0) }} to finish
 	test_light.status = LIGHT_OK
 	test_light.on = test_light.has_power()
 	test_light.switchcount = 0

--- a/code/modules/unit_tests/nightshift.dm
+++ b/code/modules/unit_tests/nightshift.dm
@@ -270,6 +270,8 @@
 	var/list/original_apcs_list
 	var/obj/machinery/power/apc/original_area_apc
 	var/original_can_fire
+	var/original_power_light
+	var/original_lightswitch
 	var/area/test_area
 	var/turf/light_turf
 	var/obj/machinery/power/apc/test_apc
@@ -281,11 +283,14 @@
 	SSnightshift.can_fire = FALSE
 	sleep(world.tick_lag)
 	SSnightshift.nightshift_refresh_running = FALSE
+	SSnightshift.nightshift_refresh_generation++ // Invalidate any running async refresh
 	test_area = get_area(run_loc_floor_bottom_left)
 	light_turf = locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z)
 	original_station_areas = GLOB.the_station_areas.Copy()
 	original_apcs_list = GLOB.apcs_list.Copy()
 	original_area_apc = test_area.power_apc
+	original_power_light = test_area.power_light
+	original_lightswitch = test_area.lightswitch
 	GLOB.the_station_areas = list(test_area.type)
 	GLOB.nightshift_apc_queue.Cut()
 	GLOB.nightshift_light_queue.Cut()
@@ -294,6 +299,8 @@
 	test_area.power_apc = test_apc
 	GLOB.apcs_list = list(test_apc)
 	test_apc.update()
+	test_area.power_light = TRUE
+	test_area.lightswitch = TRUE
 	test_light = allocate(/obj/machinery/light, light_turf)
 	test_light.status = LIGHT_OK
 	test_light.on = test_light.has_power()
@@ -307,6 +314,8 @@
 	GLOB.the_station_areas = original_station_areas
 	GLOB.apcs_list = original_apcs_list
 	test_area.power_apc = original_area_apc
+	test_area.power_light = original_power_light
+	test_area.lightswitch = original_lightswitch
 	if(original_area_apc && !QDELETED(original_area_apc))
 		original_area_apc.area = test_area
 		original_area_apc.register_area_apc()


### PR DESCRIPTION
Фиксит два бага в CI которые роняли тесты на многих PR-ах, хотя сами PR-ы к освещению отношения не имели

Первый - calculate_area_blend() крашился с пустым рантаймом когда affected_turf уже null (после force-удаления турфа). Добавлена проверка

Второй - nightshift_relight_resync флакал из-за гонки с асинхронным nightshift refresh: тест ставил nightshift_refresh_running = FALSE, но сам async proc продолжал работать и портил состояние. Теперь бампается nightshift_refresh_generation чтобы async proc вышел по early-exit. Плюс тест явно выставляет power_light/lightswitch чтобы не зависеть от того, есть ли у тестового APC реальное питание


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Исправлена ошибка в расчёте смешанного освещения, предотвращающая обращения к недействительной поверхности и повышающая стабильность обновлений уровня освещённости в зонах.

* **Tests**
  * Улучшены модульные тесты подсветки: теперь они сохраняют/восстанавливают состояние зоны, корректируют порядок и задержки и надежно инвалидируют фоновые обновления для стабильности тестирования.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->