### PR TITLE
Fix add_to_single_hud overtime

### DIFF
--- a/code/_rendering/atom_huds/atom_hud.dm
+++ b/code/_rendering/atom_huds/atom_hud.dm
@@ -130,13 +130,29 @@ GLOBAL_LIST_INIT(huds, alist(
 	var/list/atom_hud_list = A.hud_list
 	if(!atom_hud_list)
 		return
+	var/list/local_hud_icons = hud_icons
+	if(length(local_hud_icons) == 1)
+		var/hud_image = atom_hud_list[local_hud_icons[1]]
+		if(hud_image)
+			their_client.images |= hud_image
+		return
+	var/first_hud_image
 	var/list/to_add
-	for(var/i in hud_icons)
-		var/image/img = atom_hud_list[i]
-		if(img)
-			LAZYADD(to_add, img)
+	for(var/i in local_hud_icons)
+		var/hud_image = atom_hud_list[i]
+		if(!hud_image)
+			continue
+		if(!first_hud_image)
+			first_hud_image = hud_image
+			continue
+		if(!to_add)
+			to_add = list()
+			to_add += first_hud_image
+		to_add += hud_image
 	if(to_add)
 		their_client.images |= to_add
+	else if(first_hud_image)
+		their_client.images |= first_hud_image
 
 //MOB PROCS
 /mob/proc/reload_huds()


### PR DESCRIPTION
# Описание

`add_to_single_hud` больше не делает лишний временный список на каждый вызов. Для одного HUD-икона теперь быстрый путь, для нескольких батч остался.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

После прошлого “оптимизационного” (my bad, но как есть) коммита этот proc начал жрать овертайм. Теперь самый частый кейс снова дешёвый.

## Changelog

:cl:
code: убрал лишние аллокации в add_to_single_hud и вернул быстрый путь для одиночных HUD-иконок
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Оптимизация**
  * Улучшена производительность отрисовки интерфейса пользователя благодаря оптимизированному кешированию и обработке графических элементов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->