### PR TITLE
Адамантиновый щит теперь имеет стату замедления. Фикс ношения горшков, адамантинового щита в одной руке

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -110,6 +110,9 @@
 	if(!user.is_holding(parent))
 		return			//give no quarter to telekinesis powergaemrs (telekinetic wielding will desync the offhand and result in all sorts of bugs so no until someone codes it properly)
 	if(wielded)
+		if(require_twohands)
+			to_chat(user, "<span class='notice'>[parent] is too cumbersome to carry in one hand!</span>")
+			return
 		unwield(user)
 	else
 		wield(user)

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -455,6 +455,7 @@ Burning extracts:
 	throw_speed = 2
 	attack_verb = list("bashed","pounded","slammed")
 	item_flags = SLOWS_WHILE_IN_HAND
+	slowdown = 2
 
 /obj/item/shield/adamantineshield/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
# Описание

Пофиксил компонент twohanded, теперь он корректно учитывает состояние флага require_twohand при оверрайде проки attack_self. Добавил адамантиновому щиту переменную slowdown, равную щиту-башне.
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- ✅ Изменения были проверены на локальном сервере
- ✅ Этот пулл-реквест готов к тест-мерджу.
- 🟥 Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Решение команды разработки.

## Демонстрация изменений

https://discord.com/channels/875735187449847830/1052875182672449617/1504611146269851738

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Добавил щиту замедление, как у щита-башни. Его всё ещё можно подавить красным зельем.
fix: Скорректировал обработку attack_self компоненту twohanded, теперь двуручки с флагом require_twohand нельзя взять в одну руку.
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Релиз

* **Исправления ошибок**
  * Исправлена возможность носить двуручное оружие одной рукой — теперь система правильно отправляет уведомление при попытке экипировки.

* **Балансировка**
  * Адамантиновый щит теперь замедляет движение при экипировке, отражая его вес и размер.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3223)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->