### PR TITLE
Оптимизация can_close у шкафчиков

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -225,12 +225,13 @@
 				to_chat(user, span_danger("Что-то слишком большое внутри [src] мешает закрыть шкафчик."))
 			return FALSE
 	// BLUEMOON ADD START - крутое ЕРТ кропило против сатанистов
-	for(var/obj/item/aspergillum/ert/holy_thing)
-		if(iscultist(user) || is_servant_of_ratvar(user) || isclockmob(user) || isconstruct(user) || isvampire(user))
+	if(user && (iscultist(user) || is_servant_of_ratvar(user) || isclockmob(user) || isconstruct(user) || isvampire(user)))
+		var/obj/item/aspergillum/ert/holy_thing = locate() in T
+		if(!holy_thing)
+			holy_thing = locate() in src
+		if(holy_thing)
 			to_chat(user, span_cultbold("Священная энергия [holy_thing] не позволяет [src] закрыться!"))
 			return FALSE
-		else
-			break
 	// BLUEMOON ADD END
 	return TRUE
 


### PR DESCRIPTION
# Описание

Смотрел профайлер и наткнулся на: `/obj/structure/closet/proc/can_close` жрал 773 мс CPU за 9 вызовов, весь CPU - оверtime. Каждый клик "закрыть шкафчик" выбивал тик за лимит

Виноват этот кусок в проверке ЕРТ-кропила:

```dm
for(var/obj/item/aspergillum/ert/holy_thing)  // нет in-клоузы
```

Без `in` такой цикл перебирает ВСЕ объекты этого типа в мире. То есть шкаф на закрытии сканировал весь мир ради поиска кропил ЕРТ. При этом `holy_thing` нигде не использовалась для проверки близости - только подставлялась в чат. По факту логика была "если где-то на станции лежит кропило ЕРТ и ты сатанист - шкафы на всей карте не закрываются". Да и если не сатанист - цикл всё равно стартовал ради мгновенного `break`

Что поменял:
- сначала проверяем, что юзер "нечистый" (культист/вампир/сервант/клокмоб/конструкт). Для обычных игроков сразу выход, не тратим такт
- если нечистый - `locate()` по тайлу шкафа и его содержимому. O(contents) вместо O(world)
- поведение по задумке сохранено: кропило рядом или внутри всё так же блокирует закрытие сатанистам

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

На живом сервере каждое закрытие шкафа давало тиковый оверtime, а на больших раундах - ощутимый фриз на ровном месте. Плюс заодно чиним маленькую логическую дурь: раньше одна кропилка на Центкоме влияла на все шкафы станции

## Демонстрация изменений

До:
```
/obj/structure/closet/proc/can_close    self 0.773  total 0.773  overtime 0.773   calls 9
```
~86 мс self-CPU на вызов, 100% овертайма

После: O(contents) с early-exit для не-сатанистов. Для 99% кликов проверка почти бесплатна

## Changelog

:cl:
fix: ЕРТ-кропило теперь блокирует закрытие шкафа, только если лежит рядом или внутри, а не просто существует где-то в мире
code: убран world-скан в can_close() у шкафчиков, больше не жрёт овертайм на каждом закрытии
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления

* Оптимизирована проверка ограничений при закрытии контейнеров.

---

**Примечание:** Изменение сделано более эффективным с улучшенной логикой проверки условий доступа к определённым контейнерам.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->