### PR TITLE
Хотфикс плазмакаттеров

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -165,7 +165,6 @@
 				return
 			if(!I.use(1))
 				return
-			I.use(1)
 			cell.give(500)
 			to_chat(user, span_notice("Вы вдавили [I] в [src] с щебнем, добавляя заряд."))
 	else


### PR DESCRIPTION
# Описание
- Удалениеи строчки с `use(1)`

## Причина изменений
- Использовалось два куска плазменной руды вместо одного.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Исправлено двойное потребление плазменной руды при зарядке ею плазмакаттеров.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Плазменная руда больше не расходуется при использовании с плазменным резаком.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->