### PR TITLE
Не терять ники авторов на CRLF-описаниях PR

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from ruamel import yaml
 from github import Github, InputGitAuthor
 
-CL_BODY = re.compile(r":cl:(.+)?\r?\n((.|\n|\r)+?)\r?\n\/:cl:", re.MULTILINE)
+CL_BODY = re.compile(r":cl:([^\r\n]+)?\r?\n((.|\n|\r)+?)\r?\n\/:cl:", re.MULTILINE)
 CL_SPLIT = re.compile(r"(^\w+):\s+(\w.+)", re.MULTILINE)
 
 git_email = os.getenv("GIT_EMAIL")
@@ -60,7 +60,7 @@ except AttributeError:
 
 
 if cl.group(1) is not None:
-    write_cl['author'] = cl.group(1).lstrip()
+    write_cl['author'] = cl.group(1).strip()
 else:
     write_cl['author'] = pr_author
 

--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -59,10 +59,8 @@ except AttributeError:
     exit(0) # Change to '0' if you do not want the action to fail when no CL is provided
 
 
-if cl.group(1) is not None:
-    write_cl['author'] = cl.group(1).strip()
-else:
-    write_cl['author'] = pr_author
+author = cl.group(1).strip() if cl.group(1) is not None else ""
+write_cl['author'] = author if author else pr_author
 
 write_cl['delete-after'] = True
 


### PR DESCRIPTION
# Описание

Чинит баг, который сам же приехал с прошлым фиксом чейнджлога (#3262). Тогда в регекспе `\r\n` поменял на `\r?\n`, чтобы ловить PR с LF-переносами - и нечаянно сломал захват ника автора. Точка `.` в Python-регекспе матчит `\r`, поэтому жадная группа стала утаскивать хвостовой возврат каретки: на CRLF-описаниях (а это почти все PR с веба GitHub) ник превращался в `Name\r`, а `:cl:` без явного ника вообще давал пустую строку вместо гитхаб-логина. Отсюда и пропавшие/побитые ники на сервере

Ник теперь ограничен `[^\r\n]+` (перенос строки в него физически не влезет), плюс `lstrip()` заменён на `strip()` на всякий. LF-PR по-прежнему ловятся, цель #3262 не сломана

- [?] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: ники авторов снова корректно отображаются в чейнджлоге (сломалось на CRLF-описаниях PR)
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Релиз

* **Улучшения**
  * Оптимизирована система генерации changelog с более точным извлечением информации и корректной обработкой данных автора.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BlueMoon-Labs/BlueMoon-Station/pull/3279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->