### PR TITLE
fix: пачка мелких рантайм-фиксов

### DIFF
--- a/_maps/RandomZLevels/away_mission/caves.dmm
+++ b/_maps/RandomZLevels/away_mission/caves.dmm
@@ -357,9 +357,8 @@
 	color = "green";
 	name = "crown of greed";
 	desc = "it's just a crown of glowing greenish color. But you're too greedy to just leave her here.";
-	light_color = "green";
-	light_range = 1;
-	lighting_alpha = "200"
+	light_color = "#00ff00";
+	light_range = 1
 	},
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"

--- a/_maps/RandomZLevels/away_mission/ihategordon.dmm
+++ b/_maps/RandomZLevels/away_mission/ihategordon.dmm
@@ -25462,7 +25462,7 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/ihategordon/outsideofmesa)
 "iyu" = (
-/obj/item/canvas_bug,
+/obj/item/camera_bug,
 /turf/open/water/jungle,
 /area/awaymission/ihategordon/outsideofmesa)
 "iyG" = (
@@ -46404,7 +46404,7 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/canvas,
+/obj/item/camera,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -48136,7 +48136,7 @@
 /obj/item/ammo_box/magazine/pistolm9mm,
 /obj/item/ammo_box/magazine/mp5,
 /obj/item/mod/module/emp_shield/advanced,
-/obj/item/canvas_bug,
+/obj/item/camera_bug,
 /turf/open/floor/plasteel,
 /area/awaymission/ihategordon/secret_rooms)
 "pYx" = (
@@ -66419,11 +66419,11 @@
 /turf/open/floor/plating/cobblestone,
 /area/awaymission/ihategordon/opposing/comlpex)
 "vZW" = (
-/obj/item/canvas{
+/obj/item/camera{
 	pixel_x = 0;
 	pixel_y = -5
 	},
-/obj/item/canvas{
+/obj/item/camera{
 	pixel_x = 1;
 	pixel_y = 11
 	},

--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -332,6 +332,20 @@ SUBSYSTEM_DEF(persistence)
 	if(fexists(json_file))
 		paintings = json_decode(file2text(json_file))
 
+	if(islist(paintings))
+		for(var/persistence_id in paintings)
+			var/list/entries = paintings[persistence_id]
+			if(!islist(entries))
+				continue
+			var/list/valid_entries = list()
+			for(var/list/entry in entries)
+				var/entry_md5 = entry["md5"]
+				if(!entry_md5)
+					continue
+				if(fexists("data/paintings/[persistence_id]/[entry_md5].png"))
+					valid_entries += list(entry)
+			paintings[persistence_id] = valid_entries
+
 	for(var/obj/structure/sign/painting/P in painting_frames)
 		P.load_persistent()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -293,8 +293,10 @@
  */
 /atom/Destroy()
 	if(alternate_appearances)
-		for(var/K in alternate_appearances)
-			var/datum/atom_hud/alternate_appearance/AA = alternate_appearances[K]
+		var/list/aa_snapshot = alternate_appearances
+		alternate_appearances = null
+		for(var/K in aa_snapshot)
+			var/datum/atom_hud/alternate_appearance/AA = aa_snapshot[K]
 			AA.remove_from_hud(src)
 
 	if(reagents)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -166,6 +166,8 @@
 				continue
 
 			Decay(TRUE, 2) // Decay before spawning new mushrooms to reduce their endurance
+			if(QDELETED(src) || !myseed) // Decay may have killed us when endurance dropped below 1
+				return
 			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE, TRUE)
 			child.generation = generation + 1
 			shrooms_planted++

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -38,10 +38,11 @@
 
 /obj/item/door_remote/afterattack(atom/A, mob/user)
 	. = ..()
-	if(!check_access(src))
-		return
 	var/obj/machinery/door/airlock/door = A
 	if(!istype(door) || !door.hasPower() || !door.canAIControl())
+		return
+	if(!door.check_access(src))
+		to_chat(user, span_warning("Доступ запрещён."))
 		return
 
 	switch(mode)

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -38,11 +38,10 @@
 
 /obj/item/door_remote/afterattack(atom/A, mob/user)
 	. = ..()
+	if(!check_access(src))
+		return
 	var/obj/machinery/door/airlock/door = A
 	if(!istype(door) || !door.hasPower() || !door.canAIControl())
-		return
-	if(!door.check_access(src))
-		to_chat(user, span_warning("Доступ запрещён."))
 		return
 
 	switch(mode)

--- a/code/modules/buildmode/submodes/smite.dm
+++ b/code/modules/buildmode/submodes/smite.dm
@@ -14,7 +14,11 @@
 
 /datum/buildmode_mode/smite/change_settings(client/user)
 	var/punishment = input(user, "Choose a punishment", "DIVINE SMITING") as null|anything in GLOB.smites
+	if(!punishment)
+		return
 	var/smite_path = GLOB.smites[punishment]
+	if(!smite_path)
+		return
 	var/datum/smite/picking_smite = new smite_path
 	var/configuration_success = picking_smite.configure(user)
 	if (configuration_success == FALSE)

--- a/modular_bluemoon/code/modules/lobby/lobby_preferences.dm
+++ b/modular_bluemoon/code/modules/lobby/lobby_preferences.dm
@@ -49,5 +49,8 @@
 	bm_lobby_show_admin_bg = !!bm_lobby_show_admin_bg
 	var/telemetry_history_json
 	.["connection_telemetry_history"] >> telemetry_history_json
-	connection_telemetry_history = sanitize_connection_telemetry_history(json_decode(telemetry_history_json))
+	var/list/telemetry_history
+	if(istext(telemetry_history_json) && length(telemetry_history_json))
+		telemetry_history = json_decode(telemetry_history_json)
+	connection_telemetry_history = sanitize_connection_telemetry_history(telemetry_history)
 	return .

--- a/modular_bluemoon/code/modules/tgui_panel/telemetry_prefs.dm
+++ b/modular_bluemoon/code/modules/tgui_panel/telemetry_prefs.dm
@@ -13,9 +13,9 @@ SUBSYSTEM_DEF(connection_telemetry)
 	init_order = INIT_ORDER_DBCORE - 1
 	var/save_queued = FALSE
 
-/datum/controller/subsystem/connection_telemetry/Initialize()
+/datum/controller/subsystem/connection_telemetry/Initialize(start_timeofday)
 	load_connection_telemetry_cache()
-	return SS_INIT_SUCCESS
+	return ..()
 
 /datum/controller/subsystem/connection_telemetry/Shutdown()
 	save_connection_telemetry_cache()

--- a/modular_sand/code/datums/elements/holder_micro.dm
+++ b/modular_sand/code/datums/elements/holder_micro.dm
@@ -13,19 +13,22 @@
 
 /datum/element/mob_holder/micro/proc/on_resize(mob/living/micro, new_size, old_size)
 	var/obj/item/clothing/head/mob_holder/holder = micro.loc
-	if(istype(holder))
-		var/mob/living/living = get_atom_on_turf(micro.loc, /mob/living)
-		var/compare_size = 1
-		if(micro.mob_weight < MOB_WEIGHT_NORMAL)
-			compare_size = 0.8
-		if(living && (COMPARE_SIZES(living, micro)) < (compare_size / CONFIG_GET(number/max_pick_ratio)))
-			living.visible_message(span_warning("\The [living] drops [micro] as [micro.p_they()] grow\s too big to carry."),
-				span_warning("You drop \The [living] as [living.p_they()] grow\s too big to carry."),
-				target = micro,
-				target_message = span_notice("\The [living] drops you as you grow too big to carry."))
-			holder.release()
-		else if(!istype(living)) // Somehow a inside a mob_holder and the mob_holder isn't inside any livings? release.
-			holder.release()
+	if(!istype(holder))
+		return
+	var/atom/movable/topmost = get_atom_on_turf(micro.loc, /mob/living)
+	if(!isliving(topmost))
+		holder.release()
+		return
+	var/mob/living/living = topmost
+	var/compare_size = 1
+	if(micro.mob_weight < MOB_WEIGHT_NORMAL)
+		compare_size = 0.8
+	if(COMPARE_SIZES(living, micro) < (compare_size / CONFIG_GET(number/max_pick_ratio)))
+		living.visible_message(span_warning("\The [living] drops [micro] as [micro.p_they()] grow\s too big to carry."),
+			span_warning("You drop \The [living] as [living.p_they()] grow\s too big to carry."),
+			target = micro,
+			target_message = span_notice("\The [living] drops you as you grow too big to carry."))
+		holder.release()
 
 /datum/element/mob_holder/micro/on_examine(mob/living/source, mob/user, list/examine_list)
 	var/compare_size = 1
@@ -126,7 +129,11 @@
 	if(resisting.incapacitated())
 		to_chat(resisting, span_warning("You can't escape while you're restrained like this!"))
 		return
-	var/mob/living/carrier = get_atom_on_turf(src, /mob/living)
+	var/atom/movable/topmost = get_atom_on_turf(src, /mob/living)
+	if(!isliving(topmost))
+		release()
+		return
+	var/mob/living/carrier = topmost
 	visible_message(span_warning("[resisting] begins to squirm in [carrier]'s grasp!"))
 	var/time_required = COMPARE_SIZES(carrier, resisting) / 4 SECONDS //Scale how fast the resisting will be depending on size difference
 	if(get_size(resisting) > 0.5 && carrier.mob_weight < MOB_WEIGHT_NORMAL) //BLUEMOON ADD персонажу размером больше 50% выбраться из хватки лёгкого большого персонажа достаточно просто

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -694,7 +694,7 @@ const PageMain = (props, context) => {
                   content="Отменить"
                   color="bad"
                   fontSize="16px"
-                  onClick={() => setShowAlertLevelConfirm(false)}
+                  onClick={() => setShowAlertLevelConfirm([null, null])}
                 />
               </Flex.Item>
             </Flex>

--- a/tgui/packages/tgui/interfaces/CommunicationsConsoleInteq.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsoleInteq.js
@@ -694,7 +694,7 @@ const PageMain = (props, context) => {
                   content="Отменить"
                   color="bad"
                   fontSize="16px"
-                  onClick={() => setShowAlertLevelConfirm(false)}
+                  onClick={() => setShowAlertLevelConfirm([null, null])}
                 />
               </Flex.Item>
             </Flex>


### PR DESCRIPTION
# Описание

Пачка мелких фиксов, в основном nullable-проверки и UB:

- crown of greed на caves: подправил формат света (строки вместо чисел ломали)
- персистент картин чистит мёртвые записи без png-файлов
- atom/Destroy() безопасно сносит alternate_appearances (снэпшот + null до итерации)
- глоушрум не пытается размножиться после своей смерти от Decay
- door_remote проверяет доступ двери, а не свой (у палки req_access нет, чек был мёртвый)
- smite не падает, если отменить выбор наказания
- lobby_preferences не падает на пустой/битой телеметрии подключений
- micro mob_holder отпускает, если носитель внезапно не /mob/living

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Фикс рантаймов и потенциальных крашей

## Changelog

:cl:
fix: фикс света у crown of greed на away-mission caves
fix: персистент картин больше не тащит записи без png-файлов
fix: atom/Destroy() безопасно удаляет alternate_appearances
fix: глоушрум не пытается размножаться после смерти от Decay
fix: door_remote теперь правильно проверяет доступ двери, а не свой
fix: smite не крашится при отмене выбора наказания
fix: lobby_preferences не падает на пустой телеметрии
fix: micro mob_holder безопасно отпускает при странных носителях
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Исправлено поведение кнопки «Отменить» в диалогах подтверждения смены уровня тревоги на консоли коммуникаций.
  * Улучшена обработка ошибок при загрузке и валидации данных.
  * Исправлены проблемы со спавном объектов в игровом мире.

* **Улучшения**
  * Добавлены дополнительные проверки безопасности для предотвращения некорректного поведения элементов интерфейса.
  * Обновлены элементы и расположение объектов на картах.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->