### PR TITLE
nuke keeper + lone

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -8,6 +8,8 @@
 	skill_modifiers = list(/datum/skill_modifier/job/level/wiring)
 	show_to_ghosts = TRUE
 	hijack_speed = 3
+	var/is_lone = FALSE
+	var/is_syndicate = FALSE
 	var/datum/team/nuclear/nuke_team
 	var/always_new_team = FALSE //If not assigned a team by default ops will try to join existing ones, set this to TRUE to always create new team.
 	var/send_to_spawnpoint = TRUE //Should the user be moved to default spawnpoint.
@@ -15,12 +17,12 @@
 	var/title
 
 /datum/antagonist/nukeop/proc/update_synd_icons_added(mob/living/M)
-	var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
+	var/datum/atom_hud/antag/opshud = GLOB.huds[is_syndicate ? ANTAG_HUD_SPACECOP : ANTAG_HUD_OPS]
 	opshud.join_hud(M)
-	set_antag_hud(M, "inteq")
+	set_antag_hud(M, is_syndicate ? "synd" : "inteq")
 
 /datum/antagonist/nukeop/proc/update_synd_icons_removed(mob/living/M)
-	var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
+	var/datum/atom_hud/antag/opshud = GLOB.huds[is_syndicate ? ANTAG_HUD_SPACECOP : ANTAG_HUD_OPS]
 	opshud.leave_hud(M)
 	set_antag_hud(M, null)
 
@@ -41,24 +43,16 @@
 		return
 	if(!istype(H))
 		return
-	var/is_extended = GLOB.master_mode == "Extended"
-	if(is_extended)
-		H.equipOutfit(/datum/outfit/syndicate/lone)
-		priority_announce("Приветствую, Станция. Мы отправляем к вам Специалиста по Защите Ядерного Диска ввиду того, что заметили недостаточную его безопасность. Bстречайте.", "Фрегат [title] ССО Синдиката")
-	else
-		H.equipOutfit(nukeop_outfit)
 
-	if(name == "Lone Operative")
-		var/load_character = tgui_alert(H.client, "Желаете загрузить текущего своего выбранного персонажа?", "Играть своим персонажем!", list("Да", "Нет"), 10 SECONDS, TRUE)
-		if(load_character == "Да")
-			H.load_client_appearance(H.client)
+	H.equipOutfit(nukeop_outfit)
 
-	// BLUEMOON ADD START // Загрузка куклы сбрасывает языки
-	if(is_extended) // Syndicate
+	if(is_lone && tgui_alert(H.client, "Желаете загрузить текущего своего выбранного персонажа?", "Играть своим персонажем!", list("Да", "Нет"), 15 SECONDS, TRUE) == "Да")
+		H.load_client_appearance(H.client, FALSE)
+
+	if(is_syndicate) // Syndicate
 		H.grant_language(/datum/language/codespeak, source = LANGUAGE_MIND)
 	else // InteQ
 		H.grant_language(/datum/language/old_codes, source = LANGUAGE_MIND)
-	// BLUEMOON ADD END
 
 	give_alias()
 
@@ -66,7 +60,12 @@
 
 /datum/antagonist/nukeop/greet()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ops.ogg',100,0)
-	to_chat(owner, "<span class='notice'>Вы [nuke_team ? nuke_team.syndicate_name : "Интековский"] Оперативник!</span>")
+	var/msg = ""
+	if(nuke_team)
+		msg = "вы [nuke_team.syndicate_name] Оперативник!"
+	else
+		msg = "Вы Оперативник [is_syndicate ? "Синдиката" : "Интекью"]!"
+	to_chat(owner, span_notice(msg))
 	owner.announce_objectives()
 
 /datum/antagonist/nukeop/on_gain()
@@ -77,11 +76,12 @@
 	if(send_to_spawnpoint)
 		move_to_spawnpoint()
 
-
 /datum/antagonist/nukeop/get_team()
 	return nuke_team
 
 /datum/antagonist/nukeop/proc/assign_nuke()
+	if(is_syndicate && is_lone)
+		return
 	if(nuke_team && !nuke_team.tracked_nuke)
 		nuke_team.memorized_code = random_nukecode()
 		var/obj/machinery/nuclearbomb/syndicate/nuke = locate() in GLOB.nuke_list
@@ -98,12 +98,16 @@
 			nuke_team.memorized_code = null
 
 /datum/antagonist/nukeop/proc/give_alias()
+	if(is_syndicate && is_lone)
+		return
 	if(nuke_team && nuke_team.syndicate_name)
 		var/number = 1
 		number = nuke_team.members.Find(owner)
 		owner.current.real_name = "[nuke_team.syndicate_name] Оперативник #[number]"
 
 /datum/antagonist/nukeop/proc/memorize_code()
+	if(is_syndicate && is_lone)
+		return
 	if(nuke_team && nuke_team.tracked_nuke && nuke_team.memorized_code)
 		antag_memory += "<B>[nuke_team.tracked_nuke] Code</B>: [nuke_team.memorized_code]<br>"
 		to_chat(owner, "The nuclear authorization code is: <B>[nuke_team.memorized_code]</B>")
@@ -132,7 +136,10 @@
 				if(N.nuke_team)
 					nuke_team = N.nuke_team
 					return
-		nuke_team = new /datum/team/nuclear
+		if(is_syndicate)
+			nuke_team = new /datum/team/nuclear/syndicate
+		else
+			nuke_team = new
 		nuke_team.update_objectives()
 		assign_nuke() //This is bit ugly
 		return
@@ -141,7 +148,7 @@
 	nuke_team = new_team
 
 /datum/antagonist/nukeop/admin_add(datum/mind/new_owner,mob/admin)
-	new_owner.assigned_role = ROLE_INTEQ
+	new_owner.assigned_role = job_rank
 	new_owner.add_antag_datum(src)
 	message_admins("[key_name_admin(admin)] has nuke op'ed [new_owner.current].")
 	log_admin("[key_name(admin)] has nuke op'ed [new_owner.current].")
@@ -156,11 +163,11 @@
 
 /datum/antagonist/nukeop/proc/admin_tell_code(mob/admin)
 	var/code
-	for (var/obj/machinery/nuclearbomb/bombue in GLOB.machines)
-		if (length(bombue.r_code) <= 5 && bombue.r_code != initial(bombue.r_code))
+	for(var/obj/machinery/nuclearbomb/bombue in GLOB.machines)
+		if(length(bombue.r_code) <= 5 && bombue.r_code != initial(bombue.r_code))
 			code = bombue.r_code
 			break
-	if (code)
+	if(code)
 		antag_memory += "<B>InteQ Nuclear Bomb Code</B>: [code]<br>"
 		to_chat(owner.current, "The nuclear authorization code is: <B>[code]</B>")
 	else
@@ -209,7 +216,6 @@
 	owner.announce_objectives()
 	addtimer(CALLBACK(src, PROC_REF(nuketeam_name_assign)), 1)
 
-
 /datum/antagonist/nukeop/leader/proc/nuketeam_name_assign()
 	if(!nuke_team)
 		return
@@ -240,17 +246,20 @@
 
 /datum/antagonist/nukeop/lone
 	name = "Lone Operative"
+	is_lone = TRUE
 	always_new_team = TRUE
 	send_to_spawnpoint = FALSE //Handled by event
 	nukeop_outfit = /datum/outfit/inteq/lone/inteq
 
 /datum/antagonist/nukeop/lone/assign_nuke()
+	if(is_syndicate && is_lone)
+		return
 	if(nuke_team && !nuke_team.tracked_nuke)
 		nuke_team.memorized_code = random_nukecode()
 		var/obj/machinery/nuclearbomb/selfdestruct/nuke = locate() in GLOB.nuke_list
 		if(nuke)
 			nuke_team.tracked_nuke = nuke
-			if(nuke.r_code == "ADMIN")
+			if(nuke.r_code == initial(nuke.r_code))
 				nuke.r_code = nuke_team.memorized_code
 			else //Already set by admins/something else?
 				nuke_team.memorized_code = nuke.r_code
@@ -262,11 +271,24 @@
 	send_to_spawnpoint = FALSE
 	nukeop_outfit = /datum/outfit/inteq/no_crystals
 
+//////////////////////////// SYNDICATE DISK KEEPER ////////////////////////////
+
+/datum/antagonist/nukeop/lone/syndicate
+	name = "Syndicate Disk Keeper"
+	nukeop_outfit = /datum/outfit/syndicate/lone
+	is_syndicate = TRUE
+
+/datum/antagonist/nukeop/lone/syndicate/equip_op()
+	. = ..()
+	if(!.)
+		return
+	if(GLOB.master_mode == ROUNDTYPE_EXTENDED)
+		priority_announce("Приветствую, Станция. Мы отправляем к вам Специалиста по Защите Ядерного Диска ввиду того, что заметили недостаточную его безопасность. Bстречайте.", "Фрегат [title] ССО Синдиката")
+
 /datum/team/nuclear
 	var/syndicate_name
 	var/obj/machinery/nuclearbomb/tracked_nuke
 	var/core_objective = /datum/objective/nuclear
-	var/revert_objective = /datum/objective/nuclear/revert
 	var/memorized_code
 	var/list/team_discounts
 	var/datum/weakref/war_button_ref
@@ -275,16 +297,14 @@
 	..()
 	syndicate_name = syndicate_name()
 
+/datum/team/nuclear/syndicate
+	core_objective = /datum/objective/nuclear/revert
+
 /datum/team/nuclear/proc/update_objectives()
-	if(GLOB.master_mode == "Extended")
-		var/datum/objective/O = new revert_objective
+	if(core_objective)
+		var/datum/objective/O = new core_objective
 		O.team = src
 		objectives += O
-	else
-		if(core_objective)
-			var/datum/objective/O = new core_objective
-			O.team = src
-			objectives += O
 
 /datum/team/nuclear/proc/disk_rescued()
 	for(var/obj/item/disk/nuclear/D in GLOB.poi_list)

--- a/code/modules/antagonists/nukeop/syndicate_nuclear.dm
+++ b/code/modules/antagonists/nukeop/syndicate_nuclear.dm
@@ -468,7 +468,7 @@
 	/obj/item/kitchen/knife/combat/survival)
 
 	uplink_type = /obj/item/syndicate_uplink
-	tc = 120
+	tc = 60
 
 /datum/outfit/syndicate/lone/post_equip(mob/living/carbon/human/H, visualsOnly, client/preference_source)
 	. = ..()
@@ -479,6 +479,10 @@
 	W.update_label()
 	W.update_appearance()
 	H.sec_hud_set_ID()
+
+/datum/outfit/syndicate/lone/extended
+	name = "Lone Operative (Extended)"
+	tc = 120
 
 /datum/outfit/syndicate/syndiesquad
 	name = "Syndicate Special Forces"

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -45,7 +45,7 @@
 		antag_type = new /datum/antagonist/nukeop/lone/syndicate
 		antag_type.nukeop_outfit = /datum/outfit/syndicate/lone/extended
 	else if(GLOB.master_mode == ROUNDTYPE_DYNAMIC_LIGHT && !keeper_force)
-		addtimer(CALLBACK(src, PROC_REF(spawn_operative), TRUE, get_turf(spawn_loc)), (rand(150, 210) SECONDS))
+		addtimer(CALLBACK(src, PROC_REF(spawn_operative), TRUE, get_turf(spawn_loc)), 10 SECONDS)
 
 	var/antag_name = initial(antag_type.name)
 	var/datum/mind/Mind = new(selected.key)

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -12,6 +12,9 @@
 	fakeable = FALSE
 
 /datum/round_event/ghost_role/operative/spawn_role()
+	return spawn_operative()
+
+/datum/round_event/ghost_role/operative/proc/spawn_operative(keeper_force = FALSE, turf/last_spawn_loc)
 	var/list/candidates = get_candidates(ROLE_OPERATIVE, null, ROLE_OPERATIVE)
 	if(!candidates.len)
 		return NOT_ENOUGH_PLAYERS
@@ -23,21 +26,44 @@
 		spawn_locs += L.loc
 	for(var/obj/effect/landmark/loneopspawn/L in GLOB.landmarks_list)
 		spawn_locs += L.loc
+
+	if(keeper_force && spawn_locs.len > 1 && !QDELETED(last_spawn_loc))
+		spawn_locs -= last_spawn_loc
+
+	// ТЕСТЫ
+	if(!spawn_locs.len)
+		var/mob/M = GLOB.player_list[1]
+		if(M)
+			spawn_locs += get_turf(M)
+	// ТЕСТЫ
+
 	if(!spawn_locs.len)
 		return MAP_ERROR
 
-	var/mob/living/carbon/human/operative = new(pick(spawn_locs))
+	var/spawn_loc = pick(spawn_locs)
+
+	var/mob/living/carbon/human/operative = new(spawn_loc)
 	var/datum/preferences/A = new
 	A.copy_to(operative)
 	operative.dna.update_dna_identity()
-	var/datum/mind/Mind = new /datum/mind(selected.key)
-	Mind.assigned_role = "Lone Operative"
-	Mind.special_role = "Lone Operative"
+
+	var/datum/antagonist/nukeop/lone/antag_type = keeper_force ? /datum/antagonist/nukeop/lone/syndicate : /datum/antagonist/nukeop/lone
+	if(GLOB.master_mode == ROUNDTYPE_EXTENDED)
+		antag_type = new /datum/antagonist/nukeop/lone/syndicate
+		antag_type.nukeop_outfit = /datum/outfit/syndicate/lone/extended
+	else if(GLOB.master_mode == ROUNDTYPE_DYNAMIC_LIGHT && !keeper_force)
+		addtimer(CALLBACK(src, PROC_REF(spawn_operative), TRUE, get_turf(spawn_loc)), (rand(150, 210) SECONDS))
+
+	var/antag_name = initial(antag_type.name)
+	var/datum/mind/Mind = new(selected.key)
+	Mind.assigned_role = antag_name
+	Mind.special_role = antag_name
 	Mind.active = 1
 	Mind.transfer_to(operative)
-	Mind.add_antag_datum(/datum/antagonist/nukeop/lone)
 
-	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone operative by an event.")
-	log_game("[key_name(operative)] was spawned as a lone operative by an event.")
+	Mind.add_antag_datum(antag_type)
+
+	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into [antag_name] by an event.")
+	log_game("[key_name(operative)] was spawned as a [antag_name] by an event.")
 	spawned_mobs += operative
 	return SUCCESSFUL_SPAWN

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -30,13 +30,6 @@
 	if(keeper_force && spawn_locs.len > 1 && !QDELETED(last_spawn_loc))
 		spawn_locs -= last_spawn_loc
 
-	// ТЕСТЫ
-	if(!spawn_locs.len)
-		var/mob/M = GLOB.player_list[1]
-		if(M)
-			spawn_locs += get_turf(M)
-	// ТЕСТЫ
-
 	if(!spawn_locs.len)
 		return MAP_ERROR
 


### PR DESCRIPTION
# Описание
- В динамик лайт лоноп спавниться вместе с защитником ЯО
- В Лайт нет оповещения при спавне защитника ЯО
- В динамик у защитника ЯО 60 ТК, вместо 120
- Убраны коды ядерки из памяти защитника ЯО и мелкие фиксы в тексте

## Причина изменений
Запрос Главкома

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: В динамик лайт лоноп спавниться вместе с защитником ЯО
refactor: В динамик у защитника ЯО 60 ТК, вместо 120 и нет оповещения о прилете
fix: Убраны коды ядерки из памяти защитника ЯО и мелкие фиксы в тексте
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Добавлена роль «Синдикатный хранитель диска» и соответствующий вариант экипировки для расширённых раундов.

* **Changes**
  * Обновлены HUD и метки оперативников в зависимости от типа (синдикат/стандарт).
  * Изменено распределение телекристаллов для одиночных экипировок; добавлен отдельный расширенный набор.
  * Обновлена логика спавна и назначения роли оперативников, предотвращена повторная выдача некоторых ресурсов у синдикатных одиночек.
  * Скорректированы командные цели для синдикатных команд.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->