### PR TITLE
Анимированные картинки для хедшотов

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			return
 		chosen_headshot_id = text2num(chosen_headshot_id)
 		var/has_headshot_id = chosen_headshot_id <= headshots.len
-		var/usr_input = tgui_input_text(our_borgy, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
+		var/usr_input = tgui_input_text(our_borgy, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm/.mp4')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
 		if(isnull(usr_input))
 			return
 
@@ -188,14 +188,14 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			return
 
 		var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
-		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
+		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
 
 		if(!findtext(usr_input, link_regex))
 			to_chat(our_borgy, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
 			return
 
 		if(!findtext(usr_input, end_regex))
-			to_chat(our_borgy, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", or \".webm\" in the end of the link!"))
+			to_chat(our_borgy, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", \".webm\", or \".mp4\" in the end of the link!"))
 			return
 
 		var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
@@ -249,7 +249,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			var/list/headshots = chosen == "Хедшоты без одежды" ? our_mob.dna.headshot_naked_links : our_mob.dna.headshot_links
 			var/is_naked_headshot = chosen == "Хедшоты без одежды"
 			var/has_headshot_id = chosen_headshot_id <= headshots.len
-			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
+			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm/.mp4')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
 			if(isnull(usr_input))
 				return
 
@@ -264,14 +264,14 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 				return
 
 			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
-			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
+			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
 
 			if(!findtext(usr_input, link_regex))
 				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
 				return
 
 			if(!findtext(usr_input, end_regex))
-				to_chat(our_mob, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", or \".webm\" in the end of the link!"))
+				to_chat(our_mob, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", \".webm\", or \".mp4\" in the end of the link!"))
 				return
 
 			var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			return
 		chosen_headshot_id = text2num(chosen_headshot_id)
 		var/has_headshot_id = chosen_headshot_id <= headshots.len
-		var/usr_input = tgui_input_text(our_borgy, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
+		var/usr_input = tgui_input_text(our_borgy, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
 		if(isnull(usr_input))
 			return
 
@@ -187,15 +187,15 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			our_borgy.mind.headshot_links = headshots.Copy()
 			return
 
-		var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/)")
-		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg)$")
+		var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/)")
+		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
 
 		if(!findtext(usr_input, link_regex))
-			to_chat(our_borgy, span_warning("The link needs to be an unshortened Gyazo, iBB, E621 link!"))
+			to_chat(our_borgy, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, or Catbox link!"))
 			return
 
 		if(!findtext(usr_input, end_regex))
-			to_chat(our_borgy, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the end of the link!"))
+			to_chat(our_borgy, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", or \".webm\" in the end of the link!"))
 			return
 
 		var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
@@ -249,7 +249,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			var/list/headshots = chosen == "Хедшоты без одежды" ? our_mob.dna.headshot_naked_links : our_mob.dna.headshot_links
 			var/is_naked_headshot = chosen == "Хедшоты без одежды"
 			var/has_headshot_id = chosen_headshot_id <= headshots.len
-			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
+			var/usr_input = tgui_input_text(our_mob, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm')", "Headshot Image", has_headshot_id ? headshots[chosen_headshot_id] : "", 100, FALSE, FALSE)
 			if(isnull(usr_input))
 				return
 
@@ -263,15 +263,15 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 						our_mob.mind.headshot_links = headshots.Copy()
 				return
 
-			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/)")
-			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg)$")
+			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/)")
+			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
 
 			if(!findtext(usr_input, link_regex))
-				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621 link!"))
+				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, or Catbox link!"))
 				return
 
 			if(!findtext(usr_input, end_regex))
-				to_chat(our_mob, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the end of the link!"))
+				to_chat(our_mob, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", or \".webm\" in the end of the link!"))
 				return
 
 			var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -187,11 +187,11 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			our_borgy.mind.headshot_links = headshots.Copy()
 			return
 
-		var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/)")
+		var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
 		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
 
 		if(!findtext(usr_input, link_regex))
-			to_chat(our_borgy, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, or Catbox link!"))
+			to_chat(our_borgy, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
 			return
 
 		if(!findtext(usr_input, end_regex))
@@ -263,11 +263,11 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 						our_mob.mind.headshot_links = headshots.Copy()
 				return
 
-			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/)")
+			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
 			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
 
 			if(!findtext(usr_input, link_regex))
-				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, or Catbox link!"))
+				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
 				return
 
 			if(!findtext(usr_input, end_regex))

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -187,15 +187,10 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			our_borgy.mind.headshot_links = headshots.Copy()
 			return
 
-		var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
 		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
 
-		if(!findtext(usr_input, link_regex))
-			to_chat(our_borgy, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
-			return
-
 		if(!findtext(usr_input, end_regex))
-			to_chat(our_borgy, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", \".webm\", or \".mp4\" in the end of the link!"))
+			to_chat(our_borgy, span_warning("The link must be a direct image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
 			return
 
 		var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
@@ -263,15 +258,10 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 						our_mob.mind.headshot_links = headshots.Copy()
 				return
 
-			var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
 			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
 
-			if(!findtext(usr_input, link_regex))
-				to_chat(our_mob, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
-				return
-
 			if(!findtext(usr_input, end_regex))
-				to_chat(our_mob, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", \".webm\", or \".mp4\" in the end of the link!"))
+				to_chat(our_mob, span_warning("The link must be a direct image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
 				return
 
 			var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -146,6 +146,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	set desc = "Used to manage your various flavor."
 	set category = "IC"
 
+	var/static/link_regex = regex("^https?://.*\\.(jpg|png|jpeg|gif|webm|mp4)$", "i")
+
 	if(!isliving(src))
 		return
 	var/list/changeable_texts = list(
@@ -187,10 +189,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			our_borgy.mind.headshot_links = headshots.Copy()
 			return
 
-		var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
-
-		if(!findtext(usr_input, end_regex))
-			to_chat(our_borgy, span_warning("The link must be a direct image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
+		if(!findtext(usr_input, link_regex))
+			to_chat(our_borgy, span_warning("The link must be a direct http(s):// image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
 			return
 
 		var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
@@ -258,10 +258,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 						our_mob.mind.headshot_links = headshots.Copy()
 				return
 
-			var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
-
-			if(!findtext(usr_input, end_regex))
-				to_chat(our_mob, span_warning("The link must be a direct image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
+			if(!findtext(usr_input, link_regex))
+				to_chat(our_mob, span_warning("The link must be a direct http(s):// image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
 				return
 
 			var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1468,35 +1468,29 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<h2>[headshots_label]</h2>"
 
 					dat += "<a href='?_src_=prefs;preference=headshot'><b>[set_headshot_1_label]</b></a><br>"
-					if(features["headshot_link"])
-						dat += "<img src='[features["headshot_link"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += headshot_preview_html(features["headshot_link"])
 					dat += "<br><br>"
 
 					dat += "<a href='?_src_=prefs;preference=headshot1'><b>[set_headshot_2_label]</b></a><br>"
-					if(features["headshot_link1"])
-						dat += "<img src='[features["headshot_link1"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += headshot_preview_html(features["headshot_link1"])
 					dat += "<br><br>"
 
 					dat += "<a href='?_src_=prefs;preference=headshot2'><b>[set_headshot_3_label]</b></a><br>"
-					if(features["headshot_link2"])
-						dat += "<img src='[features["headshot_link2"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += headshot_preview_html(features["headshot_link2"])
 					//dat += "<br><br>"
 
 					dat += "<h2>[naked_headshots_label]</h2>"
 
 					dat += "<a href='?_src_=prefs;preference=headshot_naked'><b>[set_naked_headshot_1_label]</b></a><br>"
-					if(features["headshot_naked_link"])
-						dat += "<img src='[features["headshot_naked_link"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += headshot_preview_html(features["headshot_naked_link"])
 					dat += "<br><br>"
 
 					dat += "<a href='?_src_=prefs;preference=headshot_naked1'><b>[set_naked_headshot_2_label]</b></a><br>"
-					if(features["headshot_naked_link1"])
-						dat += "<img src='[features["headshot_naked_link1"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += headshot_preview_html(features["headshot_naked_link1"])
 					dat += "<br><br>"
 
 					dat += "<a href='?_src_=prefs;preference=headshot_naked2'><b>[set_naked_headshot_3_label]</b></a><br>"
-					if(features["headshot_naked_link2"])
-						dat += "<img src='[features["headshot_naked_link2"]]' style='border: 1px solid black' width='140px' height='140px'>"
+					dat += headshot_preview_html(features["headshot_naked_link2"])
 					dat += "<br><br>"
 					// BLUEMOON ADD END
 					dat += "</td></tr></table>"

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -90,6 +90,14 @@
 #undef ACTION_HEADSHOT_LINK_NOOP
 #undef ACTION_HEADSHOT_LINK_REMOVE
 
+/proc/headshot_preview_html(link, width = 140, height = 140)
+	if(!link)
+		return ""
+	var/static/video_regex = regex("\\.(webm|mp4)$", "i")
+	if(findtext(link, video_regex))
+		return "<video src='[link]' autoplay loop muted playsinline style='border: 1px solid black; object-fit: contain;' width='[width]' height='[height]'></video>"
+	return "<img src='[link]' style='border: 1px solid black' width='[width]px' height='[height]px'>"
+
 /datum/preferences/proc/mob_size_name_to_num(body_weight_name)
 	switch(body_weight_name)
 		if(NAME_WEIGHT_LIGHT)

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -17,7 +17,7 @@
 #define ACTION_HEADSHOT_LINK_NOOP 0
 #define ACTION_HEADSHOT_LINK_REMOVE -1
 
-#define HEADSHOT_LINK_MAX_LENGTH 100
+#define HEADSHOT_LINK_MAX_LENGTH 400
 
 
 /datum/preferences/process_link(mob/user, list/href_list)
@@ -66,7 +66,7 @@
 	if(!usr_input)
 		return ACTION_HEADSHOT_LINK_REMOVE
 
-	var/static/link_regex = regex("^https?://.*\\.(jpg|png|jpeg|gif|webm|mp4)$", "i")
+	var/static/link_regex = regex("^https?://.*\\.(jpg|png|jpeg|gif|webm|mp4)(\[?#].*)?$", "i")
 
 	if (length(usr_input) > HEADSHOT_LINK_MAX_LENGTH)
 		to_chat(user, span_warning("The link is too long! Max length: [HEADSHOT_LINK_MAX_LENGTH] characters!"))
@@ -89,7 +89,7 @@
 /proc/headshot_preview_html(link, width = 140, height = 140)
 	if(!link)
 		return ""
-	var/static/video_regex = regex("\\.(webm|mp4)$", "i")
+	var/static/video_regex = regex("\\.(webm|mp4)(\[?#]|$)", "i")
 	if(findtext(link, video_regex))
 		return "<video src='[link]' autoplay loop muted playsinline style='border: 1px solid black; object-fit: contain;' width='[width]' height='[height]'></video>"
 	return "<img src='[link]' style='border: 1px solid black; object-fit: contain;' width='[width]' height='[height]'>"

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -66,14 +66,14 @@
 	if(!usr_input)
 		return ACTION_HEADSHOT_LINK_REMOVE
 
-	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
+	var/static/link_regex = regex("^https?://.*\\.(jpg|png|jpeg|gif|webm|mp4)$", "i")
 
 	if (length(usr_input) > HEADSHOT_LINK_MAX_LENGTH)
 		to_chat(user, span_warning("The link is too long! Max length: [HEADSHOT_LINK_MAX_LENGTH] characters!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
-	if(!findtext(usr_input, end_regex))
-		to_chat(user, span_warning("The link must be a direct image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
+	if(!findtext(usr_input, link_regex))
+		to_chat(user, span_warning("The link must be a direct http(s):// image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")
@@ -85,13 +85,14 @@
 #undef ACTION_HEADSHOT_LINK_NOOP
 #undef ACTION_HEADSHOT_LINK_REMOVE
 
+/// Renders a headshot preview tag. `link` must be pre-sanitized (it is interpolated directly into an HTML attribute).
 /proc/headshot_preview_html(link, width = 140, height = 140)
 	if(!link)
 		return ""
 	var/static/video_regex = regex("\\.(webm|mp4)$", "i")
 	if(findtext(link, video_regex))
 		return "<video src='[link]' autoplay loop muted playsinline style='border: 1px solid black; object-fit: contain;' width='[width]' height='[height]'></video>"
-	return "<img src='[link]' style='border: 1px solid black' width='[width]px' height='[height]px'>"
+	return "<img src='[link]' style='border: 1px solid black; object-fit: contain;' width='[width]' height='[height]'>"
 
 /datum/preferences/proc/mob_size_name_to_num(body_weight_name)
 	switch(body_weight_name)

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -59,26 +59,26 @@
 
 
 /datum/preferences/proc/get_headshot_link(mob/user, old_link)
-	var/usr_input = input(user, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg')", "Headshot Image", old_link) as text|null
+	var/usr_input = input(user, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm')", "Headshot Image", old_link) as text|null
 	if(isnull(usr_input))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	if(!usr_input)
 		return ACTION_HEADSHOT_LINK_REMOVE
 
-	var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/)")
-	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg)$")
+	var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/)")
+	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
 
 	if (length(usr_input) > HEADSHOT_LINK_MAX_LENGTH)
 		to_chat(user, span_warning("The link is too long! Max length: [HEADSHOT_LINK_MAX_LENGTH] characters!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	if(!findtext(usr_input, link_regex))
-		to_chat(user, span_warning("The link needs to be an unshortened Gyazo, iBB, E621 link!"))
+		to_chat(user, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, or Catbox link!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	if(!findtext(usr_input, end_regex))
-		to_chat(user, span_warning("You need either \".png\", \".jpg\", or \".jpeg\" in the end of the link!"))
+		to_chat(user, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", or \".webm\" in the end of the link!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -59,7 +59,7 @@
 
 
 /datum/preferences/proc/get_headshot_link(mob/user, old_link)
-	var/usr_input = input(user, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm')", "Headshot Image", old_link) as text|null
+	var/usr_input = input(user, "Input the image link: (For Discord links, try putting the file's type at the end of the link, after the '&'. for example '&.jpg/.png/.jpeg/.gif/.webm/.mp4')", "Headshot Image", old_link) as text|null
 	if(isnull(usr_input))
 		return ACTION_HEADSHOT_LINK_NOOP
 
@@ -67,7 +67,7 @@
 		return ACTION_HEADSHOT_LINK_REMOVE
 
 	var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
-	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
+	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
 
 	if (length(usr_input) > HEADSHOT_LINK_MAX_LENGTH)
 		to_chat(user, span_warning("The link is too long! Max length: [HEADSHOT_LINK_MAX_LENGTH] characters!"))
@@ -78,7 +78,7 @@
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	if(!findtext(usr_input, end_regex))
-		to_chat(user, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", or \".webm\" in the end of the link!"))
+		to_chat(user, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", \".webm\", or \".mp4\" in the end of the link!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -66,7 +66,7 @@
 	if(!usr_input)
 		return ACTION_HEADSHOT_LINK_REMOVE
 
-	var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/)")
+	var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
 	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm)$")
 
 	if (length(usr_input) > HEADSHOT_LINK_MAX_LENGTH)
@@ -74,7 +74,7 @@
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	if(!findtext(usr_input, link_regex))
-		to_chat(user, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, or Catbox link!"))
+		to_chat(user, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	if(!findtext(usr_input, end_regex))

--- a/modular_bluemoon/code/modules/client/preferences.dm
+++ b/modular_bluemoon/code/modules/client/preferences.dm
@@ -66,19 +66,14 @@
 	if(!usr_input)
 		return ACTION_HEADSHOT_LINK_REMOVE
 
-	var/static/link_regex = regex("^(https://i\\.gyazo\\.com|https://static1\\.e621\\.net|https://i\\.ibb\\.co/|https://i\\.imgur\\.com/|https://files\\.catbox\\.moe/|https://media\\.tenor\\.com/|https://media\\.giphy\\.com/)")
 	var/static/end_regex = regex("(\\.jpg|\\.png|\\.jpeg|\\.gif|\\.webm|\\.mp4)$")
 
 	if (length(usr_input) > HEADSHOT_LINK_MAX_LENGTH)
 		to_chat(user, span_warning("The link is too long! Max length: [HEADSHOT_LINK_MAX_LENGTH] characters!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
-	if(!findtext(usr_input, link_regex))
-		to_chat(user, span_warning("The link needs to be an unshortened Gyazo, iBB, E621, Imgur, Catbox, Tenor, or Giphy link!"))
-		return ACTION_HEADSHOT_LINK_NOOP
-
 	if(!findtext(usr_input, end_regex))
-		to_chat(user, span_warning("You need either \".png\", \".jpg\", \".jpeg\", \".gif\", \".webm\", or \".mp4\" in the end of the link!"))
+		to_chat(user, span_warning("The link must be a direct image/video URL ending with .png, .jpg, .jpeg, .gif, .webm, or .mp4!"))
 		return ACTION_HEADSHOT_LINK_NOOP
 
 	var/static/list/repl_chars = list("\n"="#","\t"="#","'"="","\""=""," "="")

--- a/modular_splurt/code/modules/client/preferences.dm
+++ b/modular_splurt/code/modules/client/preferences.dm
@@ -242,8 +242,7 @@
 			//SPLURT EDIT
 			dat += "<h2>Headshot Image</h2>"
 			dat += "<a href='?_src_=prefs;preference=headshot'><b>Set Headshot Image</b></a><br>"
-			if(features["headshot_link"])
-				dat += "<img src='[features["headshot_link"]]' width='160px' height='120px'>"
+			dat += headshot_preview_html(features["headshot_link"], 160, 120)
 			dat += "<br><br>"
 			//SPLURT EDIT END
 			//SKYRAT EDIT

--- a/tgui/packages/tgui/interfaces/CharacterDirectory.js
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory.js
@@ -179,7 +179,7 @@ const ViewCharacter = (props, context) => {
   const [selectedHeadshot, setSelectedHeadshot] = useLocalState(context, 'viewHeadshot', 0);
   const safeIdx = headshots.length > 0 ? selectedHeadshot % headshots.length : 0;
   const currentLink = headshots[safeIdx];
-  const isVideo = typeof currentLink === 'string' && /\.webm$/i.test(currentLink);
+  const isVideo = typeof currentLink === 'string' && /\.(webm|mp4)$/i.test(currentLink);
   const mediaStyle = {
     'max-width': '256px',
     'max-height': '256px',

--- a/tgui/packages/tgui/interfaces/CharacterDirectory.js
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory.js
@@ -178,6 +178,13 @@ const ViewCharacter = (props, context) => {
   const headshots = (overlay.headshot_links || []).filter(link => link && link.length);
   const [selectedHeadshot, setSelectedHeadshot] = useLocalState(context, 'viewHeadshot', 0);
   const safeIdx = headshots.length > 0 ? selectedHeadshot % headshots.length : 0;
+  const currentLink = headshots[safeIdx];
+  const isVideo = typeof currentLink === 'string' && /\.webm$/i.test(currentLink);
+  const mediaStyle = {
+    'max-width': '256px',
+    'max-height': '256px',
+    'object-fit': 'contain',
+  };
 
   return (
     <Section
@@ -186,14 +193,21 @@ const ViewCharacter = (props, context) => {
       {headshots.length > 0 && (
         <Section level={2} title="Арт" textAlign="center">
           <Box mb={1}>
-            <img
-              src={headshots[safeIdx]}
-              style={{
-                'max-width': '256px',
-                'max-height': '256px',
-                'object-fit': 'contain',
-              }}
-            />
+            {isVideo ? (
+              <video
+                src={currentLink}
+                autoPlay
+                loop
+                muted
+                playsInline
+                style={mediaStyle}
+              />
+            ) : (
+              <img
+                src={currentLink}
+                style={mediaStyle}
+              />
+            )}
           </Box>
           {headshots.length > 1 && (
             <Box>

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -155,7 +155,7 @@ const CharacterProfileImageElement = (props, context) => {
   );
 
   const currentLink = headshot_links[safeSelectedHeadshot];
-  const isVideo = typeof currentLink === 'string' && /\.webm$/i.test(currentLink);
+  const isVideo = typeof currentLink === 'string' && /\.(webm|mp4)$/i.test(currentLink);
   const mediaStyle = {
     width: '256px',
     height: '256px',

--- a/tgui/packages/tgui/interfaces/CharacterProfile.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterProfile.tsx
@@ -154,19 +154,34 @@ const CharacterProfileImageElement = (props, context) => {
     (safeSelectedHeadshot + 1) % headshot_links.length
   );
 
+  const currentLink = headshot_links[safeSelectedHeadshot];
+  const isVideo = typeof currentLink === 'string' && /\.webm$/i.test(currentLink);
+  const mediaStyle = {
+    width: '256px',
+    height: '256px',
+    'max-width': '256px',
+    'max-height': '256px',
+    'object-fit': 'contain',
+  };
+
   if (headshot_links.length) { return (
     <Section title="Арт персонажа" pb="12" textAlign="center">
       <Box mb={1}>
-        <img
-          src={headshot_links[safeSelectedHeadshot]}
-          style={{
-            width: '256px',
-            height: '256px',
-            'max-width': '256px',
-            'max-height': '256px',
-            'object-fit': 'contain',
-          }}
-        />
+        {isVideo ? (
+          <video
+            src={currentLink as string}
+            autoPlay
+            loop
+            muted
+            playsInline
+            style={mediaStyle}
+          />
+        ) : (
+          <img
+            src={currentLink as string}
+            style={mediaStyle}
+          />
+        )}
       </Box>
       {headshot_links.length > 1 ? (
         <Box>


### PR DESCRIPTION
# Описание

Теперь в качестве картинки персонажа можно запихнуть не только статичную PNG-шку, но и гифку, webm или mp4. В TGUI и при осмотре в игре, и в окне создания персонажа - видосы проигрываются автоматически в цикле и без звука (muted обязателен, иначе браузер автоплей не пустит; да и не надо оно никому - представь экзамайн с хором орущих mp4).

Заодно снёс whitelist хостов. Толку от такой фильтрации было сомнительно - проверка расширения в конце ссылки и так отсекает HTML-страницы и всякий мусор, а легитимных хостов в интернете не сто штук. Так что теперь достаточно прямой ссылки, заканчивающейся на `.jpg/.jpeg/.png/.gif/.webm/.mp4`, и плевать откуда. Правда, по ходу ревью вспомнил, что без схемы проверка пропускала бы `data:`, `javascript:` и всякую такую дичь - теперь от ссылки требуется начинаться с `http://` или `https://`. Заодно валидация стала регистронезависимой, так что `.MP4` и `.GIF` тоже пройдут

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Пусть себе смотрят анимированные картинки?

## Демонстрация изменений

<img width="950" height="740" alt="Screen-Recording-2026-04-19-150459" src="https://github.com/user-attachments/assets/f9e0df6f-818b-42c3-aed3-66a61eb0d091" />


## Changelog

:cl:
add: Теперь в качестве хедшота персонажа можно использовать GIF, WebM и MP4 - видео проигрывается автоматически в цикле без звука.
qol: Убран whitelist хостов для ссылок на хедшоты. Теперь подойдёт любая прямая http(s)-ссылка - главное, чтобы она заканчивалась на .jpg/.jpeg/.png/.gif/.webm/.mp4 (в любом регистре).
fix: Превью MP4/WebM-хедшотов в окне создания персонажа теперь отображается корректно, а не ломается из-за `<img>`.
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлена поддержка видеохедшотов (webm, mp4) в дополнение к изображениям.
  * Расширена длина допустимых ссылок (до 400 символов).
  * Упрощена валидация ссылок: теперь принимаются любые прямые http(s) ссылки на изображения и видео.

* **Рефакторинг**
  * Оптимизирована система отображения предпросмотра хедшотов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->