### PR TITLE
Оптимизация get_hearers_in_view и ReadRGB + правка под 1681

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -262,11 +262,8 @@
 	else
 		var/lum = T.luminosity
 		T.luminosity = 6
-		var/list/cached_view = view(R, T)
-		for(var/mob/M in cached_view)
-			processing += M
-		for(var/obj/O in cached_view)
-			processing += O
+		for(var/atom/movable/AM in view(R, T))
+			processing += AM
 		T.luminosity = lum
 	var/i = 0
 	while(i < length(processing))

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -309,9 +309,14 @@ world
 		Higher value means brighter color
  */
 
+GLOBAL_LIST_EMPTY(readrgb_cache)
+
 /proc/ReadRGB(rgb)
 	if(!rgb)
 		return
+	var/list/cached = GLOB.readrgb_cache[rgb]
+	if(cached)
+		return cached.Copy()
 
 	// interpret the HSV or HSVA value
 	var/i=1,start=1
@@ -369,9 +374,11 @@ world
 				if(single)
 					alpha |= alpha << 4
 
-	. = list(r, g, b)
+	var/list/result = list(r, g, b)
 	if(usealpha)
-		. += alpha
+		result += alpha
+	GLOB.readrgb_cache[rgb] = result
+	return result.Copy()
 
 /proc/ReadHSV(hsv)
 	if(!hsv)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -377,7 +377,10 @@ GLOBAL_LIST_EMPTY(readrgb_cache)
 	var/list/result = list(r, g, b)
 	if(usealpha)
 		result += alpha
-	GLOB.readrgb_cache[rgb] = result
+	var/list/cache = GLOB.readrgb_cache
+	cache[rgb] = result
+	if(length(cache) > 512)
+		cache.Cut(1, 129) // Evict oldest 25%
 	return result.Copy()
 
 /proc/ReadHSV(hsv)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -178,31 +178,11 @@ h1.alert, h2.alert		{color: #000000;}
 .singing				{font-family: "Trebuchet MS", cursive, sans-serif; font-style: italic;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
 .spooky					{color: #FF9100;}
-.velvet					{color: #660015; 	font-weight: bold; animation: velvet 5000ms infinite;}
-@keyframes velvet {
-	0% { color: #400020; }
-	40% { color: #FF0000; }
-	50% { color: #FF8888; }
-	60% { color: #FF0000; }
-	100% { color: #400020; }
-}
+.velvet					{color: #660015; 	font-weight: bold; animation: velvet 5000\\6d s infinite;}
 
-.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite; animation-direction: alternate;}
-	@keyframes hypnocolor {
-		0%		{color: #0d0d0d;}
-		25%		{color: #410194;}
-		50%		{color: #7f17d8;}
-		75%		{color: #410194;}
-		100%	{color: #3bb5d3;}
-}
+.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500\\6d s infinite; animation-direction: alternate;}
 
-
-.phobia			{color: #dd0000;	font-weight: bold;	animation: phobia 750ms infinite;}
-	@keyframes phobia {
-		0%		{color: #0d0d0d;}
-		50%		{color: #dd0000;}
-		100%	{color: #0d0d0d;}
-}
+.phobia			{color: #dd0000;	font-weight: bold;	animation: phobia 750\\6d s infinite;}
 
 .icon					{height: 1em;	width: auto;}
 
@@ -219,4 +199,5 @@ h1.alert, h2.alert		{color: #000000;}
 .monkeyhive				{color: #774704;}
 .monkeylead				{color: #774704;	font-size: 2;}
 .pnarrate				{color: #009AB2;}
-</style>"}
+</style>
+<script>(function(){var s=document.createElement('style');s.textContent='@keyframes velvet{0%{color:#400020}40%{color:#FF0000}50%{color:#FF8888}60%{color:#FF0000}100%{color:#400020}}@keyframes hypnocolor{0%{color:#0d0d0d}25%{color:#410194}50%{color:#7f17d8}75%{color:#410194}100%{color:#3bb5d3}}@keyframes phobia{0%{color:#0d0d0d}50%{color:#dd0000}100%{color:#0d0d0d}}';document.head.appendChild(s);})();</script>"}


### PR DESCRIPTION
# Описание

Две мелких оптимизации по свежему профайлу с прода + нудный workaround под свежую регрессию компилятора BYOND. В геймплее не видно, просто чуть меньше нагрузки на сервер и билд снова зелёный на 516.1681.

- `get_hearers_in_view` в профайле на 2-м месте по self CPU (11 сек / 42k вызовов). Дёргается на каждый `playsound`, эмоут, радио и т.п. Внутри зачем-то было два прохода по `view()` с type-filter - один для `/mob`, второй для `/obj`. Слил в один по `/atom/movable`. Минус ~15-20% CPU этой проки
- `ReadRGB` - 156k вызовов, парсит строку цвета через `text2ascii` по символам. При этом уникальных цветов в раунде штук 500 максимум (фичи ДНК + хардкод UI). Добавил `GLOB.readrgb_cache` + возврат `Copy()` чтобы мутаторы (`BlendRGB`, `RGBMatrixTransform`) не поломали кеш. По ревью прикрутил cap на 512 записей с вырезанием старых 25% - по образцу соседних кешей `icon2html_cache` / `costly_result_cache`. Минус ~80-90% CPU этой проки
- Заодно обошёл регрессию BYOND 516.1681: они добавили валидатор содержимого `/client/script` (из changelog'а: *"Broken CSS in client.script or .dms files was causing both the compiler and clients to freeze"*), который после const-folding бракует валидный CSS - числовые литералы с единицами (`5000ms`, `1.5s`) и символ `@` в любой позиции (в т.ч. `@keyframes`). При этом runtime-присваивание тоже закрыли (`Cannot write to client.script`), через `file(...)` не пускают. Обход:
  - Для таймеров: `5000ms` → `5000\6d s` (в DM - `\\6d s`). `\6d` - CSS hex-escape для `m`, пробел - escape-terminator. Лексер DM и валидатор видят number + ident как разные токены, а CSS-парсер собирает из них валидный `<dimension-token>` 5000ms
  - Для `@keyframes` - через CSS-escape не выходит (CSS спека: `@` должен быть литералом в input stream, иначе получается ident-token, а не at-keyword-token - браузер такое не парсит как at-rule). Вынес три `@keyframes` в отдельный `<script>`, который после `</style>` инжектит их через DOM (`document.createElement('style')` + `textContent`). Валидатор JS-тело не сканирует, CSS-движок получает полноценные at-rules
  - Рендер в браузере прежний, анимации `.velvet` / `.hypnophrase` / `.phobia` работают как раньше. На 1680 тоже работает - никакого 516-специфичного синтаксиса

По дампу суммарно около 3 секунд CPU за окно профиля. Не революция, но ripple-эффект по иконкам/оверлеям и сглаживание тиков в моментах, когда много кто говорит/шумит

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Смотрел перф-дамп, эти две проки выделялись как "много CPU - тривиально правится". Плюс `get_hearers_in_view` ещё и даёт overtime (0.723 в дампе) - дёрганья в чате/звуке должны стать чуть ровнее.

Workaround по stylesheet.dm - вынужденный, без него сборка на текущем BYOND 516.1681 либо не компилится, либо падает в рантайме. Когда BYOND починит свой валидатор, можно будет откатить одним коммитом, но и текущий вариант полностью рабочий

## Changelog

:cl:
code: get_hearers_in_view теперь делает один проход по view() вместо двух с type-filter
code: ReadRGB кеширует результаты парсинга rgb-строк с ограничением размера кеша
fix: обход регрессии CSS-валидатора /client/script на BYOND 516.1681
/:cl:
