### PR TITLE
Restore align and other HTML attrs stripped by ALLOWED_ATTR

### DIFF
--- a/tgui/packages/tgui/sanitize.js
+++ b/tgui/packages/tgui/sanitize.js
@@ -52,26 +52,6 @@ const advTag = ['img', 'video', 'source', 'track'];
 // Attributes that are explicitly forbidden (removed even if tag is allowed)
 const defAttr = ['class', 'style'];
 
-// Additional attributes that should be allowed for all tags when advHtml = true
-// (DOMPurify already allows safe attributes like 'src', 'width', etc., but we
-// explicitly list them to be safe and ensure video attributes pass through).
-const allowedAttributes = [
-  'href',
-  'src',
-  'width',
-  'height',
-  'controls',
-  'autoplay',
-  'loop',
-  'muted',
-  'preload',
-  'type',
-  'class',
-  'style',
-  'alt',
-  'title',
-];
-
 /**
  * Feed it a string and it should spit out a sanitized version.
  *
@@ -97,13 +77,8 @@ export const sanitizeText = (
     tags = tags.concat(advTags);
   }
 
-  // Configure DOMPurify with allowed tags, forbidden attributes,
-  // and an explicit list of allowed attributes to support video embedding.
   return DOMPurify.sanitize(input, {
     ALLOWED_TAGS: tags,
     FORBID_ATTR: forbidAttr,
-    ALLOWED_ATTR: allowedAttributes,
-    // Keep data: URIs disabled (default) for security.
-    // If you need data: images, you may add 'img' to ALLOWED_URI_REGEXP.
   });
 };


### PR DESCRIPTION
# Описание

В апреле когда добавляли видосики в бумажки, заодно нечаянно прибили кучу HTML-атрибутов. В DOMPurify прописали `ALLOWED_ATTR` со списком, а он не дополняет, а **заменяет** дефолтный белый список. Из-за этого срезалось `align`, `colspan`, `rowspan`, `valign`, `border`, `cellpadding`, `cellspacing` и прочее.

Убрал эту строчку, теперь `<p align=right>` и таблицы с нормальным форматированием снова работают. Видосики не сломались, их атрибуты (`controls`, `autoplay`, `loop`, `muted`, `preload`) и так в дефолтном списке DOMPurify.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Демонстрация изменений

До: `<p align=right>текст</p>` -> просто `<p>текст</p>`, выравнивание теряется.
После: выравнивание работает, как и остальные стандартные HTML-атрибуты.

## Changelog

:cl:
fix: Починил `<p align>`, colspan/rowspan в таблицах и прочие HTML-атрибуты в бумажках, которые сломались вместе с добавлением видосиков.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Улучшена обработка текстового контента путём изменения конфигурации санитизации. Встраивание видео через санитизацию текста больше не поддерживается.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->