### PR TITLE
Правки лееров одежды, фикс рисования ботинок поверх платьев, фикс перекрытия хуяк ботинками

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -51,7 +51,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define SHIRT_LAYER				30
 #define UNIFORM_LAYER			29
 #define SHOES_LAYER				28
-#define DRESS_LAYER				27
+#define DRESS_LAYER				27		//Any uniform that should be drawn on top of shoes, including jumpskirts
 #define ID_LAYER				26
 #define GENITALS_EXPOSED_LAYER	25
 #define HANDS_PART_LAYER		24

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -46,16 +46,16 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define BODY_LAYER				35		//Eyes, lips(makeup)
 #define BODY_ADJ_UPPER_LAYER	34
 #define FRONT_MUTATIONS_LAYER	33		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
-#define DAMAGE_LAYER			32		//damage indicators (cuts and burns)
-#define UNDERWEAR_LAYER			31
-#define SOCKS_LAYER				30
-#define SHIRT_LAYER				29
-#define UNIFORM_LAYER			28
-#define SHOES_LAYER				27
-#define DRESS_LAYER				26
-#define ID_LAYER				25
-#define GENITALS_EXPOSED_LAYER	24
-#define HANDS_PART_LAYER		23
+#define UNDERWEAR_LAYER			32
+#define SOCKS_LAYER				31
+#define SHIRT_LAYER				30
+#define UNIFORM_LAYER			29
+#define SHOES_LAYER				28
+#define DRESS_LAYER				27
+#define ID_LAYER				26
+#define GENITALS_EXPOSED_LAYER	25
+#define HANDS_PART_LAYER		24
+#define DAMAGE_LAYER			23		//damage indicators (cuts and burns)
 #define LOWER_MEDICINE_LAYER	22		//Medicine, like gauze and tourniquets
 #define MEDICINE_LAYER			21		//Medicine, like gauze and tourniquets
 #define GLOVES_LAYER			20

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -36,27 +36,28 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 
 //Human Overlays Indexes/////////
 //LOTS OF CIT CHANGES HERE. BE CAREFUL WHEN UPSTREAM ADDS MORE LAYERS
-#define MUTATIONS_LAYER			41		//mutations. Tk headglows, cold resistance glow, etc
-#define GENITALS_BEHIND_LAYER	40		//Some genitalia needs to be behind everything, such as with taurs (Taurs use body_behind_layer
-#define BODY_BEHIND_LAYER		39		//certain mutantrace features (tail when looking south) that must appear behind the body parts
-#define BODYPARTS_LAYER			38		//Initially "AUGMENTS", this was repurposed to be a catch-all bodyparts flag
-#define MARKING_LAYER			37		//Matrixed body markings because clashing with snouts?
-#define BODY_ADJ_LAYER			36		//certain mutantrace features (snout, body markings) that must appear above the body parts
-#define GENITALS_FRONT_LAYER	35		//Draws some genitalia above clothes and the TAUR body if need be.
-#define BODY_LAYER				34		//underwear, undershirts, socks, eyes, lips(makeup)
-#define BODY_ADJ_UPPER_LAYER	33
-#define FRONT_MUTATIONS_LAYER	32		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
+#define MUTATIONS_LAYER			42		//mutations. Tk headglows, cold resistance glow, etc
+#define GENITALS_BEHIND_LAYER	41		//Some genitalia needs to be behind everything, such as with taurs (Taurs use body_behind_layer)
+#define BODY_BEHIND_LAYER		40		//certain mutantrace features (tail when looking south) that must appear behind the body parts
+#define BODYPARTS_LAYER			39		//Initially "AUGMENTS", this was repurposed to be a catch-all bodyparts flag
+#define MARKING_LAYER			38		//Matrixed body markings because clashing with snouts?
+#define BODY_ADJ_LAYER			37		//certain mutantrace features (snout, body markings) that must appear above the body parts
+#define GENITALS_FRONT_LAYER	36		//Draws some genitalia above clothes and the TAUR body if need be.
+#define BODY_LAYER				35		//Eyes, lips(makeup)
+#define BODY_ADJ_UPPER_LAYER	34
+#define FRONT_MUTATIONS_LAYER	33		//mutations that should appear above body, body_adj and bodyparts layer (e.g. laser eyes)
+#define DAMAGE_LAYER			32		//damage indicators (cuts and burns)
 #define UNDERWEAR_LAYER			31
 #define SOCKS_LAYER				30
 #define SHIRT_LAYER				29
 #define UNIFORM_LAYER			28
-#define ID_LAYER				27
-#define GENITALS_EXPOSED_LAYER	26
-#define HANDS_PART_LAYER		25
-#define DAMAGE_LAYER			24		//damage indicators (cuts and burns)
-#define LOWER_MEDICINE_LAYER	23		//Medicine, like gauze and tourniquets
-#define MEDICINE_LAYER			22		//Medicine, like gauze and tourniquets
-#define SHOES_LAYER				21
+#define SHOES_LAYER				27
+#define DRESS_LAYER				26
+#define ID_LAYER				25
+#define GENITALS_EXPOSED_LAYER	24
+#define HANDS_PART_LAYER		23
+#define LOWER_MEDICINE_LAYER	22		//Medicine, like gauze and tourniquets
+#define MEDICINE_LAYER			21		//Medicine, like gauze and tourniquets
 #define GLOVES_LAYER			20
 #define WRISTS_LAYER			19
 #define EAR_RIGHT_LAYER			18
@@ -77,7 +78,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define BODY_FRONT_LAYER		3
 #define ANTAG_LAYER				2		//stuff for things like cultism indicators (clock cult glow, cultist red halos, whatever else new that comes up)
 #define FIRE_LAYER				1		//If you're on fire
-#define TOTAL_LAYERS			41		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
+#define TOTAL_LAYERS			42		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
 
 //Human Overlay Index Shortcuts for alternate_worn_layer, layers
 //Because I *KNOW* somebody will think layer+1 means "above"
@@ -86,7 +87,6 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define UNDER_HEAD_LAYER			(HEAD_LAYER+1)
 
 //AND -1 MEANS "ABOVE", OK?, OK!?!
-#define ABOVE_SHOES_LAYER			(SHOES_LAYER-1)
 #define ABOVE_BODY_FRONT_LAYER		(BODY_FRONT_LAYER-1)
 #define ABOVE_HEAD_LAYER			(HEAD_LAYER-1) // BlueMoon added
 

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -443,7 +443,7 @@
 
 			genital_overlay.icon_state = "[G.slot]_[S.icon_state]_[size][(dna.species.use_skintones && !dna.skin_tone_override) ? "_s" : ""]_[aroused_state]_[layertext]"
 
-			if(layers_num[layer] == GENITALS_FRONT_LAYER && G.genital_flags & GENITAL_THROUGH_CLOTHES)
+			if(layers_num[layer] == GENITALS_FRONT_LAYER && (G.genital_flags & GENITAL_THROUGH_CLOTHES || G.is_exposed()))
 				genital_overlay.layer = -GENITALS_EXPOSED_LAYER
 				LAZYADD(fully_exposed, genital_overlay)
 			else

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -443,7 +443,10 @@
 
 			genital_overlay.icon_state = "[G.slot]_[S.icon_state]_[size][(dna.species.use_skintones && !dna.skin_tone_override) ? "_s" : ""]_[aroused_state]_[layertext]"
 
-			if(layers_num[layer] == GENITALS_FRONT_LAYER && (G.genital_flags & GENITAL_THROUGH_CLOTHES || G.is_exposed()))
+			// GENITALS_EXPOSED_LAYER is assigned only if such option is checked in the panel, AND/OR
+			// genital is exposed and no inner clothing is worn at the moment. Gear harness is excluded from the uniform check.
+			// Someone someday needs to make a proper check instead of this istype bullshit. I don't have time for that, sadly. As long as it works, i guess.
+			if(layers_num[layer] == GENITALS_FRONT_LAYER && (G.genital_flags & GENITAL_THROUGH_CLOTHES || (G.is_exposed() && (!w_uniform || istype(w_uniform, /obj/item/clothing/under/misc/gear_harness)))))
 				genital_overlay.layer = -GENITALS_EXPOSED_LAYER
 				LAZYADD(fully_exposed, genital_overlay)
 			else

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -443,10 +443,30 @@
 
 			genital_overlay.icon_state = "[G.slot]_[S.icon_state]_[size][(dna.species.use_skintones && !dna.skin_tone_override) ? "_s" : ""]_[aroused_state]_[layertext]"
 
-			// GENITALS_EXPOSED_LAYER is assigned only if such option is checked in the panel, AND/OR
-			// genital is exposed and no inner clothing is worn at the moment. Gear harness is excluded from the uniform check.
-			// Someone someday needs to make a proper check instead of this istype bullshit. I don't have time for that, sadly. As long as it works, i guess.
-			if(layers_num[layer] == GENITALS_FRONT_LAYER && (G.genital_flags & GENITAL_THROUGH_CLOTHES || (G.is_exposed() && (!w_uniform || istype(w_uniform, /obj/item/clothing/under/misc/gear_harness)))))
+			// Check if the flag is on, or the genitals are exposed with no uniform on (except for gear harness)
+			var/should_promote = (G.genital_flags & GENITAL_THROUGH_CLOTHES) || (G.is_exposed() && !(w_uniform && !istype(w_uniform, /obj/item/clothing/under/misc/gear_harness)))
+			// Keep the genital rendered but hidden if player is wearing underwear that got a keep_genitals_below flag on a specific genital
+			if(G.is_exposed() && !(G.genital_flags & GENITAL_THROUGH_CLOTHES))
+				var/obj/item/clothing/under_check
+				if(G.zone == BODY_ZONE_PRECISE_GROIN)
+					if(w_shirt && (w_shirt.body_parts_covered | GROIN))	// Makes sure that exposed genitals aren't drawn on top of long shirts, such as sweaters
+						under_check = (istype(w_shirt, /obj/item/clothing) ? w_shirt : null)
+					else
+						under_check = (istype(w_underwear, /obj/item/clothing) ? w_underwear : null)
+				else if(G.zone == BODY_ZONE_CHEST)
+					under_check = (istype(w_shirt, /obj/item/clothing) ? w_shirt : null)
+
+				if(under_check && under_check.keep_genitals_below)
+					should_promote = FALSE
+
+			// If a genital is exposed, we give it GENITALS_EXPOSED_LAYER when these conditions are true:
+			// Always GENITAL_THROUGH_CLOTHES flag is on AND/OR worn uniform and related underwear(if any) got the keep_genitals_underneath as FALSE (TRUE by default)
+			// Otherwise we keep it on GENITALS_FRONT_LAYER (below clothes)
+			// This way, if needed, genitals can still be rendered underneath uniform that doesn't cover them
+			// Or underneath underwear that doesn't cover them and got the keep_genitals_below flag on
+			// This makes sure that genitals, when they are TRULY exposed, are not covered by shoes and shit
+			// While still keeping the option to render them underneath the clothing when needed
+			if(layers_num[layer] == GENITALS_FRONT_LAYER && should_promote)
 				genital_overlay.layer = -GENITALS_EXPOSED_LAYER
 				LAZYADD(fully_exposed, genital_overlay)
 			else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -12,7 +12,7 @@
 	var/visor_flags = 0			//flags that are added/removed when an item is adjusted up/down
 	var/visor_flags_inv = 0		//same as visor_flags, but for flags_inv
 	var/visor_flags_cover = 0	//same as above, but for flags_cover
-//what to toggle when toggled with weldingvisortoggle()
+	//what to toggle when toggled with weldingvisortoggle()
 	var/visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | VISOR_VISIONFLAGS | VISOR_DARKNESSVIEW | VISOR_INVISVIEW
 	lefthand_file = 'icons/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing_righthand.dmi'
@@ -67,6 +67,9 @@
 	var/reinforced = FALSE
 	// These variables store info about armor piece this item has been reinforced to. Required for proper repair() handling.
 	var/obj/item/clothing/reinforcement_path
+	// This flag makes sure that if a genital is not covered by this piece of clothing, it is still drawn underneath it
+	// Generally should stay TRUE, unless you want your underwear that doesn't cover any body parts to be underneath exposed genitals
+	var/keep_genitals_below = TRUE
 
 /obj/item/clothing/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -7,6 +7,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/color/random
 	icon_state = "random_jumpsuit"

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -7,6 +7,7 @@
 	strip_delay = 100
 	resistance_flags = NONE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/costume/jabroni
 	name = "Jabroni Outfit"
@@ -36,6 +37,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/costume/schoolgirl/red
 	name = "red schoolgirl uniform"
@@ -96,6 +98,7 @@
 	icon_state = "polykilt"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/costume/kilt/polychromic/ComponentInitialize()
 	. = ..()
@@ -126,6 +129,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/costume/maid/Initialize(mapload)
 	. = ..()
@@ -136,7 +140,7 @@
 	desc = "Just looking at this makes you want to sing."
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|ARMS
-	alternate_worn_layer = ABOVE_SHOES_LAYER
+	alternate_worn_layer = DRESS_LAYER
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/singer/yellow
@@ -151,7 +155,7 @@
 	name = "blue performer's outfit"
 	icon_state = "bsing"
 	item_state = "bsing"
-	alternate_worn_layer = ABOVE_SHOES_LAYER
+	alternate_worn_layer = DRESS_LAYER
 	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/costume/geisha
@@ -286,6 +290,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 
 /obj/item/clothing/under/costume/qipao/white
@@ -340,6 +345,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/costume/kimono/black
 	name = "Black Kimono"

--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -14,6 +14,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/cargo/tech
 	name = "cargo technician's jumpsuit"
@@ -42,6 +43,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/cargo/tech/long
 	name = "cargo technician's jumpsuit (trousers)"

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -23,6 +23,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/util
 	name = "utility uniform"
@@ -106,6 +107,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/chef
 	name = "cook's suit"
@@ -121,6 +123,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel
 	desc = "It's a jumpsuit worn by someone who works in the position of \"Head of Personnel\"."
@@ -144,6 +147,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel/suit
 	name = "head of personnel's suit"
@@ -161,6 +165,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/hydroponics
 	desc = "It's a jumpsuit designed to protect against minor plant-related hazards."
@@ -178,6 +183,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/janitor
 	desc = "It's the official uniform of the station's janitor. It has minor protection from biohazards."
@@ -193,6 +199,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/janitor/maid
 	name = "maid uniform"
@@ -206,11 +213,13 @@
 	unique_reskin = list(
 		"Purple" = list("icon_state" = "janimaid_p")
 	)
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/janitor/maid/polychromic
 	icon_state = "polymaid"
 	item_state = "polymaid"
 	var/list/poly_colors = list("#FFFFFF", "#000000")
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/janitor/maid/polychromic/ComponentInitialize()
 	. = ..()
@@ -240,6 +249,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/really_black
 	name = "executive suit"
@@ -256,6 +266,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/black/skirt
 	name = "lawyer black suitskirt"
@@ -263,6 +274,7 @@
 	item_state = "lawyer_black"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/female
 	name = "female black suit"
@@ -280,6 +292,7 @@
 	item_state = "bl_suit"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/red/skirt
 	name = "lawyer red suitskirt"
@@ -287,6 +300,7 @@
 	item_state = "lawyer_red"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/blue
 	name = "lawyer blue suit"
@@ -299,6 +313,7 @@
 	item_state = "lawyer_blue"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/bluesuit
 	name = "blue suit"
@@ -317,6 +332,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
 	name = "purple suit"
@@ -334,3 +350,4 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER

--- a/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -41,6 +41,7 @@
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE //The clown suit must look funny, no taur alpha masks where possible.
 	var/list/poly_colors = list("#FF0000", "#FF99FF", "#FFFF00", "#FFFFFF")
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/polychromic_clown/ComponentInitialize()
 	. = ..()
@@ -54,6 +55,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/green
 	name = "green clown suit"
@@ -63,6 +65,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/yellow
 	name = "yellow clown suit"
@@ -72,6 +75,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/purple
 	name = "purple clown suit"
@@ -81,6 +85,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/orange
 	name = "orange clown suit"
@@ -90,6 +95,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/rainbow
 	name = "rainbow clown suit"
@@ -99,6 +105,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/jester
 	name = "jester suit"
@@ -114,6 +121,7 @@
 	item_state = "sexyclown"
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/clown/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/under/jobs/civilian/curator.dm
+++ b/code/modules/clothing/under/jobs/civilian/curator.dm
@@ -11,6 +11,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/curator/treasure_hunter
 	name = "treasure hunter uniform"

--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -28,6 +28,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/captain/suit
 	name = "captain's suit"
@@ -45,6 +46,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/captain/parade
 	name = "captain's parade uniform"
@@ -81,6 +83,7 @@
 	item_state = "bridgesecf"
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/bridgeofficer/formal
 	name = "bridge officer formal outfit"

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -16,6 +16,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/engineering/atmospheric_technician
 	desc = "It's a jumpsuit worn by atmospheric technicians. It provides decent fire protection."
@@ -34,6 +35,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/engineering/engineer
 	desc = "It's an orange high-visibility jumpsuit worn by engineers. It has minor radiation shielding."
@@ -88,3 +90,4 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -15,6 +15,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck
 	desc = "It's a turtleneck worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection, for an officer with a superior sense of style and practicality."
@@ -41,6 +42,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/medical/virologist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it."
@@ -59,6 +61,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/medical/chemist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a chemist rank stripe on it."
@@ -77,6 +80,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/medical/paramedic
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a white cross on the chest denoting that the wearer is a trained paramedic."
@@ -108,6 +112,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/medical/paramedic/skirt/light
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a dark blue cross on the chest denoting that the wearer is a trained paramedic."
@@ -125,6 +130,7 @@
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/medical/doctor
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel."
@@ -171,3 +177,4 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -14,6 +14,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/rnd/research_director/alt
 	desc = "Maybe you'll engineer your own half-man, half-pig creature some day. Its fabric provides minor protection from biological contaminants."
@@ -33,6 +34,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/rnd/research_director/turtleneck
 	desc = "A dark purple turtleneck and tan khakis, for a director with a superior sense of style."
@@ -52,6 +54,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/rnd/scientist
 	desc = "It's made of a special fiber that provides minor protection against explosives. It has markings that denote the wearer as a scientist."
@@ -82,6 +85,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/rnd/roboticist
 	desc = "It's a slimming black with reinforced seams; great for industrial work."
@@ -105,3 +109,4 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -61,6 +61,7 @@
 		"Maid red" = list("icon_state" = "secmaid_red", "item_state" = "secmaid_red"),
 		"Maid blue" = list("icon_state" = "secmaid_blue", "item_state" = "secmaid_blue"),
 	) ///bluemoon add
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/officer/skirt/no_armor // Donat stuff - Borisovych
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 0)
@@ -146,6 +147,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	alt_covers_chest = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/warden/formal
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Warden."
@@ -184,6 +186,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/detective/grey
 	name = "noir suit"
@@ -200,6 +203,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/detective/grey/skirt/no_armor // Donat stuff - famas098
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 0)
@@ -226,6 +230,7 @@
 	alt_covers_chest = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 
 /obj/item/clothing/under/rank/security/head_of_security/grey
@@ -250,6 +255,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/head_of_security/formal
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
@@ -271,6 +277,7 @@
 	item_state = "r_suit"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /*
  *Spacepol

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -384,6 +384,7 @@
 	item_state = "littleblackdress_s"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/pinktutu
 	name = "pink tutu"
@@ -392,6 +393,7 @@
 	item_state = "pinktutu_s"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/bathrobe
 	name = "bathrobe"
@@ -400,6 +402,7 @@
 	item_state = "bathrobe"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/mechsuitred
 	name = "red mech suit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -36,7 +36,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
-	alternate_appearances = DRESS_LAYER
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/prisoner/syndicate
 	name = "syndicate prisoner jumpsuit"
@@ -49,6 +49,7 @@
 	desc = "A crimson red jumpskirt worn by syndicate captives. Its sensors have been shorted out."
 	color = "#992300"
 	has_sensor = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/mailman
 	name = "mailman's jumpsuit"
@@ -249,7 +250,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
-	alternate_appearances = DRESS_LAYER
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/squatter
 	name = "Slav Squatter Tracksuit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -36,6 +36,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_appearances = DRESS_LAYER
 
 /obj/item/clothing/under/rank/prisoner/syndicate
 	name = "syndicate prisoner jumpsuit"
@@ -248,6 +249,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_appearances = DRESS_LAYER
 
 /obj/item/clothing/under/misc/squatter
 	name = "Slav Squatter Tracksuit"

--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -91,6 +91,7 @@
 	name = "denim skirt"
 	desc = "These are really just a jean leg hole cut from a pair"
 	icon_state = "denim_skirt"
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/pants/chaps
 	name = "black chaps"

--- a/code/modules/clothing/under/skirt_dress.dm
+++ b/code/modules/clothing/under/skirt_dress.dm
@@ -1,5 +1,6 @@
 /obj/item/clothing/under/dress
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/dress/skirt
 	name = "black skirt"
@@ -141,7 +142,6 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	flags_inv = HIDESHOES //You can't see shoes under the gown
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 	unique_reskin = list(
 		"Glove" = list(
 			"icon_state" = "red_evening_gown_glove",
@@ -192,7 +192,6 @@
 	item_state = "bride_white"
 	can_adjust = FALSE
 	flags_inv = HIDESHOES //You can't see shoes under the gown
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/wedding/orange
 	name = "orange wedding dress"
@@ -200,7 +199,6 @@
 	icon_state = "bride_orange"
 	item_state = "bride_orange"
 	flags_inv = HIDESHOES //You can't see shoes under the gown
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/wedding/purple
 	name = "purple wedding dress"
@@ -208,7 +206,6 @@
 	icon_state = "bride_purple"
 	item_state = "bride_purple"
 	flags_inv = HIDESHOES //You can't see shoes under the gown
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/wedding/blue
 	name = "blue wedding dress"
@@ -216,7 +213,6 @@
 	icon_state = "bride_blue"
 	item_state = "bride_blue"
 	flags_inv = HIDESHOES //You can't see shoes under the gown
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/wedding/red
 	name = "red wedding dress"
@@ -224,7 +220,6 @@
 	icon_state = "bride_red"
 	item_state = "bride_red"
 	flags_inv = HIDESHOES //You can't see shoes under the gown
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/skirt/polychromic
 	name = "polychromic skirt"

--- a/code/modules/clothing/under/suits.dm
+++ b/code/modules/clothing/under/suits.dm
@@ -15,6 +15,7 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/suit/sl
 	desc = "It's a very amish looking suit."

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -18,6 +18,7 @@
 	alt_covers_chest = TRUE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/syndicate/bloodred
 	name = "blood-red sneaksuit"
@@ -53,6 +54,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 5)
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/syndicate/sniper
 	name = "Tactical suit"

--- a/modular_bluemoon/code/modules/clothing/syndie_edits/syndie_edits.dm
+++ b/modular_bluemoon/code/modules/clothing/syndie_edits/syndie_edits.dm
@@ -136,6 +136,7 @@
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/head/maid/syndicate
 	name = "Tactical Maid Headband"
@@ -156,6 +157,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	can_adjust = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/syndicate/maid/Initialize(mapload)
 	. = ..()
@@ -173,6 +175,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	can_adjust = FALSE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/accessory/maidcorset/syndicate
 	name = "Syndicate Maid Apron"

--- a/modular_bluemoon/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/modular_bluemoon/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -6,6 +6,7 @@
 	icon_state = "boobsuit"
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/boobblouse
 	name = "custom-tailored blouse"

--- a/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
@@ -278,10 +278,19 @@
 	mob_overlay_icon = 'modular_bluemoon/icons/mob/clothing/uniform.dmi'
 	icon_state = "sexymaid"
 	item_state = "sexymaid"
-	body_parts_covered = NONE
+	body_parts_covered = CHEST|GROIN
 	fitted = NO_FEMALE_UNIFORM
-	can_adjust = FALSE
+	can_adjust = TRUE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+
+/obj/item/clothing/under/dress/skirt/maidsexy/toggle_jumpsuit_adjust()
+	if(!body_parts_covered)
+		to_chat(usr, "<span class='notice'>[src] is now covering chest and groin.</span>")
+		body_parts_covered = CHEST|GROIN
+	else
+		to_chat(usr, "<span class='notice'>[src] is no longer covering anything.</span>")
+		body_parts_covered = NONE
+	return TRUE
 
 /obj/item/clothing/under/dress/turtledress
 	name = "Turtleneck dress"

--- a/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
@@ -280,17 +280,24 @@
 	item_state = "sexymaid"
 	body_parts_covered = CHEST|GROIN
 	fitted = NO_FEMALE_UNIFORM
-	can_adjust = TRUE
+	can_adjust = FALSE	// Yeah, this flag isn't exactly working properly here. I'll still use toggle_jumpsuit_adjust() override for clarity though
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 
 /obj/item/clothing/under/dress/skirt/maidsexy/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)
-		to_chat(usr, "<span class='notice'>[src] теперь закрывает грудь и пах.</span>")
+		to_chat(usr, "<span class='notice'>Вы поправили [src], теперь она полностью закрывает ваше тело.</span>")
 		body_parts_covered = CHEST|GROIN
 	else
-		to_chat(usr, "<span class='notice'>[src] больше не закрывает гениталии.</span>")
+		to_chat(usr, "<span class='notice'>Вы приспустили [src], частично оголив ваши формы.</span>")
 		body_parts_covered = NONE
 	return TRUE
+
+/obj/item/clothing/under/dress/skirt/maidsexy/examine(mob/user)
+	. = ..()
+	if(!body_parts_covered)
+		. += "Alt-click для нормального стиля ношения."
+	else
+		. += "Alt-click для повседневного стиля ношения."
 
 /obj/item/clothing/under/dress/turtledress
 	name = "Turtleneck dress"

--- a/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
@@ -285,10 +285,10 @@
 
 /obj/item/clothing/under/dress/skirt/maidsexy/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)
-		to_chat(usr, "<span class='notice'>[src] is now covering chest and groin.</span>")
+		to_chat(usr, "<span class='notice'>[src] теперь закрывает грудь и пах.</span>")
 		body_parts_covered = CHEST|GROIN
 	else
-		to_chat(usr, "<span class='notice'>[src] is no longer covering anything.</span>")
+		to_chat(usr, "<span class='notice'>[src] больше не закрывает гениталии.</span>")
 		body_parts_covered = NONE
 	return TRUE
 

--- a/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_bluemoon/code/modules/clothing/under/miscellaneous.dm
@@ -20,6 +20,7 @@
 	body_parts_covered = CHEST|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/utility
 	name = "green utility uniform"
@@ -79,7 +80,6 @@
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	flags_inv = HIDESHOES
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/longdress
 	name = "maxi dress"
@@ -92,7 +92,6 @@
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	flags_inv = HIDESHOES
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/skirt/nightie
 	name = "transparent nightie"
@@ -174,7 +173,6 @@
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	flags_inv = HIDESHOES
-	alternate_worn_layer = ABOVE_SHOES_LAYER
 
 /obj/item/clothing/under/dress/skirt/pleatedmedium
 	name = "pleated skirt"
@@ -505,6 +503,7 @@
 	icon_state = "stylish_dress"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/sergal_brown_bib
 	name = "Sergal brown bib"

--- a/modular_bluemoon/code/modules/clothing/under/skirt_dress.dm
+++ b/modular_bluemoon/code/modules/clothing/under/skirt_dress.dm
@@ -6,6 +6,7 @@
 	body_parts_covered = CHEST|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/gothrevskirt
 	name = "Ghotic Vulgar Dress"
@@ -14,6 +15,7 @@
 	item_state = "syndicate-black"
 	body_parts_covered = CHEST|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/angelrevskirt
 	name = "Angelic Vulgar Dress"
@@ -22,6 +24,7 @@
 	item_state = "capspacehelmet"
 	body_parts_covered = CHEST|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/blackrevdress
 	name = "Black Revealing Dress"
@@ -30,6 +33,7 @@
 	item_state = "syndicate-black"
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/whiterevdress
 	name = "White Revealing Dress"
@@ -39,6 +43,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bm/ryodan
 	name = "Ryodan Suit"

--- a/modular_bluemoon/code/modules/clothing/underwear/shirts.dm
+++ b/modular_bluemoon/code/modules/clothing/underwear/shirts.dm
@@ -90,7 +90,7 @@
 	var/obj/item/organ/genital/breasts/B = H.getorganslot(ORGAN_SLOT_BREASTS)
 	if(B?.is_exposed() || H.is_chest_exposed())
 		H.update_inv_w_shirt()
-	else if(!HAS_TRAIT(H, TRAIT_HUMAN_NO_RENDER))
+	else if(HAS_TRAIT(H, TRAIT_HUMAN_NO_RENDER))
 		H.remove_overlay(SHIRT_LAYER)
 
 /obj/item/clothing/underwear/shirt/bra/bra_adjustable/update_icon_state()

--- a/modular_bluemoon/code/modules/clothing/underwear/shirts.dm
+++ b/modular_bluemoon/code/modules/clothing/underwear/shirts.dm
@@ -90,7 +90,7 @@
 	var/obj/item/organ/genital/breasts/B = H.getorganslot(ORGAN_SLOT_BREASTS)
 	if(B?.is_exposed() || H.is_chest_exposed())
 		H.update_inv_w_shirt()
-	else if(HAS_TRAIT(H, TRAIT_HUMAN_NO_RENDER))
+	else if(!HAS_TRAIT(H, TRAIT_HUMAN_NO_RENDER))
 		H.remove_overlay(SHIRT_LAYER)
 
 /obj/item/clothing/underwear/shirt/bra/bra_adjustable/update_icon_state()

--- a/modular_bluemoon/kovac_shitcode/code/modules/clothing/misc.dm
+++ b/modular_bluemoon/kovac_shitcode/code/modules/clothing/misc.dm
@@ -136,6 +136,7 @@
 		"Nun 6" = list("icon_state" = "nun6"),
 		"Nun 7" = list("icon_state" = "nun7")
 	)
+	alternate_worn_layer = DRESS_LAYER
 
 ////////////////
 

--- a/modular_bluemoon/kovac_shitcode/code/solfed.dm
+++ b/modular_bluemoon/kovac_shitcode/code/solfed.dm
@@ -47,6 +47,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	icon = 'modular_bluemoon/kovac_shitcode/icons/solfed/obj_sol.dmi'
 	mob_overlay_icon = 'modular_bluemoon/kovac_shitcode/icons/solfed/mob_sol.dmi'
+	alternate_worn_layer = DRESS_LAYER
 
 /// Suits
 

--- a/modular_bluemoon/krashly/code/modules/clothing/under.dm
+++ b/modular_bluemoon/krashly/code/modules/clothing/under.dm
@@ -98,6 +98,7 @@
 	icon_state = "inteq_skirt"
 	item_state = "inteq_skirt"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/inteq/eng
 	name = "brown engineering turtleneck"
@@ -118,6 +119,7 @@
 	item_state = "inteqeng_skirt"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/inteq/maid
 	name = "brown combat maidsuit"
@@ -131,6 +133,7 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/inteq/maid/Initialize(mapload)
 	. = ..()
@@ -163,3 +166,4 @@
 	icon_state = "inteqmed_skirt"
 	item_state = "inteqmed_skirt"
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER

--- a/modular_citadel/code/modules/custom_loadout/custom_items.dm
+++ b/modular_citadel/code/modules/custom_loadout/custom_items.dm
@@ -252,7 +252,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/custom_w.dmi'
 	item_state = "singer"
 	fitted = NO_FEMALE_UNIFORM
-	alternate_worn_layer = ABOVE_SHOES_LAYER
+	alternate_worn_layer = DRESS_LAYER
 	can_adjust = 0
 	mutantrace_variation = NONE
 

--- a/modular_splurt/code/modules/clothing/kinkyclothes.dm
+++ b/modular_splurt/code/modules/clothing/kinkyclothes.dm
@@ -84,6 +84,7 @@
 	heat_protection = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	//armor = list("melee" = 60, "bullet" = 80, "laser" = 80, "energy" = 90, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
+	alternate_appearances = DRESS_LAYER
 
 /obj/item/clothing/under/centcomdress/vk
 	name = "Virginkiller CentCom Dress Uniform"

--- a/modular_splurt/code/modules/clothing/kinkyclothes.dm
+++ b/modular_splurt/code/modules/clothing/kinkyclothes.dm
@@ -84,7 +84,7 @@
 	heat_protection = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	//armor = list("melee" = 60, "bullet" = 80, "laser" = 80, "energy" = 90, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
-	alternate_appearances = DRESS_LAYER
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/centcomdress/vk
 	name = "Virginkiller CentCom Dress Uniform"

--- a/modular_splurt/code/modules/clothing/under/jobs/centcom.dm
+++ b/modular_splurt/code/modules/clothing/under/jobs/centcom.dm
@@ -22,7 +22,7 @@
 	icon_state = "centcom_skirt"
 	item_state = "centcom_skirt"
 	can_adjust = TRUE
-	alternate_appearances = DRESS_LAYER
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/centcom/officer
 	name = "centcom officer jumpsuit"
@@ -101,4 +101,4 @@
 	desc = "An elegant uniform worn by CentCom's station officials, comfortable skirt and silver marking denoting the rank of \"Representative\"."
 	icon_state = "rep_skirt"
 	item_state = "rep_skirt"
-	alternate_appearances = DRESS_LAYER
+	alternate_worn_layer = DRESS_LAYER

--- a/modular_splurt/code/modules/clothing/under/jobs/centcom.dm
+++ b/modular_splurt/code/modules/clothing/under/jobs/centcom.dm
@@ -22,6 +22,7 @@
 	icon_state = "centcom_skirt"
 	item_state = "centcom_skirt"
 	can_adjust = TRUE
+	alternate_appearances = DRESS_LAYER
 
 /obj/item/clothing/under/rank/centcom/officer
 	name = "centcom officer jumpsuit"
@@ -100,3 +101,4 @@
 	desc = "An elegant uniform worn by CentCom's station officials, comfortable skirt and silver marking denoting the rank of \"Representative\"."
 	icon_state = "rep_skirt"
 	item_state = "rep_skirt"
+	alternate_appearances = DRESS_LAYER

--- a/modular_splurt/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/modular_splurt/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -14,6 +14,7 @@
 	icon_state = "hop_parade_female"
 	item_state = "hop_parade_female"
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/civilian/lawyer/galaxy_blue
 	name = "\improper De Void of Soul"

--- a/modular_splurt/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/modular_splurt/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -20,3 +20,4 @@
 	icon_state = "clussy_outfit"
 	item_state = "clussy_outfit"
 	mutantrace_variation = STYLE_DIGITIGRADE | STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER

--- a/modular_splurt/code/modules/clothing/under/jobs/civilian/suits.dm
+++ b/modular_splurt/code/modules/clothing/under/jobs/civilian/suits.dm
@@ -24,6 +24,7 @@
 	anthro_mob_worn_overlay = 'modular_splurt/icons/mob/clothing/under/suits_digi.dmi'
 	fitted = FEMALE_UNIFORM_TOP //So it won't create holes in skirt texture. - Gardelin0
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/suit/pencil/black_really
 	name = "executive pencilskirt"
@@ -86,6 +87,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/suit/inferno
 	name = "inferno suit"
@@ -112,6 +114,7 @@
 	)
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/suit/inferno/beeze
 	name = "designer inferno suit"
@@ -134,6 +137,7 @@
 	icon_state = "helltakerskirt"
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/suit/error
 	name = "error suit"

--- a/modular_splurt/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/under/miscellaneous.dm
@@ -7,6 +7,7 @@
 	can_adjust = FALSE
 	mutantrace_variation = NONE
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/latex
 	name = "full latex jumpsuit"
@@ -73,6 +74,7 @@
 	can_adjust = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS // Это буквально платье для тонкоспрайтов с Бея. Оно не работает. Очередной наркоманский элемент папки modular_splurt. Заменил на спрайт синего платья как заглушку до того, как перерисуем.
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/bluedress
 	name = "Blue Royal Dress"
@@ -85,6 +87,7 @@
 	fitted = NO_FEMALE_UNIFORM // So it won't delete boobs
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/performer
 	name = "Performers one piece"
@@ -97,6 +100,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/blutigen_undergarment
 	name = "Blutigen Undergarments"
@@ -129,6 +133,7 @@
 	body_parts_covered = CHEST
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/skirt/slut
 	name = "slutty security jumpskirt"
@@ -141,6 +146,7 @@
 	can_adjust = FALSE
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/uniform.dmi'
 	mutantrace_variation = NONE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/skirt/slut/pink
 	desc = "A \"\"\"tactical\"\"\" security jumpsuit with the legs replaced by a skirt. No matter how you adjust it, it always feels a little too small. This one seems to have an experimental color scheme."
@@ -151,6 +157,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/uniform.dmi'
 	mutantrace_variation = NONE
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/security/stripper
 	name = "security stripper outfit"
@@ -217,6 +224,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/rank/blueshield/skirt
 	name = "blueshield skirt"
@@ -225,6 +233,7 @@
 	item_state = "hosalt_blue_skirt"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/plasmaman/security/blueshield
 	name = "blueshield plasma envirosuit"
@@ -278,6 +287,7 @@
 	body_parts_covered = CHEST|GROIN
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	alternate_worn_layer = DRESS_LAYER
 
 // GWTB-inspired stuff wooo
 /obj/item/clothing/under/goner
@@ -342,6 +352,7 @@
 	icon = 'modular_splurt/icons/obj/clothing/uniforms.dmi'
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/uniform.dmi'
 	icon_state = "poly_performer"
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/performer/polychromic/ComponentInitialize()
 	. = ..()
@@ -416,6 +427,7 @@
 	alt_covers_chest = FALSE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/wench/ComponentInitialize()
 	. = ..()
@@ -432,6 +444,7 @@
 	item_state = "tian_dress"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/tian_dress/ComponentInitialize()
 	. = ..()
@@ -446,6 +459,7 @@
 	item_state = "vneckdress"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/vneck/ComponentInitialize()
 	. = ..()
@@ -460,6 +474,7 @@
 	item_state = "revealingdress"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/revealingdress/ComponentInitialize()
 	. = ..()
@@ -489,6 +504,7 @@
 	item_state = "gothic"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/gothic/ComponentInitialize()
 	. = ..()
@@ -503,6 +519,7 @@
 	item_state = "pentagram"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/pentagram/ComponentInitialize()
 	. = ..()
@@ -517,6 +534,7 @@
 	item_state = "swoop"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/swoop/ComponentInitialize()
 	. = ..()
@@ -531,6 +549,7 @@
 	item_state = "asym"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/asym/ComponentInitialize()
 	. = ..()
@@ -545,6 +564,7 @@
 	item_state = "sheer"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/sheer/ComponentInitialize()
 	. = ..()
@@ -559,6 +579,7 @@
 	item_state = "corsetdress"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = CHEST|GROIN|LEGS
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/corsetdress/ComponentInitialize()
 	. = ..()
@@ -573,6 +594,7 @@
 	item_state = "miniskirt"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = GROIN
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/miniskirt/ComponentInitialize()
 	. = ..()
@@ -587,6 +609,7 @@
 	item_state = "miniskirt_sheer"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 	body_parts_covered = GROIN
+	alternate_worn_layer = DRESS_LAYER
 
 /obj/item/clothing/under/misc/miniskirt_sheer/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
# Описание

- Пофиксил отрисовку ботинок поверх платьев.
Так как платья и униформа у нас делили один и тот же леер, а ботинки имеют леер выше униформы, такая же логика распространялась и на платья. В итоге, любая обувь (особенно заметно на высоких берцах), рисовалась прямо сверху платья, что выглядело очень криво. Пофиксил, добавив новый леер.
- Несколько изменил порядок существующих лееров
Ботинки рисовались значительно выше многих других элементов, перенёс их поближе к униформе.
- Починил перекрытие обнажённых гениталий ботинками
Леер открытых гениталий у нас нормально применялся лишь при изменении соответствующего пункта в ЕРП панельки. Без этого пункта использовался леер закрытых гениталий, находящийся за ботинками, и как следствие - перекрываемый ими. Я добавил пункт к проверке использования exposed леера, теперь длинные члены и большие яйца не будут упаковываться в берцы

Ну и для соответствия вышеупомянутой логике поменял sexy maid outfit, теперь она меняет закрываемые собой части тела на Alt Click, аналогично Gear Harness.

- ✅ Изменения были проверены на локальном сервере
- ✅ Этот пулл-реквест готов к тест-мерджу.
- 🟥 Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Ботинки на юбках выглядели криво, и вынуждали игроков использовать костыли в виде невидимых обмоток.

## Демонстрация изменений

<img width="244" height="936" alt="Screenshot 2026-05-26 112740" src="https://github.com/user-attachments/assets/2c5040d4-36e4-49d2-bd4f-9844ecc3477e" />
➡️➡️➡️➡️➡️
<img width="250" height="934" alt="Screenshot 2026-05-26 114810" src="https://github.com/user-attachments/assets/66750cf7-3462-47d6-9d79-e59f5c3c6010" />

<img width="248" height="935" alt="Screenshot 2026-05-26 105626" src="https://github.com/user-attachments/assets/8da72561-9999-4e91-a0b4-c672c1d61e5d" />
➡️➡️➡️➡️➡️
<img width="244" height="935" alt="Screenshot 2026-05-26 114741" src="https://github.com/user-attachments/assets/968fb0a4-b0ea-4c47-b73a-438040e7ce19" />


<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Пофиксил отображение ботинок поверх юбок
fix: Пофиксил перекрытие гениталий ботинками
code: Добавил новый леер для юбок, платьев, и любой униформы с ними
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Введён отдельный слой отображения для платьев/юбок (DRESS_LAYER) для более корректного позиционирования одежды.

* **Изменения**
  * Перестроены индексы слоёв (увеличен максимальный номер слоя); множество предметов одежды переключены на новый слой.
  * Базовые платья и многие юбки теперь наследуют альтернативный слой по умолчанию.

* **Исправления**
  * Обновлено поведение отрисовки гениталий/оверлеев — учтены случаи явного обнажения и настройки одежды; добавлена настройка, предотвращающая автоматическое «всплытие» гениталий.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->