### PR TITLE
head size up

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -18,7 +18,7 @@
 	stam_damage_coeff = 1
 	max_stamina_damage = 0 //Setting this to 0 since this has the same exact effects as the chest when disabled
 
-	dropped_size = 1.15
+	dropped_size = 1.25
 
 	var/mob/living/brain/brainmob = null //The current occupant.
 	var/obj/item/organ/brain/brain = null //The brain organ


### PR DESCRIPTION
# Описание
- Размер отрезанной головы 115% -> 125%
## Причина изменений
Все равно шакалит спрайт и он становиться мелким, особенно при повороте. Попробуем пофиксить так

@coderabbitai ignore
## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
refactor: Размер отрезанной головы 115% -> 125%
/:cl:
