### PR TITLE
mage fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -112,6 +112,8 @@
 	/// directional recoil multiplier
 	var/dir_recoil_amp = 10
 
+	var/can_shoot_yourself = TRUE
+
 /obj/item/gun/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/toggle_firemode))
 		fire_select()
@@ -368,8 +370,11 @@
 			return
 		if(!ismob(target) || user.a_intent == INTENT_HARM) //melee attack
 			return
-		if(target == user && (user.a_intent != INTENT_DISARM) && !(user.zone_selected == BODY_ZONE_PRECISE_MOUTH || (user.zone_selected == BODY_ZONE_PRECISE_GROIN && user.a_intent != INTENT_HELP))) //so we can't shoot ourselves (unless mouth selected or disarm intent) // BLUEMOON EDIT add BODY_ZONE_PRECISE_GROIN
-			return
+		if(target == user)
+			if(!can_shoot_yourself)
+				return
+			if((user.a_intent != INTENT_DISARM) && !(user.zone_selected == BODY_ZONE_PRECISE_MOUTH || (user.zone_selected == BODY_ZONE_PRECISE_GROIN && user.a_intent != INTENT_HELP))) //so we can't shoot ourselves (unless mouth selected or disarm intent) // BLUEMOON EDIT add BODY_ZONE_PRECISE_GROIN
+				return
 		if(iscarbon(target))
 			var/mob/living/carbon/C = target
 			for(var/i in C.all_wounds)

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -27,6 +27,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/heal
 	icon_state = "staffofhealing"
 	item_state = "staffofhealing"
+	can_shoot_yourself = FALSE // Dont heal yourself
 
 /obj/item/gun/magic/staff/healing/handle_suicide() //Stops people trying to commit suicide to heal themselves
 	return

--- a/code/modules/spells/spell_types/cluwnecurse.dm
+++ b/code/modules/spells/spell_types/cluwnecurse.dm
@@ -21,7 +21,7 @@
 		to_chat(user, "<span class='notice'>No target found in range.</span>")
 		return
 	var/mob/living/carbon/target = targets[1]
-	if(!(target.type in compatible_mobs))
+	if(!(target.type in compatible_mobs) || target.anti_magic_check())
 		to_chat(user, "<span class='notice'>You are unable to curse [target]!</span>")
 		return
 	if(!(target in oview(range)))


### PR DESCRIPTION
# Описание
- Посохом хила теперь нельзя стрелять в себя
- На спелл клувнефикации добавлена проверка антимагии

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Посохом хила теперь нельзя стрелять в себя
balance: На спелл клувнефикации добавлена проверка антимагии
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Заклинание проклятия теперь должным образом проверяет защиту от магии перед применением эффекта.

## Изменения игровой механики

* Посох исцеления больше не может быть использован на своего владельца.
* Обновлена система ограничений самонацеливания для оружия.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->