### PR TITLE
Чиню рантайм update_visuals у glow-глаз

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -393,6 +393,8 @@
 	else
 		for(var/i in eye_lighting)
 			var/obj/effect/abstract/eye_lighting/L = i
+			if(!L)
+				continue
 			L.forceMove(src)
 		if(!QDELETED(on_mob))
 			on_mob.forceMove(src)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -357,17 +357,21 @@
 	remove_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/update_visuals(datum/source, olddir, newdir)
-	if((LAZYLEN(eye_lighting) < light_beam_distance) || !on_mob)
+	if(QDELETED(owner))
+		return
+	if((LAZYLEN(eye_lighting) < light_beam_distance) || QDELETED(on_mob))
 		regenerate_light_effects()
 	var/turf/scanfrom = get_turf(owner)
+	if(!istype(scanfrom))
+		clear_visuals()
+		return
 	var/scandir = owner.dir
 	if (newdir && scandir != newdir) // COMSIG_ATOM_DIR_CHANGE happens before the dir change, but with a reference to the new direction.
 		scandir = newdir
-	if(!istype(scanfrom))
-		clear_visuals()
 	var/turf/scanning = scanfrom
 	var/stop = FALSE
-	on_mob.forceMove(scanning)
+	if(on_mob)
+		on_mob.forceMove(scanning)
 	for(var/i in 1 to light_beam_distance)
 		scanning = get_step(scanning, scandir)
 		if(!scanning)
@@ -375,6 +379,8 @@
 		if(scanning.opacity || scanning.has_opaque_atom)
 			stop = TRUE
 		var/obj/effect/abstract/eye_lighting/L = LAZYACCESS(eye_lighting, i)
+		if(!L)
+			continue
 		if(stop)
 			L.forceMove(src)
 		else

--- a/code/modules/unit_tests/bugfix_coverage.dm
+++ b/code/modules/unit_tests/bugfix_coverage.dm
@@ -1,4 +1,4 @@
-/// Tests for bugfixes: offering list iteration, inteq poster null guard, pregnancy signal registration
+/// Tests for bugfixes: offering list iteration, inteq poster null guard, pregnancy signal registration, glow eyes null guards
 
 // Test subtype that bypasses throw_alert (requires client) so we can test check_owner_in_range
 /datum/status_effect/offering/unit_test
@@ -86,3 +86,26 @@
 	// Before the fix, handle_damage was incorrectly registered on COMSIG_MOB_DEATH (duplicate)
 	TEST_ASSERT_NOTNULL(carrier.comp_lookup, "Carrier has no signal registrations")
 	TEST_ASSERT_NOTNULL(carrier.comp_lookup[COMSIG_MOB_APPLY_DAMAGE], "handle_damage should be registered on COMSIG_MOB_APPLY_DAMAGE")
+
+// Test: update_visuals on High Luminosity Eyes tolerates a null entry in eye_lighting
+// without runtiming at L.forceMove() — the reported runtime scenario.
+/datum/unit_test/glow_eyes_update_visuals_null_safety/Run()
+	var/mob/living/carbon/human/test_mob = allocate(/mob/living/carbon/human)
+	var/obj/item/organ/eyes/robotic/glow/eyes = allocate(/obj/item/organ/eyes/robotic/glow)
+	eyes.Insert(test_mob, TRUE)
+	eyes.activate(silent = TRUE)
+
+	TEST_ASSERT_NOTNULL(eyes.eye_lighting, "eye_lighting should exist after activation")
+	TEST_ASSERT(LAZYLEN(eyes.eye_lighting) >= 2, "eye_lighting should have multiple entries after regenerate_light_effects")
+
+	// Inject a null into eye_lighting to simulate a soft-deleted entry
+	// (the scenario behind the reported runtime at L.forceMove())
+	eyes.eye_lighting[2] = null
+
+	// Without the null guard, this would runtime: "Cannot execute null.forceMove()"
+	eyes.update_visuals(test_mob, test_mob.dir, EAST)
+
+	// Valid entries should still be accessible
+	TEST_ASSERT_NOTNULL(LAZYACCESS(eyes.eye_lighting, 1), "First entry should still be valid after update_visuals")
+
+	eyes.deactivate(silent = TRUE)


### PR DESCRIPTION
# Описание

Фиксит рантайм в `update_visuals` у High Luminosity Eyes (те самые светящиеся глаза). Падало на `L.forceMove()` когда `LAZYACCESS(eye_lighting, i)` возвращал null - например, если запись в списке успела qdel'нуться между диспатчем сигнала `COMSIG_ATOM_DIR_CHANGE` через `CallAsync` и фактическим выполнением хэндлера.

Заодно подлатал соседние косяки в том же проке:
- проверка `!istype(scanfrom)` звала `clear_visuals()`, но проц ехал дальше с мусорным стейтом - теперь возвращаемся
- `!on_mob` не ловил QDELETED ссылку - заменил на `QDELETED(on_mob)`
- добавил ранний выход если `owner` уже QDELETED (сигнал технически не должен был прилететь, но CallAsync асинхронный)
- null-гарды на `on_mob.forceMove` и `L.forceMove`

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Игроки со светящимися киберглазами спамили рантаймами в логи при каждом движении в неудачный момент. Логика работы не меняется - только защита от null'ов

Пример из лога:
```
Runtime in code/modules/surgery/organs/eyes.dm, line 381: Cannot execute null.forceMove().
proc name: update visuals (/obj/item/organ/eyes/robotic/glow/proc/update_visuals)
```

## Changelog

:cl:
fix: пофикшен рантайм в update_visuals у High Luminosity Eyes (светящиеся киберглаза)
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Обновлена обработка светящихся робототехнических глаз при работе с эффектами освещения.

* **Tests**
  * Добавлено тестовое покрытие для проверки надежности светящихся глаз.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->