### PR TITLE
фикс актуализатора и квирка глаза с повышенной светимостью

### DIFF
--- a/modular_splurt/code/game/machinery/self_actualization_device.dm
+++ b/modular_splurt/code/game/machinery/self_actualization_device.dm
@@ -216,6 +216,10 @@
 		patient.client.prefs.save_character()
 		log_admin("All quirks for [key_name(patient)] were reset due to quirk selection blacklist (via Self-Actualization Device).")
 
+	// BLUEMOON EDIT: copy_to leaves old /datum/quirk instances on the mob; /datum/quirk/New aborts if has_quirk(type), so on_spawn never reruns and organ quirks (e.g. glow eyes) desync from the body.
+	for(var/datum/quirk/Q as anything in patient.roundstart_quirks.Copy())
+		patient.remove_quirk(Q.type)
+
 	SSquirks.AssignQuirks(patient, patient.client, TRUE, TRUE, null, FALSE, patient)
 	SSlanguage.AssignLanguage(patient, patient.client)
 	if(iscuratorjob(patient))


### PR DESCRIPTION
# Описание
фикс актуализатора и квирка глаза с повышенной светимостью
<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений
https://discord.com/channels/875735187449847830/1498761001292529835/1501693581541380245
<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

## Демонстрация изменений
<img width="223" height="235" alt="изображение" src="https://github.com/user-attachments/assets/111cc4ec-4675-418a-8e46-6649c229d385" />

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: фикс актуализатора и квирка глаза с повышенной светимостью
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* **Исправления ошибок**
  * Устройство самоосознания теперь корректно удаляет старые особенности персонажа перед назначением новых, предотвращая конфликты и десинхронизацию. Это обеспечивает надлежащую переинициализацию характеристик при использовании устройства.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->