### PR TITLE
door remote fix & updt

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -44,9 +44,9 @@
 /obj/item/door_remote/afterattack(atom/A, mob/user)
 	. = ..()
 	var/obj/machinery/door/airlock/door = A
-	if(!(door.check_access(src) || door.allowed(user)))
-		return
 	if(!istype(door) || !door.hasPower() || !door.canAIControl())
+		return
+	if(!(door.check_access(src) || door.allowed(user)))
 		return
 
 	switch(mode)

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -10,7 +10,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	icon = 'icons/obj/device.dmi'
 	name = "control wand"
-	desc = "Удаленно управляет шлюзами."
+	desc = "Удаленно управляет шлюзами. Совместим с ID картами."
 	w_class = WEIGHT_CLASS_TINY
 	var/mode = WAND_OPEN
 	var/region_access = 1 //See access.dm
@@ -23,6 +23,11 @@
 
 /obj/item/door_remote/GetAccess()
 	return access_list
+
+/obj/item/door_remote/examine(mob/user)
+	. = ..()
+	if(obj_flags & EMAGGED)
+		. += span_warning("Индикатор доступа неисправен и моргает разными цветами.")
 
 /obj/item/door_remote/attack_self(mob/user)
 	switch(mode)
@@ -38,9 +43,9 @@
 
 /obj/item/door_remote/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!check_access(src))
-		return
 	var/obj/machinery/door/airlock/door = A
+	if(!(door.check_access(src) || door.allowed(user)))
+		return
 	if(!istype(door) || !door.hasPower() || !door.canAIControl())
 		return
 
@@ -83,9 +88,17 @@
 	ntnet_send(data)
 	*/
 
+/obj/item/door_remote/emag_act()
+	if(obj_flags & EMAGGED)
+		return
+	. = ..()
+	obj_flags |= EMAGGED
+	region_access = 0
+	access_list = get_region_accesses(region_access)
+	playsound(src, 'sound/effects/light_flicker.ogg', 80, 1)
+
 /obj/item/door_remote/omni
 	name = "omni door remote"
-	desc = "This control wand can access any door on the station."
 	icon_state = "gangtool-yellow"
 	region_access = 0
 
@@ -101,7 +114,6 @@
 
 /obj/item/door_remote/quartermaster
 	name = "supply door remote"
-	desc = "Remotely controls airlocks. This remote has additional Vault access."
 	icon_state = "gangtool-green"
 	region_access = 6
 


### PR DESCRIPTION
# Описание
- Пофикшен баг, что ремоутеры не проверяли доступ шлюза при дистанционных командах

Улучшения:
- При наличии карты, ремоутеры теперь могут брать с нее доступ
- Ремоутер можно емагнуть и он получит полный доступ

## Причина изменений
Багфикс + прокачка уникальных вещей

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Пофикшен баг, что ремоутеры не проверяли доступ шлюза при дистанционных командах
add: При наличии карты, ремоутеры теперь могут брать с нее доступ
add: Ремоутер можно емагнуть и он получит полный доступ
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Поддержка взлома пульта управления дверями с визуальными эффектами мерцания.
  * При осмотре взломанного пульта выводится предупреждение о неисправности индикатора доступа.

* **Улучшения**
  * Расширена проверка доступа при использовании пульта управления дверями.
  * Обновлён текст описания пульта; удалено упоминание о доступе ко всем дверям в соответствующем варианте.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->