### PR TITLE
Перф: кэши для getFlatIcon (icon_states + directional-проба) и result-кэш для icon2html/get_icon_dmi_path

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -720,6 +720,56 @@ GLOBAL_LIST_EMPTY(readrgb_cache)
 		((hi3 >= 65 ? hi3-55 : hi3-48)<<4) | (lo3 >= 65 ? lo3-55 : lo3-48),
 		((hi4 >= 65 ? hi4-55 : hi4-48)<<4) | (lo4 >= 65 ? lo4-55 : lo4-48))
 
+/// Memoised cache of `icon_states(icon_file, mode)` results, keyed by "[icon file]|[mode]".
+/// DMI files do not change at runtime, so this never needs invalidation. In practice it is
+/// bounded by the number of distinct compile-time DMIs, but it is soft-capped anyway.
+/// IMPORTANT: callers MUST NOT mutate the returned list — treat it as read-only.
+GLOBAL_LIST_EMPTY(cached_icon_states_by_file)
+/// Soft cap on cached_icon_states_by_file entries (each value is a list of state names).
+#define ICON_STATES_FILE_CACHE_MAX 4096
+
+/// `icon_states()` but memoised for icon *files*. Runtime `/icon` datums have
+/// unstable refs (GC reuse) so those fall through to an uncached lookup.
+/proc/cached_icon_states(icon_file, mode = 0)
+	if(!icon_file || istype(icon_file, /icon))
+		return icon_states(icon_file, mode)
+	var/key = "[icon_file]|[mode]"
+	. = GLOB.cached_icon_states_by_file[key]
+	if(isnull(.))
+		. = icon_states(icon_file, mode)
+		GLOB.cached_icon_states_by_file[key] = .
+		if(length(GLOB.cached_icon_states_by_file) > ICON_STATES_FILE_CACHE_MAX)
+			GLOB.cached_icon_states_by_file.Cut(1, (ICON_STATES_FILE_CACHE_MAX / 4) + 1) // evict oldest 25%
+
+/// Memoised cache: does `(icon file, icon_state)` have N/E/W frames? Used by getFlatIcon
+/// to decide whether an atom is single-directional. Pure function of immutable DMI data,
+/// but soft-capped so a long-running round can't accumulate one entry per (DMI, state) seen.
+GLOBAL_LIST_EMPTY(cached_icon_state_directional)
+/// Soft cap on cached_icon_state_directional entries (each value is a single boolean).
+#define ICON_STATE_DIRECTIONAL_CACHE_MAX 8192
+
+/// Returns TRUE if the given icon_state in the given icon has any of NORTH/EAST/WEST frames.
+/proc/icon_state_has_directional_frames(icon_file, icon_state)
+	var/static/list/checkdirs = list(NORTH, EAST, WEST)
+	if(!icon_file)
+		return FALSE
+	if(istype(icon_file, /icon)) // runtime /icon datums: unstable refs, compute every time
+		for(var/checkdir in checkdirs)
+			if(length(icon_states(icon(icon_file, icon_state, checkdir))))
+				return TRUE
+		return FALSE
+	var/key = "[icon_file]|[icon_state]"
+	if(key in GLOB.cached_icon_state_directional)
+		return GLOB.cached_icon_state_directional[key]
+	. = FALSE
+	for(var/checkdir in checkdirs)
+		if(length(icon_states(icon(icon_file, icon_state, checkdir))))
+			. = TRUE
+			break
+	GLOB.cached_icon_state_directional[key] = .
+	if(length(GLOB.cached_icon_state_directional) > ICON_STATE_DIRECTIONAL_CACHE_MAX)
+		GLOB.cached_icon_state_directional.Cut(1, (ICON_STATE_DIRECTIONAL_CACHE_MAX / 4) + 1) // evict oldest 25%
+
 // Creates a single icon from a given /atom or /image.  Only the first argument is required.
 /proc/getFlatIcon(image/A, defdir, deficon, defstate, defblend, start = TRUE, no_anim = FALSE)
 	//Define... defines.
@@ -772,7 +822,7 @@ GLOBAL_LIST_EMPTY(readrgb_cache)
 	var/curstate = A.icon_state || defstate
 
 	if(!((noIcon = (!curicon))))
-		var/curstates = icon_states(curicon)
+		var/list/curstates = cached_icon_states(curicon)
 		if(!(curstate in curstates))
 			if("" in curstates)
 				curstate = ""
@@ -788,17 +838,10 @@ GLOBAL_LIST_EMPTY(readrgb_cache)
 	else
 		curdir = A.dir
 
-	//Try to remove/optimize this section ASAP, CPU hog.
-	//Determines if there's directionals.
-	if(!noIcon && curdir != SOUTH)
-		var/exist = FALSE
-		var/static/list/checkdirs = list(NORTH, EAST, WEST)
-		for(var/i in checkdirs)		//Not using GLOB for a reason.
-			if(length(icon_states(icon(curicon, curstate, i))))
-				exist = TRUE
-				break
-		if(!exist)
-			base_icon_dir = SOUTH
+	//Determines if there's directionals. Result is memoised per (icon file, icon_state)
+	//since it is a pure function of immutable DMI data — this used to be a documented CPU hog.
+	if(!noIcon && curdir != SOUTH && !icon_state_has_directional_frames(curicon, curstate))
+		base_icon_dir = SOUTH
 	//
 
 	if(!base_icon_dir)
@@ -1177,17 +1220,34 @@ GLOBAL_VAR(dummy_save_path)
 		return FALSE
 	return findtextEx(icon_path, "icons/") && copytext(icon_path, -4) == ".dmi"
 
+/// Memoised cache for /proc/get_icon_dmi_path, keyed by "[resolved icon file]". Only populated
+/// for file-backed icons and text paths (both immutable / stable identities); runtime /icon
+/// datums are NOT cached because they all stringify to "/icon" and would collide. An empty
+/// string is stored as the "no valid dmi path" sentinel so negatives are cached too.
+GLOBAL_LIST_EMPTY(icon_dmi_path_cache)
+/// Soft cap on icon_dmi_path_cache (bounded by distinct DMIs in practice; capped defensively).
+#define ICON_DMI_PATH_CACHE_MAX 4096
+
 /// Given an icon object, dmi file path, atom, image, or mutable_appearance,
 /// attempts to find an associated dmi file path (e.g. "icons/path/to/file.dmi").
 /// /icon objects represent both compile-time icons in the rsc and dynamic ones generated at runtime.
 /// Stringifying an rsc reference returns the dmi path ONLY if the icon is an unchanged compile-time dmi.
 /// Returns the path string on success, null otherwise.
 /proc/get_icon_dmi_path(icon/icon)
-	var/icon_path = null
-
 	if(isatom(icon) || istype(icon, /image) || istype(icon, /mutable_appearance))
 		var/atom/atom_icon = icon
 		icon = atom_icon.icon
+
+	// Resolve from cache for the stable-identity cases. Runtime /icon datums ("[icon]" == "/icon")
+	// are intentionally excluded — their stringification collides across all of them.
+	var/cache_key
+	if((isicon(icon) && isfile(icon)) || istext(icon))
+		cache_key = "[icon]"
+		var/cached = GLOB.icon_dmi_path_cache[cache_key]
+		if(!isnull(cached))
+			return (cached == "") ? null : cached
+
+	var/icon_path = null
 
 	if(isicon(icon) && isfile(icon))
 		// Compile-time dmi icons pass both isicon() and isfile().
@@ -1209,8 +1269,16 @@ GLOBAL_VAR(dummy_save_path)
 		icon_path = "[locate(rsc_ref_ref)]"
 
 	if(is_valid_dmi_file(icon_path))
+		if(cache_key)
+			GLOB.icon_dmi_path_cache[cache_key] = icon_path
+			if(length(GLOB.icon_dmi_path_cache) > ICON_DMI_PATH_CACHE_MAX)
+				GLOB.icon_dmi_path_cache.Cut(1, (ICON_DMI_PATH_CACHE_MAX / 4) + 1)
 		return icon_path
 
+	if(cache_key)
+		GLOB.icon_dmi_path_cache[cache_key] = "" // negative cache
+		if(length(GLOB.icon_dmi_path_cache) > ICON_DMI_PATH_CACHE_MAX)
+			GLOB.icon_dmi_path_cache.Cut(1, (ICON_DMI_PATH_CACHE_MAX / 4) + 1)
 	return null
 
 /**
@@ -1286,6 +1354,16 @@ GLOBAL_VAR(dummy_save_path)
  * * moving - whether to use a moving state for the given icon.
  * * sourceonly - if TRUE, only generate the asset and return its url instead of an <img> tag.
  */
+/// Bounded result cache for /proc/icon2html. Maps a stable input signature
+/// ("[icon file]|[icon_state]|[dir]|[frame]|[moving]") to list(asset_name, html, url),
+/// letting repeat calls skip the whole get_icon_dmi_path / fcopy_rsc / md5 / icon()
+/// pipeline — only the (cheap) per-target send_assets still runs. Not used for runtime
+/// /icon datums (unstable GC-reused refs), raw files, or humans (the Insert() workaround
+/// path mutates the icon and forces the slow hash anyway).
+GLOBAL_LIST_EMPTY(icon2html_result_cache)
+/// Soft cap on icon2html_result_cache entries. Each entry is three short strings.
+#define ICON2HTML_RESULT_CACHE_MAX 2048
+
 /proc/icon2html(atom/thing, client/target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE)
 	if (!thing)
 		return
@@ -1304,6 +1382,35 @@ GLOBAL_VAR(dummy_save_path)
 		return
 
 	var/icon/icon2collapse = thing
+
+	// --- Result-cache fast path -----------------------------------------------
+	// icon2html renders ONLY thing's base icon/icon_state (overlays are not flattened),
+	// so the resulting asset is a pure function of (icon file, icon_state, dir, frame,
+	// moving). Cache that mapping and short-circuit before any of the expensive work.
+	// Humans are cacheable too — the ishuman path below just Insert()s the same base
+	// icon/state and forces dir = SOUTH, so its output is still that pure function.
+	var/cache_key
+	if (!isicon(thing) && !isfile(thing))
+		var/atom/cache_atom = thing
+		var/atom_icon = cache_atom.icon
+		if (atom_icon && !istype(atom_icon, /icon))
+			var/resolved_state = icon_state
+			if (isnull(resolved_state))
+				resolved_state = cache_atom.icon_state
+				if (!(resolved_state in cached_icon_states(atom_icon, 1)))
+					resolved_state = "[initial(cache_atom.icon_state)]"
+			// ishuman forces dir = SOUTH for rendering, so fold that into the key.
+			var/resolved_dir = ishuman(thing) ? SOUTH : (isnull(dir) ? cache_atom.dir : dir)
+			cache_key = "[atom_icon]|[resolved_state]|[resolved_dir]|[frame]|[moving]"
+			var/list/cache_hit = GLOB.icon2html_result_cache[cache_key]
+			if (cache_hit)
+				if (SSassets.cache[cache_hit[1]])
+					for (var/client_target in targets)
+						SSassets.transport.send_assets(client_target, cache_hit[1])
+					return sourceonly ? cache_hit[3] : cache_hit[2]
+				// Asset was evicted from SSassets — drop the stale entry and regenerate.
+				GLOB.icon2html_result_cache -= cache_key
+	// --------------------------------------------------------------------------
 
 	// If the source icon resolves to an unchanged compile-time dmi we can later use the
 	// cheap md5(rsc_ref) hash path inside asset_cache_item instead of md5asfile().
@@ -1364,9 +1471,17 @@ GLOBAL_VAR(dummy_save_path)
 	for (var/client_target in targets)
 		SSassets.transport.send_assets(client_target, key)
 
+	var/asset_url = SSassets.transport.get_asset_url(key)
+	var/result_html = "<img class='icon icon-[icon_state]' src='[asset_url]'>"
+
+	if(cache_key)
+		GLOB.icon2html_result_cache[cache_key] = list(key, result_html, asset_url)
+		if(length(GLOB.icon2html_result_cache) > ICON2HTML_RESULT_CACHE_MAX)
+			GLOB.icon2html_result_cache.Cut(1, (ICON2HTML_RESULT_CACHE_MAX / 4) + 1) // Evict oldest 25%
+
 	if(sourceonly)
-		return SSassets.transport.get_asset_url(key)
-	return "<img class='icon icon-[icon_state]' src='[SSassets.transport.get_asset_url(key)]'>"
+		return asset_url
+	return result_html
 
 /// Bounded cache for /proc/icon2base64html — was unbounded var/static, accreted
 /// every distinct (icon, icon_state) pair seen this round. Trim 25% over cap.

--- a/code/modules/unit_tests/perf_optimizations.dm
+++ b/code/modules/unit_tests/perf_optimizations.dm
@@ -335,3 +335,194 @@
 	TEST_ASSERT_EQUAL(length(P.members), BUILD_PIPELINE_PERF_N, "All [BUILD_PIPELINE_PERF_N] pipes must be collected (got [length(P.members)])")
 	TEST_ASSERT(elapsed_ds < 5, "build_pipeline on [BUILD_PIPELINE_PERF_N]-pipe chain must run in linear time (took [elapsed_ds] ds)")
 #undef BUILD_PIPELINE_PERF_N
+
+
+// ===== Fix F: getFlatIcon directional-check + icon_states memoisation =====
+//
+// Profile snapshot: /proc/getFlatIcon — 2005 calls / 10.5s total CPU / 3.9s overtime,
+// a top tick-overtime contributor. Two pure-but-uncached lookups ran on *every* call:
+//   1. icon_states(curicon)                        — rebuilds the state list each time
+//   2. a 3-way directional probe that constructed three throwaway /icon objects plus
+//      three icon_states() calls just to pick base_icon_dir (the proc itself flagged
+//      this block as a "CPU hog").
+// Both depend only on immutable DMI data, so they are now memoised behind
+// /proc/cached_icon_states and /proc/icon_state_has_directional_frames.
+//
+// Tests:
+//   * flat_icon_state_caches — cached_icon_states / icon_state_has_directional_frames
+//     return results consistent with the raw built-ins, memoise icon *files*, and
+//     decline to cache unstable runtime /icon datums.
+//   * flat_icon_smoke — getFlatIcon still yields a valid icon in every cardinal dir
+//     (exercising the cached directional path), both cold and warm.
+
+/datum/unit_test/flat_icon_state_caches/Run()
+	var/test_icon = 'icons/effects/effects.dmi'
+	var/test_icon_key = "[test_icon]"
+
+	// cached_icon_states must mirror icon_states()...
+	var/list/raw_states = icon_states(test_icon)
+	TEST_ASSERT(length(raw_states) > 0, "test fixture icon must expose at least one icon_state")
+	var/list/cached_first = cached_icon_states(test_icon)
+	TEST_ASSERT_EQUAL(length(cached_first), length(raw_states), "cached_icon_states returned a different number of states than icon_states")
+	for(var/state in raw_states)
+		TEST_ASSERT(state in cached_first, "cached_icon_states is missing state '[state]'")
+
+	// ...and a repeat call must hand back the exact same (memoised) list.
+	var/list/cached_second = cached_icon_states(test_icon)
+	TEST_ASSERT(cached_first == cached_second, "cached_icon_states must return the memoised list on repeat calls")
+	TEST_ASSERT(GLOB.cached_icon_states_by_file["[test_icon_key]|0"] == cached_first, "GLOB.cached_icon_states_by_file must hold the returned list")
+
+	// Runtime /icon datums have unstable refs — must not be cached, but must still work.
+	var/icon/runtime_icon = icon(test_icon)
+	var/list/runtime_states = cached_icon_states(runtime_icon)
+	TEST_ASSERT_NOTNULL(runtime_states, "cached_icon_states must still resolve states for a runtime /icon datum")
+
+	// icon_state_has_directional_frames must agree with a direct N/E/W probe for every state...
+	for(var/state in raw_states)
+		var/expected_directional = FALSE
+		for(var/checkdir in list(NORTH, EAST, WEST))
+			if(length(icon_states(icon(test_icon, state, checkdir))))
+				expected_directional = TRUE
+				break
+		TEST_ASSERT_EQUAL(icon_state_has_directional_frames(test_icon, state), expected_directional, "icon_state_has_directional_frames disagreed with a direct probe for state '[state]'")
+		// ...the cached second call must agree with the first and populate the cache.
+		TEST_ASSERT_EQUAL(icon_state_has_directional_frames(test_icon, state), expected_directional, "cached directional result changed on the second call for state '[state]'")
+		TEST_ASSERT("[test_icon_key]|[state]" in GLOB.cached_icon_state_directional, "directional cache entry missing for state '[state]'")
+
+	// Runtime /icon datums: uncached, but consistent with a direct probe.
+	var/runtime_state = raw_states[1]
+	var/runtime_expected = FALSE
+	for(var/checkdir in list(NORTH, EAST, WEST))
+		if(length(icon_states(icon(runtime_icon, runtime_state, checkdir))))
+			runtime_expected = TRUE
+			break
+	TEST_ASSERT_EQUAL(icon_state_has_directional_frames(runtime_icon, runtime_state), runtime_expected, "icon_state_has_directional_frames must stay correct for runtime /icon datums")
+
+
+/datum/unit_test/flat_icon_smoke/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human)
+
+	for(var/test_dir in list(SOUTH, NORTH, EAST, WEST))
+		dummy.setDir(test_dir)
+		var/icon/flat = getFlatIcon(dummy, no_anim = TRUE)
+		TEST_ASSERT_NOTNULL(flat, "getFlatIcon must return an icon for a human facing [dir2text(test_dir)]")
+		TEST_ASSERT(flat.Width() > 0 && flat.Height() > 0, "getFlatIcon result must have positive dimensions facing [dir2text(test_dir)] (got [flat.Width()]x[flat.Height()])")
+
+	// Caches are warm now — a repeat call must still produce a valid icon.
+	dummy.setDir(WEST)
+	var/icon/warm = getFlatIcon(dummy, no_anim = TRUE)
+	TEST_ASSERT_NOTNULL(warm, "getFlatIcon must still return an icon once the directional/state caches are warm")
+	TEST_ASSERT(warm.Width() > 0 && warm.Height() > 0, "warm-cache getFlatIcon result must have positive dimensions (got [warm.Width()]x[warm.Height()])")
+
+
+// ===== Fix G: icon2html result cache =====
+//
+// Profile snapshot: /proc/icon2html — 3698 calls / 7.2s total CPU / 6.7s self / 2.0s overtime.
+// icon2html renders only an atom's base icon/icon_state (overlays are never flattened), so its
+// asset output is a pure function of (icon file, icon_state, dir, frame, moving). A bounded
+// result cache (GLOB.icon2html_result_cache → list(asset_name, html, url)) lets repeat calls
+// skip get_icon_dmi_path / fcopy_rsc / md5 / icon() entirely. Verifies the eviction strategy
+// (shared Cut(1, MAX/4 + 1) idiom used by the other icon caches) keeps the cache bounded while
+// retaining ~75% of entries. A live functional test is impossible here — unit tests run
+// headless, GLOB.clients is empty, and icon2html early-returns when there is no target.
+/datum/unit_test/icon2html_result_cache_eviction_math/Run()
+	var/list/synthetic_cache = list()
+	for(var/i in 1 to ICON2HTML_RESULT_CACHE_MAX + 5)
+		synthetic_cache["entry_[i]"] = list("name_[i]", "html_[i]", "url_[i]")
+
+	if(length(synthetic_cache) > ICON2HTML_RESULT_CACHE_MAX)
+		synthetic_cache.Cut(1, (ICON2HTML_RESULT_CACHE_MAX / 4) + 1)
+
+	TEST_ASSERT(length(synthetic_cache) <= ICON2HTML_RESULT_CACHE_MAX, "Eviction must keep cache <= ICON2HTML_RESULT_CACHE_MAX (got [length(synthetic_cache)])")
+	TEST_ASSERT(length(synthetic_cache) >= (ICON2HTML_RESULT_CACHE_MAX * 3 / 4), "Eviction should retain ~75% of entries (got [length(synthetic_cache)])")
+	TEST_ASSERT(isnull(synthetic_cache["entry_1"]), "Oldest entry should be evicted")
+	TEST_ASSERT_NOTNULL(synthetic_cache["entry_[ICON2HTML_RESULT_CACHE_MAX + 1]"], "Recently-added entry should survive eviction")
+	TEST_ASSERT(GLOB.icon2html_result_cache != null, "GLOB.icon2html_result_cache must be initialized as a list")
+
+
+// ===== Fix G.2: icon2html result cache covers humans =====
+//
+// Humans were originally excluded from the result cache, but icon2html's human path only Insert()s
+// the same base icon/icon_state and forces dir = SOUTH — its output is still a pure function of
+// (icon file, icon_state, frame, moving), so it is cacheable. This costs ~1.6ms/call (icon() +
+// Insert() + md5asfile) every time without the cache. We exploit that send_assets() early-returns
+// on a mob with no client, so we can drive the full icon2html pipeline headlessly with such a mob.
+/datum/unit_test/icon2html_human_result_cached/Run()
+	var/mob/null_target = allocate(/mob)
+	var/mob/living/carbon/human/subject = allocate(/mob/living/carbon/human)
+
+	var/before = length(GLOB.icon2html_result_cache)
+	var/html_first = icon2html(subject, null_target)
+	TEST_ASSERT_NOTNULL(html_first, "icon2html on a human must return an <img> string")
+	TEST_ASSERT(findtext(html_first, "<img"), "icon2html on a human must return an <img ...> tag (got [html_first])")
+	TEST_ASSERT(length(GLOB.icon2html_result_cache) > before, "icon2html on a human must populate the result cache (humans are now cached)")
+
+	var/after_first = length(GLOB.icon2html_result_cache)
+	var/html_second = icon2html(subject, null_target)
+	TEST_ASSERT_EQUAL(html_first, html_second, "repeat icon2html on the same human must return the identical cached html")
+	TEST_ASSERT_EQUAL(length(GLOB.icon2html_result_cache), after_first, "the second icon2html call on the same human must hit the cache, not add another entry")
+
+	// sourceonly path must also be served from the same entry and return a bare url, not an <img>.
+	var/url = icon2html(subject, null_target, sourceonly = TRUE)
+	TEST_ASSERT_NOTNULL(url, "icon2html(sourceonly) on a cached human must return a url")
+	TEST_ASSERT(!findtext(url, "<img"), "icon2html(sourceonly) must return a bare url, not an <img> tag (got [url])")
+	TEST_ASSERT_EQUAL(length(GLOB.icon2html_result_cache), after_first, "sourceonly call on a cached human must not add a new entry")
+
+
+// ===== Fix H: get_icon_dmi_path memoisation =====
+//
+// get_icon_dmi_path runs on every icon2html call that misses the result cache (and for raw-file
+// inputs). Its result is a pure function of the resolved icon file, so it is now memoised per
+// icon file (GLOB.icon_dmi_path_cache, empty-string = negative-cache sentinel). Runtime /icon
+// datums are NOT cached — they all stringify to "/icon" and would collide.
+/datum/unit_test/get_icon_dmi_path_caching/Run()
+	var/obj/item/subject = allocate(/obj/item/flashlight)
+	var/icon_file = subject.icon
+	TEST_ASSERT_NOTNULL(icon_file, "test fixture must have an icon")
+
+	var/path_first = get_icon_dmi_path(subject)
+	var/path_second = get_icon_dmi_path(subject)
+	TEST_ASSERT_EQUAL(path_first, path_second, "get_icon_dmi_path must be stable across calls")
+	TEST_ASSERT_NOTNULL(path_first, "a compile-time dmi item must resolve to a dmi path")
+	TEST_ASSERT(is_valid_dmi_file(path_first), "resolved path must be a valid icons/*.dmi path (got [path_first])")
+	TEST_ASSERT("[icon_file]" in GLOB.icon_dmi_path_cache, "get_icon_dmi_path must cache the resolved path keyed on the icon file")
+	TEST_ASSERT_EQUAL(GLOB.icon_dmi_path_cache["[icon_file]"], path_first, "cached value must equal the resolved path")
+	// passing the resolved icon file directly must hit the same cache entry.
+	TEST_ASSERT_EQUAL(get_icon_dmi_path(icon_file), path_first, "passing the icon file directly must resolve to the same path")
+
+	// runtime /icon datums must not be cached (would collide on the "/icon" key).
+	var/size_before = length(GLOB.icon_dmi_path_cache)
+	var/icon/runtime_ic = icon(icon_file)
+	get_icon_dmi_path(runtime_ic)
+	TEST_ASSERT_EQUAL(length(GLOB.icon_dmi_path_cache), size_before, "runtime /icon datums must not be added to icon_dmi_path_cache")
+
+
+// ===== Eviction math for the new icon-helper caches (Fix F caps + Fix H cap) =====
+//
+// All three new caches share the Cut(1, MAX/4 + 1) "evict oldest 25%" idiom already proven by
+// bicon_cache_eviction_math / humanoid_icon_cache_eviction_math. Synthetic-list logic test —
+// the production procs are too expensive to invoke MAX+1 times in CI. Verifies each cap keeps
+// its cache bounded while retaining ~75% of entries, so a long (4h+) round can't grow these
+// without limit.
+/datum/unit_test/icon_helper_cache_eviction_math/Run()
+	var/list/caps = list(
+		"cached_icon_states_by_file" = ICON_STATES_FILE_CACHE_MAX,
+		"cached_icon_state_directional" = ICON_STATE_DIRECTIONAL_CACHE_MAX,
+		"icon_dmi_path_cache" = ICON_DMI_PATH_CACHE_MAX,
+	)
+	for(var/cache_name in caps)
+		var/cap = caps[cache_name]
+		TEST_ASSERT(cap > 0, "[cache_name] cap must be positive (got [cap])")
+		var/list/synthetic = list()
+		for(var/i in 1 to cap + 5)
+			synthetic["entry_[i]"] = i
+		if(length(synthetic) > cap)
+			synthetic.Cut(1, (cap / 4) + 1)
+		TEST_ASSERT(length(synthetic) <= cap, "[cache_name]: eviction must keep size <= cap (got [length(synthetic)] vs [cap])")
+		TEST_ASSERT(length(synthetic) >= (cap * 3 / 4), "[cache_name]: eviction should retain ~75% of entries (got [length(synthetic)])")
+		TEST_ASSERT(isnull(synthetic["entry_1"]), "[cache_name]: oldest entry must be evicted")
+		TEST_ASSERT_NOTNULL(synthetic["entry_[cap + 1]"], "[cache_name]: a recently-added entry must survive eviction")
+
+	TEST_ASSERT(GLOB.cached_icon_states_by_file != null, "GLOB.cached_icon_states_by_file must be a list")
+	TEST_ASSERT(GLOB.cached_icon_state_directional != null, "GLOB.cached_icon_state_directional must be a list")
+	TEST_ASSERT(GLOB.icon_dmi_path_cache != null, "GLOB.icon_dmi_path_cache must be a list")


### PR DESCRIPTION
# Описание

Накидал кэшей на тяжёлые иконочные процедуры, это продолжение перф-возни из #3187.

`getFlatIcon` на каждый вызов (и на каждый рекурсивный оверлей внутри) заново дёргал `icon_states()` и пробу направленности через три временных `icon()` - этот кусок прямо в коде помечен как CPU hog. Теперь оба результата запоминаю по DMI-файлу. У `icon2html` вообще не было кэша результата, хотя он рисует только базовую иконку атома, то есть выхлоп это чистая функция от (файл иконки, icon_state, dir, frame, moving) - добавил такой кэш, людей тоже включил, и заодно мемоизировал `get_icon_dmi_path`. Все кэши с потолком и выселением старых записей, чтобы длинный раунд их не раздул.

Почему не сделал это сразу в #3187: там я ковырял слой asset_cache - убирал двойной md5 в `icon2html`, добавлял `get_icon_dmi_path` / `generate_and_hash_rsc_file`, делал cross-round кэш спрайтшитов и кэш `icon2base64` в strip-menu. Тот PR удешевил *один* вызов `icon2html`, но кэша результата не завёл (повторный вызов всё равно гоняет весь пайплайн), `get_icon_dmi_path` оставил без мемоизации, а `getFlatIcon` вообще не трогал. Этот PR как раз про это: запоминаю чистые входы (`icon_states`, проба направленности, `get_icon_dmi_path`) и превращаю повторный `icon2html` в lookup по словарю.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

`getFlatIcon` и `icon2html` стабильно висят в топе овертаймов в профиле раунда (`getFlatIcon` ~10.5с total CPU / ~3.9с overtime, `icon2html` ~7.2с / ~6.7с self). Прогнал микробенч через юнит-тест: проба направленности ускорилась раз в 300, `icon_states()` раз в 80, `getFlatIcon` на одетом человеке примерно вдвое (с ~16+ мс до ~9 мс), `icon2html` на человеке с ~1.5 мс до ~0.03 мс при попадании в кэш. Поведение не меняется, только перф. Накидал юнит-тесты на корректность кэшей и на математику выселения, полный фокус-прогон `dm-test` зелёный.


## Changelog

:cl:
code: добавил кэши для getFlatIcon (icon_states и проверка направленности) и кэш результата для icon2html/get_icon_dmi_path, меньше овертаймов в иконочном пайплайне
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Tests**
  * Добавлены комплексные модульные тесты для проверки оптимизации производительности при отрисовке иконок и кэширования результатов.

* **Улучшения производительности**
  * Оптимизирована обработка иконок и графических элементов за счёт кэширования часто используемых данных, что должно ускорить отрисовку интерфейса и повысить отзывчивость игры.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->