### PR TITLE
Дюротканевые рампарты на броню больше не заменяют статы

### DIFF
--- a/code/game/objects/items/armor_kits.dm
+++ b/code/game/objects/items/armor_kits.dm
@@ -10,6 +10,42 @@
 	var/obj/item/clothing/parent_armor_type = /obj/item/clothing/under/misc/durathread	// Path of the parent armor we're copiyng stats from
 	var/kit_prefix = "armored"	// Used for prefix and name changing. For "aegis armor kit" it should be "aegis"
 
+/// Собирает новый /datum/armor: по каждому типу урона не ниже, чем было на вещи или в шаблоне набора (укрепление не должно ослаблять броню, в т.ч. после пластин голиафа и т.п.).
+/obj/item/armorkit/proc/build_merged_armor_for_reinforcement(obj/item/clothing/wearer_piece, obj/item/clothing/template_piece)
+	var/datum/armor/current = wearer_piece.get_armor()
+	var/datum/armor/templ = template_piece.get_armor()
+	var/list/best_ratings = list()
+	for(var/armor_key in ARMOR_LIST_ALL())
+		best_ratings[armor_key] = max(current.get_rating(armor_key), templ.get_rating(armor_key))
+	return current.generate_new_with_specific(best_ratings)
+
+/// Объединяет защитные поля одежды с шаблоном набора без ухудшения: маски покрытия и температуры — «лучшее из двух».
+/obj/item/armorkit/proc/merge_reinforcement_protection_fields(obj/item/clothing/wearer_piece, obj/item/clothing/template_piece)
+	wearer_piece.body_parts_covered |= template_piece.body_parts_covered
+	wearer_piece.cold_protection |= template_piece.cold_protection
+	wearer_piece.heat_protection |= template_piece.heat_protection
+
+	if(!isnull(template_piece.min_cold_protection_temperature))
+		if(isnull(wearer_piece.min_cold_protection_temperature))
+			wearer_piece.min_cold_protection_temperature = template_piece.min_cold_protection_temperature
+		else
+			wearer_piece.min_cold_protection_temperature = min(wearer_piece.min_cold_protection_temperature, template_piece.min_cold_protection_temperature)
+
+	if(!isnull(template_piece.max_heat_protection_temperature))
+		if(isnull(wearer_piece.max_heat_protection_temperature))
+			wearer_piece.max_heat_protection_temperature = template_piece.max_heat_protection_temperature
+		else
+			wearer_piece.max_heat_protection_temperature = max(wearer_piece.max_heat_protection_temperature, template_piece.max_heat_protection_temperature)
+
+	wearer_piece.resistance_flags |= template_piece.resistance_flags
+	wearer_piece.clothing_flags |= (template_piece.clothing_flags || NONE)
+
+	if(LAZYLEN(template_piece.allowed))
+		LAZYINITLIST(wearer_piece.allowed)
+		for(var/allowed_path in template_piece.allowed)
+			if(!(allowed_path in wearer_piece.allowed))
+				wearer_piece.allowed += allowed_path
+
 // This is an amalgamation of newer BlueMoon armor kit's, and older durathread kit's afterattack procedures
 // It should be universal for all armor kits, replacing cursed copy-pasted overrides
 /obj/item/armorkit/afterattack(obj/item/target, mob/user, proximity_flag, click_parameters)
@@ -45,18 +81,11 @@
 			return	// Prevents people from bypassing clothing slot lock by equipping it in advance.
 
 	var/obj/item/clothing/P = new parent_armor_type(src)
-	C.set_armor(P.armor)
-	C.body_parts_covered = P.body_parts_covered
-	C.cold_protection = P.cold_protection
-	C.heat_protection = P.heat_protection
-	C.resistance_flags = P.resistance_flags
-	C.clothing_flags = P.clothing_flags
-	C.min_cold_protection_temperature = P.min_cold_protection_temperature
-	C.max_heat_protection_temperature = P.max_heat_protection_temperature
-	C.allowed = P.allowed
+	C.set_armor(build_merged_armor_for_reinforcement(C, P))
+	merge_reinforcement_protection_fields(C, P)
 
 	user.visible_message("<span class = 'notice'>[user] укрепляет [C] с помощью [src].</span>", \
-	"<span class = 'notice'>Вы усиливаете [C] с помощью [src], делая его уровень защиты идентичным [P.name].</span>")
+	"<span class = 'notice'>Вы усиливаете [C] с помощью [src], не ослабляя уже имеющуюся защиту и добавляя слой от [P.name].</span>")
 	qdel(P)
 	C.name = "[kit_prefix] [C.name]"
 	C.upgrade_prefix = "[kit_prefix]"


### PR DESCRIPTION
# Описание
Дюротканевые рампарты на броню больше не заменяют статы
<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений
https://discord.com/channels/875735187449847830/1508883928117674064
<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

## Демонстрация изменений
<img width="400" height="516" alt="изображение" src="https://github.com/user-attachments/assets/41da53a0-3cfc-41be-ac44-c63bb8c8331e" />

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Дюротканевые рампарты на броню больше не заменяют статы
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Улучшена система армирования брони: теперь при применении усиления автоматически сохраняются лучшие показатели защиты вашей текущей экипировки вместо их замены. Добавляется дополнительный уровень защиты от материала усиления, обеспечивая только положительный эффект.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->