### PR TITLE
Добавил кольт детектива в карго

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -284,3 +284,12 @@
 	cost = 1400
 	contains = list(/obj/item/grenade/stingbang)
 
+/datum/supply_pack/security/mars_single
+
+	name = "Colt Detective Special Single-Pack"
+	desc = "Ваш босс забрал у тебя пистолет и значок? Нет проблем! Просто заплатите абсурдный налоговый сбор, и вы тоже сможете вновь ощутить смертоносную мощь пистолета 38-го калибра!"
+	cost = 3000
+	access = FALSE
+	access_any = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+	contains = list(/obj/item/gun/ballistic/revolver/detective)
+	crate_name = "Colt Detective Special Single-Pack"


### PR DESCRIPTION
# Описание

Добавил кольт детектива в карго
## Причина изменений

Кольт детектива находится на станции в ЕДИНСТВЕННОМ числе в шкафу самого детектива в разгрузке. 

Единственный способ его получить в ещё одном виде - рандомный дроп с почты онли для дека

А ещё это единственная пушка на станции что жрёт .38, больше этот калибр нигде не достать

## Changelog

Добавил Cold .38 special в карго - раздел security, для открытия требуется доступ детектива

:cl:

balance: Добавил Colt .38 special в карго - раздел security, для открытия требуется доступ детектива

