### PR TITLE
Фикс абуза VR-а

### DIFF
--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -91,6 +91,11 @@
 	if(charges <= 0)
 		to_chat(U, "<span class='notice'>Out of charges.</span>")
 		return
+
+	if(target.z != U.z)
+		to_chat(U, "<span class='danger'>Цель в другом секторе!</span>") //Препядствует фарму бесконечных бесплатных ТК в виаре и перессылки их через вирус на станционный ПДА(за такое банят)
+		return
+
 	if(!isnull(target) && !target.toff)
 		charges--
 		var/lock_code = "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"


### PR DESCRIPTION
# Описание

Всё это время можно было получить в любой режим игры и на любой роли аплинк с бесконечным количеством ТК, что является наказуемым.

Воспроизводится баг так: 

1. Убеждаемся, что загрузился VR с аплинками
2. Заходим в VR, будучи, например на станции и имея там PDA
3. Forge-reset агентскую карту, чтобы выставилось ваше имя
4. Покупаем набор хамелиона, в нём ПДА, вставляем в него свою агентку
5. Покупаем F.R.A.M.E. картридж, фармим через перезапуски перса ТК и пихаем их именно в картридж
6. Отправляем "вирус" аплинка на свой ПДА на станции, получаем аплинк интекью с 999999999 ТК

Я добавил проверку на Z-уровень и протестировал защиту локально. Абуза больше нет.

## Причина изменений

Это критический баг, а за попытку абуза игрок может отлететь надолго на банановые острова.

## Демонстрация изменений

<img width="200" height="35" alt="изображение" src="https://github.com/user-attachments/assets/0b4742f9-de31-47cc-86c8-3fda9a63bae5" />


## Changelog

:cl:
fix: пофикшен абуз ТК через VR
/:cl:
