### PR TITLE
slaver permit fix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7728,9 +7728,6 @@
 /obj/item/clothing/glasses/sunglasses/blindfold{
 	pixel_y = 4
 	},
-/obj/item/clothing/accessory/permit/special/deviant/lust/slavers,
-/obj/item/clothing/accessory/permit/special/deviant/lust/slavers,
-/obj/item/clothing/accessory/permit/special/deviant/lust/slavers,
 /turf/open/floor/plasteel/dark,
 /area/slavers)
 "aRi" = (

--- a/modular_splurt/code/game/objects/structures/crates_lockers/closets/slaver.dm
+++ b/modular_splurt/code/game/objects/structures/crates_lockers/closets/slaver.dm
@@ -24,6 +24,10 @@
 /obj/structure/closet/crate/slaver_loadout
 	name = "slave trader standard issue loadout"
 
+/obj/structure/closet/crate/slaver_loadout/Initialize(mapload)
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
 /obj/structure/closet/crate/slaver_loadout/PopulateContents()
 	..()
 
@@ -40,6 +44,11 @@
 	new /obj/item/reagent_containers/hypospray/medipen/survival(src)
 	new /obj/item/reagent_containers/hypospray/medipen/lewdsleepy(src)
 	new /obj/item/slaver/gizmo(src)
+
+/obj/structure/closet/crate/slaver_loadout/LateInitialize()
+	. = ..()
+	if(GLOB.master_mode == ROUNDTYPE_EXTENDED)
+		new /obj/item/clothing/accessory/permit/special/deviant/lust/slavers(src)
 
 /obj/structure/closet/crate/slave_kink
 	name = "Kinkmate Supply"

--- a/modular_splurt/code/game/objects/structures/crates_lockers/closets/slaver.dm
+++ b/modular_splurt/code/game/objects/structures/crates_lockers/closets/slaver.dm
@@ -25,8 +25,9 @@
 	name = "slave trader standard issue loadout"
 
 /obj/structure/closet/crate/slaver_loadout/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
+	. = ..()
+	if(. == INITIALIZE_HINT_NORMAL)
+		. = INITIALIZE_HINT_LATELOAD
 
 /obj/structure/closet/crate/slaver_loadout/PopulateContents()
 	..()

--- a/modular_splurt/code/game/objects/structures/crates_lockers/closets/slaver.dm
+++ b/modular_splurt/code/game/objects/structures/crates_lockers/closets/slaver.dm
@@ -26,8 +26,7 @@
 
 /obj/structure/closet/crate/slaver_loadout/Initialize(mapload)
 	. = ..()
-	if(. == INITIALIZE_HINT_NORMAL)
-		. = INITIALIZE_HINT_LATELOAD
+	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(PopulateAfterRoundStart))
 
 /obj/structure/closet/crate/slaver_loadout/PopulateContents()
 	..()
@@ -46,8 +45,8 @@
 	new /obj/item/reagent_containers/hypospray/medipen/lewdsleepy(src)
 	new /obj/item/slaver/gizmo(src)
 
-/obj/structure/closet/crate/slaver_loadout/LateInitialize()
-	. = ..()
+/obj/structure/closet/crate/slaver_loadout/proc/PopulateAfterRoundStart()
+	SIGNAL_HANDLER
 	if(GLOB.master_mode == ROUNDTYPE_EXTENDED)
 		new /obj/item/clothing/accessory/permit/special/deviant/lust/slavers(src)
 


### PR DESCRIPTION
# Описание
Убираем пермит на контру слейверам с карты и спавним его только в эксту

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Слейверский пермит, на базе слейверов, теперь будет только в экстендед
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Удалены дублирующие записи на карте, что устраняет повторную генерацию одних и тех же предметов в локациях.

* **Новые функции**
  * Добавлена условная поздняя генерация специального предмета в контейнеры: предмет теперь появляется дополнительно только при включённом режиме «расширенная игра», не влияя на базовую начальную загрузку содержимого.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->