### PR TITLE
Два небольших фикса

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -368,7 +368,7 @@
 		ready = PLAYER_NOT_READY
 		return FALSE
 
-	var/mintime = max(CONFIG_GET(number/respawn_delay), (SSticker.round_start_time + (CONFIG_GET(number/respawn_minimum_delay_roundstart) * 600)) - world.time, 0)
+	var/mintime = max(CONFIG_GET(number/respawn_delay) * 600, (SSticker.round_start_time + (CONFIG_GET(number/respawn_minimum_delay_roundstart) * 600)) - world.time, 0)
 
 	var/this_is_like_playing_right = alert(src,"Are you sure you wish to observe? You will not be able to respawn for [round(mintime / 600, 0.1)] minutes!!","Player Setup","Да","Нет")
 

--- a/modular_bluemoon/code/game/objects/items/granters.dm
+++ b/modular_bluemoon/code/game/objects/items/granters.dm
@@ -4,13 +4,13 @@
 	icon_state ="booksmoke"
 	desc = "This book is overflowing with the lewd arts."
 	remarks = list("Crocin Bomb! Heh...", "Crocin bomb would do just fine too...", "Wait, there's a machine that does the same thing in chemistry?", "This book smells awful...", "Why all these horny jokes? Just tell me how to cast it...", "Wind will ruin the whole spell, good thing we're in space... Right?", "So this is how the kinkmate does it...")
-	spell = /obj/effect/proc_holder/spell/targeted/smoke/lesser
+	spell = /obj/effect/proc_holder/spell/targeted/smoke/crocin
 
 /obj/item/book/granter/spell/smoke/crocin/onlearned(mob/user)
 	if(oneuse)
 		used = TRUE
 
-/obj/effect/proc_holder/spell/targeted/smoke/lesser //Chaplain smoke book
+/obj/effect/proc_holder/spell/targeted/smoke/crocin //Chaplain smoke book
 	name = "Crocin Smoke"
 	desc = "This ability spawns a small cloud of crocin smoke at your location."
 	action_icon_state = "crocin_smoke"


### PR DESCRIPTION
# Описание
1) пофикшен баг, что дым святоши был кроциновым дымом (это был баг)
2) пофикшено время отображения кд на респавн

## Причина изменений
фиксы
## Changelog

:cl:
fix: дым священника был кроциновым, теперь он нормальный
fix: сообщение о времени респавна показывает правильное время
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Исправлен расчет длительности блокировки при возрождении и наблюдении за новыми игроками, который теперь корректно применяет конфигурируемую задержку возрождения.
  * Исправлена работа дарующей книги заклинания дыма кроцина для использования правильной реализации заклинания вместо устаревшей версии.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->