### PR TITLE
Запрет карпам грызть трубы и канистры

### DIFF
--- a/code/modules/mob/living/simple_animal/carp/carp.dm
+++ b/code/modules/mob/living/simple_animal/carp/carp.dm
@@ -166,7 +166,7 @@
 			return
 		potential_disky.forceMove(src)
 		disky = potential_disky
-		to_chat(src, span_nicegreen("ДА!! Вам удалось подобрать [disky] (Кликните где угодно, чтобы положить)."))
+		to_chat(src, span_nicegreen("ДА!! Вам удалось подобрать [disky] (Кликните в пустое место, чтобы положить)."))
 		update_icon()
 		if(!disky.fake)
 			client.give_award(/datum/award/achievement/misc/cayenne_disk, src)

--- a/code/modules/mob/living/simple_animal/carp/carp.dm
+++ b/code/modules/mob/living/simple_animal/carp/carp.dm
@@ -2,7 +2,7 @@
 
 /mob/living/simple_animal/hostile/carp
 	name = "space carp"
-	desc = "A ferocious, fang-bearing creature that resembles a fish."
+	desc = "Свирепое, клыконосное существо, напоминающее рыбу."
 	icon_state = "carp"
 	icon_living = "carp"
 	icon_dead = "carp_dead"
@@ -11,10 +11,10 @@
 	speak_chance = 0
 	turns_per_move = 5
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/carpmeat = 2)
-	response_help_continuous = "pets"
-	response_help_simple = "pet"
-	response_disarm_continuous = "gently pushes aside"
-	response_disarm_simple = "gently push aside"
+	response_help_continuous = "гладит"
+	response_help_simple = "погладил"
+	response_disarm_continuous = "мягко отталкивает в сторону"
+	response_disarm_simple = "мягко толкает в сторону"
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0
@@ -25,10 +25,10 @@
 	obj_damage = 50
 	melee_damage_lower = 15
 	melee_damage_upper = 25
-	attack_verb_continuous = "bites"
-	attack_verb_simple = "bite"
+	attack_verb_continuous = "кусает"
+	attack_verb_simple = "укусил"
 	attack_sound = 'sound/weapons/bite.ogg'
-	speak_emote = list("gnashes")
+	speak_emote = list("скрежещет острыми зубами")
 	//Space carp aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
@@ -70,7 +70,7 @@
 		heal_overall_damage(regen_amount)
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
-	if(!. && (istype(target, /obj/machinery/portable_atmospherics/canister) || istype(target, /obj/machinery/atmospherics/pipe)))
+	if(istype(target, /obj/machinery/portable_atmospherics/canister) || istype(target, /obj/machinery/atmospherics/pipe))
 		if(prob(99))
 			to_chat(src, span_warning("[target] выглядит отвратительно на вкус!"))
 		else
@@ -91,7 +91,7 @@
 /mob/living/simple_animal/hostile/carp/megacarp
 	icon = 'icons/mob/broadMobs.dmi'
 	name = "Mega Space Carp"
-	desc = "A ferocious, fang bearing creature that resembles a shark. This one seems especially ticked off."
+	desc = "Свирепое, клыконосное существо, напоминающее акулу. Оно кажется особенно сильно разозлённым..."
 	icon_state = "megacarp"
 	icon_living = "megacarp"
 	icon_dead = "megacarp_dead"
@@ -121,10 +121,11 @@
 /mob/living/simple_animal/hostile/carp/cayenne
 	name = "Cayenne"
 	real_name = "Cayenne"
-	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
+	desc = "Неудачный эксперимент Триглава по использованию технологии космических карпов в военных целях. Теперь оно служит как всеми любимый маскот."
 	gender = FEMALE
 	speak_emote = list("squeaks")
 	AIStatus = AI_OFF
+	attack_verb_simple = "укусила"
 	gold_core_spawnable = NO_SPAWN
 	faction = list(ROLE_INTEQ)
 	/// Keeping track of the nuke disk for the functionality of storing it.

--- a/code/modules/mob/living/simple_animal/carp/carp.dm
+++ b/code/modules/mob/living/simple_animal/carp/carp.dm
@@ -70,6 +70,12 @@
 		heal_overall_damage(regen_amount)
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
+	if(!. && (istype(target, /obj/machinery/portable_atmospherics/canister) || istype(target, /obj/machinery/atmospherics/pipe)))
+		if(prob(99))
+			to_chat(src, span_warning("[target] выглядит отвратительно на вкус!"))
+		else
+			to_chat(src, span_userdanger("ФУ, НЕВКУСНО!!!"))
+		return
 	. = ..()
 	if(. && ishuman(target))
 		var/mob/living/carbon/human/H = target
@@ -150,7 +156,7 @@
 /mob/living/simple_animal/hostile/carp/cayenne/examine(mob/user)
 	. = ..()
 	if(disky)
-		. += span_notice("Wait... is that [disky] in [ru_ego()] mouth?")
+		. += span_notice("Минуту... Это что, [disky] в [ru_ego()] пасти?")
 
 /mob/living/simple_animal/hostile/carp/cayenne/AttackingTarget(atom/attacked_target)
 	if(istype(attacked_target, /obj/item/disk/nuclear))
@@ -159,14 +165,14 @@
 			return
 		potential_disky.forceMove(src)
 		disky = potential_disky
-		to_chat(src, span_nicegreen("YES!! You manage to pick up [disky]. (Click anywhere to place it back down.)"))
+		to_chat(src, span_nicegreen("ДА!! Вам удалось подобрать [disky] (Кликните где угодно, чтобы положить)."))
 		update_icon()
 		if(!disky.fake)
 			client.give_award(/datum/award/achievement/misc/cayenne_disk, src)
 		return
 	if(disky)
 		if(isopenturf(attacked_target))
-			to_chat(src, span_notice("You place [disky] on [attacked_target]"))
+			to_chat(src, span_notice("Вы положили [disky] на [attacked_target]"))
 			disky.forceMove(attacked_target.drop_location())
 			disky = null
 			update_icon()


### PR DESCRIPTION
# Описание
- Карпы не могут атаковать канистры газов и трубы станции.
- Небольшие переводы для карпов.

## Причина изменений
Имплементация а-ля ТГ + необходимость в условиях массгриф потенциала.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Космические карпы и их подвиды больше не могут атаковать атмоферные трубы и канистры газов.
spellcheck: Был дан перевод некоторых строк карпов и их описаний.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Враждебные карпы теперь распознают портативные атмосферные баллоны и трубы: издают предупредительное сообщение и прекращают атаку на такие объекты.

* **Локализация**
  * Все пользовательские сообщения карпов переведены на русский — описания, фразы при атаке, реакции, эмоты и тексты взаимодействия (включая отдельные сообщения для мегакарпа/кайенны и для диска во рту).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->