### PR TITLE
[QOL] Модкор + инерт бох loc move

### DIFF
--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -54,7 +54,10 @@
 	. = ..()
 	if(!tool.use_tool(src, user, 5 SECONDS, volume = 30))
 		return
-	new /obj/item/mod/construction/core(drop_location())
+	user.temporarilyRemoveItemFromInventory(src)
+	var/created_core = new /obj/item/mod/construction/core(loc)
+	if(loc == user)
+		user.put_in_hands(created_core)
 	qdel(src)
 
 /obj/item/mod/construction/armor

--- a/modular_bluemoon/phenyamomota/code/modules/holdingfashion_port/code/backpack.dm
+++ b/modular_bluemoon/phenyamomota/code/modules/holdingfashion_port/code/backpack.dm
@@ -11,12 +11,14 @@
 		if(INTERACTING_WITH(user, src))
 			return
 		to_chat(user, span_notice("Вы начинаете вставлять [I] в [src]."))
-		if(do_after(user, 30, src))
-			var/created_boh = new backpack_type(loc)
-			qdel(I)
-			if(loc == user)
-				user.put_in_hands(created_boh)
-			qdel(src)
+		if(!do_after(user, 30, src))
+			return
+		user.temporarilyRemoveItemFromInventory(src)
+		var/created_boh = new backpack_type(loc)
+		if(loc == user)
+			user.put_in_hands(created_boh)
+		qdel(I)
+		qdel(src)
 
 /obj/item/BoH_inert/bag
 	name = "inert bag of holding"


### PR DESCRIPTION
# Описание
- Для брокен мод кора добавлены: 
   - Уборка айтема из рук игрока.
   - Создание в loc юзера целого ядра
   - Проверка на юзера и отправка нового ядра в руки.
- Для инерт бохов:
   - Уменьшена табуляция присваиванием ! для иф проверки. 
   - Введена аналогичная мод корам уборка-проверка.

## Причина изменений
- Устранение проблемы, что модкор после починки всегда падал на землю, если держался в руках. Теперь он будет создаваться только в локации, где находился до этого.
- Ditto выше

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Сумки хранения и МОД ядра теперь будут пытаться остаться в руках игрока., при трансформации из инертной и сломанной версий.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* **Улучшена механика обработки предметов** при реконструкции повреждённых компонентов модульного снаряжения — исправлена логика размещения восстановленных предметов в инвентаре пользователя.
* **Оптимизирована система создания рюкзаков** — добавлена проверка успешного завершения действия перед обработкой предметов, улучшена последовательность операций с инвентарём.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->