### PR TITLE
Портальные трусики теперь разрывают все соединения при смерти носителя.

### DIFF
--- a/modular_bluemoon/code/game/objects/items/_portal_toys.dm
+++ b/modular_bluemoon/code/game/objects/items/_portal_toys.dm
@@ -1553,7 +1553,7 @@ GLOBAL_VAR_INIT(portal_telecomms_cache_expire, 0)
 			PL.update_appearance()
 			playsound(PL, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			return TRUE
-		if("disconnect_all")	//
+		if("disconnect_all")
 			// Notify all before clearing
 			for(var/obj/item/portallight/PL in portallight)
 				var/mob/living/carbon/human/holder = get_fleshlight_holder(PL)

--- a/modular_bluemoon/code/game/objects/items/_portal_toys.dm
+++ b/modular_bluemoon/code/game/objects/items/_portal_toys.dm
@@ -921,6 +921,21 @@ GLOBAL_VAR_INIT(portal_telecomms_cache_expire, 0)
 		return equipment.get_wearer()
 	return null
 
+/obj/item/clothing/underwear/briefs/panties/portalpanties/proc/death_disconnect()	// Копия процедуры смены режима на PORTAL_MODE_DISABLED, активируется сигналом COMSIG_LIVING_DEATH
+	if(!portal_settings)
+		return
+	portal_settings.connection_mode = PORTAL_MODE_DISABLED
+	notify_all_connected("Аномальные показатели биометрии партнёра. Автоматический разрыв связи.")
+	for(var/obj/item/portallight/PL in portallight)
+		unregister_remote_vibration(PL)
+		PL.portalunderwear = null
+		PL.icon_state = "unpaired"
+		PL.update_appearance()
+		playsound(PL, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+	LAZYCLEARLIST(portallight)
+	LAZYCLEARLIST(remote_vibrations)  // Clear any orphaned remote vibrations
+	private_pair = null
+
 /obj/item/clothing/underwear/briefs/panties/portalpanties/proc/trigger_safeword(mob/living/carbon/human/user)
 	// Instantly disconnect all connections
 	to_chat(user, span_warning("СТОП-СЛОВО АКТИВИРОВАНО! Все соединения разорваны."))
@@ -1538,7 +1553,7 @@ GLOBAL_VAR_INIT(portal_telecomms_cache_expire, 0)
 			PL.update_appearance()
 			playsound(PL, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			return TRUE
-		if("disconnect_all")
+		if("disconnect_all")	//
 			// Notify all before clearing
 			for(var/obj/item/portallight/PL in portallight)
 				var/mob/living/carbon/human/holder = get_fleshlight_holder(PL)

--- a/modular_bluemoon/code/game/objects/items/fleshlight.dm
+++ b/modular_bluemoon/code/game/objects/items/fleshlight.dm
@@ -475,6 +475,7 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 			portal_settings?.owner = user
 			START_PROCESSING(SSfastprocess, src)
 			RegisterSignal(user, COMSIG_MOVABLE_HEAR, PROC_REF(on_owner_hear), override = TRUE)
+			RegisterSignal(user, COMSIG_LIVING_DEATH, PROC_REF(death_disconnect))
 			// Grant control action for worn panties
 			if(!worn_control_action)
 				worn_control_action = new /datum/action/portal_device_control(src)
@@ -489,10 +490,13 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 					var/mob/living/carbon/human/holder = get_fleshlight_holder(PL)
 					if(holder)
 						to_chat(holder, span_notice("Портальные трусики надеты снова — соединение восстановлено."))
+	else
+		UnregisterSignal(user, COMSIG_LIVING_DEATH)	// portalpanties экипированы куда-то кроме слота (условно, в руку)
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/dropped(mob/user)
 	. = ..()
 	UnregisterSignal(user, COMSIG_MOVABLE_HEAR)
+	UnregisterSignal(user, COMSIG_LIVING_DEATH)
 	// Suspend (not destroy) connection on undress - reconnects automatically when re-equipped
 	if(LAZYLEN(portallight))
 		for(var/obj/item/portallight/PL in portallight)
@@ -654,6 +658,7 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 		register_climax_signal(G.owner)
 		// Register for safeword hearing
 		RegisterSignal(G.owner, COMSIG_MOVABLE_HEAR, PROC_REF(on_owner_hear), override = TRUE)
+		RegisterSignal(G.owner, COMSIG_LIVING_DEATH, PROC_REF(death_disconnect))
 		portal_settings?.owner = G.owner
 		START_PROCESSING(SSfastprocess, src)
 	return TRUE
@@ -686,6 +691,7 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 	if(G.owner)
 		unregister_climax_signal(G.owner)
 		UnregisterSignal(G.owner, COMSIG_MOVABLE_HEAR)
+		UnregisterSignal(G.owner, COMSIG_LIVING_DEATH)
 		portal_settings?.owner = null
 		STOP_PROCESSING(SSfastprocess, src)
 	if(inserted_control_action)


### PR DESCRIPTION
# Описание

Надетые порталки следят за сигналом смерти носителя, при его получении - разрывают все связи, выдавая характерное сообщение.


- ✅ Изменения были проверены на локальном сервере
- ✅ Этот пулл-реквест готов к тест-мерджу.
- 🟥 Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Ебать трупы, по мнению большинства, не круто. Сообщать человеку с фонариком, что ты труп в ООС - тоже не круто.

## Демонстрация изменений

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Порталки теперь разрывают связь с портальными фонариками при смерти владельца
/:cl:
