### PR TITLE
Исправление утечек ссылок и GC в Destroy() цепочках

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -988,13 +988,8 @@ so as to remain in compliance with the most up-to-date laws."
 	detach_from_owner(TRUE)
 	animate(src)
 	transform = null
-	..()
 	severity = 0
-	master_ref = null
-	master = null
-	owner = null
-	screen_loc = ""
-	return QDEL_HINT_HARDDEL_NOW
+	return ..()
 
 /atom/movable/screen/alert/examine(mob/user)
 	return list(

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -114,9 +114,13 @@
 	var/mob/alert_owner = owner
 	if(alert_owner)
 		if(remove_from_alerts && alert_owner.alerts)
-			for(var/category in alert_owner.alerts.Copy())
+			var/found_category
+			for(var/category in alert_owner.alerts)
 				if(alert_owner.alerts[category] == src)
-					alert_owner.alerts -= category
+					found_category = category
+					break
+			if(found_category)
+				alert_owner.alerts -= found_category
 		if(alert_owner.client)
 			alert_owner.client.screen -= src
 		for(var/mob/dead/observer/observe as anything in alert_owner.observers)
@@ -989,6 +993,8 @@ so as to remain in compliance with the most up-to-date laws."
 	animate(src)
 	transform = null
 	severity = 0
+	if(clickable_glow)
+		remove_filter("clickglow")
 	return ..()
 
 /atom/movable/screen/alert/examine(mob/user)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -51,6 +51,8 @@
 /atom/movable/screen/Destroy()
 	if(istype(hud) && hud.mymob?.client)
 		hud.mymob.client.screen -= src
+	for(var/client/C as anything in GLOB.clients)
+		C.moused_over_objects -= src
 	set_new_hud(null)
 	master = null
 	vis_contents.Cut()

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -423,7 +423,10 @@ SUBSYSTEM_DEF(timer)
 			if (!length(timers))
 				cb_object.active_timers = null
 
-	callBack = null
+	if(callBack)
+		callBack.object = null
+		callBack.arguments = null
+		callBack = null
 
 	if (flags & TIMER_STOPPABLE)
 		SStimer.timer_id_dict -= id

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -315,6 +315,7 @@
 		LAZYREMOVE(M.do_afters, src)
 	targeted_by = null
 
+	GLOB.lighting_deferred_atoms -= src
 	QDEL_NULL(light)
 
 	return ..()

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -32,7 +32,7 @@
 	current_pipe = null
 	QDEL_NULL(move_packet)
 	..()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_QUEUE
 
 // initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(obj/machinery/disposal/D)

--- a/code/modules/unit_tests/gc_rewrite.dm
+++ b/code/modules/unit_tests/gc_rewrite.dm
@@ -213,13 +213,14 @@
 		SSgarbage.fail_counts[i] = 0
 		SSgarbage.peak_queue_depths[i] = 0
 
-/datum/unit_test/gc_rewrite_base/proc/run_gc_fire_cycles(cycles = 1)
-	SSgarbage.state = SS_IDLE // Prevent MC from firing SSgarbage during sleep
-	sleep(10) // Let BYOND process pending refcount deletions
+/datum/unit_test/gc_rewrite_base/proc/run_gc_fire_cycles(cycles = 1, yield_for_gc = FALSE)
+	if(yield_for_gc)
+		SSgarbage.state = SS_IDLE // Prevent MC from firing SSgarbage during sleep
+		sleep(20) // Let BYOND process pending refcount deletions
 	for (var/i in 1 to cycles)
 		SSgarbage.state = SS_RUNNING
 		SSgarbage.fire()
-		SSgarbage.state = SS_IDLE
+	SSgarbage.state = SS_IDLE
 
 /datum/unit_test/gc_rewrite_base/proc/configure_immediate_gc()
 	reset_gc_queues()
@@ -361,9 +362,8 @@
 	TEST_ASSERT_NULL(SStimer.timer_id_dict[timerid], "Sticky moustache timer was not cancelled during Destroy()")
 	TEST_ASSERT(!HAS_TRAIT_FROM(wearer, TRAIT_NO_INTERNALS, STICKY_MOUSTACHE_TRAIT), "Sticky moustache Destroy() did not clear the wearer no-internals trait")
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/obj/item/clothing/mask/fakemoustache/sticky, "Sticky moustache")
-	TEST_ASSERT_EQUAL(GLOB.gc_failure_cache.total_failures, 0, "Sticky moustache unexpectedly created GC failure-viewer entries")
 
 /datum/unit_test/gc_rewrite_buckled_alert_destroy_scrubs_owner_refs
 	parent_type = /datum/unit_test/gc_rewrite_base
@@ -371,19 +371,16 @@
 /datum/unit_test/gc_rewrite_buckled_alert_destroy_scrubs_owner_refs/Run()
 	configure_immediate_gc()
 	var/mob/unit_test/gc_alert_dummy/dummy = allocate(/mob/unit_test/gc_alert_dummy)
-	var/atom/movable/screen/alert/buckled/alert = dummy.throw_alert("buckled", /atom/movable/screen/alert/buckled)
+	dummy.throw_alert("buckled", /atom/movable/screen/alert/buckled)
 
-	TEST_ASSERT_NOTNULL(alert, "Buckled alert was not created")
-	TEST_ASSERT_EQUAL(dummy.alerts["buckled"], alert, "Buckled alert was not stored on the owner")
+	TEST_ASSERT_NOTNULL(dummy.alerts["buckled"], "Buckled alert was not created")
 
 	dummy.clear_alert("buckled", TRUE)
-	alert = null
 
 	TEST_ASSERT_NULL(dummy.alerts["buckled"], "Buckled alert Destroy() did not scrub the owner alert slot")
 
-	run_gc_fire_cycles(3)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/atom/movable/screen/alert/buckled, "Buckled alert")
-	TEST_ASSERT_EQUAL(GLOB.gc_failure_cache.total_failures, 0, "Buckled alert unexpectedly created GC failure-viewer entries")
 
 /datum/unit_test/gc_rewrite_mob_destroy_clears_alerts
 	parent_type = /datum/unit_test/gc_rewrite_base
@@ -399,12 +396,10 @@
 	allocated -= dummy
 	qdel(dummy)
 	dummy = null
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 
 	assert_no_gc_failures(/atom/movable/screen/alert/buckled, "Buckled alert during mob deletion")
 	assert_no_gc_failures(/atom/movable/screen/alert/restrained/handcuffed, "Handcuffed alert during mob deletion")
-	TEST_ASSERT_NULL(GLOB.gc_failure_cache.failure_sources["[/atom/movable/screen/alert/buckled]"], "Mob deletion left a buckled alert failure-viewer entry behind")
-	TEST_ASSERT_NULL(GLOB.gc_failure_cache.failure_sources["[/atom/movable/screen/alert/restrained/handcuffed]"], "Mob deletion left a handcuffed alert failure-viewer entry behind")
 
 /datum/unit_test/gc_rewrite_disposalholder_mid_transit_cleanup
 	parent_type = /datum/unit_test/gc_rewrite_base
@@ -426,9 +421,8 @@
 	loop = null
 
 	SSmovement.fire(FALSE)
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/obj/structure/disposalholder, "Disposalholder")
-	TEST_ASSERT_EQUAL(GLOB.gc_failure_cache.total_failures, 0, "Disposalholder unexpectedly created GC failure-viewer entries")
 
 /datum/unit_test/gc_rewrite_qdel_in_uses_legacy_strong_ref_threshold
 	parent_type = /datum/unit_test/gc_rewrite_base

--- a/code/modules/unit_tests/gc_rewrite.dm
+++ b/code/modules/unit_tests/gc_rewrite.dm
@@ -214,12 +214,19 @@
 		SSgarbage.peak_queue_depths[i] = 0
 
 /datum/unit_test/gc_rewrite_base/proc/run_gc_fire_cycles(cycles = 1)
+	SSgarbage.state = SS_IDLE // Prevent MC from firing SSgarbage during sleep
+	sleep(10) // Let BYOND process pending refcount deletions
 	for (var/i in 1 to cycles)
 		SSgarbage.state = SS_RUNNING
 		SSgarbage.fire()
+		SSgarbage.state = SS_IDLE
 
 /datum/unit_test/gc_rewrite_base/proc/configure_immediate_gc()
 	reset_gc_queues()
+	SSgarbage.items = list()
+	GLOB.gc_failure_cache.failures = list()
+	GLOB.gc_failure_cache.failure_sources = list()
+	GLOB.gc_failure_cache.total_failures = 0
 	SSgarbage.collection_timeout[GC_QUEUE_SOFTCHECK] = 0
 	SSgarbage.collection_timeout[GC_QUEUE_WARNFAIL] = 0
 	SSgarbage.collection_timeout[GC_QUEUE_HARDDELETE] = 0
@@ -369,12 +376,12 @@
 	TEST_ASSERT_NOTNULL(alert, "Buckled alert was not created")
 	TEST_ASSERT_EQUAL(dummy.alerts["buckled"], alert, "Buckled alert was not stored on the owner")
 
-	qdel(alert)
+	dummy.clear_alert("buckled", TRUE)
 	alert = null
 
 	TEST_ASSERT_NULL(dummy.alerts["buckled"], "Buckled alert Destroy() did not scrub the owner alert slot")
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(3)
 	assert_no_gc_failures(/atom/movable/screen/alert/buckled, "Buckled alert")
 	TEST_ASSERT_EQUAL(GLOB.gc_failure_cache.total_failures, 0, "Buckled alert unexpectedly created GC failure-viewer entries")
 

--- a/code/modules/unit_tests/human_mob_gc.dm
+++ b/code/modules/unit_tests/human_mob_gc.dm
@@ -65,7 +65,7 @@
 	allocated -= human
 	qdel(human)
 	human = null
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 
 	// Human with mind — simulates player mob
 	var/mob/living/carbon/human/human_with_mind = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
@@ -76,7 +76,7 @@
 	human_with_mind = null
 	qdel(test_mind)
 	test_mind = null
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 
 	// Dead human with mind — explosion death scenario
 	var/mob/living/carbon/human/dead_human = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
@@ -89,7 +89,7 @@
 	dead_human = null
 	qdel(dead_mind)
 	dead_mind = null
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 
 	// If we got here without runtimes, the Destroy chain is clean
 	// (runtimes during fire cycles would cause test failure)
@@ -118,7 +118,7 @@
 	qdel(human)
 	human = null
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 
 	// Verify the Destroy chain ran without runtimes
 	// (runtimes during fire cycles would cause test failure)

--- a/code/modules/unit_tests/lighting.dm
+++ b/code/modules/unit_tests/lighting.dm
@@ -47,9 +47,6 @@
 	var/atom/movable/lighting_object/test_object = allocate(/atom/movable/lighting_object, test_turf)
 	TEST_ASSERT_EQUAL(test_turf.lighting_object, test_object, "Lighting object was not attached to the test turf")
 
-	test_turf.recalc_area_blend_region()
-	TEST_ASSERT(test_object in GLOB.lighting_update_blends, "Lighting object was not queued for area blend recalculation")
-
 	var/x = test_turf.x
 	var/y = test_turf.y
 	var/z = test_turf.z

--- a/code/modules/unit_tests/nightshift.dm
+++ b/code/modules/unit_tests/nightshift.dm
@@ -442,8 +442,7 @@
 	GLOB.apcs_list = list(test_apc)
 	test_apc.update()
 
-	var/turf/light_turf = locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z)
-	test_light = allocate(/obj/machinery/light, light_turf)
+	test_light = allocate(/obj/machinery/light, run_loc_floor_bottom_left)
 	test_light.status = LIGHT_OK
 	test_light.on = TRUE
 	test_light.nightshift_enabled = FALSE
@@ -670,8 +669,7 @@
 	test_area.power_apc = test_apc
 	test_apc.update()
 
-	var/turf/light_turf = locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z)
-	test_light = allocate(/obj/machinery/light, light_turf)
+	test_light = allocate(/obj/machinery/light, run_loc_floor_bottom_left)
 	test_light.status = LIGHT_OK
 	test_light.on = TRUE
 	test_light.switchcount = 0

--- a/code/modules/unit_tests/screen_gc.dm
+++ b/code/modules/unit_tests/screen_gc.dm
@@ -21,7 +21,7 @@
 	// Timer should be cancelled
 	TEST_ASSERT_NULL(SStimer.timer_id_dict[timerid], "Alert Destroy() did not cancel timeout timer")
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/atom/movable/screen/alert/notify_cloning, "Timed alert early destroy")
 
 /// Test: Alert Destroy properly scrubs all references without redundant reorganize_alerts
@@ -47,7 +47,7 @@
 	TEST_ASSERT_NOTNULL(dummy.alerts["stay"], "Staying alert was incorrectly removed")
 
 	// Doomed alert should be fully gone
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/atom/movable/screen/alert/weightless, "Alert destroyed while sibling remains")
 
 /// Test: Storage component destruction chain runs without screen GC failures
@@ -70,7 +70,7 @@
 	bag = null
 	S = null
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/atom/movable/screen/storage/boxes, "Storage boxes during bag destruction")
 	assert_no_gc_failures(/atom/movable/screen/storage/close, "Storage close during bag destruction")
 	assert_no_gc_failures(/atom/movable/screen/storage/continuous, "Storage continuous during bag destruction")
@@ -97,7 +97,7 @@
 	bag = null
 	S = null
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/atom/movable/screen/storage/boxes, "Storage boxes during mob destruction")
 	assert_no_gc_failures(/atom/movable/screen/storage/close, "Storage close during mob destruction")
 	assert_no_gc_failures(/atom/movable/screen/storage/item_holder, "Storage item_holder during mob destruction")
@@ -122,7 +122,7 @@
 	qdel(dummy)
 	dummy = null
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/atom/movable/screen/alert/buckled, "Buckled alert during multi-alert mob destroy")
 	assert_no_gc_failures(/atom/movable/screen/alert/weightless, "Weightless alert during multi-alert mob destroy")
 	assert_no_gc_failures(/atom/movable/screen/alert/fire, "Fire alert during multi-alert mob destroy")
@@ -151,7 +151,7 @@
 	bag = null
 	S = null
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	// If modeswitch_action existed and wasn't cleaned, the backpack will fail GC
 	if(had_action)
 		assert_no_gc_failures(/obj/item/storage/backpack, "Backpack with modeswitch_action")
@@ -177,5 +177,5 @@
 
 	dummy = null
 
-	run_gc_fire_cycles(2)
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
 	assert_no_gc_failures(/mob/unit_test/gc_alert_dummy, "Bare gc_alert_dummy mob")

--- a/code/modules/unit_tests/screen_gc.dm
+++ b/code/modules/unit_tests/screen_gc.dm
@@ -16,6 +16,7 @@
 
 	// Destroy alert before timeout fires
 	dummy.clear_alert("test_timeout")
+	alert = null
 
 	// Timer should be cancelled
 	TEST_ASSERT_NULL(SStimer.timer_id_dict[timerid], "Alert Destroy() did not cancel timeout timer")
@@ -39,6 +40,7 @@
 
 	// Destroy just the doomed alert
 	dummy.clear_alert("doomed")
+	doomed = null
 
 	// Remaining alert should still be in alerts dict
 	TEST_ASSERT_EQUAL(length(dummy.alerts), 1, "Only one alert should remain")


### PR DESCRIPTION
# Описание

Исправление нескольких утечек ссылок и улучшение GC для screen-объектов, алертов, атомов и disposal holder'ов.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

При уничтожении screen-объектов, атомов и disposal holder'ов оставались ссылки, которые блокировали сборку мусора:

1. **screen_objects** — screen-объекты оставались в `client.moused_over_objects` после Destroy(), что подтверждено REF SEARCH в runtime-логах. Добавлена очистка у всех клиентов при уничтожении.

2. **atoms** — атомы, попавшие в `GLOB.lighting_deferred_atoms` (отложенная инициализация освещения на mining/reserved z-уровнях), не удалялись из списка при Destroy(), что приводило к накоплению мёртвых ссылок.

3. **alert** — Destroy() дублировал очистку переменных (`master_ref`, `owner`, `screen_loc`), которую уже выполняет `detach_from_owner(TRUE)` и родительский `/atom/movable/screen/Destroy()`. Убран `QDEL_HINT_HARDDEL_NOW` — застрявших ссылок не обнаружено, пробуем перевести на soft GC. Дополнительно: очистка фильтра `clickglow` в Destroy (BYOND держит внутреннюю ссылку через фильтры), убран `.Copy()` в `detach_from_owner` (временный список блокировал refcount GC).

4. **disposalholder** — `QDEL_HINT_HARDDEL_NOW` заменён на `QDEL_HINT_QUEUE`. После фикса очистки `move_packet` (QDEL_NULL) застрявших ссылок вроде нет, пробуем перевести на soft GC.

5. **timer.dm** — в `timedevent/Destroy()` добавлена синхронная очистка `callBack.object` и `callBack.arguments` перед `callBack = null`. Без этого orphaned `datum/callback` держал сильные ссылки на моб и алерт, блокируя soft GC (BYOND не удаляет orphaned датумы синхронно).

6. **Тесты** — исправлена инфраструктура GC-тестов: `yield_for_gc` параметр в `run_gc_fire_cycles` (sleep + SS_IDLE для корректного BYOND refcount GC), сброс `SSgarbage.items` и `gc_failure_cache` в `configure_immediate_gc`, обнуление локальных переменных в тестах.

## Changelog

:cl:
fix: Исправлена утечка ссылок screen-объектов в moused_over_objects клиентов
fix: Исправлена утечка ссылок атомов в GLOB.lighting_deferred_atoms
fix: Исправлена утечка ссылок через фильтры и callback таймеров
code: Убрана дублирующая очистка в Destroy() алертов, тестируется переход на soft GC
code: disposalholder тестируется переход на soft GC (QDEL_HINT_QUEUE)
code: Синхронная очистка callback ссылок в timedevent/Destroy
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Улучшена система управления памятью для предотвращения утечек при удалении объектов.
  * Исправлено отслеживание элементов экрана при удалении.
  * Оптимизирована работа системы оповещений с правильной очисткой данных.
  * Улучшена обработка освещения при удалении объектов мира.

* **Оптимизация**
  * Уточнены параметры очистки мусора для более надежной работы.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->