### PR TITLE
Недельный сброс рейтинга; Выдача очков за рейтинг; Простая защита от накрутки.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/tetris.dm
+++ b/code/modules/modular_computers/file_system/programs/tetris.dm
@@ -145,6 +145,16 @@
 			if(!del_score)
 				return FALSE
 			return del_score.admin_delete_record(usr, ckey(params["ckey"]))
+		if("forceReset")
+			if(!check_rights_for(usr?.client, R_ADMIN))
+				return FALSE
+			if(SStetris_weekly_rewards.processing_rewards)
+				to_chat(usr, span_warning("Сброс уже выполняется, подождите."))
+				return FALSE
+			log_admin("[key_name(usr)] принудительно запустил недельный сброс рейтинга тетриса.")
+			message_admins("[key_name_admin(usr)] принудительно запустил недельный сброс рейтинга тетриса.")
+			SStetris_weekly_rewards.begin_reward_cycle()
+			return TRUE
 
 #undef NTOS_TETRIS_SCORE_HIGH
 #undef NTOS_TETRIS_SCORE_MAX

--- a/code/modules/modular_computers/file_system/programs/tetris.dm
+++ b/code/modules/modular_computers/file_system/programs/tetris.dm
@@ -32,6 +32,8 @@
 	/// Защита от дурочков с href
 	var/game_active = FALSE
 	var/mob/active_game_player = null
+	/// Время старта игры
+	var/game_start_time = 0
 
 /datum/computer_file/program/tetris/ui_close(mob/user)
 	. = ..()
@@ -84,6 +86,7 @@
 				return FALSE
 			game_active = TRUE
 			active_game_player = usr
+			game_start_time = world.time
 			return TRUE
 		if("sfx")
 			if(!computer)
@@ -113,6 +116,15 @@
 			game_active = FALSE
 			active_game_player = null
 			var/temp_score = clamp(text2num(params["score"]) || 0, 0, NTOS_TETRIS_SCORE_MAX)
+			var/game_duration = max(0, world.time - game_start_time)
+			game_start_time = 0
+
+			// Простая антифиддер защита. Пидорки что лезят в код чтобы накрутить счет - сосите хуй
+			if(game_duration < 1 MINUTES && temp_score > 30000)
+				log_admin("[key_name(usr)] отправил подозрительный счёт [temp_score] в тетрисе за [game_duration/10]с — отклонено.")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] пытался накрутить счёт в планшетном тетрисе: [temp_score] очков за [game_duration/10]с.")
+				return FALSE
+
 			if(temp_score > high_score)
 				high_score = temp_score
 

--- a/modular_bluemoon/code/controllers/subsystem/tetris_weekly_rewards.dm
+++ b/modular_bluemoon/code/controllers/subsystem/tetris_weekly_rewards.dm
@@ -1,0 +1,251 @@
+#define TETRIS_WEEKLY_REWARD_INTERVAL (7 * 24 HOURS)
+#define TETRIS_WEEKLY_REWARD_CHECK_INTERVAL (5 MINUTES)
+#define TETRIS_WEEKLY_REWARD_STATE_FILE "data/tetris_weekly_rewards.json"
+#define TETRIS_WEEKLY_REWARD_PROGRESS_FILE "data/tetris_weekly_rewards_progress.json"
+
+SUBSYSTEM_DEF(tetris_weekly_rewards)
+	name = "Tetris Weekly Rewards"
+	init_order = INIT_ORDER_ACHIEVEMENTS - 1
+	wait = TETRIS_WEEKLY_REWARD_CHECK_INTERVAL
+	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING
+	var/next_reset_realtime = 0
+	var/processing_rewards = FALSE
+	var/current_index = 1
+	var/list/current_entries = list()
+	var/list/paid_ckeys = list()
+	var/list/granting_ckeys = list()
+	var/current_cycle_started = 0
+	var/leaderboard_reset_done = FALSE
+	var/reset_index = 1
+
+/datum/controller/subsystem/tetris_weekly_rewards/Initialize()
+	. = ..()
+	load_state()
+	load_progress()
+	if(!next_reset_realtime)
+		next_reset_realtime = world.realtime + TETRIS_WEEKLY_REWARD_INTERVAL
+		save_state()
+	if(length(current_entries))
+		processing_rewards = TRUE
+
+/datum/controller/subsystem/tetris_weekly_rewards/fire(resumed = FALSE)
+	if(processing_rewards)
+		continue_reward_cycle()
+		return
+	if(world.realtime >= next_reset_realtime)
+		begin_reward_cycle()
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/load_state()
+	var/json = file2text(TETRIS_WEEKLY_REWARD_STATE_FILE)
+	if(!json)
+		return
+	var/list/data = json_decode(json)
+	if(!islist(data))
+		return
+	next_reset_realtime = json_number(data["next_reset_realtime"]) || 0
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/save_state()
+	var/list/data = list()
+	data["next_reset_realtime"] = next_reset_realtime
+	fdel(TETRIS_WEEKLY_REWARD_STATE_FILE)
+	WRITE_FILE(file(TETRIS_WEEKLY_REWARD_STATE_FILE), json_encode(data))
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/load_progress()
+	var/json = file2text(TETRIS_WEEKLY_REWARD_PROGRESS_FILE)
+	if(!json)
+		return
+	var/list/data = json_decode(json)
+	if(!islist(data))
+		return
+	current_cycle_started = json_number(data["cycle_started"]) || 0
+	current_index = max(1, json_number(data["current_index"]) || 1)
+	current_entries = islist(data["entries"]) ? data["entries"] : list()
+	paid_ckeys = islist(data["paid_ckeys"]) ? data["paid_ckeys"] : list()
+	granting_ckeys = islist(data["granting_ckeys"]) ? data["granting_ckeys"] : list()
+	leaderboard_reset_done = data["leaderboard_reset_done"] ? TRUE : FALSE
+	reset_index = max(1, json_number(data["reset_index"]) || 1)
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/json_number(value)
+	return isnum(value) ? value : text2num(value)
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/save_progress()
+	var/list/data = list()
+	data["cycle_started"] = current_cycle_started
+	data["current_index"] = current_index
+	data["entries"] = current_entries
+	data["paid_ckeys"] = paid_ckeys
+	data["granting_ckeys"] = granting_ckeys
+	data["leaderboard_reset_done"] = leaderboard_reset_done
+	data["reset_index"] = reset_index
+	fdel(TETRIS_WEEKLY_REWARD_PROGRESS_FILE)
+	WRITE_FILE(file(TETRIS_WEEKLY_REWARD_PROGRESS_FILE), json_encode(data))
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/clear_progress()
+	current_cycle_started = 0
+	current_index = 1
+	current_entries = list()
+	paid_ckeys = list()
+	granting_ckeys = list()
+	processing_rewards = FALSE
+	leaderboard_reset_done = FALSE
+	reset_index = 1
+	fdel(TETRIS_WEEKLY_REWARD_PROGRESS_FILE)
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/begin_reward_cycle()
+	if(!SSachievements?.achievements_enabled || !SSdbcore.Connect())
+		return
+	var/list/entries = collect_tetris_entries()
+	if(isnull(entries))
+		return
+	current_entries = entries
+	paid_ckeys = list()
+	granting_ckeys = list()
+	current_index = 1
+	current_cycle_started = world.realtime
+	leaderboard_reset_done = FALSE
+	reset_index = 1
+	processing_rewards = TRUE
+	save_progress()
+	continue_reward_cycle()
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/collect_tetris_entries()
+	var/list/entries = list()
+	var/datum/db_query/Q = SSdbcore.NewQuery(
+		"SELECT ckey,value FROM [format_table_name("achievements")] WHERE achievement_key = :achievement_key ORDER BY value DESC",
+		list("achievement_key" = TETRIS_SCORE)
+	)
+	if(!Q.warn_execute())
+		qdel(Q)
+		return null
+	var/rank = 0
+	while(Q.NextRow())
+		var/key = ckey(Q.item[1])
+		var/score = json_number(Q.item[2]) || 0
+		if(!key || score <= 0)
+			continue
+		rank++
+		entries += list(list(
+			"ckey" = key,
+			"score" = score,
+			"rank" = rank,
+			"amount" = reward_amount_for_rank(rank)
+		))
+	qdel(Q)
+	return entries
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/reward_amount_for_rank(rank)
+	switch(rank)
+		if(1)
+			return 250
+		if(2)
+			return 200
+		if(3)
+			return 100
+		if(4 to 10)
+			return 50
+	return 0
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/continue_reward_cycle()
+	if(!leaderboard_reset_done)
+		if(!reset_tetris_leaderboard())
+			save_progress()
+			return
+		leaderboard_reset_done = TRUE
+		save_progress()
+	while(current_index <= length(current_entries))
+		var/list/entry = current_entries[current_index]
+		var/key = ckey(entry["ckey"])
+		if(!key || paid_ckeys[key])
+			current_index++
+			continue
+		if(!grant_tetris_reward(entry))
+			save_progress()
+			return
+		paid_ckeys[key] = TRUE
+		granting_ckeys -= key
+		current_index++
+		save_progress()
+		if(MC_TICK_CHECK)
+			return
+	var/completed_records = length(current_entries)
+	clear_progress()
+	advance_next_reset()
+	log_admin("Tetris weekly rewards: completed weekly payout/reset for [completed_records] records.")
+	message_admins("Tetris weekly rewards: рейтинг тетриса сброшен, недельные награды выданы.")
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/grant_tetris_reward(list/entry)
+	var/key = ckey(entry["ckey"])
+	var/amount = round(json_number(entry["amount"]) || 0)
+	if(!key || amount <= 0)
+		return TRUE
+	var/list/ctx = bm_tgs_get_prefs_for_ckey(key)
+	if(!ctx)
+		log_admin("Tetris weekly rewards: failed to load preferences for [key], reward [amount] M$ skipped until retry.")
+		return FALSE
+	var/datum/preferences/P = ctx["prefs"]
+	if(!granting_ckeys[key])
+		granting_ckeys[key] = list("old_balance" = P.metadollars, "new_balance" = max(0, round(P.metadollars + amount)), "amount" = amount)
+		save_progress()
+	else
+		var/list/granting_data = granting_ckeys[key]
+		var/expected_new_balance = json_number(granting_data["new_balance"]) || 0
+		if(P.metadollars >= expected_new_balance)
+			bm_tgs_finish_prefs_edit(ctx, FALSE)
+			return TRUE
+	P.metadollars = max(0, round(P.metadollars + amount))
+	if(!bm_tgs_finish_prefs_edit(ctx, TRUE))
+		log_admin("Tetris weekly rewards: failed to save preferences for [key], reward [amount] M$ will retry.")
+		return FALSE
+	var/client/C = GLOB.directory[key]
+	if(C?.mob)
+		to_chat(C.mob, span_purple("Вы получили [amount] М$ за недельный рейтинг тетриса."))
+	var/rank = json_number(entry["rank"]) || 0
+	var/score = json_number(entry["score"]) || 0
+	log_admin("Tetris weekly rewards: granted [amount] M$ to [key] for rank #[rank], score [score].")
+	return TRUE
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/reset_tetris_leaderboard()
+	if(!SSdbcore.Connect())
+		return FALSE
+	while(reset_index <= length(current_entries))
+		var/list/entry = current_entries[reset_index]
+		var/key = ckey(entry["ckey"])
+		var/score = json_number(entry["score"]) || 0
+		if(!key || score <= 0)
+			reset_index++
+			continue
+		var/datum/db_query/Q = SSdbcore.NewQuery(
+			"DELETE FROM [format_table_name("achievements")] WHERE ckey = :ckey AND achievement_key = :achievement_key AND value = :value",
+			list("ckey" = key, "achievement_key" = TETRIS_SCORE, "value" = score)
+		)
+		if(!Q.warn_execute())
+			qdel(Q)
+			return FALSE
+		qdel(Q)
+		reset_index++
+		save_progress()
+		if(MC_TICK_CHECK)
+			return FALSE
+	var/datum/award/score/highscore/tetris/S = SSachievements.scores[/datum/award/score/highscore/tetris]
+	if(S)
+		S.high_scores = list()
+	for(var/key in GLOB.player_details)
+		var/datum/player_details/PD = GLOB.player_details[key]
+		if(!PD?.achievements)
+			continue
+		PD.achievements.data[/datum/award/score/highscore/tetris] = 0
+		PD.achievements.original_cached_data[/datum/award/score/highscore/tetris] = 0
+	return TRUE
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/advance_next_reset()
+	if(!next_reset_realtime)
+		next_reset_realtime = world.realtime + TETRIS_WEEKLY_REWARD_INTERVAL
+	else
+		while(next_reset_realtime <= world.realtime)
+			next_reset_realtime += TETRIS_WEEKLY_REWARD_INTERVAL
+	save_state()
+
+#undef TETRIS_WEEKLY_REWARD_INTERVAL
+#undef TETRIS_WEEKLY_REWARD_CHECK_INTERVAL
+#undef TETRIS_WEEKLY_REWARD_STATE_FILE
+#undef TETRIS_WEEKLY_REWARD_PROGRESS_FILE

--- a/modular_bluemoon/code/controllers/subsystem/tetris_weekly_rewards.dm
+++ b/modular_bluemoon/code/controllers/subsystem/tetris_weekly_rewards.dm
@@ -16,14 +16,13 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 	var/list/granting_ckeys = list()
 	var/current_cycle_started = 0
 	var/leaderboard_reset_done = FALSE
-	var/reset_index = 1
 
 /datum/controller/subsystem/tetris_weekly_rewards/Initialize()
 	. = ..()
 	load_state()
 	load_progress()
 	if(!next_reset_realtime)
-		next_reset_realtime = world.realtime + TETRIS_WEEKLY_REWARD_INTERVAL
+		next_reset_realtime = next_monday_midnight()
 		save_state()
 	if(length(current_entries))
 		processing_rewards = TRUE
@@ -63,7 +62,6 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 	paid_ckeys = islist(data["paid_ckeys"]) ? data["paid_ckeys"] : list()
 	granting_ckeys = islist(data["granting_ckeys"]) ? data["granting_ckeys"] : list()
 	leaderboard_reset_done = data["leaderboard_reset_done"] ? TRUE : FALSE
-	reset_index = max(1, json_number(data["reset_index"]) || 1)
 
 /datum/controller/subsystem/tetris_weekly_rewards/proc/json_number(value)
 	return isnum(value) ? value : text2num(value)
@@ -76,7 +74,6 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 	data["paid_ckeys"] = paid_ckeys
 	data["granting_ckeys"] = granting_ckeys
 	data["leaderboard_reset_done"] = leaderboard_reset_done
-	data["reset_index"] = reset_index
 	fdel(TETRIS_WEEKLY_REWARD_PROGRESS_FILE)
 	WRITE_FILE(file(TETRIS_WEEKLY_REWARD_PROGRESS_FILE), json_encode(data))
 
@@ -88,7 +85,6 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 	granting_ckeys = list()
 	processing_rewards = FALSE
 	leaderboard_reset_done = FALSE
-	reset_index = 1
 	fdel(TETRIS_WEEKLY_REWARD_PROGRESS_FILE)
 
 /datum/controller/subsystem/tetris_weekly_rewards/proc/begin_reward_cycle()
@@ -103,7 +99,6 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 	current_index = 1
 	current_cycle_started = world.realtime
 	leaderboard_reset_done = FALSE
-	reset_index = 1
 	processing_rewards = TRUE
 	save_progress()
 	continue_reward_cycle()
@@ -184,18 +179,19 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 		return FALSE
 	var/datum/preferences/P = ctx["prefs"]
 	if(!granting_ckeys[key])
-		granting_ckeys[key] = list("old_balance" = P.metadollars, "new_balance" = max(0, round(P.metadollars + amount)), "amount" = amount)
+		granting_ckeys[key] = list("old_balance" = P.metadollars, "amount" = amount, "reward_saved" = FALSE)
 		save_progress()
 	else
 		var/list/granting_data = granting_ckeys[key]
-		var/expected_new_balance = json_number(granting_data["new_balance"]) || 0
-		if(P.metadollars >= expected_new_balance)
+		if(granting_data["reward_saved"])
 			bm_tgs_finish_prefs_edit(ctx, FALSE)
 			return TRUE
 	P.metadollars = max(0, round(P.metadollars + amount))
 	if(!bm_tgs_finish_prefs_edit(ctx, TRUE))
 		log_admin("Tetris weekly rewards: failed to save preferences for [key], reward [amount] M$ will retry.")
 		return FALSE
+	var/list/granting_data = granting_ckeys[key]
+	granting_data["reward_saved"] = TRUE
 	var/client/C = GLOB.directory[key]
 	if(C?.mob)
 		to_chat(C.mob, span_purple("Вы получили [amount] М$ за недельный рейтинг тетриса."))
@@ -207,25 +203,14 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 /datum/controller/subsystem/tetris_weekly_rewards/proc/reset_tetris_leaderboard()
 	if(!SSdbcore.Connect())
 		return FALSE
-	while(reset_index <= length(current_entries))
-		var/list/entry = current_entries[reset_index]
-		var/key = ckey(entry["ckey"])
-		var/score = json_number(entry["score"]) || 0
-		if(!key || score <= 0)
-			reset_index++
-			continue
-		var/datum/db_query/Q = SSdbcore.NewQuery(
-			"DELETE FROM [format_table_name("achievements")] WHERE ckey = :ckey AND achievement_key = :achievement_key AND value = :value",
-			list("ckey" = key, "achievement_key" = TETRIS_SCORE, "value" = score)
-		)
-		if(!Q.warn_execute())
-			qdel(Q)
-			return FALSE
+	var/datum/db_query/Q = SSdbcore.NewQuery(
+		"DELETE FROM [format_table_name("achievements")] WHERE achievement_key = :achievement_key",
+		list("achievement_key" = TETRIS_SCORE)
+	)
+	if(!Q.warn_execute())
 		qdel(Q)
-		reset_index++
-		save_progress()
-		if(MC_TICK_CHECK)
-			return FALSE
+		return FALSE
+	qdel(Q)
 	var/datum/award/score/highscore/tetris/S = SSachievements.scores[/datum/award/score/highscore/tetris]
 	if(S)
 		S.high_scores = list()
@@ -238,12 +223,18 @@ SUBSYSTEM_DEF(tetris_weekly_rewards)
 	return TRUE
 
 /datum/controller/subsystem/tetris_weekly_rewards/proc/advance_next_reset()
-	if(!next_reset_realtime)
-		next_reset_realtime = world.realtime + TETRIS_WEEKLY_REWARD_INTERVAL
-	else
-		while(next_reset_realtime <= world.realtime)
-			next_reset_realtime += TETRIS_WEEKLY_REWARD_INTERVAL
+	next_reset_realtime = next_monday_midnight()
 	save_state()
+
+/datum/controller/subsystem/tetris_weekly_rewards/proc/next_monday_midnight()
+	var/realtime_seconds = round(world.realtime / 10)
+	var/days_since_epoch = round(realtime_seconds / 86400)
+	var/dow = (days_since_epoch + 5) % 7
+	var/days_until_monday = (7 - dow) % 7
+	if(days_until_monday == 0)
+		days_until_monday = 7
+	var/next_monday_seconds = (days_since_epoch + days_until_monday) * 86400
+	return next_monday_seconds * 10
 
 #undef TETRIS_WEEKLY_REWARD_INTERVAL
 #undef TETRIS_WEEKLY_REWARD_CHECK_INTERVAL

--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -20,6 +20,8 @@
 	/// Все еще защита от дурочков с href, разделяем состояние игры.
 	var/game_active = FALSE
 	var/mob/active_game_player = null
+	/// Время старта игры
+	var/game_start_time = 0
 
 /obj/machinery/computer/arcade/tetris/ui_interact(mob/user, datum/tgui/ui)
 	if(!isliving(user))
@@ -129,6 +131,7 @@
 				return FALSE
 			game_active = TRUE
 			active_game_player = usr
+			game_start_time = world.time
 			start_tetris_music(usr)
 			return TRUE
 		if("music_stop")
@@ -142,6 +145,14 @@
 			// Sanitize score as an integer
 			// Restricts maximum score to (default) 100,000
 			var/temp_score = sanitize_num_clamp(text2num(params["score"]), max=TETRIS_SCORE_MAX)
+			var/game_duration = max(0, world.time - game_start_time)
+			game_start_time = 0
+
+			// Простая антифиддер защита. Пидорки что лезят в код чтобы накрутить счет - сосите хуй
+			if(game_duration < 1 MINUTES && temp_score > 30000)
+				log_admin("[key_name(usr)] отправил подозрительный счёт [temp_score] в аркадном тетрисе за [game_duration/10]с — отклонено.")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] пытался накрутить счёт в аркадном тетрисе: [temp_score] очков за [game_duration/10]с.")
+				return FALSE
 
 			if(usr?.client && SSachievements.achievements_enabled)
 				usr.client.give_award(/datum/award/score/highscore/tetris, usr, temp_score)

--- a/modular_sand/code/game/machinery/computer/arcade/tetris.dm
+++ b/modular_sand/code/game/machinery/computer/arcade/tetris.dm
@@ -201,6 +201,16 @@
 			if(!del_score)
 				return FALSE
 			return del_score.admin_delete_record(usr, ckey(params["ckey"]))
+		if("forceReset")
+			if(!check_rights_for(usr?.client, R_ADMIN))
+				return FALSE
+			if(SStetris_weekly_rewards.processing_rewards)
+				to_chat(usr, span_warning("Сброс уже выполняется, подождите."))
+				return FALSE
+			log_admin("[key_name(usr)] принудительно запустил недельный сброс рейтинга тетриса.")
+			message_admins("[key_name_admin(usr)] принудительно запустил недельный сброс рейтинга тетриса.")
+			SStetris_weekly_rewards.begin_reward_cycle()
+			return TRUE
 
 	add_fingerprint(usr)
 	. = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4317,6 +4317,7 @@
 #include "modular_bluemoon\code\controllers\subsystem\autotransfer.dm"
 #include "modular_bluemoon\code\controllers\subsystem\hilbertshotel.dm"
 #include "modular_bluemoon\code\controllers\subsystem\metadollars.dm"
+#include "modular_bluemoon\code\controllers\subsystem\tetris_weekly_rewards.dm"
 #include "modular_bluemoon\code\controllers\subsystem\ticker.dm"
 #include "modular_bluemoon\code\controllers\subsystem\vote.dm"
 #include "modular_bluemoon\code\controllers\subsystem\who.dm"

--- a/tgui/packages/tgui/interfaces/ArcadeTetris.js
+++ b/tgui/packages/tgui/interfaces/ArcadeTetris.js
@@ -52,6 +52,7 @@ class TetrisGame extends Component {
       paused: false,
       started: false,
       showLeaderboard: false,
+      showResetConfirm: false,
     };
     this.board = [];
     this.colors = [];
@@ -376,7 +377,7 @@ class TetrisGame extends Component {
   }
 
   render() {
-    const { score, level, lines, gameOver, paused, started, showLeaderboard } = this.state;
+    const { score, level, lines, gameOver, paused, started, showLeaderboard, showResetConfirm } = this.state;
     const { leaderboard = [], personal_best = 0, is_admin = false } = this.props;
     const isAdmin = !!is_admin;
 
@@ -434,6 +435,46 @@ class TetrisGame extends Component {
                   {'Ваш рекорд: ' + personal_best}
                 </Box>
               )}
+              {isAdmin && (
+                <Box mt={1}>
+                  <Button
+                    fluid
+                    icon="sync"
+                    color="bad"
+                    onClick={() => this.setState({ showResetConfirm: true })}>
+                    {'Принудительный недельный сброс'}
+                  </Button>
+                </Box>
+              )}
+            </Section>
+          </Modal>
+        )}
+        {/* Reset confirmation modal */}
+        {showResetConfirm && (
+          <Modal width="280px">
+            <Section
+              title="⚠ Сброс рейтинга"
+              buttons={
+                <Button
+                  icon="times"
+                  color="transparent"
+                  onClick={() => this.setState({ showResetConfirm: false })}
+                />
+              }
+            >
+              <Box mb={1}>
+                {'Вы уверены? Будут выданы награды за текущую неделю, и рейтинг будет очищен.'}
+              </Box>
+              <Button
+                fluid
+                icon="check"
+                color="bad"
+                onClick={() => {
+                  this.setState({ showResetConfirm: false });
+                  this.props.act('forceReset');
+                }}>
+                {'Да, сбросить рейтинг'}
+              </Button>
             </Section>
           </Modal>
         )}

--- a/tgui/packages/tgui/interfaces/NtosTetris.js
+++ b/tgui/packages/tgui/interfaces/NtosTetris.js
@@ -51,6 +51,7 @@ class TetrisGame extends Component {
       paused: false,
       started: false,
       showLeaderboard: false,
+      showResetConfirm: false,
     };
     this.board = [];
     this.colors = [];
@@ -364,7 +365,7 @@ class TetrisGame extends Component {
   }
 
   render() {
-    const { score, level, lines, gameOver, paused, started, showLeaderboard } = this.state;
+    const { score, level, lines, gameOver, paused, started, showLeaderboard, showResetConfirm } = this.state;
     const { highScore, leaderboard = [], personal_best = 0, is_admin = false } = this.props;
     const isAdmin = !!is_admin;
 
@@ -422,6 +423,46 @@ class TetrisGame extends Component {
                   {'Ваш рекорд: ' + personal_best}
                 </Box>
               )}
+              {isAdmin && (
+                <Box mt={1}>
+                  <Button
+                    fluid
+                    icon="sync"
+                    color="bad"
+                    onClick={() => this.setState({ showResetConfirm: true })}>
+                    {'Принудительный недельный сброс'}
+                  </Button>
+                </Box>
+              )}
+            </Section>
+          </Modal>
+        )}
+        {/* Reset confirmation modal */}
+        {showResetConfirm && (
+          <Modal width="280px">
+            <Section
+              title="⚠ Сброс рейтинга"
+              buttons={
+                <Button
+                  icon="times"
+                  color="transparent"
+                  onClick={() => this.setState({ showResetConfirm: false })}
+                />
+              }
+            >
+              <Box mb={1}>
+                {'Вы уверены? Будут выданы награды за текущую неделю, и рейтинг будет очищен.'}
+              </Box>
+              <Button
+                fluid
+                icon="check"
+                color="bad"
+                onClick={() => {
+                  this.setState({ showResetConfirm: false });
+                  this.props.act('forceReset');
+                }}>
+                {'Да, сбросить рейтинг'}
+              </Button>
             </Section>
           </Modal>
         )}


### PR DESCRIPTION
# Описание

Сброс SQL раз в неделю, каждый понедельник 00 UTC (Наш сервер). 1/2/3 места получают 250/200/100 соответственно, 4-10 места получают утешительные 50 метадолларов. Добавлена антифидлер(простенькая) система, которая проверяет фактический результат и время игры. Логику думаю ботик напишет.

## Причина изменений

Гойда

## Changelog

:cl:
add: Сброс лидерборда тетриса раз в неделю, выдача наград за рейтинг. 
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Еженедельная система вознаграждений Tetris** — автоматическое распределение призов между лучшими игроками по лидерборду.
* **Проверка безопасности** — отклонение подозрительно высоких очков, набранных менее чем за 1 минуту.
* **Принудительный сброс** — административная функция для ручного запуска еженедельного рейтинга.
* **Отслеживание времени игры** — регистрация длительности сеансов Tetris.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->