### PR TITLE
Оптимизация UI жукбокса: кеширование списка треков

### DIFF
--- a/code/controllers/subsystem/jukeboxes.dm
+++ b/code/controllers/subsystem/jukeboxes.dm
@@ -29,6 +29,8 @@ SUBSYSTEM_DEF(jukeboxes)
 	wait = 5
 	priority = FIRE_PRIORITY_SOUND_LOOPS
 	var/list/songs = list()
+	var/list/song_names = list()
+	var/list/songs_by_name = list()
 	var/list/activejukeboxes = list()
 	var/list/freejukeboxchannels = list()
 
@@ -152,6 +154,10 @@ SUBSYSTEM_DEF(jukeboxes)
 		if(!track_datum)
 			continue
 		songs |= track_datum
+
+	for(var/datum/track/T in songs)
+		song_names += T.song_name
+		songs_by_name[T.song_name] = T
 
 	return ..()
 

--- a/code/datums/components/jukebox/jukebox.dm
+++ b/code/datums/components/jukebox/jukebox.dm
@@ -188,6 +188,11 @@
 		ui = new(user, src, "Jukebox", box.name)
 		ui.open()
 
+/datum/component/jukebox/ui_static_data(mob/user)
+	var/list/data = list()
+	data["songs"] = SSjukeboxes.song_names
+	return data
+
 /datum/component/jukebox/ui_data(mob/user)
 	var/obj/box = parent
 	var/list/data = list()
@@ -211,10 +216,6 @@
 	data["cost_for_play"] = queuecost
 	data["has_access"] = box.allowed(user)
 	data["repeat"] = repeat
-	var/list/all_song_names = list()
-	for (var/datum/track/T in SSjukeboxes.songs)
-		all_song_names += T.song_name
-	data["songs"] = all_song_names
 	data["favorite_tracks"] = user?.client?.prefs?.favorite_tracks
 	data["playlists"] = user?.client?.prefs?.playlists
 
@@ -257,13 +258,10 @@
 		if("add_to_queue")
 			return add_to_queue(params["track"], usr, params["up"])
 		if("select_track")
-			var/list/available = list()
-			for(var/datum/track/S in SSjukeboxes.songs)
-				available[S.song_name] = S
 			var/selected = params["track"]
-			if(QDELETED(src) || QDELETED(box) || !selected || !istype(available[selected], /datum/track))
+			if(QDELETED(src) || QDELETED(box) || !selected || !istype(SSjukeboxes.songs_by_name[selected], /datum/track))
 				return
-			selectedtrack = available[selected]
+			selectedtrack = SSjukeboxes.songs_by_name[selected]
 			return TRUE
 		if("set_volume")
 			if(!box.allowed(usr))
@@ -334,9 +332,7 @@
 	if(QDELETED(src) || QDELETED(box) || !tracks || !COOLDOWN_FINISHED(src, queuecooldown))
 		return
 
-	var/list/available = list()
-	for(var/datum/track/S in SSjukeboxes.songs)
-		available[S.song_name] = S
+	var/list/available = SSjukeboxes.songs_by_name
 	if(!islist(tracks))
 		tracks = list(tracks)
 


### PR DESCRIPTION
# Описание

Оптимизация UI жукбокса - устранение лагов при открытии интерфейса.

Список треков (`songs`) пересылался клиенту на **каждый** вызов `ui_data()` (поллинг, любое действие пользователя), каждый раз заново итерируя все треки в `SSjukeboxes.songs`. Дополнительно, `select_track` и `add_to_queue` каждый раз пересоздавали словарь `name -> track` тем же циклом. При сотнях треков сами понимаете - **ДОРОГО**

**Что сделано:**
- Список имён треков и словарь `name -> track` кешируются один раз при инициализации `SSjukeboxes`
- Список треков перенесён из `ui_data()` в `ui_static_data()` - отправляется клиенту **один раз** при открытии UI, а не на каждый поллинг
- Повторные циклы поиска треков заменены на O(1) обращения к кешированному словарю

- [ ] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу

## Changelog

:cl:
fix: Исправлены лаги при открытии жукбокса (возможно, а может и нет)
code: Список треков жукбокса кеширован и отправляется клиенту один раз вместо каждого обновления UI
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Оптимизация**
  * Повышена производительность системы управления музыкой в ящиках с пластинками. Оптимизированы внутренние алгоритмы для ускорения операций поиска и выбора песен. Улучшена общая отзывчивость интерфейса проигрывателя при работе с музыкальными композициями. Ускорено отображение полного каталога доступных треков в системе. Оптимизирована обработка запросов на добавление композиций в очередь воспроизведения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->