### PR TITLE
Принимать LF-окончания строк в :cl: блоке

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from ruamel import yaml
 from github import Github, InputGitAuthor
 
-CL_BODY = re.compile(r":cl:(.+)?\r\n((.|\n|\r)+?)\r\n\/:cl:", re.MULTILINE)
+CL_BODY = re.compile(r":cl:(.+)?\r?\n((.|\n|\r)+?)\r?\n\/:cl:", re.MULTILINE)
 CL_SPLIT = re.compile(r"(^\w+):\s+(\w.+)", re.MULTILINE)
 
 git_email = os.getenv("GIT_EMAIL")


### PR DESCRIPTION
# Описание
Чейнджлог-генератор теперь принимает `\n`-окончания внутри `:cl:` блока, а не только `\r\n`. Одно слово `\r?` в регекспе.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений
У @Silver-Paws (и потенциально других) PR-ки молча проваливались мимо чейнджлога весь май. Регексп `CL_BODY` жёстко требовал CRLF вокруг `:cl:`/`/:cl:`, а если описание PR редактировалось через мобильный GitHub, GitHub Desktop или пастилось из unix-редактора - окончания строк оставались LF. Скрипт писал "No CL found!" и тихо выходил с 0

## Changelog

:cl:
fix: Чейнджлог-генератор больше не игнорирует PR с LF-окончаниями строк в :cl: блоке.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Улучшения и исправления

* **Bug Fixes**
  * Исправлена обработка символов конца строки при извлечении текста changelog. Инструмент теперь корректно работает с файлами, использующими как CRLF, так и LF форматы переносов строк.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->