### PR TITLE
Пачка рантайм-гардов от пустых сообщений и битых ссылок

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -138,7 +138,7 @@
 	save_position()
 
 /atom/movable/screen/movable/action_button/proc/save_position()
-	var/mob/user = our_hud.mymob
+	var/mob/user = our_hud?.mymob
 	if(!user?.client)
 		return
 	var/position_info = ""
@@ -154,14 +154,14 @@
 	user.client.prefs.queue_save_pref(1 SECONDS, TRUE)
 
 /atom/movable/screen/movable/action_button/proc/load_position()
-	var/mob/user = our_hud.mymob
+	var/mob/user = our_hud?.mymob
 	if(!user)
 		return
 	var/position_info = user.client?.prefs?.action_buttons_screen_locs["[name]_[id]"] || SCRN_OBJ_DEFAULT
 	user.hud_used.position_action(src, position_info)
 
 /atom/movable/screen/movable/action_button/proc/dump_save()
-	var/mob/user = our_hud.mymob
+	var/mob/user = our_hud?.mymob
 	if(!user?.client)
 		return
 	user.client.prefs.action_buttons_screen_locs -= "[name]_[id]"

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -480,6 +480,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	listed_actions.check_against_view()
 	palette_actions.check_against_view()
 	for(var/atom/movable/screen/movable/action_button/floating_button as anything in floating_actions)
+		if(isnull(floating_button))
+			continue
 		var/list/current_offsets = screen_loc_to_offset(floating_button.screen_loc)
 		// We set the view arg here, so the output will be properly hemm'd in by our new view
 		floating_button.screen_loc = offset_to_screen_loc(current_offsets[1], current_offsets[2], view = our_view)

--- a/code/datums/accents.dm
+++ b/code/datums/accents.dm
@@ -32,7 +32,7 @@
 
 /datum/accent/lizard/modify_speech(list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*" && message[1] != "!")
+	if(length(message) && message[1] != "*" && message[1] != "!")
 		speech_args[SPEECH_MESSAGE] = applyAccent(message,replacements)
 	return speech_args
 
@@ -46,7 +46,7 @@
 
 /datum/accent/canine/modify_speech(list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*" && message[1] != "!")
+	if(length(message) && message[1] != "*" && message[1] != "!")
 		speech_args[SPEECH_MESSAGE] = applyAccent(message,replacements)
 	return speech_args
 
@@ -62,7 +62,7 @@
 
 /datum/accent/feline/modify_speech(list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*" && message[1] != "!")
+	if(length(message) && message[1] != "*" && message[1] != "!")
 		speech_args[SPEECH_MESSAGE] = applyAccent(message,replacements)
 	return speech_args
 
@@ -78,7 +78,7 @@
 
 /datum/accent/bird/modify_speech(list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*" && message[1] != "!")\
+	if(length(message) && message[1] != "*" && message[1] != "!")
 		speech_args[SPEECH_MESSAGE] = applyAccent(message,replacements)
 	return speech_args
 
@@ -94,7 +94,7 @@
 
 /datum/accent/fly/modify_speech(list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*" && message[1] != "!")
+	if(length(message) && message[1] != "*" && message[1] != "!")
 		speech_args[SPEECH_MESSAGE] = applyAccent(message,replacements)
 	return speech_args
 
@@ -157,7 +157,7 @@
 
 /datum/accent/fluffy/modify_speech(list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*" && message[1] != "!")
+	if(length(message) && message[1] != "*" && message[1] != "!")
 		speech_args[SPEECH_MESSAGE] = applyAccent(message,replacements)
 	return speech_args
 

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -35,6 +35,7 @@
 
 /datum/brain_trauma/special/imaginary_friend/on_lose()
 	..()
+	QDEL_NULL(friend_spawner) // спавнер держит ссылки на trauma/friend, чистим его первым, иначе они не соберутся
 	QDEL_NULL(friend)
 
 //If the friend goes afk, make a brand new friend. Plenty of fish in the sea of imagination.
@@ -50,6 +51,7 @@
 /datum/brain_trauma/special/imaginary_friend/proc/make_friend_spawner()
 	if(!friend)
 		make_friend()
+	QDEL_NULL(friend_spawner) // не плодим спавнеры при рероле
 	friend_spawner = new(friend, src)
 // BLUEMOON ADD END
 

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -100,12 +100,15 @@
 
 		if(!turf_footstep)
 			return
+		var/list/footstep_entry = footstep_sounds[turf_footstep]
+		if(!footstep_entry)
+			return
 		playsound(
 			T,
-			pick(footstep_sounds[turf_footstep][1]),
-			footstep_sounds[turf_footstep][2] * volume,
+			pick(footstep_entry[1]),
+			footstep_entry[2] * volume,
 			TRUE,
-			footstep_sounds[turf_footstep][3] + e_range,
+			footstep_entry[3] + e_range,
 			falloff_distance = 1
 		)
 	play_fov_effect(LM, 3, "footstep", dir = LM.dir, ignore_self = FALSE)
@@ -147,14 +150,16 @@
 			|| (H.shoes && (H.shoes.body_parts_covered & FEET))
 
 		if(feetCover)
-			playsound(
-				T,
-				pick(GLOB.footstep[T.footstep][1]),
-				GLOB.footstep[T.footstep][2] * volume,
-				TRUE,
-				GLOB.footstep[T.footstep][3] + e_range,
-				falloff_distance = 1
-			)
+			var/list/shoe_entry = GLOB.footstep[T.footstep]
+			if(shoe_entry)
+				playsound(
+					T,
+					pick(shoe_entry[1]),
+					shoe_entry[2] * volume,
+					TRUE,
+					shoe_entry[3] + e_range,
+					falloff_distance = 1
+				)
 			play_fov_effect(H, 3, "footstep", dir = H.dir, ignore_self = FALSE)
 			return
 
@@ -164,14 +169,16 @@
 	if(!special && H.dna.species.special_step_sounds)
 		playsound(T, pick(H.dna.species.special_step_sounds), 50, TRUE, falloff_distance = 1)
 	else
-		playsound(
-			T,
-			pick(L[turf_footstep][1]),
-			L[turf_footstep][2] * volume,
-			TRUE,
-			L[turf_footstep][3] + e_range,
-			falloff_distance = 1
-		)
+		var/list/footstep_entry = L[turf_footstep]
+		if(footstep_entry)
+			playsound(
+				T,
+				pick(footstep_entry[1]),
+				footstep_entry[2] * volume,
+				TRUE,
+				footstep_entry[3] + e_range,
+				falloff_distance = 1
+			)
 
 	play_fov_effect(H, 3, "footstep", dir = H.dir, ignore_self = FALSE)
 

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -139,6 +139,10 @@
 		return
 
 	if(connected_holopad)
+		//Already answered by this pad: a double-answer from a stale TGUI snapshot
+		//(rapid re-click, or process() auto-answer racing a queued connectcall). No-op.
+		if(connected_holopad == H)
+			return
 		CRASH("Multi-connection holocall")
 
 	for(var/I in dialed_holopads)

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -133,13 +133,24 @@ Simple datum which is instanced once per type and is used for every object of sa
 	if(isopenturf(T))
 		if(turf_sound_override)
 			var/turf/open/O = T
-			O.footstep = turf_sound_override
-			O.barefootstep = turf_sound_override + "barefoot"
-			O.clawfootstep = turf_sound_override + "claw"
+			O.footstep = (turf_sound_override in GLOB.footstep) ? turf_sound_override : null
+			O.barefootstep = resolve_footstep_key(GLOB.barefootstep, turf_sound_override, "barefoot")
+			O.clawfootstep = resolve_footstep_key(GLOB.clawfootstep, turf_sound_override, "claw")
 			O.heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	// if(alpha < 255)
 	// 	T.AddElement(/datum/element/turf_z_transparency, TRUE)
 	return
+
+/// Maps a turf_sound_override into a footstep key that actually exists in the given sound list.
+/// Tries the suffixed variant first ("wood" -> "woodbarefoot"), then the plain key ("sand"/"meat"),
+/// otherwise returns null so the footstep code skips playback instead of indexing a missing key.
+/datum/material/proc/resolve_footstep_key(list/sound_list, base_key, suffix)
+	var/suffixed_key = base_key + suffix
+	if(suffixed_key in sound_list)
+		return suffixed_key
+	if(base_key in sound_list)
+		return base_key
+	return null
 
 ///This proc is called when the material is removed from an object.
 /datum/material/proc/on_removed(atom/source, amount, material_flags)

--- a/code/modules/admin/admin_ticket_panel.dm
+++ b/code/modules/admin/admin_ticket_panel.dm
@@ -178,6 +178,8 @@
 		if("follow")
 			if(!selected_ticket || !selected_ticket.initiator || !selected_ticket.initiator.mob)
 				return TRUE
+			if(!usr.client)
+				return TRUE
 			if(!isobserver(usr) && !usr.client.admin_ghost())
 				return TRUE
 			var/mob/dead/observer/observer = usr.client.mob

--- a/code/modules/admin/view_variables/topic_list.dm
+++ b/code/modules/admin/view_variables/topic_list.dm
@@ -2,7 +2,7 @@
 /client/proc/vv_do_list(list/target, href_list)
 	var/target_index = text2num(GET_VV_VAR_TARGET)
 	if(check_rights(R_VAREDIT))
-		if(target_index)
+		if(target_index && target_index <= length(target))
 			if(href_list[VV_HK_LIST_EDIT])
 				mod_list(target, null, "list", "contents", target_index, autodetect_class = TRUE)
 			if(href_list[VV_HK_LIST_CHANGE])

--- a/code/modules/admin/view_variables/topic_list.dm
+++ b/code/modules/admin/view_variables/topic_list.dm
@@ -2,7 +2,7 @@
 /client/proc/vv_do_list(list/target, href_list)
 	var/target_index = text2num(GET_VV_VAR_TARGET)
 	if(check_rights(R_VAREDIT))
-		if(target_index && target_index <= length(target))
+		if(target_index >= 1 && target_index <= length(target))
 			if(href_list[VV_HK_LIST_EDIT])
 				mod_list(target, null, "list", "contents", target_index, autodetect_class = TRUE)
 			if(href_list[VV_HK_LIST_CHANGE])

--- a/code/modules/antagonists/clockcult/clock_helpers/fabrication_helpers.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/fabrication_helpers.dm
@@ -55,7 +55,7 @@
 	if(locate(/obj/structure/falsewall) in contents)
 		to_chat(user, "<span class='warning'>There is a false wall in the way, preventing you from fabricating a clockwork wall on [src].</span>")
 		return
-	if(is_blocked_turf(src, TRUE))
+	if(src.is_blocked_turf(exclude_mobs = TRUE))
 		to_chat(user, "<span class='warning'>Something is in the way, preventing you from fabricating a clockwork wall on [src].</span>")
 		return TRUE
 	var/operation_time = 100

--- a/code/modules/antagonists/clockcult/clock_scripture.dm
+++ b/code/modules/antagonists/clockcult/clock_scripture.dm
@@ -317,6 +317,7 @@ Judgement 80k power or nine converts
 /datum/clockwork_scripture/ranged_ability/Destroy()
 	if(progbar)
 		progbar.end_progress()
+		progbar = null
 	return ..()
 
 /datum/clockwork_scripture/ranged_ability/scripture_effects()

--- a/code/modules/antagonists/clockcult/clock_scripture.dm
+++ b/code/modules/antagonists/clockcult/clock_scripture.dm
@@ -315,7 +315,8 @@ Judgement 80k power or nine converts
 	var/datum/progressbar/progbar
 
 /datum/clockwork_scripture/ranged_ability/Destroy()
-	progbar.end_progress()
+	if(progbar)
+		progbar.end_progress()
 	return ..()
 
 /datum/clockwork_scripture/ranged_ability/scripture_effects()

--- a/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
@@ -41,7 +41,8 @@
 	update_icon_nopipes()
 	update_parents()
 	var/datum/pipeline/parent1 = parents[1]
-	parent1.reconcile_air()
+	if(parent1)
+		parent1.reconcile_air()
 
 /obj/machinery/atmospherics/components/binary/relief_valve/proc/close()
 	opened = FALSE

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -39,7 +39,8 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 		update_icon_nopipes()
 		update_parents()
 		var/datum/pipeline/parent1 = parents[1]
-		parent1.reconcile_air()
+		if(parent1)
+			parent1.reconcile_air()
 		investigate_log("was opened by [usr ? key_name(usr) : "a remote signal"]", INVESTIGATE_ATMOS)
 
 /obj/machinery/atmospherics/components/binary/valve/interact(mob/user)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -18,9 +18,13 @@
 	SSair.currentrun -= src
 	if(air?.return_volume())  //	BLUEMOON EDIT: TODO:runtime
 		temporarily_store_air()
-	for(var/obj/machinery/atmospherics/pipe/P as anything in members)
+	// Implicitly-typed `for(... in list)` skips null entries; `as anything` does
+	// not. A member pipe/component hard-deleted elsewhere leaves a stale null in
+	// these lists, so the filtering form is load-bearing here (same reason as the
+	// build_pipeline note below). Do not "optimize" it back to `as anything`.
+	for(var/obj/machinery/atmospherics/pipe/P in members)
 		P.parent = null
-	for(var/obj/machinery/atmospherics/components/C as anything in other_atmosmch)
+	for(var/obj/machinery/atmospherics/components/C in other_atmosmch)
 		if(!C.parents)
 			continue
 		for(var/i in 1 to length(C.parents))
@@ -60,7 +64,7 @@
 	// BFS quadratic on large pipenets. Seed it with whatever is already in
 	// `members` (the base pipe, when it is one) so it is found as a neighbor.
 	var/list/seen_members = list()
-	for(var/obj/machinery/atmospherics/pipe/already as anything in members)
+	for(var/obj/machinery/atmospherics/pipe/already in members)
 		seen_members[already] = TRUE
 
 	// Index-cursor BFS instead of `for(... in list); list -= current`. The old
@@ -152,10 +156,10 @@
 		return
 	air.set_volume(air.return_volume() + E.air.return_volume())
 	members.Add(E.members)
-	for(var/obj/machinery/atmospherics/pipe/S as anything in E.members)
+	for(var/obj/machinery/atmospherics/pipe/S in E.members)
 		S.parent = src
 	air.merge(E.air)
-	for(var/obj/machinery/atmospherics/components/C as anything in E.other_atmosmch)
+	for(var/obj/machinery/atmospherics/components/C in E.other_atmosmch)
 		C.replacePipenet(E, src)
 	other_atmosmch |= E.other_atmosmch
 	if(null in E.other_airs)
@@ -185,7 +189,7 @@
 /datum/pipeline/proc/temporarily_store_air()
 	//Update individual gas_mixtures by volume ratio
 
-	for(var/obj/machinery/atmospherics/pipe/member as anything in members)
+	for(var/obj/machinery/atmospherics/pipe/member in members)
 		member.air_temporary = new
 		member.air_temporary.set_volume(member.volume)
 		member.air_temporary.copy_from(air)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -102,6 +102,8 @@
 				squash(hit_atom)
 
 /obj/item/reagent_containers/food/snacks/grown/proc/squash(atom/target)
+	if(QDELETED(src)) //teleport/slip traits can delete us mid-throw before throw_impact calls squash
+		return
 	var/turf/T = get_turf(target)
 	if(ispath(splat_type, /obj/effect/decal/cleanable/plant_smudge))
 		if(filling_color)
@@ -119,9 +121,10 @@
 		for(var/datum/plant_gene/trait/trait in seed.genes)
 			trait.on_squash(src, target)
 
-	reagents.reaction(T)
-	for(var/A in T)
-		reagents.reaction(A)
+	if(reagents) //on_squash traits (smoke/teleport) may clear or delete our reagents
+		reagents.reaction(T)
+		for(var/A in T)
+			reagents.reaction(A)
 
 	qdel(src)
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -237,10 +237,10 @@
 
 	if(!suiciding)
 		blood_data["cloneable"] = 1
-	blood_data["blood_type"] = dna.blood_type
+	blood_data["blood_type"] = dna?.blood_type //runtime guard для мобов без dna (например, ксеносов)
 	blood_data["gender"] = gender
 	blood_data["real_name"] = real_name
-	blood_data["features"] = dna.features
+	blood_data["features"] = dna?.features //runtime guard для мобов без dna
 	blood_data["factions"] = faction
 	blood_data["quirks"] = list()
 	for(var/V in roundstart_quirks)

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -1,14 +1,17 @@
 
 /mob/living/carbon/human/Stun(amount, updating = 1, ignore_canstun = 0)
-	amount = dna.species.spec_stun(src,amount)
+	if(dna?.species)
+		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
 /mob/living/carbon/human/DefaultCombatKnockdown(amount, updating = TRUE, ignore_canknockdown = FALSE, override_hardstun, override_stamdmg, knocktofloor)
-	amount = dna.species.spec_stun(src,amount)
+	if(dna?.species)
+		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
 /mob/living/carbon/human/Unconscious(amount, updating = 1, ignore_canunconscious = 0)
-	amount = dna.species.spec_stun(src,amount)
+	if(dna?.species)
+		amount = dna.species.spec_stun(src,amount)
 	if(HAS_TRAIT(src, TRAIT_HEAVY_SLEEPER))
 		amount *= rand(1.25, 1.3)
 	return ..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -559,11 +559,15 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return TRUE
 
 /mob/living/proc/get_key(message)
+	if(!length(message))
+		return
 	var/key = message[1]
 	if((key in GLOB.department_radio_prefixes) && length(message) > length(key))
 		return lowertext(message[1 + length(key)])
 
 /mob/living/proc/get_message_language(message)
+	if(!length(message))
+		return null
 	if(message[1] == ",")
 		var/comma_len = length(message[1])
 		if(length(message) <= comma_len)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -178,10 +178,10 @@
 							"<span class='userdanger'>The [P.name] is reflected by your armored shell!</span>")
 
 			// Find a turf near or on the original location to bounce to
-			if(P.starting)
+			var/turf/curloc = get_turf(src)
+			if(P.starting && curloc)
 				var/new_x = P.starting.x + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
 				var/new_y = P.starting.y + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
-				var/turf/curloc = get_turf(src)
 
 				// redirect the projectile
 				P.original = locate(new_x, new_y, P.z)

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -95,6 +95,8 @@
 
 /// Called when the module is selected from the TGUI
 /obj/item/mod/module/proc/on_select()
+	if(!mod?.wearer) //the control's TGUI is reachable on an unworn suit; every module action below needs a wearer
+		return
 	if(((!mod.active || mod.activating) && !allowed_inactive) || module_type == MODULE_PASSIVE)
 		if(mod.wearer)
 			balloon_alert(mod.wearer, "not active!")

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -26,6 +26,8 @@
 	. = ..()
 	if(.)
 		return
+	if(!magazine) // нечего заряжать без барабана/магазина (напр. он извлечён через Alt-click или оружие создано без него)
+		return
 	var/num_loaded = 0
 	if(istype(A, /obj/item/ammo_box)) //проверка что контейнер с боеприпасами и приведение к типу
 		var/obj/item/ammo_box/AM = A

--- a/code/modules/unit_tests/perf_optimizations.dm
+++ b/code/modules/unit_tests/perf_optimizations.dm
@@ -337,6 +337,64 @@
 #undef BUILD_PIPELINE_PERF_N
 
 
+/// Regression coverage for the reported pipeline teardown runtimes
+/// ("Cannot modify null.parent" in Destroy, "Cannot modify null.air_temporary"
+/// in temporarily_store_air). BYOND leaves a null slot in a list when a
+/// referenced object is hard-deleted, so a member pipe deleted elsewhere leaves
+/// `members` holding a null. The teardown loops must skip those quietly; an
+/// `as anything` iteration dereferences the null and crashes. The runtime
+/// counter catches it because DM keeps executing past a null-deref runtime.
+/datum/unit_test/pipeline_teardown_skips_null_members/Run()
+	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/p1 = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)
+
+	var/datum/pipeline/P = new()
+	allocated += P // double-qdel is safe; this just guarantees cleanup on early assert failure
+	P.members += p1
+	P.members += null // simulate a member pipe hard-deleted elsewhere
+	p1.parent = P
+	// air must have volume so Destroy takes the temporarily_store_air() branch.
+	P.air = new /datum/gas_mixture()
+	P.air.set_volume(100)
+	P.air.set_temperature(T20C)
+
+	var/runtimes_before = GLOB.total_runtimes
+	P.temporarily_store_air()
+	qdel(P) // Destroy() iterates members again ("P.parent = null")
+	var/runtimes_added = GLOB.total_runtimes - runtimes_before
+
+	TEST_ASSERT_EQUAL(runtimes_added, 0, "pipeline teardown must not raise runtimes on a null member (got [runtimes_added])")
+	TEST_ASSERT_NOTNULL(p1.air_temporary, "the real member must still get its air_temporary parcel")
+
+
+/// merge() walks the absorbed pipeline's members/other_atmosmch to re-parent
+/// them. If that pipeline holds a stale null (same hard-delete cause as above),
+/// the re-parent loop must skip it rather than deref null.parent / null methods.
+/datum/unit_test/pipeline_merge_skips_null_members/Run()
+	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/p1 = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)
+	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/p2 = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)
+
+	var/datum/pipeline/keeper = new()
+	allocated += keeper
+	keeper.air = new /datum/gas_mixture()
+	keeper.air.set_volume(100)
+	keeper.members += p1
+	p1.parent = keeper
+
+	var/datum/pipeline/absorbed = new()
+	absorbed.air = new /datum/gas_mixture()
+	absorbed.air.set_volume(100)
+	absorbed.members += p2
+	absorbed.members += null // stale null in the pipeline being merged in
+	p2.parent = absorbed
+
+	var/runtimes_before = GLOB.total_runtimes
+	keeper.merge(absorbed) // merge() qdels absorbed for us
+	var/runtimes_added = GLOB.total_runtimes - runtimes_before
+
+	TEST_ASSERT_EQUAL(runtimes_added, 0, "merge() must not raise runtimes on a null member (got [runtimes_added])")
+	TEST_ASSERT_EQUAL(p2.parent, keeper, "the real absorbed member must be re-parented to the keeper")
+
+
 // ===== Fix F: getFlatIcon directional-check + icon_states memoisation =====
 //
 // Profile snapshot: /proc/getFlatIcon — 2005 calls / 10.5s total CPU / 3.9s overtime,

--- a/modular_bluemoon/code/game/objects/items/fleshlight.dm
+++ b/modular_bluemoon/code/game/objects/items/fleshlight.dm
@@ -329,6 +329,8 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 	else if(user.client && user.client.prefs.muted & MUTE_IC)
 		to_chat(user, "Вы не можете отправлять IC сообщения (заглушены).")
 		return FALSE
+	if(!ishuman(user))
+		return FALSE
 	var/mob/living/carbon/human/H_user = user
 
 	var/list/select = list()

--- a/modular_splurt/code/datums/components/pregnancy.dm
+++ b/modular_splurt/code/datums/components/pregnancy.dm
@@ -181,18 +181,21 @@
 /datum/component/pregnancy/proc/handle_life(seconds)
 	SIGNAL_HANDLER
 
+	if(!carrier)
+		return
+
 	if(!HAS_TRAIT(carrier, TRAIT_COMMON_PREGNANCY)) //For normal pregnancy - Gardelin0
 		if(oviposition)
 			handle_ovi_preg()
 		else
 			handle_incubation()
 
-	if((stage >= 2) && !revealed && carrier)
+	if((stage >= 2) && !revealed)
 		revealed = TRUE
 		carrier.apply_status_effect(/datum/status_effect/pregnancy)
 		carrier.apply_status_effect(/datum/status_effect/lactation)
 
-	if(carrier && !HAS_TRAIT(carrier, TRAIT_COMMON_PREGNANCY)) //For normal pregnancy - Gardelin0
+	if(!HAS_TRAIT(carrier, TRAIT_COMMON_PREGNANCY)) //For normal pregnancy - Gardelin0
 		if(stage > 3 && ishuman(carrier) && oviposition)
 			SEND_SIGNAL(carrier, COMSIG_ADD_MOOD_EVENT, "pregnancy", /datum/mood_event/pregnant_negative)
 

--- a/modular_splurt/code/datums/components/pregnancy.dm
+++ b/modular_splurt/code/datums/components/pregnancy.dm
@@ -192,7 +192,7 @@
 		carrier.apply_status_effect(/datum/status_effect/pregnancy)
 		carrier.apply_status_effect(/datum/status_effect/lactation)
 
-	if(!HAS_TRAIT(carrier, TRAIT_COMMON_PREGNANCY)) //For normal pregnancy - Gardelin0
+	if(carrier && !HAS_TRAIT(carrier, TRAIT_COMMON_PREGNANCY)) //For normal pregnancy - Gardelin0
 		if(stage > 3 && ishuman(carrier) && oviposition)
 			SEND_SIGNAL(carrier, COMSIG_ADD_MOOD_EVENT, "pregnancy", /datum/mood_event/pregnant_negative)
 


### PR DESCRIPTION
# Описание

Накидал пачку мелких рантайм-фиксов.

Первая порция:
- акценты (ящер, пёс, кот, птица, муха, пушистик) и `get_key`/`get_message_language` больше не падают на пустых сообщениях - добавил проверку длины перед обращением к `message[1]`
- воображаемый друг теперь чистит свой спавнер в `on_lose` и не плодит дубли при рероле (раньше спавнер держал ссылки и мешал сборке мусора)
- часовой скрипт `ranged_ability` проверяет `progbar` перед `end_progress()`
- `squash()` у растений не валится, если предмет уже удалён или реагенты вычистили мид-броском (телепорт/слип-трейты)
- поправил вызов `is_blocked_turf` в фабрикации часовых стен

Вторая порция (гарды от битых ссылок и отсутствующих ключей):
- `action_button`: `our_hud?.mymob` вместо разыменования возможного null
- `hud`: пропуск null-кнопок в `floating_actions` при репозиционировании
- `footstep`/`_material`: проверка наличия ключа в `footstep_sounds`/`GLOB.footstep` перед индексацией; `resolve_footstep_key` подбирает существующий ключ звука шага (или null), чтобы материал-оверрайд не индексировал отсутствующий ключ
- `holocall`: повторный ответ того же холопада (двойной ответ из устаревшего TGUI-снапшота) теперь no-op вместо `CRASH`
- `admin_ticket_panel`: проверка `usr.client` перед `admin_ghost()`
- `topic_list`: проверка границ индекса перед `mod_list`
- `valve`/`relief_valve`: проверка `parents[1]` перед `reconcile_air()`
- `blood`: `dna?.blood_type`/`features` для мобов без dna (ксеносы и т.п.)
- `constructs`: `get_turf` перед использованием в отражении пуль
- `mod/_module`: `on_select()` выходит без `mod.wearer`
- `fleshlight`: проверка `ishuman(user)` перед кастом в human
- `pregnancy`: проверка `carrier` перед `HAS_TRAIT`

Третья порция:
- `datum_pipeline`: итерация `members`/`other_atmosmch` снова фильтрует null (implicit-typed `for` вместо `as anything`). Hard-delete трубы оставляет null в списке, из-за чего `Destroy`/`merge`/`temporarily_store_air` падали на нём ("Cannot modify null.parent" и "Cannot modify null.air_temporary"). Регресс из #2599; добавил юнит-тесты на тиардаун и слияние пайпнетов
- `status_procs`: `dna?.species` перед `spec_stun()` - мобы без dna/вида не падают на `Stun`/`Unconscious`/`DefaultCombatKnockdown`
- `revolver`: выход из заряжания, если барабан/магазин извлечён

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: акценты и радио-префиксы больше не вызывают рантаймы на пустых сообщениях
fix: воображаемый друг корректно чистит спавнер и не дюпается при рероле
fix: убрал рантаймы при разрушении растений и часовых скриптов
fix: пачка гардов от битых ссылок и отсутствующих ключей (кнопки действий, шаги, холозвонки, клапаны, кровь без dna, модули МОДкостюма)
fix: трубопровод больше не падает на null-членах при разборке и слиянии пайпнетов; оглушение мобов без dna и заряжание револьвера без барабана
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Исправления и улучшения

* **Исправления ошибок**
  * Устранены падения при обработке пустых сообщений в речевой/коммуникационной системе.
  * Исправлено повторное завершение прогресс-баров и утечки при удалении связанных объектов.
  * Предотвращены обращения к несуществующим объектам в спавнерах, клапанах, атмопайплайнах и HUD.
  * Исправлена логика выбора и воспроизведения звуков шагов, добавлены проверки отсутствующих записей.
* **Поведение**
  * Предотвращены двойные ответы вызовов и нежелательное создание спавнеров.
* **Тесты**
  * Добавлены unit-тесты на корректную работу пайплайнов при null-элементах.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
