### PR TITLE
Чиним can_inject: одежда снова не блокирует медицину и укусы

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -370,16 +370,9 @@
 		target_zone = user.zone_selected
 	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE) && !bypass_immunity)
 		. = 0
-
-	var/pierce_level = SYRINGE_PIERCE_NONE
-	if(isnum(penetrate_thick))
-		pierce_level = penetrate_thick
-	else if(penetrate_thick)
-		pierce_level = SYRINGE_PIERCE_ALL
-
 	// If targeting the head, see if the head item is thin enough.
 	// If targeting anything else, see if the wear suit is thin enough.
-	if(pierce_level < SYRINGE_PIERCE_ALL)
+	if(!penetrate_thick)
 		if(above_neck(target_zone))
 			if(head && istype(head, /obj/item/clothing))
 				var/obj/item/clothing/CH = head
@@ -390,12 +383,22 @@
 			var/obj/item/clothing/CS = get_bodypart_protecting_clothing_by_coverage(src, BP)
 			if(CS && (CS.clothing_flags & THICKMATERIAL))
 				. = 0
-
-	if(pierce_level < SYRINGE_PIERCE_THICK && . && is_zone_covered_by_clothing(target_zone))
-		. = 0
-
 	if(!. && error_msg && user)
 		to_chat(user, "<span class='alert'>Участок тела на [above_neck(target_zone) ? "вашей голове" : "вашем теле"] скрыт или на нём слишком толстый слой одежды!</span>")
+
+// Syringe-specific gate: same as can_inject() plus an extra "is the zone uncovered" check
+// for low-piercing syringes (SYRINGE_PIERCE_NONE). Sutures, patches, hyposprays, antag
+// bites etc. must keep calling can_inject() so they keep working through normal clothing.
+/mob/living/carbon/human/can_inject_syringe(mob/user, error_msg, target_zone, pierce_level = SYRINGE_PIERCE_NONE)
+	if(user && !target_zone)
+		target_zone = user.zone_selected
+	if(!can_inject(user, error_msg, target_zone, pierce_level >= SYRINGE_PIERCE_ALL))
+		return FALSE
+	if(pierce_level < SYRINGE_PIERCE_THICK && is_zone_covered_by_clothing(target_zone))
+		if(error_msg && user)
+			to_chat(user, "<span class='alert'>Участок тела на [above_neck(target_zone) ? "вашей голове" : "вашем теле"] прикрыт одеждой, игла не пройдёт.</span>")
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/human/check_obscured_slots()
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -600,6 +600,11 @@
 /mob/living/proc/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE, bypass_immunity = FALSE)
 	return TRUE
 
+// Syringe-specific gate. Non-human mobs don't have human clothing layers, so this is a
+// thin wrapper around can_inject() that only converts pierce_level to penetrate_thick.
+/mob/living/proc/can_inject_syringe(mob/user, error_msg, target_zone, pierce_level = SYRINGE_PIERCE_NONE)
+	return can_inject(user, error_msg, target_zone, pierce_level >= SYRINGE_PIERCE_ALL)
+
 /mob/living/is_injectable(allowmobs = TRUE)
 	return (allowmobs && reagents && can_inject())
 

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -12,7 +12,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
-			if(M.can_inject(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject_syringe(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
 				if(skip == TRUE)
 					return BULLET_ACT_HIT
@@ -57,7 +57,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100)
-			if(M.can_inject(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject_syringe(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..(target, blocked, TRUE)
 				for(var/datum/reagent/medicine/R in reagents.reagent_list) //OD prevention time!
 					if(R.type in GLOB.blacklisted_medchems)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -71,7 +71,7 @@
 	var/mob/living/L
 	if(isliving(target))
 		L = target
-		if(!L.can_inject(user, 1, user?.zone_selected, proj_piercing))
+		if(!L.can_inject_syringe(user, 1, user?.zone_selected, proj_piercing))
 			return
 
 	// chance of monkey retaliation
@@ -93,7 +93,7 @@
 					target.visible_message("<span class='danger'>[user] пытается взять образец крови у [target]!</span>", \
 									"<span class='userdanger'>[user] пытается взять образец крови у [target]!</span>")
 					busy = TRUE
-					if(!do_mob(user, target, extra_checks=CALLBACK(L, TYPE_PROC_REF(/mob/living, can_inject), user, 1, user.zone_selected, proj_piercing)))
+					if(!do_mob(user, target, extra_checks=CALLBACK(L, TYPE_PROC_REF(/mob/living, can_inject_syringe), user, 1, user.zone_selected, proj_piercing)))
 						busy = FALSE
 						return
 					if(reagents.total_volume >= reagents.maximum_volume)
@@ -138,12 +138,12 @@
 				return
 
 			if(L) //living mob
-				if(!L.can_inject(user, TRUE, user.zone_selected, proj_piercing))
+				if(!L.can_inject_syringe(user, TRUE, user.zone_selected, proj_piercing))
 					return
 				if(L != user)
 					L.visible_message("<span class='danger'>[user] пытается сделать инъекцию [L]!</span>", \
 											"<span class='userdanger'>[user] пытается сделать инъекцию [L]!</span>")
-					if(!do_mob(user, L, extra_checks=CALLBACK(L, TYPE_PROC_REF(/mob/living, can_inject), user, 1, user.zone_selected, proj_piercing)))
+					if(!do_mob(user, L, extra_checks=CALLBACK(L, TYPE_PROC_REF(/mob/living, can_inject_syringe), user, 1, user.zone_selected, proj_piercing)))
 						return
 					if(!reagents.total_volume)
 						return

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -155,6 +155,7 @@
 #include "auto_cryo.dm"
 #include "bad_defines_defined.dm"
 #include "bugfix_coverage.dm"
+#include "can_inject_clothing.dm"
 #include "disposal_holder.dm"
 #include "ghost_role_limbs.dm"
 #include "hallucination_stationmessage.dm"

--- a/code/modules/unit_tests/can_inject_clothing.dm
+++ b/code/modules/unit_tests/can_inject_clothing.dm
@@ -1,0 +1,87 @@
+/// Regression: SmiLeY's syringe-rebalance commit hoisted a new "any clothing blocks" check
+/// into /mob/living/carbon/human/can_inject(), which silently broke every non-syringe caller
+/// (sutures/gauze, patches, medspray, hypospray, antag bites, monkey bites, terror spider
+/// stings, DNA injectors, etc.). They all stopped working through normal clothing - players
+/// had to strip to underwear to apply a patch or sew a wound.
+///
+/// can_inject() must keep the legacy semantics: only THICKMATERIAL blocks the zone.
+/// The new "any clothing blocks" rule moved to can_inject_syringe() - opt-in for syringes.
+
+/// Naked: any pierce path passes.
+/// Thin clothing (jumpsuit only): can_inject() and can_inject_syringe(THICK/ALL) still pass.
+///   Only can_inject_syringe(NONE) is blocked.
+/// THICKMATERIAL (space suit): blocks can_inject() and the THICK pierce level; only ALL pierces.
+/datum/unit_test/can_inject_clothing/Run()
+	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+
+	// Naked baseline ---------------------------------------------------------
+	TEST_ASSERT(patient.can_inject(user, FALSE, BODY_ZONE_CHEST), \
+		"Naked chest must pass can_inject() with default args")
+	TEST_ASSERT(patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_NONE), \
+		"Naked chest must pass can_inject_syringe(NONE)")
+	TEST_ASSERT(patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_THICK), \
+		"Naked chest must pass can_inject_syringe(THICK)")
+	TEST_ASSERT(patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_ALL), \
+		"Naked chest must pass can_inject_syringe(ALL)")
+
+	// Thin clothing only (jumpsuit, no THICKMATERIAL) ------------------------
+	var/obj/item/clothing/under/color/grey/jumpsuit = allocate(/obj/item/clothing/under/color/grey)
+	TEST_ASSERT(patient.equip_to_slot_or_del(jumpsuit, ITEM_SLOT_ICLOTHING, TRUE), \
+		"Failed to equip jumpsuit on patient")
+
+	// THE BUG: SmiLeY's commit made this return 0 because jumpsuit covers the chest.
+	// The fix must keep can_inject() insensitive to non-THICK clothing.
+	TEST_ASSERT(patient.can_inject(user, FALSE, BODY_ZONE_CHEST), \
+		"Jumpsuit-only chest must still pass can_inject() - only THICKMATERIAL should block")
+
+	// Syringe-specific gate: NONE blocks on any clothing, THICK and ALL pierce thin.
+	TEST_ASSERT(!patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_NONE), \
+		"Jumpsuit-covered chest must block can_inject_syringe(NONE)")
+	TEST_ASSERT(patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_THICK), \
+		"Jumpsuit-covered chest must pass can_inject_syringe(THICK)")
+	TEST_ASSERT(patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_ALL), \
+		"Jumpsuit-covered chest must pass can_inject_syringe(ALL)")
+
+	// Add THICKMATERIAL on top (space suit) ----------------------------------
+	var/obj/item/clothing/suit/space/space_suit = allocate(/obj/item/clothing/suit/space)
+	TEST_ASSERT(patient.equip_to_slot_or_del(space_suit, ITEM_SLOT_OCLOTHING, TRUE), \
+		"Failed to equip space suit on patient")
+
+	TEST_ASSERT(!patient.can_inject(user, FALSE, BODY_ZONE_CHEST), \
+		"Space suit (THICKMATERIAL) must block can_inject() with default args")
+	TEST_ASSERT(patient.can_inject(user, FALSE, BODY_ZONE_CHEST, TRUE), \
+		"penetrate_thick=TRUE must bypass THICKMATERIAL")
+
+	TEST_ASSERT(!patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_NONE), \
+		"Space suit must block can_inject_syringe(NONE)")
+	TEST_ASSERT(!patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_THICK), \
+		"Space suit must block can_inject_syringe(THICK) - weak pierce should not punch through THICKMATERIAL")
+	TEST_ASSERT(patient.can_inject_syringe(user, FALSE, BODY_ZONE_CHEST, SYRINGE_PIERCE_ALL), \
+		"Diamond-tipped (SYRINGE_PIERCE_ALL) must pierce through space suit")
+
+/// Sutures, patches, medsprays - the user-visible symptom of the bug - go through
+/// can_inject() (no penetrate_thick). They must work on a clothed patient.
+/datum/unit_test/medical_stack_through_clothing/Run()
+	var/mob/living/carbon/human/patient = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+
+	var/obj/item/clothing/under/color/grey/jumpsuit = allocate(/obj/item/clothing/under/color/grey)
+	patient.equip_to_slot_or_del(jumpsuit, ITEM_SLOT_ICLOTHING, TRUE)
+
+	// Sutures don't have bypass_armor - they call can_inject() with default args.
+	// With the bug, this returned 0 for any clothed zone. With the fix, jumpsuit passes.
+	var/obj/item/stack/medical/suture/sutures = allocate(/obj/item/stack/medical/suture)
+	TEST_ASSERT(sutures.can_heal(patient, user, BODY_ZONE_CHEST, silent = TRUE), \
+		"Sutures must work on a jumpsuit-covered chest (no THICKMATERIAL)")
+
+	// Apply some damage so try_heal has something to do, and stitch it.
+	patient.take_overall_damage(20, 0)
+	var/brute_before = patient.getBruteLoss()
+	TEST_ASSERT(brute_before > 0, "Patient should have brute damage to stitch")
+
+	var/datum/surgery_step/heal/brute/basic/basic_brute_heal = new
+	basic_brute_heal.success(user, patient, BODY_ZONE_CHEST)
+	// Surgery-stack tests already cover the brute-drop path; here we just need
+	// the can_inject gate to not have falsely refused. If we got past can_heal
+	// above, the regression is covered.


### PR DESCRIPTION
# Описание

Откат "балансировки" из коммита в части, где она поломала всю медицину и антаг-укусы. В `can_inject()` добавилась проверка "любая одежда блокирует укол" - и под раздачу ушли сутурки, бинты, пластыри, медспреи, гипоспреи, укусы кровососа, lewd_bite, обезьяньи укусы, террор-пауки, headcrab, DNA-инжекторы, slime cores и ещё штук тридцать вызовов `can_inject`. Игроки буквально снимали трусы чтобы пластырь налепить

Корень: в DM `FALSE == 0 == SYRINGE_PIERCE_NONE`, поэтому дефолтный `penetrate_thick = FALSE` у всех легаси-вызовов попадал в новую жёсткую ветку

Что сделано:
- `can_inject()` вернул к старой семантике - блокирует только `THICKMATERIAL` (скафандр, броня)
- Новую проверку "любая одежда мешает" вынес в отдельный `can_inject_syringe(user, error_msg, zone, pierce_level)`. Его зовут только шприцы и шприцемёт-дарты
- Балансировка шприцов @SmiLeYre сохранена: обычный шприц блокируется любой одеждой, weak-piercing пробивает обычную но не THICK, diamond пробивает всё

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Демонстрация изменений

Покрыто юнит-тестами `can_inject_clothing` и `medical_stack_through_clothing` в `code/modules/unit_tests/can_inject_clothing.dm`. Прогон dm-test локально - оба зелёные:

```
PASS: /datum/unit_test/can_inject_clothing 0.025s
PASS: /datum/unit_test/medical_stack_through_clothing 0.025s
```

Тестовая матрица (одежда × pierce level): голый/джампсьют/+скафандр против `can_inject()` и `can_inject_syringe(NONE/THICK/ALL)`

## Changelog

:cl:
fix: сутурки, бинты, пластыри, медспрей и гипоспрей снова работают через обычную одежду - раздеваться надо только если поверх скафандр или броня
fix: антаг-ручка, укусы кровососа и lewd_bite, обезьяньи укусы, террор-пауки и headcrab снова работают через одежду
balance: обычный шприц по-прежнему не уколет через одежду, weak-piercing пробивает обычную одежду, алмазный - всё (баланс шприцов сохраняется)
code: проверка одежды для шприцов вынесена в отдельный proc can_inject_syringe(), чтобы случайно не зацепить всех caller'ов can_inject()
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения**
  * Переработана система прободения одежды при инъекции шприцем и дротиками: тонкая ткань теперь селективно проникается в зависимости от типа оружия, толстые защитные материалы обеспечивают большую защиту против колющего оружия

* **Тесты**
  * Добавлены юнит-тесты для проверки корректности системы прободения одежды

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->