### PR TITLE
Хотфикс тайпа ядра для крафта БоХ

### DIFF
--- a/modular_bluemoon/phenyamomota/code/modules/holdingfashion_port/code/backpack.dm
+++ b/modular_bluemoon/phenyamomota/code/modules/holdingfashion_port/code/backpack.dm
@@ -7,7 +7,7 @@
 
 /obj/item/BoH_inert/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
-	if(I.type == /obj/item/assembly/signaler/anomaly && !(user.a_intent == INTENT_HARM))
+	if(I.type == /obj/item/assembly/signaler/anomaly/bluespace && !(user.a_intent == INTENT_HARM))
 		if(INTERACTING_WITH(user, src))
 			return
 		to_chat(user, span_notice("Вы начинаете вставлять [I] в [src]."))


### PR DESCRIPTION
# Описание
- Тайп для айтема поменялся с `/obj/item/assembly/signaler/anomaly` на `/obj/item/assembly/signaler/anomaly/bluespace` для проверок на атаку инерт boh

## Причина изменений
- Ошибка, исправляю

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Исправлена невозможность крафта блюспейс сумки хранения кликом ядром по инертной сумке.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлена совместимость рюкзака-переноски с датчиками аномалий. Теперь рюкзак принимает только датчики определённого типа.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->