### PR TITLE
Багфиксы + юнит тесты: offering, inteq постер, pregnancy

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -157,10 +157,14 @@
 /datum/status_effect/offering/proc/check_owner_in_range(mob/living/carbon/source)
 	SIGNAL_HANDLER
 
+	var/list/to_remove
 	for(var/i in possible_takers)
 		var/mob/living/carbon/checking_taker = i
 		if(!istype(checking_taker) || !owner.CanReach(checking_taker) || IS_DEAD_OR_INCAP(checking_taker))
-			remove_candidate(checking_taker)
+			LAZYADD(to_remove, checking_taker)
+
+	for(var/mob/living/carbon/removed in to_remove)
+		remove_candidate(removed)
 
 /// We lost the item, give it up
 /datum/status_effect/offering/proc/dropped_item(obj/item/source)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -146,6 +146,7 @@
 /// BLUEMOON TESTS
 #include "auto_cryo.dm"
 #include "bad_defines_defined.dm"
+#include "bugfix_coverage.dm"
 #include "disposal_holder.dm"
 #include "memory_leak_limits.dm"
 #include "human_mob_gc.dm"

--- a/code/modules/unit_tests/bugfix_coverage.dm
+++ b/code/modules/unit_tests/bugfix_coverage.dm
@@ -1,0 +1,88 @@
+/// Tests for bugfixes: offering list iteration, inteq poster null guard, pregnancy signal registration
+
+// Test subtype that bypasses throw_alert (requires client) so we can test check_owner_in_range
+/datum/status_effect/offering/unit_test
+	id = "offering_unit_test"
+
+/datum/status_effect/offering/unit_test/on_creation(mob/living/new_owner, obj/item/offer, give_alert_override)
+	owner = new_owner
+	offered_item = offer
+	if(owner)
+		LAZYADD(owner.status_effects, src)
+	return TRUE
+
+// Test: check_owner_in_range collects removals into a separate list before modifying possible_takers
+// If the old code (modifying list during iteration) were present, this would runtime
+/datum/unit_test/offering_remove_on_move/Run()
+	var/mob/living/carbon/human/test_owner = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/taker1 = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/taker2 = allocate(/mob/living/carbon/human)
+	var/obj/item/storage/toolbox/test_item = allocate(/obj/item/storage/toolbox)
+
+	// Place owner and takers adjacent
+	test_owner.forceMove(run_loc_floor_bottom_left)
+	taker1.forceMove(get_step(run_loc_floor_bottom_left, EAST))
+	taker2.forceMove(get_step(run_loc_floor_bottom_left, NORTH))
+
+	test_owner.put_in_active_hand(test_item, forced = TRUE)
+
+	// Create offering effect via test subtype that skips client-dependent alert logic
+	test_owner.apply_status_effect(/datum/status_effect/offering/unit_test, test_item)
+	var/datum/status_effect/offering/effect = test_owner.has_status_effect(/datum/status_effect/offering/unit_test)
+	TEST_ASSERT_NOTNULL(effect, "Offering status effect was not applied")
+
+	// Manually populate possible_takers (bypassing throw_alert)
+	LAZYADD(effect.possible_takers, taker1)
+	LAZYADD(effect.possible_takers, taker2)
+
+	TEST_ASSERT_EQUAL(LAZYLEN(effect.possible_takers), 2, "Should have 2 takers registered")
+
+	// Move takers far away so they are out of range
+	taker1.forceMove(locate(run_loc_floor_bottom_left.x + 5, run_loc_floor_bottom_left.y + 5, run_loc_floor_bottom_left.z))
+	taker2.forceMove(locate(run_loc_floor_bottom_left.x + 5, run_loc_floor_bottom_left.y + 4, run_loc_floor_bottom_left.z))
+
+	// Call the fixed proc — old code would crash from list modification during iteration
+	effect.check_owner_in_range(test_owner)
+
+	// Both takers should have been removed
+	TEST_ASSERT(!LAZYLEN(effect.possible_takers), "All out-of-range takers should have been removed")
+
+// Test: InteQ poster process() handles null demotivator gracefully
+/datum/unit_test/inteq_poster_null_demotivator/Run()
+	var/obj/structure/sign/poster/contraband/inteq/poster = allocate(/obj/structure/sign/poster/contraband/inteq/inteq_recruitment)
+
+	TEST_ASSERT_NOTNULL(poster.demotivator, "Poster should have demotivator after initialization")
+
+	// Simulate wirecutter removing demotivator
+	QDEL_NULL(poster.demotivator)
+
+	// This should not runtime with the null guard fix
+	poster.process()
+
+	// If we got here without a runtime, the null guard works
+	TEST_ASSERT_NULL(poster.demotivator, "Demotivator should still be null after process()")
+
+// Test: Pregnancy component registers handle_damage on COMSIG_MOB_APPLY_DAMAGE, not COMSIG_MOB_DEATH
+/datum/unit_test/pregnancy_damage_signal/Run()
+	var/mob/living/carbon/human/carrier = allocate(/mob/living/carbon/human)
+
+	// Set up organ for egg placement
+	var/obj/item/organ/genital/womb/womb = allocate(/obj/item/organ/genital/womb)
+	womb.Insert(carrier)
+	TEST_ASSERT_EQUAL(womb.owner, carrier, "Womb organ should be owned by carrier after Insert")
+
+	// Create egg inside the womb
+	var/obj/item/oviposition_egg/egg = allocate(/obj/item/oviposition_egg)
+	egg.forceMove(womb)
+
+	// Add pregnancy component — carrier is the womb's owner
+	egg.AddComponent(/datum/component/pregnancy, carrier, carrier)
+
+	var/datum/component/pregnancy/preg = egg.GetComponent(/datum/component/pregnancy)
+	TEST_ASSERT_NOTNULL(preg, "Pregnancy component was not added")
+	TEST_ASSERT_NOTNULL(preg.carrier, "Pregnancy component has no carrier")
+
+	// Verify COMSIG_MOB_APPLY_DAMAGE is registered on the carrier (the bug fix)
+	// Before the fix, handle_damage was incorrectly registered on COMSIG_MOB_DEATH (duplicate)
+	TEST_ASSERT_NOTNULL(carrier.comp_lookup, "Carrier has no signal registrations")
+	TEST_ASSERT_NOTNULL(carrier.comp_lookup[COMSIG_MOB_APPLY_DAMAGE], "handle_damage should be registered on COMSIG_MOB_APPLY_DAMAGE")

--- a/modular_bluemoon/code/game/objects/effects/contraband.dm
+++ b/modular_bluemoon/code/game/objects/effects/contraband.dm
@@ -219,6 +219,9 @@
 	return ..()
 
 /obj/structure/sign/poster/contraband/inteq/process()
+	if(!demotivator)
+		STOP_PROCESSING(SSobj, src)
+		return
 	if(world.time < demotivator.next_scare)
 		return
 	var/scared_someone = FALSE
@@ -242,9 +245,11 @@
 /obj/structure/sign/poster/contraband/inteq/attackby(obj/item/tool, mob/user, params)
 	if (tool.tool_behaviour == TOOL_WIRECUTTER)
 		QDEL_NULL(demotivator)
+		STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/structure/sign/poster/contraband/inteq/Destroy()
+	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(demotivator)
 	return ..()
 

--- a/modular_splurt/code/datums/components/pregnancy.dm
+++ b/modular_splurt/code/datums/components/pregnancy.dm
@@ -116,7 +116,7 @@
 	RegisterSignal(carrier, COMSIG_MOB_DEATH, PROC_REF(fetus_mortus))
 	RegisterSignal(carrier, COMSIG_LIVING_BIOLOGICAL_LIFE, PROC_REF(handle_life))
 	RegisterSignal(carrier, COMSIG_HEALTH_SCAN, PROC_REF(on_scan))
-	RegisterSignal(carrier, COMSIG_MOB_DEATH, PROC_REF(handle_damage))
+	RegisterSignal(carrier, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(handle_damage))
 	if(oviposition)
 		RegisterSignal(carrier, COMSIG_MOB_CLIMAX, PROC_REF(on_climax))
 


### PR DESCRIPTION
Пофиксил три мелких бага: в offering'е список тейкеров модифицировался прямо во время итерации (крашило), в inteq постере process() падал при null демотиваторе, и в pregnancy компоненте handle_damage сидел на неправильном сигнале (COMSIG_MOB_DEATH вместо COMSIG_MOB_APPLY_DAMAGE). Добавил юнит тесты на все три кейса

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Исправлена проблема с некорректным удалением недействительных получателей при работе со статус-эффектами
  * Исправлена критическая ошибка, которая могла привести к сбою при взаимодействии с постерами InteQ
  * Улучшена обработка сигналов повреждений в системе беременности

* **Тесты**
  * Добавлены новые автоматические тесты для проверки исправленных ошибок

<!-- end of auto-generated comment: release notes by coderabbit.ai -->