### PR TITLE
Optimize machinery

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -93,7 +93,7 @@
 				if(!(machine_stat & BROKEN))
 					return
 				to_chat(user, "<span class='notice'>Вы починили [src].</span>")
-				machine_stat &= ~BROKEN
+				set_machine_stat(machine_stat & ~BROKEN)
 				obj_integrity = max_integrity
 				update_icon()
 		else
@@ -105,7 +105,7 @@
 /obj/machinery/pdapainter/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(!(machine_stat & BROKEN))
-			machine_stat |= BROKEN
+			set_machine_stat(machine_stat | BROKEN)
 			update_icon()
 */
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -214,7 +214,7 @@ Class Procs:
 		return
 	. = machine_stat
 	machine_stat = new_value
-	on_stat_update(machine_stat)
+	on_stat_update(.)
 
 ///Called when the value of `stat` changes, so we can react to it.
 /obj/machinery/proc/on_stat_update(old_value)
@@ -287,12 +287,13 @@ Class Procs:
 	occupant = new_occupant
 
 /obj/machinery/proc/auto_use_power()
-	if(!powered(power_channel))
+	var/area/our_area = get_area(src)
+	if(!our_area?.powered(power_channel))
 		return FALSE
-	if(use_power == 1)
-		use_power(idle_power_usage,power_channel)
-	else if(use_power >= 2)
-		use_power(active_power_usage,power_channel)
+	if(use_power == IDLE_POWER_USE)
+		our_area.use_power(idle_power_usage, power_channel)
+	else if(use_power >= ACTIVE_POWER_USE)
+		our_area.use_power(active_power_usage, power_channel)
 	return TRUE
 
 /**

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -159,6 +159,7 @@ Class Procs:
 	if(!armor)
 		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 70)
 	. = ..()
+	set_is_operational(!(machine_stat & (NOPOWER|BROKEN|MAINT)))
 	SSmachines.register_machine(src)
 	GLOB.machines += src
 
@@ -218,13 +219,7 @@ Class Procs:
 
 ///Called when the value of `stat` changes, so we can react to it.
 /obj/machinery/proc/on_stat_update(old_value)
-	//From off to on.
-	if((old_value & (NOPOWER|BROKEN|MAINT)) && !(machine_stat & (NOPOWER|BROKEN|MAINT)))
-		set_is_operational(TRUE)
-		return
-	//From on to off.
-	if(machine_stat & (NOPOWER|BROKEN|MAINT))
-		set_is_operational(FALSE)
+	set_is_operational(!(machine_stat & (NOPOWER|BROKEN|MAINT)))
 
 /obj/machinery/emp_act(severity)
 	. = ..()
@@ -548,7 +543,7 @@ Class Procs:
 /obj/machinery/obj_break(damage_flag)
 	. = ..()
 	if(!(machine_stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		SEND_SIGNAL(src, COMSIG_MACHINERY_BROKEN, damage_flag)
 		update_appearance()
 		return TRUE

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -32,9 +32,9 @@
 		return
 	else
 		if(powered())
-			machine_stat &= ~NOPOWER
+			set_machine_stat(machine_stat & ~NOPOWER)
 		else
-			machine_stat |= NOPOWER
+			set_machine_stat(machine_stat | NOPOWER)
 		if((machine_stat & (NOPOWER|BROKEN)) || cooldown_time > world.time || !uses)
 			icon_state = "ai-slipper0"
 		else

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 		return
 	else if(P.tool_behaviour == TOOL_MULTITOOL && panel_open && (machine_stat & BROKEN))
 		to_chat(user, "<span class='notice'>You reset [src]'s firmware.</span>")
-		machine_stat &= ~BROKEN
+		set_machine_stat(machine_stat & ~BROKEN)
 		update_icon()
 	else
 		return ..()

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -106,7 +106,7 @@
 				if(!(machine_stat & BROKEN))
 					return
 				to_chat(user, "<span class='notice'>Вы починили [src].</span>")
-				machine_stat &= ~BROKEN
+				set_machine_stat(machine_stat & ~BROKEN)
 				obj_integrity = max(obj_integrity, max_integrity)
 				update_icon()
 		else
@@ -117,7 +117,7 @@
 /obj/machinery/aug_manipulator/obj_break(damage_flag)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(!(machine_stat & BROKEN))
-			machine_stat |= BROKEN
+			set_machine_stat(machine_stat | BROKEN)
 			update_icon()
 
 /obj/machinery/aug_manipulator/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -102,7 +102,7 @@
 			var/list/previous_network = network
 			network = list()
 			GLOB.cameranet.removeCamera(src)
-			machine_stat |= EMPED
+			set_machine_stat(machine_stat | EMPED)
 			set_light(0)
 			emped = emped+1  //Increase the number of consecutive EMP's
 			update_icon()
@@ -112,7 +112,7 @@
 					triggerCameraAlarm() //camera alarm triggers even if multiple EMPs are in effect.
 					if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
 						network = previous_network
-						machine_stat &= ~EMPED
+						set_machine_stat(machine_stat & ~EMPED)
 						update_icon()
 						if(can_use())
 							GLOB.cameranet.addCamera(src)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -289,7 +289,7 @@
 	else if (machine_stat & EMPED)
 		icon_state = "[initial(icon_state)]emp"
 	else
-		icon_state = "[initial(icon_state)][in_use_lights ? "_in_use" : ""]"
+		icon_state = "[initial(icon_state)][in_use_lights > 0 ? "_in_use" : ""]"
 
 /obj/machinery/camera/proc/toggle_cam(mob/user, displaymessage = 1)
 	status = !status
@@ -402,13 +402,3 @@
 		user.sight = 0
 		user.see_in_dark = 2
 	return TRUE
-
-// (ADD) Pe4henika bluemoon -- start
-/obj/machinery/camera/update_icon_state()
-    if(!status)
-        icon_state = "[initial(icon_state)]1"
-    else if (machine_stat & EMPED)
-        icon_state = "[initial(icon_state)]emp"
-    else
-        icon_state = "[initial(icon_state)][in_use_lights > 0 ? "_in_use" : ""]"
-// (ADD) Pe4henika bluemoon -- end

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -175,7 +175,7 @@
 		return
 	. = ..()
 	if(. && !(machine_stat & BROKEN))
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		typing = FALSE
 		playsound(loc, 'sound/effects/glassbr3.ogg', 100, TRUE)
 		set_light(0)

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -97,7 +97,7 @@
 	return FALSE
 
 /obj/machinery/computer/process(delta_time)
-	. = is_operational()
+	. = is_operational
 
 	check_typing()
 	if(typing)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -19,8 +19,9 @@
 /obj/machinery/computer/station_alert/ui_interact(mob/user)
 	alert_control.ui_interact(user)
 
-/obj/machinery/computer/station_alert/on_stat_update(stat)
-	if(stat & BROKEN)
+/obj/machinery/computer/station_alert/on_stat_update(old_value)
+	. = ..()
+	if(machine_stat & BROKEN)
 		alert_control.listener.prevent_alarm_changes()
 	else
 		alert_control.listener.allow_alarm_changes()

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -177,12 +177,12 @@
 		log_game("[key_name(user)] has set the teleporter target to [target_station] at [AREACOORD(T)]")
 		target = target_station.teleporter_hub
 		target_station.linked_stations |= power_station
-		target_station.machine_stat &= ~NOPOWER
+		target_station.set_machine_stat(target_station.machine_stat & ~NOPOWER)
 		if(target_station.teleporter_hub)
-			target_station.teleporter_hub.machine_stat &= ~NOPOWER
+			target_station.teleporter_hub.set_machine_stat(target_station.teleporter_hub.machine_stat & ~NOPOWER)
 			target_station.teleporter_hub.update_icon()
 		if(target_station.teleporter_console)
-			target_station.teleporter_console.machine_stat &= ~NOPOWER
+			target_station.teleporter_console.set_machine_stat(target_station.teleporter_console.machine_stat & ~NOPOWER)
 			target_station.teleporter_console.update_icon()
 
 /obj/machinery/computer/teleporter/proc/untarget_implant() //untargets from mob the racker was once implanted in to prevent issues.

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1104,7 +1104,7 @@
 								"<span class='italics'>You hear welding.</span>")
 				if(W.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, PROC_REF(weld_checks), W, user)))
 					obj_integrity = max_integrity
-					machine_stat &= ~BROKEN
+					set_machine_stat(machine_stat & ~BROKEN)
 					user.visible_message("[user.name] has repaired [src].", \
 										"<span class='notice'>You finish repairing the airlock.</span>")
 					update_icon()
@@ -1437,7 +1437,7 @@
 
 /obj/machinery/door/airlock/obj_break(damage_flag)
 	if(!(flags_1 & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		if(!panel_open)
 			panel_open = TRUE
 		wires.cut_all()

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -497,7 +497,7 @@
 
 /obj/machinery/door/airlock/cult/obj_break(damage_flag)
 	if(!(flags_1 & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		if(!panel_open)
 			panel_open = TRUE
 		update_icon()

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -151,7 +151,7 @@
 				targets += T
 
 		if(targets.len==0)
-			machine_stat |= BROKEN
+			set_machine_stat(machine_stat | BROKEN)
 		update_icon()
 
 /obj/machinery/door_timer/Destroy()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -127,10 +127,10 @@
 
 /obj/machinery/door/firedoor/power_change()
 	if(powered(power_channel))
-		machine_stat &= ~NOPOWER
+		set_machine_stat(machine_stat & ~NOPOWER)
 		INVOKE_ASYNC(src, PROC_REF(latetoggle))
 	else
-		machine_stat |= NOPOWER
+		set_machine_stat(machine_stat | NOPOWER)
 
 /obj/machinery/door/firedoor/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)
 	if(operating || !density)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -165,10 +165,10 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	else
 		if(powered() && anchored)
 			icon_state = initial(icon_state)
-			machine_stat &= ~NOPOWER
+			set_machine_stat(machine_stat & ~NOPOWER)
 		else
 			icon_state = "[initial(icon_state)]-off"
-			machine_stat |= NOPOWER
+			set_machine_stat(machine_stat | NOPOWER)
 
 //Portable version, built into EOD equipment. It simply provides an explosion's three damage levels.
 /obj/machinery/doppler_array/integrated

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -136,9 +136,9 @@
 /obj/machinery/droneDispenser/power_change()
 	..()
 	if(powered())
-		machine_stat &= ~NOPOWER
+		set_machine_stat(machine_stat & ~NOPOWER)
 	else
-		machine_stat |= NOPOWER
+		set_machine_stat(machine_stat | NOPOWER)
 	update_icon()
 
 /obj/machinery/droneDispenser/process()
@@ -235,7 +235,7 @@
 			"<span class='notice'>[user] fixes [src]!</span>",
 			"<span class='notice'>You restore [src] to operation.</span>")
 
-		machine_stat &= ~BROKEN
+		set_machine_stat(machine_stat & ~BROKEN)
 		obj_integrity = max_integrity
 		update_icon()
 	else
@@ -248,7 +248,7 @@
 				audible_message("<span class='warning'>[src] [break_message]</span>")
 			if(break_sound)
 				playsound(src, break_sound, 50, 1)
-			machine_stat |= BROKEN
+			set_machine_stat(machine_stat | BROKEN)
 			update_icon()
 
 /obj/machinery/droneDispenser/deconstruct(disassembled = TRUE)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -283,7 +283,7 @@
 						if(buildstage == 1)
 							if(machine_stat & BROKEN)
 								to_chat(user, "<span class='notice'>You remove the destroyed circuit.</span>")
-								machine_stat &= ~BROKEN
+								set_machine_stat(machine_stat & ~BROKEN)
 							else
 								to_chat(user, "<span class='notice'>You pry out the circuit.</span>")
 								new /obj/item/electronics/firealarm(user.loc)
@@ -348,7 +348,7 @@
 /obj/machinery/firealarm/obj_break(damage_flag)
 	if(!(machine_stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1) && buildstage != 0) //can't break the electronics if there isn't any inside.
 		LAZYREMOVE(myarea.firealarms, src)
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		update_icon()
 
 /obj/machinery/firealarm/deconstruct(disassembled = TRUE)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -45,13 +45,13 @@
 
 /obj/machinery/flasher/power_change()
 	if (powered() && anchored && bulb)
-		machine_stat &= ~NOPOWER
+		set_machine_stat(machine_stat & ~NOPOWER)
 		if(bulb.crit_fail)
 			icon_state = "[base_state]1-p"
 		else
 			icon_state = "[base_state]1"
 	else
-		machine_stat |= NOPOWER
+		set_machine_stat(machine_stat | NOPOWER)
 		icon_state = "[base_state]1-p"
 
 //Don't want to render prison breaks impossible
@@ -140,7 +140,7 @@
 /obj/machinery/flasher/obj_break(damage_flag)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(!(machine_stat & BROKEN))
-			machine_stat |= BROKEN
+			set_machine_stat(machine_stat | BROKEN)
 			if(bulb)
 				bulb.burn_out()
 				power_change()

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -82,11 +82,11 @@
 
 /obj/machinery/sparker/power_change()
 	if ( powered() && disable == 0 )
-		machine_stat &= ~NOPOWER
+		set_machine_stat(machine_stat & ~NOPOWER)
 		icon_state = "[base_state]"
 //		src.sd_SetLuminosity(2)
 	else
-		machine_stat |= ~NOPOWER
+		set_machine_stat(machine_stat | ~NOPOWER)
 		icon_state = "[base_state]-p"
 //		src.sd_SetLuminosity(0)
 

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -86,7 +86,7 @@
 		icon_state = "[base_state]"
 //		src.sd_SetLuminosity(2)
 	else
-		set_machine_stat(machine_stat | ~NOPOWER)
+		set_machine_stat(machine_stat | NOPOWER)
 		icon_state = "[base_state]-p"
 //		src.sd_SetLuminosity(0)
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -132,9 +132,9 @@
 /obj/machinery/light_switch/power_change()
 	if(!otherarea)
 		if(powered(LIGHT))
-			machine_stat &= ~NOPOWER
+			set_machine_stat(machine_stat & ~NOPOWER)
 		else
-			machine_stat |= NOPOWER
+			set_machine_stat(machine_stat | NOPOWER)
 	update_appearance()
 
 /obj/machinery/light_switch/emp_act(severity)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -4,6 +4,11 @@
 #define POPUP_ANIM_TIME 5
 #define POPDOWN_ANIM_TIME 5 //Be sure to change the icon animation at the same time or it'll look bad
 
+/// How often process() re-scans the surroundings (view(), mechs, blobs) for new targets.
+/// Between scans it reuses the cached list — so it keeps shooting, but notices a fresh
+/// intruder up to this much later. SSmachines fires every 2 s, so this is "every other fire".
+#define TURRET_TARGET_SCAN_INTERVAL (4 SECONDS)
+
 #define TURRET_FLAG_SHOOT_ALL_REACT		(1<<0)	// The turret gets pissed off and shoots at people nearby (unless they have sec access!)
 #define TURRET_FLAG_AUTH_WEAPONS		(1<<1)	// Checks if it can shoot people that have a weapon they aren't authorized to have
 #define TURRET_FLAG_SHOOT_CRIMINALS		(1<<2)	// Checks if it can shoot people that are wanted
@@ -108,6 +113,9 @@ DEFINE_BITFIELD(turret_flags, list(
 	var/mob/remote_controller
 	/// MISSING:
 	var/shot_stagger = 0
+	/// Cached result of the last scan_for_targets() call, reused on the fires in between scans.
+	var/list/cached_targets
+	COOLDOWN_DECLARE(target_scan_cooldown)
 
 /obj/machinery/porta_turret/Initialize(mapload)
 	. = ..()
@@ -441,6 +449,27 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(!on || (machine_stat & (NOPOWER|BROKEN)) || manual_control)
 		return PROCESS_KILL
 
+	var/list/targets
+	if(COOLDOWN_FINISHED(src, target_scan_cooldown))
+		targets = scan_for_targets()
+		cached_targets = targets.Copy() // tryToShootAt() mutates `targets`; keep an untouched cache
+		COOLDOWN_START(src, target_scan_cooldown, TURRET_TARGET_SCAN_INTERVAL)
+	else
+		// reuse the last scan; build a fresh, mutable list and drop anything deleted since then
+		targets = list()
+		for(var/atom/movable/candidate as anything in cached_targets)
+			if(!QDELETED(candidate))
+				targets += candidate
+
+	if(targets.len)
+		tryToShootAt(targets)
+	else if(!always_up)
+		popDown() // no valid targets, close the cover
+
+/// Scans the turret's surroundings (view(), mechs, blobs) for things it should shoot at and
+/// returns them as a list. Throttled by process() behind target_scan_cooldown — between scans
+/// process() reuses the cached result instead of calling this.
+/obj/machinery/porta_turret/proc/scan_for_targets()
 	var/list/targets = list()
 	for(var/mob/A in view(scan_range, base))
 		if(A.invisibility > SEE_INVISIBLE_LIVING)
@@ -504,10 +533,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		for(var/obj/structure/blob/B in view(scan_range, base))
 			targets += B
 
-	if(targets.len)
-		tryToShootAt(targets)
-	else if(!always_up)
-		popDown() // no valid targets, close the cover
+	return targets
 
 /obj/machinery/porta_turret/proc/randomize_shot_stagger()
 	shot_stagger = rand(0, min(2 SECONDS, round(shot_delay/3, world.tick_lag)))

--- a/code/game/machinery/poweredfans/fan_assembly.dm
+++ b/code/game/machinery/poweredfans/fan_assembly.dm
@@ -12,7 +12,7 @@
 	anchored = FALSE
 	density = FALSE
 	CanAtmosPass = ATMOS_PASS_YES
-	machine_stat = 1
+	var/build_state = 1
 	var/buildstacktype = /obj/item/stack/sheet/plasteel
 	var/buildstackamount = 5
 	/*
@@ -22,14 +22,14 @@
 	*/
 
 /obj/machinery/fan_assembly/attackby(obj/item/W, mob/living/user, params)
-	switch(machine_stat)
+	switch(build_state)
 		if(1)
 			// Stat 1
 			if(W.tool_behaviour == TOOL_WELDER)
 				if(weld(W, user))
 					to_chat(user, "<span class='notice'>You weld the fan assembly securely into place.</span>")
 					setAnchored(TRUE)
-					machine_stat = 2
+					build_state = 2
 					update_icon_state()
 				return
 		if(2)
@@ -41,7 +41,7 @@
 				to_chat(user, "<span class='notice'>You start to add wires to the assembly...</span>")
 				if(W.use_tool(src, user, 30, volume=50, amount=2))
 					to_chat(user, "<span class='notice'>You add wires to the fan assembly.</span>")
-					machine_stat = 3
+					build_state = 3
 					var/obj/machinery/poweredfans/F = new(loc, src)
 					forceMove(F)
 					F.setDir(src.dir)
@@ -49,14 +49,14 @@
 			else if(W.tool_behaviour == TOOL_WELDER)
 				if(weld(W, user))
 					to_chat(user, "<span class='notice'>You unweld the fan assembly from its place.</span>")
-					machine_stat = 1
+					build_state = 1
 					update_icon_state()
 					setAnchored(FALSE)
 				return
 	return ..()
 
 /obj/machinery/fan_assembly/wrench_act(mob/user, obj/item/I)
-	if(machine_stat != 1)
+	if(build_state != 1)
 		return FALSE
 	user.visible_message("<span class='warning'>[user] disassembles [src].</span>",
 		"<span class='notice'>You start to disassemble [src]...</span>", "You hear wrenching noises.")
@@ -69,7 +69,7 @@
 		return
 	if(!W.tool_start_check(user, amount=0))
 		return FALSE
-	switch(machine_stat)
+	switch(build_state)
 		if(1)
 			to_chat(user, "<span class='notice'>You start to weld \the [src]...</span>")
 		if(2)
@@ -85,7 +85,7 @@
 
 /obj/machinery/fan_assembly/examine(mob/user)
 	. = ..()
-	switch(machine_stat)
+	switch(build_state)
 		if(1)
 			to_chat(user, "<span class='notice'>The fan assembly seems to be <b>unwelded</b> and loose.</span>")
 		if(2)
@@ -95,7 +95,7 @@
 
 /obj/machinery/fan_assembly/update_icon_state()
 	. = ..()
-	switch(machine_stat)
+	switch(build_state)
 		if(1)
 			icon_state = "mfan_assembly"
 		if(2)

--- a/code/game/machinery/poweredfans/poweredfans.dm
+++ b/code/game/machinery/poweredfans/poweredfans.dm
@@ -19,7 +19,7 @@
 		if(!assembly)
 			assembly = new()
 		assembly.forceMove(drop_location())
-		assembly.machine_stat = 2
+		assembly.build_state = 2
 		assembly.setAnchored(TRUE)
 		assembly.setDir(dir)
 		assembly = null
@@ -39,7 +39,7 @@
 		assembly = FA
 	else
 		assembly = new(src)
-		assembly.machine_stat = 3
+		assembly.build_state = 3
 	air_update_turf(TRUE)
 
 /obj/machinery/poweredfans/power_change()

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -114,7 +114,7 @@
 
 /obj/machinery/shieldgen/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
-		if(!(machine_stat && BROKEN))
+		if(!(machine_stat & BROKEN))
 			set_machine_stat(machine_stat | BROKEN)
 			locked = pick(0,1)
 			update_icon()

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -115,7 +115,7 @@
 /obj/machinery/shieldgen/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(!(machine_stat && BROKEN))
-			machine_stat |= BROKEN
+			set_machine_stat(machine_stat | BROKEN)
 			locked = pick(0,1)
 			update_icon()
 
@@ -161,7 +161,7 @@
 		to_chat(user, "<span class='notice'>You begin to replace the wires...</span>")
 		if(W.use_tool(src, user, 30, 1))
 			obj_integrity = max_integrity
-			machine_stat &= ~BROKEN
+			set_machine_stat(machine_stat & ~BROKEN)
 			to_chat(user, "<span class='notice'>Вы починили \the [src].</span>")
 			update_icon()
 

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -41,6 +41,14 @@
 	var/speed = 0
 	var/power_gen = 4000	// amount of power output at max speed
 
+	/// The (current_mode, line1, line2) the per-tick shuttle/supply timer helpers last pushed
+	/// to set_messages(). They run every SSmachines fire and almost always push the same text
+	/// (e.g. "" / "" while no shuttle timer is running, > 95 % of the round); this lets them
+	/// early-out instead of doing a redundant set_messages() → update_appearance() icon rebuild.
+	var/last_status_push_mode
+	var/last_status_push_line1
+	var/last_status_push_line2
+
 /obj/machinery/status_display/proc/get_power_output()
 	if(speed && !machine_stat && anchored)
 		return power_gen * speed / MAX_SPEED
@@ -109,6 +117,24 @@
 		message2 = line2
 
 	update_appearance()
+
+/**
+ * Push (line1, line2) to set_messages() only when it differs from what we last pushed.
+ *
+ * The shuttle / supply / evac displays call this from process() every SSmachines fire, and the
+ * text is almost always identical to the previous tick's (e.g. "" / "" while no shuttle timer is
+ * running). Skipping the redundant set_messages() avoids a full update_appearance() icon/overlay
+ * rebuild every fire. set_messages() itself (and all the mode-transition rebuilds that go through
+ * it from receive_signal(), set_picture(), power_change()) is untouched, so this only suppresses
+ * the no-op per-tick rebuilds.
+ */
+/obj/machinery/status_display/proc/set_timer_messages(line1, line2)
+	if(current_mode == last_status_push_mode && line1 == last_status_push_line1 && line2 == last_status_push_line2)
+		return
+	last_status_push_mode = current_mode
+	last_status_push_line1 = line1
+	last_status_push_line2 = line2
+	set_messages(line1, line2)
 
 /**
  * Remove both message objs and null the fields.
@@ -227,7 +253,7 @@
 /obj/machinery/status_display/proc/display_shuttle_status(obj/docking_port/mobile/shuttle)
 	if(!shuttle)
 		// the shuttle is missing - no processing
-		set_messages("shutl?","")
+		set_timer_messages("shutl?","")
 		return PROCESS_KILL
 	else if(shuttle.timer)
 		var/line1 = "-[shuttle.getModeStr()]-"
@@ -235,10 +261,10 @@
 
 		if(length_char(line2) > CHARS_PER_LINE)
 			line2 = "error"
-		set_messages(line1, line2)
+		set_timer_messages(line1, line2)
 	else
 		// don't kill processing, the timer might turn back on
-		set_messages("", "")
+		set_timer_messages("", "")
 
 /obj/machinery/status_display/proc/examine_shuttle(mob/user, obj/docking_port/mobile/shuttle)
 	if (shuttle)
@@ -415,7 +441,7 @@
 		line2 = SSshuttle.supply.getTimerStr()
 		if(length_char(line2) > CHARS_PER_LINE)
 			line2 = "Error"
-	set_messages(line1, line2)
+	set_timer_messages(line1, line2)
 
 /obj/machinery/status_display/supply/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -807,10 +807,10 @@
 /obj/machinery/treadmill_monitor/emp_act(severity)
 	..()
 	if(!(machine_stat & BROKEN))
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		update_icon()
 		spawn(100)
-			machine_stat &= ~BROKEN
+			set_machine_stat(machine_stat & ~BROKEN)
 			update_icon()
 
 #undef CHARS_PER_LINE

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -14,7 +14,6 @@ GLOBAL_VAR_INIT(singularity_counter, 0)
 	anchored = FALSE
 	density = TRUE
 	layer = BELOW_MOB_LAYER //so people can't hide it and it's REALLY OBVIOUS
-	machine_stat = 0
 	verb_say = "states"
 	var/cooldown = 0
 	var/active = FALSE

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -155,7 +155,7 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 		return
 	if(prob(severity))
 		if(!(machine_stat & EMPED))
-			machine_stat |= EMPED
+			set_machine_stat(machine_stat | EMPED)
 			var/duration = severity * 35
 			spawn(rand(duration - 20, duration + 20)) // Takes a long time for the machines to reboot.
-				machine_stat &= ~(EMPED)
+				set_machine_stat(machine_stat & ~(EMPED))

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -1,4 +1,10 @@
 //Ocular warden: Low-damage, low-range turret. Deals constant damage to whoever it makes eye contact with.
+
+/// How often (in game time) the ocular warden re-scans for nearby targets. Between scans it
+/// keeps damaging its current target and reuses the cached target list. Lives in SSfastprocess
+/// (0.2s ticks), so this is ~5 ticks between viewers() scans instead of one every tick.
+#define OCULAR_WARDEN_SCAN_INTERVAL (1 SECONDS)
+
 /obj/structure/destructible/clockwork/ocular_warden
 	name = "ocular warden"
 	desc = "A large brass eye with tendrils trailing below it and a wide red iris."
@@ -14,6 +20,9 @@
 	var/damage_per_tick = 3
 	var/sight_range = 3
 	var/atom/movable/target
+	/// Cached result of the last acquire_nearby_targets() call, reused on non-scan ticks.
+	var/list/cached_targets
+	COOLDOWN_DECLARE(target_scan_cooldown)
 	var/list/idle_messages = list(" sulkily glares around.", " lazily drifts from side to side.", " looks around for something to burn.", " slowly turns in circles.")
 
 /obj/structure/destructible/clockwork/ocular_warden/Initialize(mapload)
@@ -53,9 +62,15 @@
 	if(!anchored)
 		lose_target()
 		return
-	var/list/validtargets = acquire_nearby_targets()
+	var/list/validtargets = cached_targets
+	if(COOLDOWN_FINISHED(src, target_scan_cooldown))
+		validtargets = acquire_nearby_targets()
+		cached_targets = validtargets
+		COOLDOWN_START(src, target_scan_cooldown, OCULAR_WARDEN_SCAN_INTERVAL)
+	if(!islist(validtargets))
+		validtargets = list()
 	if(target)
-		if(!(target in validtargets))
+		if(QDELETED(target) || !(target in validtargets))
 			lose_target()
 		else
 			if(isliving(target))
@@ -164,3 +179,5 @@
 					break
 		. -= (get_dist(src, target) * 0.05)
 		. = max(., 0.1) //The lowest damage a warden can do is 10% of its normal amount (0.25 by default)
+
+#undef OCULAR_WARDEN_SCAN_INTERVAL

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -57,6 +57,11 @@
 
 #define AALARM_REPORT_TIMEOUT 100
 
+/// Adaptive process() backoff cap: once danger_level has been stable, the air alarm reads
+/// the turf air at most every this-many SSmachines fires (2 s each). The instant danger_level
+/// changes it snaps back to reading every fire. (Not #undef'd — read by the regression test.)
+#define AALARM_MAX_PROCESS_INTERVAL 2
+
 #define AALARM_OVERLAY_OFF		"alarm_off"
 #define AALARM_OVERLAY_GREEN	"alarm_green"
 #define AALARM_OVERLAY_WARN		"alarm_amber"
@@ -82,6 +87,13 @@
 
 	var/danger_level = 0
 	var/mode = AALARM_MODE_SCRUBBING
+
+	/// Adaptive process() throttle: how many SSmachines fires between full turf air reads.
+	/// 1 = every fire. Grows toward AALARM_MAX_PROCESS_INTERVAL while danger_level is stable;
+	/// resets to 1 the instant danger_level changes.
+	var/process_interval = 1
+	/// Fires left to skip (cheap early-out) before the next full air read.
+	var/process_skips_left = 0
 
 	var/locked = TRUE
 	var/aidisabled = 0
@@ -738,6 +750,12 @@
 	if((machine_stat & (NOPOWER|BROKEN)) || shorted)
 		return
 
+	// While danger_level has been stable, skip the (relatively expensive) turf air read on
+	// most fires. Snaps back to reading every fire the moment danger_level changes (below).
+	if(process_skips_left > 0)
+		process_skips_left--
+		return
+
 	var/turf/location = get_turf(src)
 	if(!location)
 		return
@@ -766,6 +784,15 @@
 
 	if(old_danger_level != danger_level)
 		apply_danger_level()
+
+	// Adaptive backoff: read every fire while danger_level is moving (or we're mid-air-replacement
+	// and watching for the pressure cutoff); coast at AALARM_MAX_PROCESS_INTERVAL once it settles.
+	if(old_danger_level != danger_level || mode == AALARM_MODE_REPLACEMENT)
+		process_interval = 1
+	else
+		process_interval = min(process_interval + 1, AALARM_MAX_PROCESS_INTERVAL)
+	process_skips_left = process_interval - 1
+
 	if(mode == AALARM_MODE_REPLACEMENT && environment_pressure < ONE_ATMOSPHERE * 0.05)
 		mode = AALARM_MODE_SCRUBBING
 		apply_mode()
@@ -956,7 +983,7 @@
 	qdel(src)
 
 /obj/machinery/airalarm/proc/handle_decomp_alarm()
-	if(!is_operational() || !COOLDOWN_FINISHED(src, decomp_alarm))
+	if(!is_operational || !COOLDOWN_FINISHED(src, decomp_alarm))
 		return
 	var/area/A = get_base_area(src)
 	A.firealert(src)

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -75,7 +75,7 @@
 
 /obj/machinery/atmospherics/components/binary/circulator/update_icon()
 	. = ..()
-	if(!is_operational())
+	if(!is_operational)
 		icon_state = "circ-p-[flipped]"
 	else if(last_pressure_delta > 0)
 		if(last_pressure_delta > ONE_ATMOSPHERE)

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -42,7 +42,7 @@
 		var/image/cap = getpipeimage(icon, "dpvent_cap", dir, piping_layer = piping_layer)
 		add_overlay(cap)
 
-	if(!on || !is_operational())
+	if(!on || !is_operational)
 		icon_state = "vent_off"
 	else
 		icon_state = pump_direction ? "vent_out" : "vent_in"

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -54,11 +54,11 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/binary/pump/update_icon_nopipes()
-	icon_state = (on && is_operational()) ? "pump_on" : "pump_off"
+	icon_state = (on && is_operational) ? "pump_on" : "pump_off"
 
 /obj/machinery/atmospherics/components/binary/pump/process_atmos()
 //	..()
-	if(!on || !is_operational())
+	if(!on || !is_operational)
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]
@@ -177,7 +177,7 @@
 /obj/machinery/atmospherics/components/binary/pump/can_unwrench(mob/user)
 	. = ..()
 	var/area/A = get_area(src)
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 	else

--- a/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
@@ -30,7 +30,7 @@
 		setDir(EAST)
 	cut_overlays()
 
-	if(!nodes[1] || !opened || !is_operational())
+	if(!nodes[1] || !opened || !is_operational)
 		icon_state = "relief_valve-t"
 		return
 
@@ -50,7 +50,7 @@
 /obj/machinery/atmospherics/components/binary/relief_valve/process_atmos()
 	..()
 
-	if(!is_operational())
+	if(!is_operational)
 		return
 
 	var/datum/gas_mixture/air_one = airs[1]

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -63,7 +63,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OPEN_SILICON
 
 /obj/machinery/atmospherics/components/binary/valve/digital/update_icon_nopipes(animation)
-	if(!is_operational())
+	if(!is_operational)
 		normalize_cardinal_directions()
 		icon_state = "dvalve_nopower"
 		return

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -52,11 +52,11 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
-	icon_state = on && is_operational() ? "volpump_on" : "volpump_off"
+	icon_state = on && is_operational ? "volpump_on" : "volpump_off"
 
 /obj/machinery/atmospherics/components/binary/volume_pump/process_atmos()
 //	..()
-	if(!on || !is_operational())
+	if(!on || !is_operational)
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]
@@ -174,7 +174,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/can_unwrench(mob/user)
 	. = ..()
 	var/area/A = get_area(src)
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 	else

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -62,7 +62,7 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/trinary/filter/update_icon_nopipes()
-	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational()
+	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational
 	icon_state = "filter_[on_state ? "on" : "off"][flipped ? "_f" : ""]"
 
 /obj/machinery/atmospherics/components/trinary/filter/power_change()
@@ -73,7 +73,7 @@
 
 /obj/machinery/atmospherics/components/trinary/filter/process_atmos()
 	..()
-	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational())
+	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational)
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]
@@ -166,7 +166,7 @@
 
 /obj/machinery/atmospherics/components/trinary/filter/can_unwrench(mob/user)
 	. = ..()
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -40,7 +40,7 @@
 		. += getpipeimage(icon, "cap", direction, pipe_color, piping_layer, TRUE)
 
 /obj/machinery/atmospherics/components/trinary/mixer/update_icon_nopipes()
-	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational()
+	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational
 	icon_state = "mixer_[on_state ? "on" : "off"][flipped ? "_f" : ""]"
 
 /obj/machinery/atmospherics/components/trinary/mixer/New()
@@ -51,7 +51,7 @@
 
 /obj/machinery/atmospherics/components/trinary/mixer/process_atmos()
 	..()
-	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational())
+	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational)
 		return
 
 	//Get those gases, mah boiiii
@@ -165,7 +165,7 @@
 
 /obj/machinery/atmospherics/components/trinary/mixer/can_unwrench(mob/user)
 	. = ..()
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -125,7 +125,7 @@
 		occupant_overlay.dir = SOUTH
 		occupant_overlay.pixel_y = 22
 
-		if(on && !running_anim && is_operational())
+		if(on && !running_anim && is_operational)
 			icon_state = "pod-on"
 			running_anim = TRUE
 			run_anim(TRUE, occupant_overlay)
@@ -134,7 +134,7 @@
 			add_overlay(occupant_overlay)
 			add_overlay("cover-off")
 
-	else if(on && is_operational())
+	else if(on && is_operational)
 		icon_state = "pod-on"
 		add_overlay("cover-on")
 	else
@@ -142,7 +142,7 @@
 		add_overlay("cover-off")
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/proc/run_anim(anim_up, image/occupant_overlay)
-	if(!on || !occupant || !is_operational())
+	if(!on || !occupant || !is_operational)
 		running_anim = FALSE
 		return
 	cut_overlays()
@@ -164,7 +164,7 @@
 
 	if(!on)
 		return
-	if(!is_operational())
+	if(!is_operational)
 		on = FALSE
 		update_icon()
 		return

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -45,7 +45,7 @@
 		// everything is already shifted so don't shift the cap
 		add_overlay(getpipeimage(icon, "inje_cap", initialize_directions))
 
-	if(!nodes[1] || !on || !is_operational())
+	if(!nodes[1] || !on || !is_operational)
 		icon_state = "inje_off"
 	else
 		icon_state = "inje_on"
@@ -62,7 +62,7 @@
 
 	injecting = 0
 
-	if(!on || !is_operational())
+	if(!on || !is_operational)
 		return
 
 	var/datum/gas_mixture/air_contents = airs[1]
@@ -75,7 +75,7 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/proc/inject()
 
-	if(on || injecting || !is_operational())
+	if(on || injecting || !is_operational)
 		return
 
 	var/datum/gas_mixture/air_contents = airs[1]
@@ -182,7 +182,7 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/can_unwrench(mob/user)
 	. = ..()
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
@@ -29,7 +29,7 @@
 /obj/machinery/atmospherics/components/unary/relief_valve/update_icon_nopipes()
 	cut_overlays()
 
-	if(!nodes[1] || !opened || !is_operational())
+	if(!nodes[1] || !opened || !is_operational)
 		icon_state = "relief_valve-e"
 		return
 
@@ -38,7 +38,7 @@
 /obj/machinery/atmospherics/components/unary/relief_valve/process_atmos()
 	..()
 
-	if(!is_operational())
+	if(!is_operational)
 		return
 
 	var/datum/gas_mixture/air_contents = airs[1]

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -45,7 +45,7 @@
 
 	if(panel_open)
 		icon_state = icon_state_open
-	else if(on && is_operational())
+	else if(on && is_operational)
 		icon_state = icon_state_on
 	else
 		icon_state = icon_state_off

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -57,7 +57,7 @@
 		icon_state = "vent_welded"
 		return
 
-	if(!nodes[1] || !on || !is_operational())
+	if(!nodes[1] || !on || !is_operational)
 		if(icon_state == "vent_welded")
 			icon_state = "vent_off"
 			return
@@ -84,7 +84,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_pump/process_atmos()
 	..()
-	if(!is_operational())
+	if(!is_operational)
 		return
 	if(!nodes[1])
 		on = FALSE
@@ -173,7 +173,7 @@
 	..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal(datum/signal/signal)
-	if(!is_operational())
+	if(!is_operational)
 		return
 	// log_admin("DEBUG \[[world.timeofday]\]: /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal([signal.debug_print()])")
 	if(!signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
@@ -264,7 +264,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_unwrench(mob/user)
 	. = ..()
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -59,7 +59,14 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/auto_use_power()
-	if(!on || welded || !is_operational() || !powered(power_channel))
+	if(!on || welded || !is_operational)
+		return FALSE
+	// Fetch the area once and call its procs directly, instead of going through powered()
+	// (a get_area()) and then use_power() (another get_area()) — same shape as the base
+	// /obj/machinery/proc/auto_use_power(). use_power is IDLE_POWER_USE here so powered()'s
+	// "!use_power → return TRUE" early-out never fired; this is behaviour-equivalent.
+	var/area/our_area = get_area(src)
+	if(!our_area?.powered(power_channel))
 		return FALSE
 
 	var/amount = idle_power_usage
@@ -71,7 +78,7 @@
 
 	if(widenet)
 		amount += amount * (adjacent_turfs.len * (adjacent_turfs.len / 2))
-	use_power(amount, power_channel)
+	our_area.use_power(amount, power_channel)
 	return TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/update_icon_nopipes()
@@ -84,7 +91,7 @@
 		icon_state = "scrub_welded"
 		return
 
-	if(!nodes[1] || !on || !is_operational())
+	if(!nodes[1] || !on || !is_operational)
 		icon_state = "scrub_off"
 		return
 
@@ -146,7 +153,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/process_atmos()
 	..()
-	if(welded || !is_operational())
+	if(welded || !is_operational)
 		return FALSE
 	if(!nodes[1] || !on)
 		on = FALSE
@@ -196,7 +203,7 @@
 		adjacent_turfs = T.GetAtmosAdjacentTurfs(alldir = 1)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/receive_signal(datum/signal/signal)
-	if(!is_operational() || !signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
+	if(!is_operational || !signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return FALSE
 
 	var/mob/signal_sender = signal.data["user"]
@@ -263,7 +270,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/can_unwrench(mob/user)
 	. = ..()
-	if(. && on && is_operational())
+	if(. && on && is_operational)
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -77,8 +77,9 @@
 	update_icon()
 
 /obj/machinery/atmospherics/miner/proc/set_broken(setting)
-	if(broken != setting)
-		broken = setting
+	if(broken == setting)
+		return // check_operation() calls this every process_atmos() tick — don't rebuild the icon for nothing
+	broken = setting
 	update_icon()
 
 /obj/machinery/atmospherics/miner/proc/update_power()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -282,7 +282,7 @@
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)
 	if((machine_stat & BROKEN) || (flags_1 & NODECONSTRUCT_1))
 		return
-	machine_stat |= BROKEN
+	set_machine_stat(machine_stat | BROKEN)
 	canister_break()
 
 /obj/machinery/portable_atmospherics/canister/proc/canister_break()

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -19,7 +19,7 @@
 	. = ..()
 	pump = new(src, FALSE)
 	pump.on = TRUE
-	pump.machine_stat = 0
+	pump.set_machine_stat(0)
 	SSair.add_to_rebuild_queue(pump)
 
 /obj/machinery/portable_atmospherics/pump/Destroy()

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(is_operational())
+	if(is_operational)
 		if(prob(severity/2))
 			on = !on
 		if(prob(severity))

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -50,7 +50,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(is_operational())
+	if(is_operational)
 		if(prob(severity/3))
 			on = !on
 		update_icon()
@@ -117,7 +117,7 @@
 	icon_state = "scrubber:[on]"
 
 /obj/machinery/portable_atmospherics/scrubber/huge/process_atmos()
-	if((!anchored && !movable) || !is_operational())
+	if((!anchored && !movable) || !is_operational)
 		on = FALSE
 		update_icon()
 	use_power = on ? ACTIVE_POWER_USE : IDLE_POWER_USE

--- a/code/modules/newscaster/newscaster_machine.dm
+++ b/code/modules/newscaster/newscaster_machine.dm
@@ -84,11 +84,11 @@ GLOBAL_LIST_EMPTY(allCasters)
 	if(machine_stat & BROKEN)
 		return
 	if(powered())
-		machine_stat &= ~NOPOWER
+		set_machine_stat(machine_stat & ~NOPOWER)
 		update_icon()
 	else
 		spawn(rand(0, 15))
-			machine_stat |= NOPOWER
+			set_machine_stat(machine_stat | NOPOWER)
 			update_icon()
 
 /obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
@@ -578,7 +578,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 					return
 				to_chat(user, "<span class='notice'>You repair [src].</span>")
 				obj_integrity = max_integrity
-				machine_stat &= ~BROKEN
+				set_machine_stat(machine_stat & ~BROKEN)
 				update_icon()
 		else
 			to_chat(user, "<span class='notice'>[src] does not need repairs.</span>")
@@ -605,7 +605,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 
 /obj/machinery/newscaster/obj_break()
 	if(!(machine_stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 		playsound(loc, 'sound/effects/glassbr3.ogg', 100, 1)
 		update_icon()
 

--- a/code/modules/pool/pool_wires.dm
+++ b/code/modules/pool/pool_wires.dm
@@ -54,6 +54,6 @@
 			P.shock(usr, 50)
 		if(WIRE_SHOCK)
 			if(mend)
-				P.machine_stat &= ~NOPOWER
+				P.set_machine_stat(P.machine_stat & ~NOPOWER)
 			else
-				P.machine_stat |= NOPOWER
+				P.set_machine_stat(P.machine_stat | NOPOWER)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -608,7 +608,7 @@
 			switch (has_electronics)
 				if (APC_ELECTRONICS_INSTALLED)
 					has_electronics = APC_ELECTRONICS_SECURED
-					machine_stat &= ~MAINT
+					set_machine_stat(machine_stat & ~MAINT)
 					W.play_tool_sound(src)
 					to_chat(user, "<span class='notice'>You screw the circuit electronics into place.</span>")
 				if (APC_ELECTRONICS_SECURED)
@@ -780,7 +780,7 @@
 		if(do_after(user, 50, target = src))
 			to_chat(user, "<span class='notice'>You replace the damaged APC frame with a new one.</span>")
 			qdel(W)
-			machine_stat &= ~BROKEN
+			set_machine_stat(machine_stat & ~BROKEN)
 			obj_integrity = max_integrity
 			if (opened==APC_COVER_REMOVED)
 				opened = APC_COVER_OPENED

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	obj_break()
 
 /obj/machinery/gravity_generator/proc/set_fix()
-	machine_stat &= ~BROKEN
+	set_machine_stat(machine_stat & ~BROKEN)
 
 /obj/machinery/gravity_generator/part/Destroy()
 	if(main_part)

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -202,7 +202,7 @@
 /obj/machinery/power/rad_collector/obj_break(damage_flag)
 	if(!(machine_stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
 		eject()
-		machine_stat |= BROKEN
+		set_machine_stat(machine_stat | BROKEN)
 
 /obj/machinery/power/rad_collector/proc/eject()
 	locked = FALSE

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -88,7 +88,7 @@
 	turbine = locate() in get_step(src, get_dir(inturf, src))
 	if(turbine)
 		turbine.locate_machinery()
-		machine_stat &= ~BROKEN
+		set_machine_stat(machine_stat & ~BROKEN)
 
 /obj/machinery/power/compressor/RefreshParts()
 	var/E = 0
@@ -111,7 +111,7 @@
 		locate_machinery()
 		if(turbine)
 			to_chat(user, "<span class='notice'>Turbine connected.</span>")
-			machine_stat &= ~BROKEN
+			set_machine_stat(machine_stat & ~BROKEN)
 		else
 			to_chat(user, "<span class='alert'>Turbine not connected.</span>")
 			obj_break()
@@ -190,12 +190,12 @@
 	compressor = locate() in get_step(src, get_dir(outturf, src))
 	if(compressor)
 		compressor.locate_machinery()
-		machine_stat &= ~BROKEN
+		set_machine_stat(machine_stat & ~BROKEN)
 
 /obj/machinery/power/turbine/process()
 
 	if(!compressor)
-		machine_stat = BROKEN
+		set_machine_stat(BROKEN)
 
 	if((machine_stat & BROKEN) || panel_open)
 		return
@@ -238,7 +238,7 @@
 		locate_machinery()
 		if(compressor)
 			to_chat(user, "<span class='notice'>Compressor connected.</span>")
-			machine_stat &= ~BROKEN
+			set_machine_stat(machine_stat & ~BROKEN)
 		else
 			to_chat(user, "<span class='alert'>Compressor not connected.</span>")
 			obj_break()

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -195,7 +195,7 @@
 /obj/machinery/power/turbine/process()
 
 	if(!compressor)
-		set_machine_stat(BROKEN)
+		set_machine_stat(machine_stat | BROKEN)
 
 	if((machine_stat & BROKEN) || panel_open)
 		return

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 // make the conveyor broken
 // also propagate inoperability to any connected conveyor with the same ID
 /obj/machinery/conveyor/proc/broken()
-	machine_stat |= BROKEN
+	set_machine_stat(machine_stat | BROKEN)
 	update()
 
 	var/obj/machinery/conveyor/C = locate() in get_step(src, dir)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -51,6 +51,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		operating = FALSE
 	else
 		operating = TRUE
+		START_PROCESSING(SSfastprocess, src)
 	icon_state = "conveyor[operating * verted]"
 
 // create a conveyor
@@ -127,9 +128,9 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	// move items to the target location
 /obj/machinery/conveyor/process()
 	if(machine_stat & (BROKEN | NOPOWER))
-		return
+		return PROCESS_KILL
 	if(!operating)
-		return
+		return PROCESS_KILL
 	use_power(6)
 	affecting = loc.contents - src		// moved items will be all in loc
 	addtimer(CALLBACK(src, PROC_REF(convey), affecting), 1)
@@ -273,6 +274,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	for(var/obj/machinery/conveyor/C in GLOB.conveyors_by_id[id])
 		C.operating = position
 		C.update_move_direction()
+		if(position)
+			START_PROCESSING(SSfastprocess, C)
 		CHECK_TICK
 
 /obj/machinery/conveyor_switch/process()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -86,7 +86,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	machine_stat |= EMPED
+	set_machine_stat(machine_stat | EMPED)
 	addtimer(CALLBACK(src, PROC_REF(unemp)), severity*9)
 	refresh_working()
 
@@ -102,7 +102,7 @@
 	return TRUE
 
 /obj/machinery/rnd/server/proc/unemp()
-	machine_stat &= ~EMPED
+	set_machine_stat(machine_stat & ~EMPED)
 	refresh_working()
 
 /obj/machinery/rnd/server/proc/mine()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -98,6 +98,7 @@
 #include "lighting.dm"
 #include "lighting_performance.dm"
 #include "machine_disassembly.dm"
+#include "machinery_optimization.dm"
 #include "mapload_space_verification.dm"	// BLUEMOON EDIT: Invalid Space Turfs
 #include "mapping.dm"						// BLUEMOON EDIT: Invalid Space Turfs
 #include "medical_wounds.dm"

--- a/code/modules/unit_tests/machinery_optimization.dm
+++ b/code/modules/unit_tests/machinery_optimization.dm
@@ -1,0 +1,413 @@
+// Regression tests guarding the machinery optimization pass.
+// These pin observable behaviour — they pass before AND after the optimizations.
+
+/// A1: auto_use_power() must charge the machine's area exactly the same amount as before
+/// the rewrite (idle / active / unpowered), and return the area's powered state.
+/datum/unit_test/machinery_auto_use_power/Run()
+	var/turf/floor = run_loc_floor_bottom_left
+	// The reservation z-level turfs live in /area/space, which unconditionally
+	// overrides powered() to return FALSE. Create a synthetic plain /area (base type,
+	// not the space subtype), move the turf into it for the duration of the test,
+	// and restore at the end.
+	var/area/original_area = get_area(floor)
+	var/area/test_area = new /area
+	allocated += test_area
+	test_area.contents.Add(floor) // reassigns floor.loc → test_area
+
+	// The base /area has requires_power = TRUE and power_equip = TRUE by default.
+	TEST_ASSERT(test_area.powered(EQUIP), "synthetic area must be powered on EQUIP by default")
+
+	var/obj/machinery/machine = allocate(/obj/machinery)
+	machine.forceMove(floor)
+	machine.power_channel = EQUIP
+	machine.idle_power_usage = 100
+	machine.active_power_usage = 500
+
+	// --- idle power ---
+	machine.use_power = IDLE_POWER_USE
+	test_area.clear_usage()
+	var/before = test_area.used_equip
+	var/result = machine.auto_use_power()
+	TEST_ASSERT(result, "auto_use_power() should return TRUE in a powered area")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 100, "idle machine must add idle_power_usage to area EQUIP usage")
+
+	// --- active power ---
+	machine.use_power = ACTIVE_POWER_USE
+	before = test_area.used_equip
+	machine.auto_use_power()
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 500, "active machine must add active_power_usage to area EQUIP usage")
+
+	// --- unpowered channel ---
+	test_area.power_equip = FALSE
+	before = test_area.used_equip
+	result = machine.auto_use_power()
+	TEST_ASSERT(!result, "auto_use_power() should return FALSE when the area's EQUIP channel is unpowered")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 0, "unpowered machine must not consume power")
+
+	// Restore floor to its original area before test_area is qdel'd by teardown.
+	original_area.contents.Add(floor)
+
+/// A2: the is_operational *var* must stay identical to the is_operational() proc result on
+/// any machine that does not override the proc, across machine_stat transitions — this is
+/// what makes swapping the proc calls for var reads a no-op.
+/datum/unit_test/machinery_is_operational_invariant/Run()
+	var/obj/machinery/machine = allocate(/obj/machinery)
+	machine.forceMove(run_loc_floor_bottom_left)
+
+	machine.set_machine_stat(0)
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree with no stat flags")
+	TEST_ASSERT(machine.is_operational, "machine with no stat flags should be operational")
+
+	machine.set_machine_stat(NOPOWER)
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree with NOPOWER")
+	TEST_ASSERT(!machine.is_operational, "NOPOWER machine should not be operational")
+
+	machine.set_machine_stat(BROKEN)
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree with BROKEN")
+
+	machine.set_machine_stat(MAINT)
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree with MAINT")
+
+	machine.set_machine_stat(NOPOWER | BROKEN | MAINT)
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree with all flags")
+
+	machine.set_machine_stat(0)
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree after clearing flags")
+	TEST_ASSERT(machine.is_operational, "machine should be operational again after clearing flags")
+
+/// A2: the four machines that DO override is_operational() must keep returning their custom
+/// value (we deliberately do NOT swap their call sites).
+/datum/unit_test/machinery_is_operational_overrides/Run()
+	var/obj/machinery/bloodbankgen/bbg = allocate(/obj/machinery/bloodbankgen)
+	bbg.setAnchored(FALSE)
+	TEST_ASSERT(!bbg.is_operational(), "unanchored bloodbankgen reports not operational")
+
+	var/obj/machinery/ntnet_relay/relay = allocate(/obj/machinery/ntnet_relay)
+	relay.set_machine_stat(0)
+	relay.enabled = FALSE
+	TEST_ASSERT(!relay.is_operational(), "ntnet_relay with !enabled reports not operational even with no stat flags")
+
+/// Counts how many times the miner rebuilds its overlays.
+/obj/machinery/mineral/bluespace_miner/unit_test_icon_counter
+	var/icon_rebuilds = 0
+
+/obj/machinery/mineral/bluespace_miner/unit_test_icon_counter/update_overlays()
+	icon_rebuilds++
+	return ..()
+
+/// A3: with no change to any of the inputs that drive the miner's appearance, repeatedly
+/// asking it to refresh must NOT rebuild the overlays; changing a tracked input must.
+/datum/unit_test/bluespace_miner_icon_throttle/Run()
+	var/obj/machinery/mineral/bluespace_miner/unit_test_icon_counter/miner = allocate(/obj/machinery/mineral/bluespace_miner/unit_test_icon_counter)
+	miner.forceMove(run_loc_floor_bottom_left)
+
+	miner.icon_rebuilds = 0
+	for(var/i in 1 to 10)
+		miner.update_miner_icon_if_changed()
+	TEST_ASSERT(miner.icon_rebuilds <= 1, "miner rebuilt its icon [miner.icon_rebuilds] times across 10 unchanged refreshes (expected ≤1)")
+
+	var/rebuilds_after_steady = miner.icon_rebuilds
+	miner.panel_open = TRUE
+	miner.update_miner_icon_if_changed()
+	TEST_ASSERT_EQUAL(miner.icon_rebuilds, rebuilds_after_steady + 1, "opening the panel must trigger exactly one rebuild")
+
+	miner.update_miner_icon_if_changed()
+	TEST_ASSERT_EQUAL(miner.icon_rebuilds, rebuilds_after_steady + 1, "a second refresh with the panel still open must not rebuild again")
+
+/// B2: an idle conveyor must drop out of SSfastprocess (process() returns PROCESS_KILL),
+/// and a belt that turns back on must re-register itself (exercised here via the auto
+/// variant's update() — the same one-line START_PROCESSING is in conveyor_switch/do_process()).
+/datum/unit_test/conveyor_idle_processing/Run()
+	var/obj/machinery/conveyor/belt = allocate(/obj/machinery/conveyor)
+	belt.forceMove(run_loc_floor_bottom_left)
+	belt.operating = 0
+
+	// An idle conveyor must ask the fast-process subsystem to drop it.
+	TEST_ASSERT_EQUAL(belt.process(2), PROCESS_KILL, "an idle conveyor's process() must return PROCESS_KILL")
+	STOP_PROCESSING(SSfastprocess, belt) // mimic what the subsystem does with that return value
+	TEST_ASSERT(!(belt in SSfastprocess.processing), "the idle belt should now be out of SSfastprocess")
+
+	// An auto conveyor that was evicted must re-register itself when update() turns it back on
+	// (this is the power-restore path: power_change() -> update()).
+	var/obj/machinery/conveyor/auto/auto_belt = allocate(/obj/machinery/conveyor/auto)
+	auto_belt.forceMove(run_loc_floor_bottom_left)
+	auto_belt.set_machine_stat(0) // clear NOPOWER — the test reservation area is unpowered
+	STOP_PROCESSING(SSfastprocess, auto_belt)
+	TEST_ASSERT(!(auto_belt in SSfastprocess.processing), "the auto belt should start out of SSfastprocess for this check")
+	auto_belt.update()
+	TEST_ASSERT_EQUAL(auto_belt.operating, 1, "a powered auto conveyor must turn operating on in update()")
+	TEST_ASSERT(auto_belt.datum_flags & DF_ISPROCESSING, "an operating auto conveyor must be flagged DF_ISPROCESSING")
+	TEST_ASSERT(auto_belt in SSfastprocess.processing, "an operating auto conveyor must (re-)register itself in SSfastprocess via update()")
+	// Stop it so teardown doesn't queue a convey() timer on a soon-to-be-qdel'd belt.
+	STOP_PROCESSING(SSfastprocess, auto_belt)
+	auto_belt.operating = 0
+
+/// Counts how many times the warden re-scans for targets.
+/obj/structure/destructible/clockwork/ocular_warden/unit_test_scan_counter
+	var/scan_count = 0
+
+/obj/structure/destructible/clockwork/ocular_warden/unit_test_scan_counter/acquire_nearby_targets()
+	scan_count++
+	return ..()
+
+/// B1: the warden must re-scan for targets at most once per scan interval, not every tick.
+/datum/unit_test/ocular_warden_scan_throttle/Run()
+	var/obj/structure/destructible/clockwork/ocular_warden/unit_test_scan_counter/warden = allocate(/obj/structure/destructible/clockwork/ocular_warden/unit_test_scan_counter)
+	warden.forceMove(run_loc_floor_bottom_left)
+	warden.setAnchored(TRUE)
+
+	warden.scan_count = 0
+	warden.process()
+	TEST_ASSERT_EQUAL(warden.scan_count, 1, "the first process() (cooldown unset) must scan once")
+	for(var/i in 1 to 5)
+		warden.process()
+	TEST_ASSERT_EQUAL(warden.scan_count, 1, "process() calls inside the scan interval must NOT re-scan")
+
+	warden.scan_count = 0
+	warden.target_scan_cooldown = world.time - 1 // force the cooldown to be finished
+	warden.process()
+	TEST_ASSERT_EQUAL(warden.scan_count, 1, "process() after the cooldown lapses must scan again")
+
+// ---------------------------------------------------------------------------
+// Tier 1 follow-up: air alarm backoff, turret scan throttle, status display gate
+// ---------------------------------------------------------------------------
+
+/// C1: a stable air alarm reads the turf air less often over time (interval ramps to the cap
+/// and saturates), a queued skip short-circuits before the air read, and danger_level changing
+/// snaps it back to reading every fire.
+/datum/unit_test/airalarm_process_backoff/Run()
+	var/obj/machinery/airalarm/alarm = allocate(/obj/machinery/airalarm)
+	alarm.forceMove(run_loc_floor_bottom_left)
+	alarm.set_machine_stat(0) // clear NOPOWER — the test reservation is unpowered
+
+	TEST_ASSERT_EQUAL(alarm.process_interval, 1, "a fresh air alarm processes every fire")
+	TEST_ASSERT_EQUAL(alarm.process_skips_left, 0, "...with nothing queued to skip")
+
+	// Steady state: the per-fire interval ramps up to the cap and stays there. Each iteration
+	// first burns any queued skips so we always observe the result of a real air read.
+	for(var/i in 1 to 2 * AALARM_MAX_PROCESS_INTERVAL + 4)
+		while(alarm.process_skips_left > 0)
+			alarm.process()
+		var/interval_before = alarm.process_interval
+		alarm.process()
+		TEST_ASSERT(alarm.process_interval >= interval_before, "process_interval must not shrink while danger_level is stable (was [interval_before], now [alarm.process_interval])")
+		TEST_ASSERT(alarm.process_interval <= AALARM_MAX_PROCESS_INTERVAL, "process_interval ([alarm.process_interval]) must never exceed AALARM_MAX_PROCESS_INTERVAL ([AALARM_MAX_PROCESS_INTERVAL])")
+		TEST_ASSERT_EQUAL(alarm.process_skips_left, alarm.process_interval - 1, "after a real read the alarm queues (interval - 1) skipped fires")
+	TEST_ASSERT_EQUAL(alarm.process_interval, AALARM_MAX_PROCESS_INTERVAL, "process_interval must saturate at the cap in steady state")
+
+	// A queued skip must not touch the air: a real read can never produce this danger_level.
+	alarm.process_skips_left = AALARM_MAX_PROCESS_INTERVAL
+	var/sentinel = 1234
+	alarm.danger_level = sentinel
+	var/queued = alarm.process_skips_left
+	alarm.process()
+	TEST_ASSERT_EQUAL(alarm.danger_level, sentinel, "an air alarm with skips queued must not read the air")
+	TEST_ASSERT_EQUAL(alarm.process_skips_left, queued - 1, "a skipped fire decrements the skip counter")
+	while(alarm.process_skips_left > 0)
+		alarm.process()
+	TEST_ASSERT_EQUAL(alarm.danger_level, sentinel, "danger_level stays untouched while skips remain")
+	alarm.process()
+	TEST_ASSERT_NOTEQUAL(alarm.danger_level, sentinel, "with no skips queued the alarm reads the air and recomputes danger_level")
+
+	// danger_level changing snaps the alarm back to processing every fire. Rig a TLV so the
+	// next read produces a different level than the current one (no_checks → 0; an impossibly
+	// high lower pressure bound → danger 2 for any real pressure), then read.
+	alarm.process_interval = AALARM_MAX_PROCESS_INTERVAL
+	alarm.process_skips_left = 0
+	var/level_before = alarm.danger_level
+	if(level_before == 2)
+		for(var/tlv_key in alarm.TLV)
+			alarm.TLV[tlv_key] = new /datum/tlv/no_checks
+	else
+		alarm.TLV["pressure"] = new /datum/tlv(INFINITY, INFINITY, -1, -1)
+	alarm.process()
+	TEST_ASSERT_NOTEQUAL(alarm.danger_level, level_before, "the rigged TLV must change danger_level on the next read (was [level_before])")
+	TEST_ASSERT_EQUAL(alarm.process_interval, 1, "danger_level changing resets the alarm to every-fire processing")
+	TEST_ASSERT_EQUAL(alarm.process_skips_left, 0, "...with no skips queued")
+
+/// Counts how many times a turret re-scans its surroundings for targets.
+/obj/machinery/porta_turret/unit_test_scan_counter
+	var/scan_count = 0
+
+/obj/machinery/porta_turret/unit_test_scan_counter/scan_for_targets()
+	scan_count++
+	return ..()
+
+/// C2: a powered-on turret re-scans (view()/mechs/blobs) at most once per scan interval, not
+/// every fire — between scans process() reuses the cached target list.
+/datum/unit_test/turret_scan_throttle/Run()
+	var/obj/machinery/porta_turret/unit_test_scan_counter/turret = allocate(/obj/machinery/porta_turret/unit_test_scan_counter)
+	turret.forceMove(run_loc_floor_bottom_left)
+	turret.set_machine_stat(0) // clear NOPOWER — the test reservation is unpowered
+	turret.on = TRUE
+
+	turret.scan_count = 0
+	turret.process()
+	TEST_ASSERT_EQUAL(turret.scan_count, 1, "the first process() (cooldown unset) must scan once")
+	for(var/i in 1 to 5)
+		turret.process()
+	TEST_ASSERT_EQUAL(turret.scan_count, 1, "process() calls inside the scan interval must reuse the cache, not re-scan")
+
+	turret.scan_count = 0
+	turret.target_scan_cooldown = world.time - 1 // force the cooldown to be finished
+	turret.process()
+	TEST_ASSERT_EQUAL(turret.scan_count, 1, "process() after the scan cooldown lapses must scan again")
+
+/// Counts how many times a status display rebuilds its appearance/overlays.
+/obj/machinery/status_display/unit_test_appearance_counter
+	var/appearance_updates = 0
+
+/obj/machinery/status_display/unit_test_appearance_counter/update_appearance(updates=ALL)
+	appearance_updates++
+	return ..()
+
+/// C3: set_timer_messages() — the per-tick shuttle/supply/evac path — pushes to set_messages()
+/// (and thus rebuilds the appearance) only when the (current_mode, line1, line2) differs from
+/// what it last pushed; repeated identical pushes (the idle evac-display path) are no-ops, a
+/// changed line or a mode change forces exactly one rebuild. set_messages() itself stays
+/// unconditional, so direct callers (receive_signal, set_picture, …) always rebuild.
+/datum/unit_test/status_display_timer_gate/Run()
+	var/obj/machinery/status_display/unit_test_appearance_counter/display = allocate(/obj/machinery/status_display/unit_test_appearance_counter)
+	display.forceMove(run_loc_floor_bottom_left)
+	display.set_machine_stat(0) // clear NOPOWER — the test reservation is unpowered
+	display.current_mode = SD_MESSAGE
+
+	display.appearance_updates = 0
+	display.set_timer_messages("-CALL-", "5:00")
+	TEST_ASSERT_EQUAL(display.appearance_updates, 1, "the first set_timer_messages() push must rebuild the appearance once")
+	TEST_ASSERT_EQUAL(display.message1, "-CALL-", "set_timer_messages() must push the lines through set_messages()")
+
+	for(var/i in 1 to 10)
+		display.set_timer_messages("-CALL-", "5:00")
+	TEST_ASSERT_EQUAL(display.appearance_updates, 1, "set_timer_messages() with an unchanged (mode, line1, line2) must not rebuild the appearance")
+
+	display.set_timer_messages("-CALL-", "4:59")
+	TEST_ASSERT_EQUAL(display.appearance_updates, 2, "a changed line must rebuild the appearance exactly once")
+
+	display.current_mode = SD_EMERGENCY
+	display.set_timer_messages("-CALL-", "4:59")
+	TEST_ASSERT_EQUAL(display.appearance_updates, 3, "a current_mode change must rebuild even if the lines are unchanged (overlays depend on the mode)")
+
+	// The idle path: blank, then "still blank" every fire.
+	display.set_timer_messages("", "")
+	var/after_blank = display.appearance_updates
+	for(var/i in 1 to 10)
+		display.set_timer_messages("", "")
+	TEST_ASSERT_EQUAL(display.appearance_updates, after_blank, "repeated blank set_timer_messages() (the idle evac-display path) must not rebuild the appearance")
+
+	// set_messages() stays unconditional — this is what keeps the receive_signal()/set_picture()
+	// mode-transition rebuilds working independently of the timer-push cache.
+	var/before_direct = display.appearance_updates
+	display.set_messages("", "") // identical to what set_timer_messages last pushed, but a direct call
+	TEST_ASSERT_EQUAL(display.appearance_updates, before_direct + 1, "a direct set_messages() call must always rebuild, even when the content is unchanged")
+
+/// Counts how many times an atmos gas miner rebuilds its icon overlays.
+/obj/machinery/atmospherics/miner/unit_test_icon_counter
+	var/icon_rebuilds = 0
+
+/obj/machinery/atmospherics/miner/unit_test_icon_counter/update_icon()
+	icon_rebuilds++
+	return ..()
+
+/// C4 (A3-pattern): set_broken() is called every process_atmos() tick by check_operation()
+/// while the miner is in a broken condition — it must only rebuild the icon on an actual
+/// broken-state transition, not on every call.
+/datum/unit_test/gas_miner_icon_throttle/Run()
+	var/obj/machinery/atmospherics/miner/unit_test_icon_counter/miner = allocate(/obj/machinery/atmospherics/miner/unit_test_icon_counter)
+	miner.forceMove(run_loc_floor_bottom_left)
+
+	miner.icon_rebuilds = 0
+	for(var/i in 1 to 10)
+		miner.set_broken(TRUE)
+	TEST_ASSERT_EQUAL(miner.icon_rebuilds, 1, "set_broken(TRUE) x10 must rebuild the icon exactly once (the FALSE->TRUE transition), not every call")
+	TEST_ASSERT(miner.broken, "the miner must be flagged broken after set_broken(TRUE)")
+
+	miner.set_broken(FALSE)
+	TEST_ASSERT_EQUAL(miner.icon_rebuilds, 2, "clearing the broken flag must rebuild the icon exactly once")
+	TEST_ASSERT(!miner.broken, "the miner must be un-broken after set_broken(FALSE)")
+	for(var/i in 1 to 10)
+		miner.set_broken(FALSE)
+	TEST_ASSERT_EQUAL(miner.icon_rebuilds, 2, "set_broken(FALSE) on an already-unbroken miner must not rebuild the icon")
+
+	miner.set_broken(TRUE)
+	TEST_ASSERT_EQUAL(miner.icon_rebuilds, 3, "re-breaking the miner must rebuild the icon exactly once")
+
+/// C5 (A1-pattern): vent_scrubber/auto_use_power() must charge its area exactly the same
+/// amount as the old powered()+use_power() (= two get_area()s) version did, across the
+/// scrubbing/siphoning/widenet modes, and return FALSE (charging nothing) when off / welded /
+/// not operational / the area's channel is unpowered.
+/datum/unit_test/vent_scrubber_auto_use_power/Run()
+	var/turf/floor = run_loc_floor_bottom_left
+	// Same trick as machinery_auto_use_power: the reservation z lives in /area/space, which
+	// overrides powered() to FALSE. Move the floor into a synthetic plain /area for the test.
+	var/area/original_area = get_area(floor)
+	var/area/test_area = new /area
+	allocated += test_area
+	test_area.contents.Add(floor) // reassigns floor.loc → test_area
+
+	var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber = allocate(/obj/machinery/atmospherics/components/unary/vent_scrubber)
+	scrubber.forceMove(floor)
+	scrubber.set_machine_stat(0) // clear NOPOWER → is_operational TRUE
+	scrubber.power_channel = EQUIP // so we can poke test_area.power_equip / used_equip
+	scrubber.on = TRUE
+	scrubber.welded = FALSE
+	scrubber.filter_types = list()
+	scrubber.widenet = FALSE
+
+	// scrubbing-mode values: vent_scrubber.dm #define's SCRUBBING = 1 / SIPHONING = 0 file-local
+	// (and #undef's them), so use the literals here.
+
+	// --- idle scrubbing: idle_power_usage ---
+	scrubber.scrubbing = 1 // SCRUBBING
+	test_area.clear_usage()
+	var/before = test_area.used_equip
+	var/result = scrubber.auto_use_power()
+	TEST_ASSERT(result, "auto_use_power() returns TRUE when on / powered / operational")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, scrubber.idle_power_usage, "idle scrubbing must draw idle_power_usage from the area")
+
+	// --- siphoning: active_power_usage ---
+	scrubber.scrubbing = 0 // SIPHONING
+	before = test_area.used_equip
+	scrubber.auto_use_power()
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, scrubber.active_power_usage, "siphoning must draw active_power_usage from the area")
+
+	// --- widenet over 2 turfs: amount += amount * (2 * (2/2)) = amount * 2 → triples ---
+	scrubber.scrubbing = 1 // SCRUBBING
+	scrubber.widenet = TRUE
+	scrubber.adjacent_turfs = list(floor, floor) // only .len matters here
+	before = test_area.used_equip
+	scrubber.auto_use_power()
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, scrubber.idle_power_usage * 3, "widenet scrubbing over 2 adjacent turfs must triple the draw")
+	scrubber.widenet = FALSE
+	scrubber.adjacent_turfs = list()
+	scrubber.scrubbing = 1 // SCRUBBING
+
+	// --- welded / off / not operational / unpowered channel: FALSE, charges nothing ---
+	scrubber.welded = TRUE
+	before = test_area.used_equip
+	result = scrubber.auto_use_power()
+	TEST_ASSERT(!result, "a welded scrubber's auto_use_power() returns FALSE")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 0, "a welded scrubber draws no power")
+	scrubber.welded = FALSE
+
+	scrubber.on = FALSE
+	before = test_area.used_equip
+	result = scrubber.auto_use_power()
+	TEST_ASSERT(!result, "an off scrubber's auto_use_power() returns FALSE")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 0, "an off scrubber draws no power")
+	scrubber.on = TRUE
+
+	scrubber.set_machine_stat(NOPOWER) // is_operational → FALSE
+	before = test_area.used_equip
+	result = scrubber.auto_use_power()
+	TEST_ASSERT(!result, "a non-operational scrubber's auto_use_power() returns FALSE")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 0, "a non-operational scrubber draws no power")
+	scrubber.set_machine_stat(0)
+
+	test_area.power_equip = FALSE
+	before = test_area.used_equip
+	result = scrubber.auto_use_power()
+	TEST_ASSERT(!result, "auto_use_power() returns FALSE when the area's channel is unpowered")
+	TEST_ASSERT_EQUAL(test_area.used_equip - before, 0, "an unpowered scrubber draws no power")
+
+	original_area.contents.Add(floor) // restore the floor before test_area is qdel'd by teardown

--- a/code/modules/unit_tests/machinery_optimization.dm
+++ b/code/modules/unit_tests/machinery_optimization.dm
@@ -72,10 +72,15 @@
 	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree with all flags")
 
 	machine.set_machine_stat(0)
+	machine.obj_break()
+	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree after obj_break")
+	TEST_ASSERT(!machine.is_operational, "obj_break should make the machine not operational")
+
+	machine.set_machine_stat(0)
 	TEST_ASSERT_EQUAL(machine.is_operational, machine.is_operational(), "var/proc must agree after clearing flags")
 	TEST_ASSERT(machine.is_operational, "machine should be operational again after clearing flags")
 
-/// A2: the four machines that DO override is_operational() must keep returning their custom
+/// A2: the three machines that DO override is_operational() must keep returning their custom
 /// value (we deliberately do NOT swap their call sites).
 /datum/unit_test/machinery_is_operational_overrides/Run()
 	var/obj/machinery/bloodbankgen/bbg = allocate(/obj/machinery/bloodbankgen)
@@ -86,6 +91,10 @@
 	relay.set_machine_stat(0)
 	relay.enabled = FALSE
 	TEST_ASSERT(!relay.is_operational(), "ntnet_relay with !enabled reports not operational even with no stat flags")
+
+	var/obj/machinery/computer/camera_advanced/shuttle_creator/shuttle_creator = allocate(/obj/machinery/computer/camera_advanced/shuttle_creator)
+	shuttle_creator.set_machine_stat(BROKEN | NOPOWER | MAINT)
+	TEST_ASSERT(shuttle_creator.is_operational(), "shuttle_creator reports operational even with stat flags")
 
 /// Counts how many times the miner rebuilds its overlays.
 /obj/machinery/mineral/bluespace_miner/unit_test_icon_counter

--- a/modular_sand/code/modules/mining/machine_bluespaceminer/machine_bluespaceminer.dm
+++ b/modular_sand/code/modules/mining/machine_bluespaceminer/machine_bluespaceminer.dm
@@ -87,6 +87,13 @@ GLOBAL_VAR_INIT(bsminers_lock, FALSE)
 
 	COOLDOWN_DECLARE(instability_cooldown)
 	var/bsm_rainbow_until = 0
+	/// Cached snapshot of the inputs that drive our appearance, so process() doesn't
+	/// rebuild the icon every tick. -1 means "never computed".
+	var/last_icon_operational = -1
+	var/last_icon_instability = -1
+	var/last_icon_panel_open = -1
+	var/last_icon_has_core = -1
+	var/last_icon_rainbow = -1
 	/// `REALTIMEOFDAY` последнего оповещения по порогу 50% / 10%; сброс в 0 при целостности выше порога (как `lastwarning` у СМ).
 	var/last_core_radio_warning_50 = 0
 	var/last_core_radio_warning_10 = 0
@@ -244,6 +251,25 @@ GLOBAL_VAR_INIT(bsminers_lock, FALSE)
 			prism.blend_mode = BLEND_ADD
 			. += prism
 
+/// Rebuilds the miner's icon only when one of the inputs that affects its appearance changed.
+/obj/machinery/mineral/bluespace_miner/proc/update_miner_icon_if_changed()
+	var/operational = is_operational()
+	var/instability = get_instability_level()
+	var/has_core = bs_core ? TRUE : FALSE
+	var/rainbow = (world.time < bsm_rainbow_until) ? TRUE : FALSE
+	if(operational == last_icon_operational \
+		&& instability == last_icon_instability \
+		&& panel_open == last_icon_panel_open \
+		&& has_core == last_icon_has_core \
+		&& rainbow == last_icon_rainbow)
+		return
+	last_icon_operational = operational
+	last_icon_instability = instability
+	last_icon_panel_open = panel_open
+	last_icon_has_core = has_core
+	last_icon_rainbow = rainbow
+	MINER_UPDATE_ICON
+
 /obj/machinery/mineral/bluespace_miner/attackby(obj/item/I, mob/living/user, params)
 	if(bs_core || !istype(I, ANOMALY_CORE_BLUESPACE))
 		return ..()
@@ -260,7 +286,7 @@ GLOBAL_VAR_INIT(bsminers_lock, FALSE)
 		CORE_INSERT_REG_SIGNAL
 
 /obj/machinery/mineral/bluespace_miner/process(delta_time)
-	MINER_UPDATE_ICON
+	update_miner_icon_if_changed()
 	core_damage_updt(delta_time)
 	var/operational = is_operational()
 	zlevel_reg(!operational)


### PR DESCRIPTION
# Описание
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

Немного оптимизации машинерии. Идея простая: убрать лишнюю работу на путях, которые крутятся каждый тик у сотен объектов сразу.

Что поменялось:

- `auto_use_power()` теперь резолвит `get_area()` один раз и дёргает `powered()`/`use_power()` прямо у зоны, а не через атомные обёртки (а те внутри ещё пару раз `get_area()` зовут). Заодно поменял голые `1`/`2` на дефайны `IDLE_POWER_USE`/`ACTIVE_POWER_USE`. То же самое сделал для vent_scrubber.
- `is_operational` теперь кешируется и читается как переменная, а не пересчитывается через одноимённый прок каждый тик. Это компьютеры, венты, скрубберы, помпы, фильтры, миксеры, крио, газовый майнер, портативные помпа/скруббер.
- Раз уж завёл кеш `is_operational`, пришлось навести порядок с обновлением статуса машин: куча мест по коду меняли `machine_stat` напрямую через `|= BROKEN` и т.п. в обход `set_machine_stat()`, из-за чего кеш мог протухнуть. Теперь всё это идёт через `set_machine_stat()`, `on_stat_update()` упрощён, а начальное значение `is_operational` выставляется в `Initialize()`.
- Воздушная тревога перестаёт читать воздух турфа каждый fire, пока danger_level не меняется. Сидит на максимальном интервале, и как только уровень опасности скакнул, сразу возвращается к частым проверкам.
- Турели и окулярный страж пересканируют view()/viewers() на цели не каждый тик, а с интервалом, между сканами берут кешированный список (удалённое из него выкидывается). Стрелять не перестают, просто нового нарушителя заметят чуть позже.
- Статус-дисплеи (шаттл/снабжение/эвакуация) не перестраивают иконку, если текст не поменялся.
- Выключенные и обесточенные конвейеры возвращают `PROCESS_KILL` вместо вечного процессинга, и заново регистрируются в SSfastprocess когда их включают.
- Блюспейс-майнер обновляет иконку только когда поменялось что-то, что реально влияет на внешний вид.
- Попутно два бага: консоль алертов станции получала в `on_stat_update()` устаревшее значение `machine_stat`; газовый майнер дёргал `set_broken()` с перестройкой иконки даже когда значение не менялось.
- Добавил юнит-тесты на всё это (`code/modules/unit_tests/machinery_optimization.dm`).

## Причина изменений

Машинерии на станции дофига, и любая мелочь умножается на сотни объектов и тики. Меньше лишних `get_area()`, проков и перерисовок иконок = меньше нагрузки на MC, тики ровнее. Для игроков ничего не меняется (ну кроме того, что турель может среагировать на полсекунды позже, не критично).

Прогнал микробенчмарки (старый путь vs новый в одном заходе), вот что вышло:

| Что | До | После | Профит |
|---|---|---|---|
| `auto_use_power()`, один `get_area()` | 4.56 дс | 2.81 дс | x1.6 |
| `is_operational()` прок -> переменная | 1.5 дс | 0.44 дс | x3.4 |
| Воздушная тревога, backoff чтения атмосферы | 13.8 дс | 7.25 дс | x1.9 |
| Турель, троттлинг скана view() | 3.56 дс | 0.25 дс | x14 |
| Статус-дисплей, gate перерисовки | 6.25 дс | 0.25 дс | x25 |
| Газовый майнер, guard на `set_broken()` | 3.44 дс | 0.13 дс | x28 |
| `vent_scrubber.auto_use_power()` | 6.19 дс | 4.38 дс | x1.4 |

Плюс простаивающие конвейеры вообще убраны из горячего цикла SSfastprocess.

`node tools/build/build.js dm-test` гонял несколько раз, тесты зелёные, в рантайме чисто, регрессий не нашёл.

## Changelog

:cl:
code: оптимизированы горячие пути машинерии, меньше лишних get_area(), вызовов is_operational() и перерисовок иконок каждый тик
fix: машины корректно обновляют кеш состояния (is_operational) при поломке и смене питания
fix: консоль алертов станции больше не получает устаревшее значение machine_stat при обновлении статуса
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения производительности**
  * Кэширование и ограничение частоты сканирования для турелей и NPC‑сидов, адаптивный бэкоф для сигналов тревоги, реже перерисовки и обновления индикаторов.
* **Исправления ошибок**
  * Более надежная обработка питания и состояний устройств (исправлены некорректные переходы при поломках/питании).
* **Новые возможности**
  * Добавлена настройка интервала сканирования для переносных турелей.
* **Tests**
  * Расширены модульные тесты, покрывающие оптимизации и корректность состояний.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->