### PR TITLE
Фикс поломанного наследования

### DIFF
--- a/modular_sand/code/datums/interactions/interaction_datums/lewd/fuck.dm
+++ b/modular_sand/code/datums/interactions/interaction_datums/lewd/fuck.dm
@@ -82,7 +82,10 @@
 
 /datum/interaction/lewd/fuck/anal/display_interaction(mob/living/user, mob/living/partner)
 	var/datum/interaction/lewd/parent_interaction = new /datum/interaction/lewd
+
 	var/is_hidden = parent_interaction.display_interaction(user, partner) // я хз как иначе обойти вызов родителя /datum/interaction/lewd/fuck, дабы получить is_hidden из базового /datum/interaction/lewd
+	qdel(parent_interaction)
+
 	var/message
 	//var/u_His = user.ru_ego()
 	//var/t_His = partner.ru_ego()

--- a/modular_sand/code/datums/interactions/interaction_datums/lewd/fuck.dm
+++ b/modular_sand/code/datums/interactions/interaction_datums/lewd/fuck.dm
@@ -12,6 +12,13 @@
 	)
 
 /datum/interaction/lewd/fuck/display_interaction(mob/living/user, mob/living/partner)
+	var/distance = 7
+	var/volume = 50
+	var/is_hidden = ..()
+	if(is_hidden)
+		distance = 1
+		volume = sound_quiet_volume
+	var/picked_hidden = pick(hidden_additional)
 	var/message
 	//var/u_His = user.ru_ego()
 	//var/genital_name = user.get_penetrating_genital_name() - Стал не нужным.
@@ -20,13 +27,6 @@
 	var/has_balls = user.has_balls()
 	var/shape_desc = get_penis_shape_desc(user) //  Описания каким органом ты трахаешь // BlueMoon Add
 //BLUEMOON ADD END
-	var/is_hidden = ..()
-	var/distance = 7
-	var/volume = 50
-	if(is_hidden)
-		distance = 1
-		volume = sound_quiet_volume
-	var/picked_hidden = pick(hidden_additional)
 	if(user.is_fucking(partner, CUM_TARGET_VAGINA))
 		message = pick(
 			"долбится в киску <b>[partner]</b>, пуская в ход свой [shape_desc].",
@@ -81,6 +81,8 @@
 	additional_details = null // no pregnancy
 
 /datum/interaction/lewd/fuck/anal/display_interaction(mob/living/user, mob/living/partner)
+	var/datum/interaction/lewd/parent_interaction = new /datum/interaction/lewd
+	var/is_hidden = parent_interaction.display_interaction(user, partner) // я хз как иначе обойти вызов родителя /datum/interaction/lewd/fuck, дабы получить is_hidden из базового /datum/interaction/lewd
 	var/message
 	//var/u_His = user.ru_ego()
 	//var/t_His = partner.ru_ego()
@@ -90,7 +92,6 @@
 	var/has_balls = user.has_balls()
 	var/shape_desc = get_penis_shape_desc(user) //  Описания каким органом ты трахаешь // BlueMoon Add
 	//BLUEMOON ADD END
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -156,6 +157,7 @@
 	p13target_strength = PLUG13_STRENGTH_NORMAL
 
 /datum/interaction/lewd/breastfuck/display_interaction(mob/living/user, mob/living/partner) // BLUEMOON EDIT
+	var/is_hidden = ..()
 	var/message
 	var/genital_name = user.get_penetrating_genital_name()
 	//BLUEMOON ADD START
@@ -163,7 +165,6 @@
 	var/has_balls = user.has_balls()
 	var/shape_desc = get_penis_shape_desc(user) //  Описания каким органом ты трахаешь // BlueMoon Add
 	//BLUEMOON ADD END
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -205,12 +206,12 @@
 	p13user_strength = PLUG13_STRENGTH_NORMAL
 
 /datum/interaction/lewd/footfuck/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/picked_hidden = pick(hidden_additional)
 	var/message
 	//var/genital_name = user.get_penetrating_genital_name() - Стал не нужным.
 	var/has_penis = user.has_penis() // BLUEMOON ADD
 	var/shape_desc = get_penis_shape_desc(user) //  Описания каким органом ты трахаешь // BlueMoon Add
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -241,6 +242,7 @@
 	require_target_num_feet = 2
 
 /datum/interaction/lewd/footfuck/double/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/message
 	//var/u_His = user.ru_ego()
 	//var/genital_name = user.get_penetrating_genital_name() - Стал не нужным.
@@ -248,7 +250,6 @@
 	var/shape_desc = get_penis_shape_desc(user) // BlueMoon Add
 
 	var/shoes = partner.get_shoes()
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -285,8 +286,8 @@
 	p13user_emote = PLUG13_EMOTE_VAGINA
 
 /datum/interaction/lewd/footfuck/vag/display_interaction(mob/living/user, mob/living/partner)
-	var/message
 	var/is_hidden = ..()
+	var/message
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -323,9 +324,9 @@
 	interaction_sound = null
 
 /datum/interaction/lewd/double_penetration/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/message
 	var/shape_desc = get_penis_shape_desc(user)
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -382,9 +383,9 @@
 	interaction_sound = null
 
 /datum/interaction/lewd/double_vaginal/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/message
 	var/shape_desc = get_penis_shape_desc(user)
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -433,9 +434,9 @@
 	interaction_sound = null
 
 /datum/interaction/lewd/double_anal/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/message
 	var/shape_desc = get_penis_shape_desc(user)
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -485,9 +486,9 @@
 	additional_details = list(INTERACTION_MAY_CAUSE_PREGNANCY)
 
 /datum/interaction/lewd/knot_fuck/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/message
 	var/shape_desc = get_penis_shape_desc(user)
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)
@@ -530,9 +531,9 @@
 	interaction_sound = null
 
 /datum/interaction/lewd/knot_anal_fuck/display_interaction(mob/living/user, mob/living/partner)
+	var/is_hidden = ..()
 	var/message
 	var/shape_desc = get_penis_shape_desc(user)
-	var/is_hidden = ..()
 	var/distance = 7
 	var/volume = 50
 	if(is_hidden)


### PR DESCRIPTION
# Описание

Сделано по багрепорту https://discord.com/channels/875735187449847830/1504572695499636848

Интеракт, указанный в багрепорте - единичный случай
а всё потому что только в файле с ним есть настолько вложенные интеракты
обычно, почти все из них прописаны как /datum/interaction/lewd/НАЗВАНИЕ ИНТЕРАКЦИИ
а в данном случае это /datum/interaction/lewd/fuck/НАЗВАНИЕ ИНТЕРАКЦИИ
/datum/interaction/lewd/fuck вместо того, чтобы быть базовым типом, без логики, сам является полноценной интеракцией
из-за этого факта ломается наследование, которое я закладывал изначально, целью которого было использования функционала из /datum/interaction/lewd/
я наплодил небольшой костыль который исправляет описанную проблему


## Причина изменений

Исправление бага

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Refactor**
  * Внутренне переработана логика формирования отображения интимных взаимодействий — изменён порядок вычислений и локальных переменных.
  * Изменены внутренние механизмы получения некоторых признаков взаимодействия в одном варианте поведения.
  * Для пользователей видимых изменений поведения или интерфейса не ожидается.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->