### PR TITLE
Мелкие фиксы интегрального usage модуля, бс майнера, рации

### DIFF
--- a/code/game/atom/atom_tool_acts.dm
+++ b/code/game/atom/atom_tool_acts.dm
@@ -9,7 +9,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	PROTECTED_PROC(TRUE)
 
-	if(tool.tool_behaviour && !SEND_SIGNAL(usr, COMSIG_COMBAT_MODE_CHECK, COMBAT_MODE_ACTIVE))
+	if(tool.tool_behaviour && !SEND_SIGNAL(user, COMSIG_COMBAT_MODE_CHECK, COMBAT_MODE_ACTIVE))
 		var/tool_return = tool_act(user, tool, tool.tool_behaviour)
 		if(tool_return)
 			return tool_return

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -300,7 +300,8 @@
 
 	// Non-subspace radios will check in a couple of seconds, and if the signal
 	// was never received, send a mundane broadcast (no headsets).
-	addtimer(CALLBACK(src, PROC_REF(backup_transmission), signal), 20)
+	if(!QDELETED(src))
+		addtimer(CALLBACK(src, PROC_REF(backup_transmission), signal), 20)
 
 /obj/item/radio/proc/backup_transmission(datum/signal/subspace/vocal/signal)
 	var/turf/T = get_turf(src)

--- a/modular_sand/code/modules/mining/machine_bluespaceminer/machine_bluespaceminer.dm
+++ b/modular_sand/code/modules/mining/machine_bluespaceminer/machine_bluespaceminer.dm
@@ -515,6 +515,8 @@ GLOBAL_VAR_INIT(bsminers_lock, FALSE)
 
 	if(bs_core)
 		if(I.use_tool(src, user, 2 SECONDS, volume = 50))
+			if(!bs_core || QDELETED(bs_core))
+				return
 			if(ishuman(user))	// put_in_hands proc fails silently if user has no hands, leaving bs cores inside the machine. This check makes sure it's only called for human users.
 				user.put_in_hands(bs_core)
 			else

--- a/modular_sand/code/modules/mining/machine_bluespaceminer/machine_bluespaceminer.dm
+++ b/modular_sand/code/modules/mining/machine_bluespaceminer/machine_bluespaceminer.dm
@@ -515,7 +515,10 @@ GLOBAL_VAR_INIT(bsminers_lock, FALSE)
 
 	if(bs_core)
 		if(I.use_tool(src, user, 2 SECONDS, volume = 50))
-			user.put_in_hands(bs_core)
+			if(ishuman(user))	// put_in_hands proc fails silently if user has no hands, leaving bs cores inside the machine. This check makes sure it's only called for human users.
+				user.put_in_hands(bs_core)
+			else
+				bs_core.forceMove(get_turf(user))
 			on_core_remove()
 			to_chat(user, span_notice("Вы извлекли Bluespace ядро из машины."))
 		return


### PR DESCRIPTION
# Описание

- Пофиксил редкий рантайм при вызове проки base_item_interaction интегралкой (смена usr на user)
- Пофиксил редкий рантайм при добавлении таймера qdeleted рации
- Пофиксил "пропажу" бс ядра при вытаскивании его мобом без рук (тот же usage модуль)

Будет круто получить ТМ дня на 3, чтобы посмотреть, не сломаются ли основные игровые системы. На обнажившиеся баги с интегралками похуй. Мы народ терпеливый, потерпим.

- ✅ Изменения были проверены на локальном сервере
- ✅ Этот пулл-реквест готов к тест-мерджу.
- 🟥 Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

(https://discord.com/channels/875735187449847830/1504105060823466054)

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Пофиксил выдачу ядра мобу без рук при вытаскивании оного ломом
fix: Пофиксил рантайм при вынимании ядра интегралкой
fix: Пофиксил рантайм при добавлении таймера нон-сабспейс сигнала qdeleteнутой рации
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок
- Исправлена работа боевого режима при взаимодействии с предметами и инструментами в игре
- Исправлена потенциальная ошибка с передачей радиосигналов, которая могла возникнуть при определённых игровых ситуациях
- Добавлена корректная поддержка для небиологических существ при извлечении ядра Bluespace через использование инструментов

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->