### PR TITLE
Сменил токс и АП патроны ВТ на янтарный код

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -115,7 +115,7 @@
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	min_security_level = SEC_LEVEL_RED
+	min_security_level = SEC_LEVEL_AMBER //SEC_LEVEL_RED
 
 /datum/design/mag_oldsmg/ic_mag
 	name = "WT-550 Semi-Auto SMG Incendiary Magazine (4.6x30mm IC)"
@@ -133,7 +133,7 @@
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/uranium = 2000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wttx
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-	min_security_level = SEC_LEVEL_RED
+	min_security_level = SEC_LEVEL_AMBER //SEC_LEVEL_RED
 
 /datum/design/mag_oldsmg/rubber_mag
 	name = "WT-550 Semi-Auto SMG rubberbullets Magazine (4.6x30mm rubber)"


### PR DESCRIPTION
# Описание

Сменил токс и АП патроны ВТ на янтарный код

## Причина изменений

В двух словах - ни АП ни токс патроны не играют против антагов своего кода. 

Подробнее: 

Среди антагов красного когда, блюмун насчитывает

Ксеносов - симплмоб
Свармеров - симплмоб
Пауков ужаса- симплмоб
Дракона- симплмоб
Блоб - симплмоб
Еретика на возвышении - раунд энд
Культ на возвышении - раунд энд
Нюкеров - отдельная тема

Из них, не выделяя что два из трёх антагов раскачка которых даёт красный код это конец игры - нюкеры:
1. ставят механом Лямбду, высылая шаттлом снарягу, достаточную что бы нормально вооружить отряд
2. ставят ИЦ регуляции на снятие ограничений, давая игрокам закупить в карго калаши 5,56 - и забить хуй на патроны
3. Не дают времени на раскачку, и добычу ресурсов, не давая использовать патроны на ВТ 


## Changelog
Сменил токс и АП патроны ВТ на янтарный код

:cl:
balance: Изменил уровень кода для печати патрон ВТ
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Балансировка**
  * Повышены требования уровня безопасности для доступа к определённым магазинам оружия WT-550 Semi-Auto SMG.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->