### PR TITLE
Хирургический стол показывает "влияющие на операции" трейты персонажа

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -40,7 +40,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "fl" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/disk/design_disk/golem_shell,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
@@ -99,7 +99,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "jx" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/surgical_drapes{
 	pixel_x = -3;
 	pixel_y = 0
@@ -112,7 +112,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "jU" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
@@ -128,7 +128,7 @@
 "kX" = (
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/brute,
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/machinery/light,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
@@ -141,7 +141,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "lc" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "lm" = (
@@ -149,7 +149,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "lw" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/pod/dark,
@@ -157,7 +157,7 @@
 "ly" = (
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "mm" = (
@@ -208,7 +208,7 @@
 /area/shuttle/golems)
 "oR" = (
 /obj/machinery/reagentgrinder,
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "pv" = (
@@ -346,7 +346,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "zL" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/gps/mining{
 	pixel_x = -9;
 	pixel_y = 6
@@ -400,7 +400,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "ES" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/areaeditor/blueprints{
 	desc = "Use to build new structures in the wastes.";
 	name = "land claim"
@@ -439,7 +439,7 @@
 "JW" = (
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/brute,
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "Ki" = (
@@ -524,7 +524,7 @@
 /turf/template_noop,
 /area/template_noop)
 "SR" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/item/resonator/upgraded,
 /obj/machinery/light{
 	dir = 1
@@ -536,7 +536,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/golems)
 "UD" = (
-/obj/structure/table/reinforced/ctf,
+/obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -113,11 +113,11 @@
 		data["patient"]["fireLoss"] = patient.getFireLoss()
 		data["patient"]["toxLoss"] = patient.getToxLoss()
 		data["patient"]["oxyLoss"] = patient.getOxyLoss()
-		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_NOBREATH) ? "Апное (отсутсвие дыхания) \n" : null
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_NOBREATH) ? "Апноэ (отсутсвие дыхания) \n" : null
 		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_BLUEMOON_FEAR_OF_SURGEONS) ? "Ятрофобия (страх операций) \n" : null
 		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_BLUEMOON_HIGH_PAIN_THRESHOLD) ? "Высокий болевой порог \n" : null
 		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_ONELIFE) ? "Невозможность реанимации при смерти \n" : null
-		data["patient"]["special_condition"] += HAS_TRAIT(patient, BLUEMOON_TRAIT_NAME_COMPLEX_MAINTENANCE) ? "Сложные технические модули (требуется консультация роботехнического персонала) \n" : null
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_BLUEMOON_COMPLEX_MAINTENANCE) ? "Сложные технические модули (требуется консультация роботехнического персонала) \n" : null
 		data["patient"]["is_robotic_organism"] = HAS_TRAIT(patient, TRAIT_ROBOTIC_ORGANISM)
 		data["procedures"] = list()
 		if(patient.surgeries.len)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -113,6 +113,11 @@
 		data["patient"]["fireLoss"] = patient.getFireLoss()
 		data["patient"]["toxLoss"] = patient.getToxLoss()
 		data["patient"]["oxyLoss"] = patient.getOxyLoss()
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_NOBREATH) ? "Апное (отсутсвие дыхания) \n" : null
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_BLUEMOON_FEAR_OF_SURGEONS) ? "Ятрофобия (страх операций) \n" : null
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_BLUEMOON_HIGH_PAIN_THRESHOLD) ? "Высокий болевой порог \n" : null
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, TRAIT_ONELIFE) ? "Невозможность реанимации при смерти \n" : null
+		data["patient"]["special_condition"] += HAS_TRAIT(patient, BLUEMOON_TRAIT_NAME_COMPLEX_MAINTENANCE) ? "Сложные технические модули (требуется консультация роботехнического персонала) \n" : null
 		data["patient"]["is_robotic_organism"] = HAS_TRAIT(patient, TRAIT_ROBOTIC_ORGANISM)
 		data["procedures"] = list()
 		if(patient.surgeries.len)

--- a/tgui/packages/tgui/interfaces/OperatingComputer.js
+++ b/tgui/packages/tgui/interfaces/OperatingComputer.js
@@ -158,6 +158,12 @@ const PatientStateView = (props, context) => {
           </LabeledList>
         </Section>
       ))}
+      {patient && patient.special_condition ? (
+      <Section title="Особенности пациента" preserveWhitespace>
+        {patient.special_condition}
+      </Section>
+      ) : ""
+      }
     </Fragment>
   );
 };


### PR DESCRIPTION
# Описание
1) фикс столов на корабле големов (были неразрушимые столы)
2) добавлено меню в операционном компьютере отображающее влияющие на операцию квирки (боязнь хирургов, высокий болевой порог, одна жизнь, сложное техническое обслуживание)

## Причина изменений
упрощение жизни хирургам
## Демонстрация изменений
<img width="499" height="465" alt="image" src="https://github.com/user-attachments/assets/20d88ff8-4a69-4705-9647-90ea0256f90f" />


## Changelog
:cl:
qol:  operating computer получил возможность показывать особые состояния пациента влияющие на операцию
map: столы на корабле големов были заменены на разрушаемые
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Операционный компьютер теперь отображает специальные состояния пациента (боязнь хирургов, высокий порог боли и прочие особенности) в интерфейсе.

* **Chores**
  * Обновлены элементы мебели в одной из локаций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->