### PR TITLE
Сообщение в рацию при смерти борга, фикс исчезновения ММИ при гибе сломанного корпуса

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,6 +1,6 @@
 /mob/living/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
 	var/prev_lying = lying
-	if(stat != DEAD)
+	if((stat != DEAD) || istype(src, /mob/living/silicon/robot))	// Robot's death() proc is called even if he's dead on gib()
 		death(1)
 
 	if(!prev_lying)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -23,6 +23,25 @@
 	else
 		logevent("FATAL -- SYSTEM HALT")
 		modularInterface.shutdown_computer()
+
+		var/jammed = FALSE
+		var/turf/position = get_turf(src)	// Проверка на воздействие джаммеров
+		for(var/obj/item/jammer/jammer in GLOB.active_jammers)
+			var/turf/jammer_turf = get_turf(jammer)
+			if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) < jammer.range))
+				jammed = TRUE
+				break
+		if(!jammed && !emagged)	// Джаммер, или емаг акт должен полностью блокировать оповещения о смерти юнитов
+			var/obj/machinery/announcement_system/AAS = null	// AAS my beloved
+			for(var/obj/machinery/announcement_system/S in GLOB.announcement_systems)
+				if(is_station_level(S.z) && S.is_operational())	// Проверка существующей на уровне станции рабочей системы оповещений
+					AAS = S
+					break
+			if(AAS)
+				var/area/A = get_area(src)
+				var/message = "Зафиксирован непредвиденный отказ систем киборга в [A ? A.name : "неизвестной локации"]. Рекомендуется транспортировка в роботехнический отдел с последующим ремонтом."
+				message = Gibberish(message, TRUE, 5)	// Лёгкий коррупт-эффект для вайбов, не должен мешать чтению текста
+				AAS.radio?.talk_into(src, message, RADIO_CHANNEL_SCIENCE, list(SPAN_YELL))	// Броадкаст делается из радио ААС, поскольку броадкаст от имени борга натыкается на множественные ошибки, связанные с асинхронной отправкой сигнала и процессингом смерти борга
 	. = ..()
 
 	locked = FALSE //unlock cover

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -15,6 +15,8 @@
 
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)
+		if(gibbed)
+			dump_into_mmi()
 		return
 	if(gibbed)
 		dump_into_mmi()

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -31,7 +31,7 @@
 			if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) < jammer.range))
 				jammed = TRUE
 				break
-		if(!jammed && !emagged)	// Джаммер, или емаг акт должен полностью блокировать оповещения о смерти юнитов
+		if(!jammed && !emagged)	// Джаммер, или емаг акт полностью блокирует оповещения о смерти юнитов
 			var/obj/machinery/announcement_system/AAS = null	// AAS my beloved
 			for(var/obj/machinery/announcement_system/S in GLOB.announcement_systems)
 				if(is_station_level(S.z) && S.is_operational())	// Проверка существующей на уровне станции рабочей системы оповещений

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -476,8 +476,10 @@
 	if(emagged)
 		QDEL_NULL(mmi)
 		explosion(loc,1,2,4,flame_range = 2)
-	else
-		explosion(loc,-1,0,2)
+		gib()
+		return
+	explosion(loc,-1,0,2)
+	death(1)
 	gib()
 
 /mob/living/silicon/robot/proc/UnlinkSelf()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -479,7 +479,8 @@
 		gib()
 		return
 	explosion(loc,-1,0,2)
-	death(1)
+	if(stat == DEAD)
+		death(1)	// self destruction of a borg that was already dead bypassed death() proc, preventing it from dropping mmi.
 	gib()
 
 /mob/living/silicon/robot/proc/UnlinkSelf()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -476,11 +476,8 @@
 	if(emagged)
 		QDEL_NULL(mmi)
 		explosion(loc,1,2,4,flame_range = 2)
-		gib()
-		return
-	explosion(loc,-1,0,2)
-	if(stat == DEAD)
-		death(1)	// self destruction of a borg that was already dead bypassed death() proc, preventing it from dropping mmi.
+	else
+		explosion(loc,-1,0,2)
 	gib()
 
 /mob/living/silicon/robot/proc/UnlinkSelf()


### PR DESCRIPTION
# Описание
Добавил сообщение о смерти борга в научный канал рации. Имеется взаимодействие с джаммерами.

Сообщение делается в рацию ААС от имени борга, поскольку асинхронный вызов брооадкасита с рации самого киборга создавал кучу проблем (вероятно, из-за работающих в это время прок смерти корпуса)

Пофиксил баг, при котором гиб уже мёртвого борга (как, например, при self_destruct() через консоль управления, подчистую уничтожал его ММИ, полностью выводя игрока из раунда.

- ✅ Изменения были проверены на локальном сервере
- ✅ Этот пулл-реквест готов к тест-мерджу.
- 🟥 Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

(https://discord.com/channels/875735187449847830/1501593992633258066)

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Добавил посмертное сообщение в научный канал при смерти киборга
fix: Починил исчезновение ММИ при гибе уже мёртвого борга, например при активации самоуничтожения через консоль
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Добавлена система объявлений о выходе из строя киборгов в научный канал при отсутствии помех.
  * Объявления блокируются при наличии активных глушилок или при взломе устройства.

* **Bug Fixes**
  * Исправлена логика обработки смерти киборгов при полном разрушении.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->