### PR TITLE
gondola fix

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -31,7 +31,7 @@
 	maxHealth = 200
 	health = 200
 	del_on_death = TRUE
-	playable_by_ghost = TRUE
+	playable_by_ghost = FALSE
 	ghost_possess_title = "Гондола"
 	ghost_possess_question = "Стать гондолой?"
 

--- a/modular_sand/code/modules/mining/machine_bluespaceminer/low_threat.dm
+++ b/modular_sand/code/modules/mining/machine_bluespaceminer/low_threat.dm
@@ -134,6 +134,7 @@ GLOBAL_LIST_INIT(bsm_low_threat_pool, list(
 	if(!drop)
 		return
 	var/mob/living/simple_animal/pet/gondola/spawned_gondola = new /mob/living/simple_animal/pet/gondola(drop)
+	spawned_gondola.playable_by_ghost = TRUE
 	play_bluespace_sparks(machine)
 	machine.balloon_alert_to_viewers("гондола...")
 	machine.visible_message(span_notice("Из разлома выходит гондола и молча принимает мир таким, какой он есть."))


### PR DESCRIPTION
# Описание
- За раундстарт гондол больше нельзя зайти, только появившихся из БС майнера

:cl:
refactor: За раундстарт гондол больше нельзя зайти, только появившихся из БС майнера
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Изменения

* **Балансировка Игры**
  * Изменено управление привидениями для гондол: теперь они не могут быть захвачены привидениями по умолчанию
  * Сделано исключение для специального события добычи

<!-- end of auto-generated comment: release notes by coderabbit.ai -->