### PR TITLE
Icemoon DS-1 минорный маппинг

### DIFF
--- a/_maps/map_files/bluemoon_maps/icemoonstation.dmm
+++ b/_maps/map_files/bluemoon_maps/icemoonstation.dmm
@@ -48777,7 +48777,8 @@
 /obj/effect/turf_decal/bot/yellow,
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8;
-	mob_name = "a Syndicate 'Glacier' Researcher"
+	mob_name = "a Syndicate 'Glacier' Researcher";
+	name = "DS-1 Glacier Specialist"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
@@ -102753,7 +102754,8 @@
 /obj/effect/turf_decal/bot/yellow,
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4;
-	mob_name = "a Syndicate 'Glacier' Researcher"
+	mob_name = "a Syndicate 'Glacier' Researcher";
+	name = "DS-1 Glacier Specialist"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)

--- a/_maps/map_files/bluemoon_maps/icemoonstation.dmm
+++ b/_maps/map_files/bluemoon_maps/icemoonstation.dmm
@@ -3657,7 +3657,8 @@
 /obj/effect/turf_decal/bot/yellow,
 /obj/effect/mob_spawn/human/lavaland_syndicate/shaft{
 	dir = 8;
-	mob_name = "a Syndicate 'Glacier' Combatant"
+	mob_name = "a Syndicate 'Glacier' Combatant";
+	short_desc = "Вы Специалист по обеспечению безопасности Синдиката, работающий на Аванпосту Айсмуна и изучающий аномальное поле Системы Синих Лун. Вы второй по главенству оперативник после Специалиста Прослушки на Глейсире."
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
@@ -48778,7 +48779,8 @@
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8;
 	mob_name = "a Syndicate 'Glacier' Researcher";
-	name = "DS-1 Glacier Specialist"
+	name = "DS-1 Glacier Specialist";
+	short_desc = "Вы Научный Специалист Синдиката, работающий на Аванпосту Айсмуна и изучающий аномальное поле Системы Синих Лун."
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
@@ -66444,7 +66446,8 @@
 /obj/effect/turf_decal/bot/yellow,
 /obj/effect/mob_spawn/human/lavaland_syndicate/offcomm{
 	dir = 4;
-	mob_name = "a Syndicate 'Glacier' Leader"
+	mob_name = "a Syndicate 'Glacier' Leader";
+	short_desc = "Вы Офицер Коммуникаций, работающий на Аванпосту Айсмуна и руководящий объектом. Обеспечьте функционирование вверенного вам аванпоста. Проводите отчётную деятельность."
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
@@ -102755,7 +102758,8 @@
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4;
 	mob_name = "a Syndicate 'Glacier' Researcher";
-	name = "DS-1 Glacier Specialist"
+	name = "DS-1 Glacier Specialist";
+	short_desc = "Вы Научный Специалист Синдиката, работающий на Аванпосту Айсмуна и изучающий аномальное поле Системы Синих Лун."
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)

--- a/_maps/map_files/bluemoon_maps/icemoonstation.dmm
+++ b/_maps/map_files/bluemoon_maps/icemoonstation.dmm
@@ -3650,15 +3650,15 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/tcommsat/computer)
 "aLa" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
-	dir = 8;
-	faction = list("Syndicate")
-	},
 /obj/machinery/button/door/directional/south{
 	name = "privacy shutters";
 	id = "glacierdorm3"
 	},
 /obj/effect/turf_decal/bot/yellow,
+/obj/effect/mob_spawn/human/lavaland_syndicate/shaft{
+	dir = 8;
+	mob_name = "a Syndicate 'Glacier' Combatant"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
 "aLc" = (
@@ -14025,7 +14025,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/window/northleft{
 	name = "First-Aid Supplies";
-
 	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/white/textured/edge{
@@ -48771,15 +48770,15 @@
 /turf/open/floor/plasteel/smooth/edge,
 /area/hallway/primary/fore)
 "iPj" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
-	dir = 8;
-	faction = list("Syndicate")
-	},
 /obj/machinery/button/door/directional/south{
 	name = "privacy shutters";
 	id = "glacierdorm1"
 	},
 /obj/effect/turf_decal/bot/yellow,
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	dir = 8;
+	mob_name = "a Syndicate 'Glacier' Researcher"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
 "iPk" = (
@@ -53412,7 +53411,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/window/northleft{
 	name = "First-Aid Supplies";
-
 	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/white/textured/edge{
@@ -66443,8 +66441,9 @@
 /area/commons/fitness/pool)
 "lUN" = (
 /obj/effect/turf_decal/bot/yellow,
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	dir = 4
+/obj/effect/mob_spawn/human/lavaland_syndicate/offcomm{
+	dir = 4;
+	mob_name = "a Syndicate 'Glacier' Leader"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
@@ -81555,7 +81554,8 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /mob/living/simple_animal/pet/cat/kitten{
-	faction = list("neutral", "Syndicate")
+	faction = list("neutral", "Syndicate");
+	name = "Murder Mittens"
 	},
 /turf/open/floor/wood/wood_large,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
@@ -102746,14 +102746,15 @@
 /turf/open/floor/plating,
 /area/tcommsat/lounge)
 "sFQ" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate{
-	dir = 4
-	},
 /obj/machinery/button/door/directional/south{
 	name = "privacy shutters";
 	id = "glacierdorm2"
 	},
 /obj/effect/turf_decal/bot/yellow,
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	dir = 4;
+	mob_name = "a Syndicate 'Glacier' Researcher"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/icemoon/unpowered/glacier/dormitories)
 "sFW" = (
@@ -123700,7 +123701,8 @@
 	dir = 4
 	},
 /mob/living/simple_animal/pet/cat/kitten{
-	faction = list("neutral", "Syndicate")
+	faction = list("neutral", "Syndicate");
+	name = "Bayonet"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/icemoon/unpowered/glacier/cafeteria)


### PR DESCRIPTION
# Описание
- Вместо старого агента прослушки дан оффком ДС-1 обычных станций.
- Спавнеры учёных:
   - Кастомнейм спавнеров "you really want to become..." переименованы на Глейсир из Дюны.
   - Имя спавнера lavaland -> glacier
   - Вместо одного из учёных дан бригофицер ДС-1
- Котята переименованы в Мардер Миттенс и Байонет


## Причина изменений
- Устаревшая роль, не востребована.
- Корректировки под Айсмун + разнообразие.
- For fun.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
map: Icemoon DS-1: спавнер агента прослушки заменён на оффкома; один спавнер учёного заменён на бригофицера; котята переименованы в Murder Mittens и Bayonet.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления карты

* **Обновления**
  * Изменены конфигурации спаунеров врагов Синдиката на ледяной станции с добавлением специализированных ролей и уникальных идентификаторов
  * Обновлены спаунеры питомцев-котят с присвоением уникальных имён
  * Произведены микрокорректировки форматирования элементов карты

<!-- end of auto-generated comment: release notes by coderabbit.ai -->