### PR TITLE
Микрофикс автоматиской синхронизации изучений

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -585,7 +585,7 @@ SUBSYSTEM_DEF(research)
 				techweb_boost_items[path] = list(node.id = node.boost_item_paths[path])
 		CHECK_TICK
 
-// Начало упаковки ID-шек, вызывается процедурой /datum/techweb_node/proc/succesful_research
+// Начало упаковки ID-шек, вызывается rdconsole.dm
 /datum/controller/subsystem/research/proc/on_node_researched(node_id)
 	if(!(node_id in pending_research_node_ids))
 		pending_research_node_ids += node_id

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -433,7 +433,7 @@
 	SIGNAL_HANDLER
 	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
 		return
-	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 0.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
 
 /obj/machinery/rnd/production/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
 	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -433,7 +433,7 @@
 	SIGNAL_HANDLER
 	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
 		return
-	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
 
 /obj/machinery/rnd/production/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
 	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -23,6 +23,7 @@
 	/// What color is this machine's stripe? Leave null to not have a stripe.
 	var/stripe_color = null
 	COOLDOWN_DECLARE(cooldown_say) // Отвечает за КД SAY машины и за КД update_research()
+	var/deferred_sync_timer	// Отвечает за кд перед автосинхронизацией, и не даёт упёршимся в него же сигналам изучений потеряться *temp*
 	var/const/cooldown_say_time = 1.5 SECONDS
 	var/const/max_build_amount = 60 // Отвечает за максимум в кнопке [Max: XXX] TGUI и максимум пердметов на печать в 1 пачке
 
@@ -430,7 +431,13 @@
 
 /obj/machinery/rnd/production/proc/on_node_unlocked(datum/source, node_id)	// Дизайны обновляются после изучения ноды на консоли
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(update_research))
+	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
+		return
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 0.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+
+/obj/machinery/rnd/production/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
+	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера
+	INVOKE_ASYNC(src, PROC_REF(update_research))	// Асинк в качестве второй защиты от обсёра, надеюсь даже после 100+ нод этого будет достаточно
 
 /obj/machinery/rnd/production/proc/on_research_batch_complete(datum/source, list/node_ids)	// Регистрация сигнала завершения упаковки пакета нод
 	SIGNAL_HANDLER

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -45,6 +45,9 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_RESEARCH_BATCH_COMPLETE, PROC_REF(on_research_batch_complete))
 
 /obj/machinery/rnd/production/Destroy()
+	if(deferred_sync_timer)
+		deltimer(deferred_sync_timer)
+		deferred_sync_timer = null
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_RESEARCH_NODE_UNLOCKED, COMSIG_GLOB_RESEARCH_BATCH_COMPLETE))
 	materials = null
 	cached_designs = null
@@ -433,9 +436,11 @@
 	SIGNAL_HANDLER
 	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
 		return
-	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1.5 SECONDS, TIMER_STOPPABLE)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
 
 /obj/machinery/rnd/production/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
+	if(QDELETED(src))
+		return
 	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера
 	INVOKE_ASYNC(src, PROC_REF(update_research))	// Асинк в качестве второй защиты от обсёра, надеюсь даже после 100+ нод этого будет достаточно
 

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -88,6 +88,9 @@
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/Destroy()
+	if(deferred_sync_timer)
+		deltimer(deferred_sync_timer)
+		deferred_sync_timer = null
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_RESEARCH_NODE_UNLOCKED, COMSIG_GLOB_RESEARCH_BATCH_COMPLETE))
 	QDEL_NULL(stored_research)
 	rmat = null
@@ -538,9 +541,11 @@
 	SIGNAL_HANDLER
 	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
 		return
-	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1.5 SECONDS, TIMER_STOPPABLE)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
 
 /obj/machinery/mecha_part_fabricator/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
+	if(QDELETED(src))
+		return
 	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера
 	INVOKE_ASYNC(src, PROC_REF(sync), TRUE, TRUE)	// Асинк в качестве второй защиты от обсёра, надеюсь даже после 100+ нод этого будет достаточно
 

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -538,7 +538,7 @@
 	SIGNAL_HANDLER
 	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
 		return
-	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 0.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
 
 /obj/machinery/mecha_part_fabricator/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
 	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -538,7 +538,7 @@
 	SIGNAL_HANDLER
 	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
 		return
-	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 1.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
 
 /obj/machinery/mecha_part_fabricator/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
 	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -68,6 +68,7 @@
 								"Savannah-Ivanov"
 								)
 	COOLDOWN_DECLARE(cooldown_say) // Отвечает за КД SAY машины
+	var/deferred_sync_timer	// Отвечает за кд перед автосинхронизацией, и не даёт упёршимся в него же сигналам изучений потеряться *temp*
 	var/const/cooldown_say_time = 1.5 SECONDS
 
 	var/on_station = TRUE
@@ -535,7 +536,13 @@
 
 /obj/machinery/mecha_part_fabricator/proc/on_node_unlocked(datum/source, node_id)	// Дизайны обновляются после изучения ноды на консоли
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(sync), TRUE, TRUE)	// ignore_timer = TRUE; Is_silent = TRUE
+	if(deferred_sync_timer)	// Если мы всё ещё в кулдауне, не делаем ничего - нет необходимости
+		return
+	deferred_sync_timer = addtimer(CALLBACK(src, PROC_REF(perform_deferred_sync)), 0.5 SECONDS)	// Синхронизация проводится после таймера, по совместительству очищая его и открывая гейт новым сигналам
+
+/obj/machinery/mecha_part_fabricator/proc/perform_deferred_sync()	// Временный фикс нагрузки сервера update_research() проками. Потом сделаю нормальный, минималистичный on_auto_sync для работы с единичными нодами
+	deferred_sync_timer = null	// Проведение синхронизации происходит вместе с очисткой таймера
+	INVOKE_ASYNC(src, PROC_REF(sync), TRUE, TRUE)	// Асинк в качестве второй защиты от обсёра, надеюсь даже после 100+ нод этого будет достаточно
 
 /obj/machinery/mecha_part_fabricator/proc/on_research_batch_complete(datum/source, list/node_ids)	// Регистрация сигнала о завершении упаковки пакета ID-шек
 	SIGNAL_HANDLER


### PR DESCRIPTION
# Описание

Запиленная в мой первый ПР система с глобальными сигналами поднимала update_research() при каждом изучении ноды на каждую печатную машину в игровом мире. Данная процедура была сделана для работы с одной машиной раз в секунду, поэтому могла позволить себе **каждый раз** проверять **полный список** всех изученных технологий. По мере его заполнения изученными нодами в раунде, процедура становится всё дороже и дороже.
В определённый момент, время её выполнения становилось слишком долгим, и при быстром проклике нод на TGUI интерфейсе консоли забивали очередь её асинхронными вызовами, вызывая значительные провисания.

Я добавил систему КД с отложенным вызовом через всё тот же INVOKE_ASYNC. Теперь процедура вызывается не более чем раз в 1 секунду у каждой печатной машины. Отложенный вызов нужен, чтобы "упёршиеся" в КД сигналы не терялись.

Решение временное, процедура всё ещё становится жирнее и жирнее в течении раунда. Если серверу и без того плохо, или в билд добавят ещё пару сотен нод - 1.5 секунды может не хватить. В планах сделать нормальную проку, работающую с конкретным нодом - отправляющий её глобальный сигнал у нас уже есть. Но это потребует куда больше кода и тестировки. Пока что будет простой фикс, чтобы сервер не хлебал мочу.
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- ✅ Изменения были проверены на локальном сервере
- ✅ Этот пулл-реквест готов к тест-мерджу.
- 🟥 Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Фикс моего первого опыта в щиткодинге, дап.
(https://discord.com/channels/875735187449847830/1502751399211962519)

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Пофиксил лаги сервера при быстром изучении большого количества научных нод
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Исследовательская машина и фабрика мехов теперь используют отложенную синхронизацию при разблокировке технологий, улучшая производительность системы.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->