### PR TITLE
Fix require-twohands unwield drop

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -221,12 +221,12 @@
 
 	user.update_inv_hands() // Bluemoon Edit-Fix || Вынес, чтобы обновляло всегда.
 
-	// if the item requires two handed drop the item on unwield
-	/* // Bluemoon Removed - Start // Нахуя оно надо? Автор, ты еблан? Это буквально руин на ровном месте, который иначе никак не используется.
-	Короче крашли нихуя не пояснил зачем это нужно, а на самом деле нужно чтобы положить предмет который требует две руки в слот пояса или т.п.
-	// if(require_twohands)
-	// 	user.dropItemToGround(parent, force=TRUE)
-	*/ // Bluemoon Removed - End
+	// BLUEMOON FIX - require_twohands предмет нельзя удерживать одной рукой:
+	// при анвилде сбрасываем его на пол. Проверка is_holding нужна, чтобы не ломать
+	// перенос предмета в другой слот (тогда unwield вызывается из on_equip/on_drop,
+	// а предмет уже удалён из held_items другим кодом).
+	if(require_twohands && user.is_holding(parent))
+		user.dropItemToGround(parent, force=TRUE)
 
 	// Show message if requested
 	if(show_message)


### PR DESCRIPTION
# Описание

Чинит двуручные предметы, которые после `Z` могли оставаться в одной руке и продолжать давать свои бонусы

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

`require_twohands`-предметы не должны работать в одной руке. Теперь при анвилде они нормально падают на пол, а не остаются висеть в руке с активными эффектами

## Changelog

:cl:
fix: Двуручные предметы, которым реально нужны две руки, больше не остаются рабочими в одной руке после анвилда.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Исправлена механика отпускания двуручного оружия и предметов — они теперь корректно падают на землю при разоружении, если остаются в руках персонажа.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3222)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->