### PR TITLE
ghost friend fix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -28918,6 +28918,7 @@
 /area/centcom/vip)
 "uQc" = (
 /obj/machinery/vending/sexmachine,
+/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "uRd" = (

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -184,13 +184,12 @@
 		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(flick_overlay), MA, list(owner.client), 30)
 
 	for(var/mob/M in GLOB.dead_mob_list)
-		if(!M.client)
+		if(!M.client || !isobserver(M))
 			continue
 		if(get_dist(M, owner) > 7 || M.z != owner.z)
 			if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 				continue
-		var/link = FOLLOW_LINK(M, owner)
-		to_chat(M, "[link] [dead_rendered]")
+		to_chat(M, "[FOLLOW_LINK(M, owner)] [dead_rendered]")
 
 /mob/camera/imaginary_friend/Move(NewLoc, Dir = 0)
 	if(world.time < move_delay)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -186,7 +186,7 @@
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!M.client)
 			continue
-		if(get_dist(M, owner) > 7 || M.z != z)
+		if(get_dist(M, owner) > 7 || M.z != owner.z)
 			if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 				continue
 		var/link = FOLLOW_LINK(M, owner)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -184,6 +184,11 @@
 		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(flick_overlay), MA, list(owner.client), 30)
 
 	for(var/mob/M in GLOB.dead_mob_list)
+		if(!M.client)
+			continue
+		if(get_dist(M, owner) > 7 || M.z != z)
+			if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				continue
 		var/link = FOLLOW_LINK(M, owner)
 		to_chat(M, "[link] [dead_rendered]")
 

--- a/code/modules/spells/spell_types/telepathy.dm
+++ b/code/modules/spells/spell_types/telepathy.dm
@@ -25,9 +25,10 @@
 		to_chat(user, "<span class='[boldnotice]'>You transmit to [M]:</span> <span class='[notice]'>[msg]</span>")
 		if(!M.anti_magic_check(magic_check, holy_check, tinfoil_check, 0)) //hear no evil
 			to_chat(M, "<span class='[boldnotice]'>You hear something behind you talking...</span> <span class='[notice]'>[msg]</span>")
-		for(var/ded in GLOB.dead_mob_list)
-			if(!isobserver(ded))
+		for(var/mob/observer in GLOB.dead_mob_list)
+			if(!observer.client || !isobserver(observer))
 				continue
-			var/follow_rev = FOLLOW_LINK(ded, user)
-			var/follow_whispee = FOLLOW_LINK(ded, M)
-			to_chat(ded, "[follow_rev] <span class='[boldnotice]'>[user] [name]:</span> <span class='[notice]'>\"[msg]\" to</span> [follow_whispee] <span class='name'>[M]</span>")
+			if(get_dist(observer, user) > 7 || observer.z != user.z)
+				if(!(observer.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+					continue
+			to_chat(observer, "[FOLLOW_LINK(observer, user)] <span class='[boldnotice]'>[user] [name]:</span> <span class='[notice]'>\"[msg]\" to</span> [FOLLOW_LINK(observer, M)] <span class='name'>[M]</span>")


### PR DESCRIPTION
# Описание
- Теперь воображаемый друг и карен не спамит гостам в чат, если у них выключен соответствующий преф
- Добавил тинифан под гиббер в ГК, что бы он не вонял

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Добавлен тинифан под гиббер в ГК (невидимый)
fix: Воображаемый друг и карен не спамит гостам в чат, если у них выключен соответствующий преф
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Оптимизирована доставка сообщений от воображаемого друга и телепатии: сообщения не отправляются неподключённым или неподходящим наблюдателям.
  * Удалённые призраки получают сообщения только при соблюдении расстояния/уровня или если включена соответствующая призрачная чат-настройка, что уменьшает спам.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3196)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->