### PR TITLE
icon2html: кэш для human-пути

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1206,6 +1206,7 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 		targets = target
 		if (!targets.len)
 			return
+	var/is_human = FALSE
 	if (!isicon(I))
 		if (isfile(thing)) //special snowflake
 			var/name = sanitize_filename("[generate_asset_name(thing)].png")
@@ -1229,10 +1230,11 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 		if (isnull(dir))
 			dir = A.dir
 
-		if (ishuman(thing)) // Shitty workaround for a BYOND issue.
-			var/icon/temp = I
-			I = icon()
-			I.Insert(temp, dir = SOUTH)
+		// Human workaround (see below) forces dir=SOUTH; record that now so the
+		// cache key matches the post-workaround slice without yet running the
+		// expensive icon()/Insert() pair.
+		is_human = ishuman(thing)
+		if (is_human)
 			dir = SOUTH
 	else
 		if (isnull(dir))
@@ -1241,9 +1243,11 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 			icon_state = ""
 
 	// Result-level cache: skip icon() constructor + asset registration on repeat calls.
-	// Only cacheable when I is a file reference (e.g. 'icons/obj/food.dmi') — these
-	// stringify to a unique file path. /icon datums all stringify to "/icon", causing
-	// massive key collisions where different icons return the same cached result.
+	// Cacheable when the SOURCE icon (A.icon, before any workaround) is a file ref —
+	// file refs stringify to a unique path; /icon datums all stringify to "/icon",
+	// causing massive key collisions. The is_human flag in the key keeps post-
+	// workaround entries from sharing keys with non-human callers that happened to
+	// pass the same (file, state, SOUTH) combo.
 	// Note: isicon() returns TRUE for both /icon datums AND .dmi file references,
 	// so we use isfile() which is TRUE only for file references.
 	var/can_cache = isfile(I)
@@ -1251,7 +1255,7 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 	var/static/list/icon2html_cache = list()
 
 	if(can_cache)
-		cache_key = "[I]:[icon_state]:[dir]:[frame]:[moving]"
+		cache_key = "[I]:[icon_state]:[dir]:[frame]:[moving]:[is_human]"
 		var/list/cached = icon2html_cache[cache_key]
 		if(cached)
 			for(var/thing2 in targets)
@@ -1259,6 +1263,11 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 			if(sourceonly)
 				return cached[3]
 			return cached[2]
+
+	if (is_human) // Shitty workaround for a BYOND issue.
+		var/icon/temp = I
+		I = icon()
+		I.Insert(temp, dir = SOUTH)
 
 	I = icon(I, icon_state, dir, frame, moving)
 


### PR DESCRIPTION
# Описание

icon2html для людей не использовал кэш и гнал полный пайплайн на каждый examine. Поправил, теперь у людей тоже хиты в кэше.

- [ ] Изменения были проверены на локальном сервере
- [ ] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

В перфлоге icon2html и его дружки (icon2base64, md5asfile) висели сверху по овертайму. Копнул, оказалось у людей внутри был workaround, который ломал кэш, и каждый examine человека гнал полный icon() + md5 + сейв в savefile. После фикса всё это нормально кэшируется.

## Changelog

:cl:
code: icon2html теперь кэширует результат и для людей, снизив нагрузку при их examine
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Исправления ошибок**
* Исправлена обработка кеширования значков для корректного отображения различных типов персонажей в игре.
* Оптимизирована система кеширования путём предотвращения конфликтов и исключения избыточных перестроений при повторных вызовах, что улучшает производительность приложения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->