### PR TITLE
"Drift 2.0": починка космического дрейфа и поведения мехов

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -58,6 +58,8 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define DEFAULT_INERTIA_SPEED 4
 #define INERTIA_SPEED_COEF 0.4
 #define INERTIA_FORCE_CAP 15
+/// Recoil/click sources (weapon fire) may top drift up to this ceiling, but never beyond it and never as a brake. Stops "click to accelerate".
+#define INERTIA_FORCE_RECOIL_CAP 3
 #define INERTIA_FORCE_SPACEMOVE_GRAB 0.4
 #define INERTIA_FORCE_SPACEMOVE_REDUCTION 0.2
 

--- a/code/controllers/subsystem/movement/movement.dm
+++ b/code/controllers/subsystem/movement/movement.dm
@@ -52,7 +52,11 @@ SUBSYSTEM_DEF(movement)
 	while(processing.len)
 		var/datum/move_loop/loop = processing[processing.len]
 		processing.len--
-		loop.process() //This shouldn't get nulls, if it does, runtime
+		// A hard-delete (e.g. SSgarbage force-collecting a still-bucketed, already-qdel'd loop) nulls this slot.
+		// Skip dead/null entries instead of runtiming on null.process(); a deleted loop has nothing left to do.
+		if(QDELETED(loop))
+			continue
+		loop.process()
 		if(!QDELETED(loop)) //Re-Insert the loop
 			loop.timer = world.time + loop.delay
 			queue_loop(loop)

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -179,6 +179,12 @@
 	if(ignore_next_glide)
 		ignore_next_glide = FALSE
 		return
+	// Defer the drift at most once per loop cycle. A held thrust/move key fires a glide update on every step
+	// (vehicle_move's set_glide_size, plus Move()'s glide_size_override from step()); re-pausing on each one keeps
+	// shoving the loop's next fire past the key-repeat interval, so the drift never advances and the mech "freezes"
+	// in place until the key is released. before_move clears `delayed` on every real fire, so this self-resets.
+	if(delayed)
+		return
 	var/glide_delay = round(world.icon_size / max(glide_size, 1), 1) * world.tick_lag
 	drifting_loop.pause_for(glide_delay)
 	delayed = TRUE

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -91,7 +91,9 @@
 	var/force_y = cos(drifting_loop.angle) * drift_force + cos(inertia_angle) * applied_force / parent.inertia_force_weight
 
 	var/uncapped_force = sqrt(force_x * force_x + force_y * force_y)
-	var/effective_cap = !isnull(controlled_cap) ? controlled_cap : INERTIA_FORCE_CAP
+	// controlled_cap (recoil/click sources) is a top-up ceiling: it can add drift up to the cap but must never clamp away
+	// drift the parent already built from movement, otherwise firing would become a free brake / reverse exploit.
+	var/effective_cap = isnull(controlled_cap) ? INERTIA_FORCE_CAP : max(drift_force, controlled_cap)
 	drift_force = clamp(uncapped_force, 0, effective_cap)
 	if(drift_force < 0.1)
 		qdel(src)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -391,7 +391,9 @@
 /atom/movable/proc/set_glide_size(target = 8)
 #ifdef SMOOTH_MOVEMENT
 	SEND_SIGNAL(src, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, target)
-	glide_size = target
+	// Cap the upper bound: fast space drift feeds glide via the unclamped MOVEMENT_ADJUSTED_GLIDE_SIZE, and under MC lag the
+	// inflated visual_delay makes the sprite slide past one tile per render -> "teleport" look. Don't raise the floor: 0 means an instant move.
+	glide_size = min(target, MAX_GLIDE_SIZE)
 
 	for(var/mob/buckled_mob as anything in buckled_mobs)
 		buckled_mob.set_glide_size(target)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -17,7 +17,7 @@
 		SEND_SIGNAL(src, COMSIG_PELLET_CLOUD_INIT, target, user, fired_from, randomspread, spread, zone_override, params, distro)
 
 	user.DelayNextAction(considered_action = TRUE, immediate = FALSE)
-	user.newtonian_move(get_dir(target, user), drift_force = newtonian_force)
+	user.newtonian_move(get_dir(target, user), drift_force = newtonian_force, controlled_cap = INERTIA_FORCE_RECOIL_CAP)
 	update_icon()
 	return TRUE
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -167,6 +167,7 @@
 #include "preload_size_budgets.dm"
 #include "image_leak_audit.dm"
 #include "screen_gc.dm"
+#include "space_drift.dm"
 #include "statpanel_listedturf.dm"
 #include "ssmobs_optimization.dm"
 #include "tattoo_system.dm"

--- a/code/modules/unit_tests/space_drift.dm
+++ b/code/modules/unit_tests/space_drift.dm
@@ -5,6 +5,8 @@
 //  - drift_glide_clamp:     fast drift can't make the sprite visually "teleport"
 //  - mecha_stabilizer:      mechs can hold position with a jetpack-style stabilizer
 //  - mecha_turn_decoupled:  mechs can turn in zero-g and turning doesn't eat the move cooldown (#6)
+//  - mecha_drift_stepsound: a drifting mech doesn't play its walking sound on every drift tick
+//  - drift_glide_no_starve: holding a thrust key while drifting doesn't freeze the mech in place
 
 /// A multi-ton exosuit must resist nudges and have a capped top drift speed, unlike a human (defaults 1/1).
 /datum/unit_test/mecha_inertia_mass/Run()
@@ -96,3 +98,43 @@
 	ripley.setDir(NORTH)
 	ripley.vehicle_move(EAST)
 	TEST_ASSERT_EQUAL(ripley.dir, NORTH, "strafe mode without Alt must not rotate the mech")
+
+/// A drifting mech played its walking sound on every drift tick. play_stepsound must skip inertia (drift)
+/// moves and consume step_silent (set for thrust / push-off) - neither of which is an actual footstep.
+/datum/unit_test/mecha_drift_stepsound/Run()
+	var/obj/vehicle/sealed/mecha/working/ripley/ripley = allocate(/obj/vehicle/sealed/mecha/working/ripley)
+
+	// Thrust / push-off marks step_silent; play_stepsound must eat it (and stay silent) rather than walk-sound.
+	ripley.step_silent = TRUE
+	ripley.play_stepsound()
+	TEST_ASSERT(!ripley.step_silent, "play_stepsound must consume step_silent (thrust/push-off is not a footstep)")
+
+	// A drift-loop move sets inertia_moving; play_stepsound must be a no-op and must not clear the flag.
+	ripley.inertia_moving = TRUE
+	ripley.play_stepsound()
+	TEST_ASSERT(ripley.inertia_moving, "play_stepsound must not run its body during a drift (inertia) move")
+
+/// Holding a thrust/move key while drifting froze the mech: every voluntary step fires a glide update and the
+/// drift handler re-paused its move loop each time, shoving the next fire past the key-repeat interval forever.
+/// The handler must defer the loop at most once per cycle so the drift keeps advancing.
+/datum/unit_test/drift_glide_no_starve/Run()
+	var/turf/center = locate(run_loc_floor_bottom_left.x + 2, run_loc_floor_bottom_left.y + 2, run_loc_floor_bottom_left.z)
+	var/obj/item/pen/thing = allocate(/obj/item/pen, center)
+	thing.AddElement(/datum/element/forced_gravity, 0) // weightless, so the drift actually starts
+	thing.newtonian_move(NORTH, drift_force = 5, force_loop = FALSE)
+	var/datum/drift_handler/handler = thing.drift_handler
+	TEST_ASSERT_NOTNULL(handler, "newtonian_move should have started a drift")
+	TEST_ASSERT_NOTNULL(handler.drifting_loop, "the drift should have a move loop")
+
+	// First glide change of the cycle defers the loop once (the intended visual sync) and marks it delayed.
+	// Clear both gating flags so the call is deterministic regardless of the loop's init-time running state.
+	handler.delayed = FALSE
+	handler.ignore_next_glide = FALSE
+	handler.handle_glidesize_update(thing, 8)
+	TEST_ASSERT(handler.delayed, "an external glide change while drifting should defer the drift loop once")
+
+	// Already delayed: further glide changes (a held key) must be ignored, so the loop's timer isn't pushed out.
+	var/locked_timer = handler.drifting_loop.timer
+	handler.handle_glidesize_update(thing, 4)
+	handler.handle_glidesize_update(thing, 2)
+	TEST_ASSERT_EQUAL(handler.drifting_loop.timer, locked_timer, "repeated glide changes must not keep re-deferring the drift loop (anti-starvation)")

--- a/code/modules/unit_tests/space_drift.dm
+++ b/code/modules/unit_tests/space_drift.dm
@@ -1,0 +1,98 @@
+// Regression tests for the Drift 2.0 space-movement fixes.
+// Each datum proves one of the reported problems is fixed:
+//  - mecha_inertia_mass:    mechs have mass (were drifting like a 70kg human)
+//  - drift_recoil_cap:      firing can't "click to accelerate" and can't brake movement drift
+//  - drift_glide_clamp:     fast drift can't make the sprite visually "teleport"
+//  - mecha_stabilizer:      mechs can hold position with a jetpack-style stabilizer
+//  - mecha_turn_decoupled:  mechs can turn in zero-g and turning doesn't eat the move cooldown (#6)
+
+/// A multi-ton exosuit must resist nudges and have a capped top drift speed, unlike a human (defaults 1/1).
+/datum/unit_test/mecha_inertia_mass/Run()
+	var/obj/vehicle/sealed/mecha/working/ripley/ripley = allocate(/obj/vehicle/sealed/mecha/working/ripley)
+	TEST_ASSERT_EQUAL(ripley.inertia_force_weight, 8, "mechs must resist impulses (inertia_force_weight should be 8)")
+	TEST_ASSERT_EQUAL(ripley.inertia_move_multiplier, 3, "mechs must have a capped top drift speed (inertia_move_multiplier should be 3)")
+
+/// Recoil from firing must never exceed the recoil cap and must never brake drift the player built by moving.
+/datum/unit_test/drift_recoil_cap/Run()
+	var/turf/center = locate(run_loc_floor_bottom_left.x + 2, run_loc_floor_bottom_left.y + 2, run_loc_floor_bottom_left.z)
+
+	// Build movement-style drift first (each voluntary nudge adds ~1 force, weight 1 for a plain item).
+	var/obj/item/pen/mover = allocate(/obj/item/pen, center)
+	mover.AddElement(/datum/element/forced_gravity, 0) // weightless, so drift accumulates instead of being killed by gravity
+	for(var/i in 1 to 5)
+		mover.newtonian_move(NORTH, drift_force = 1, force_loop = FALSE)
+	TEST_ASSERT_NOTNULL(mover.drift_handler, "five voluntary nudges should have started a drift")
+	var/built_force = mover.drift_handler.drift_force
+	TEST_ASSERT(built_force >= 4.5, "five north nudges should build drift_force to ~5, got [built_force]")
+
+	// Firing while already moving must neither reduce (brake) nor increase the existing drift.
+	mover.newtonian_move(NORTH, drift_force = 1, controlled_cap = INERTIA_FORCE_RECOIL_CAP, force_loop = FALSE)
+	var/after_recoil = mover.drift_handler.drift_force
+	TEST_ASSERT(after_recoil >= built_force - 0.01, "recoil must not brake movement-built drift ([after_recoil] < [built_force])")
+	TEST_ASSERT(after_recoil <= built_force + 0.01, "recoil must not push drift past what movement built ([after_recoil] > [built_force])")
+
+	// Spam-firing from rest must plateau at the recoil cap, not ratchet up to the global cap.
+	var/turf/elsewhere = locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y + 2, run_loc_floor_bottom_left.z)
+	var/obj/item/pen/clicker = allocate(/obj/item/pen, elsewhere)
+	clicker.AddElement(/datum/element/forced_gravity, 0)
+	for(var/i in 1 to 8)
+		clicker.newtonian_move(NORTH, drift_force = 1, controlled_cap = INERTIA_FORCE_RECOIL_CAP, force_loop = FALSE)
+	TEST_ASSERT_NOTNULL(clicker.drift_handler, "recoil should have started a drift")
+	TEST_ASSERT(clicker.drift_handler.drift_force <= INERTIA_FORCE_RECOIL_CAP + 0.01, "spam-firing must not exceed the recoil cap, got [clicker.drift_handler.drift_force]")
+
+/// glide_size must be clamped so high-speed drift can't make the sprite slide past one tile per frame ("teleport").
+/datum/unit_test/drift_glide_clamp/Run()
+	var/obj/item/pen/thing = allocate(/obj/item/pen)
+	thing.set_glide_size(MAX_GLIDE_SIZE + 64)
+	TEST_ASSERT_EQUAL(thing.glide_size, MAX_GLIDE_SIZE, "glide_size above the icon size must clamp to MAX_GLIDE_SIZE")
+	thing.set_glide_size(8)
+	TEST_ASSERT_EQUAL(thing.glide_size, 8, "a normal glide_size must be left untouched")
+	thing.set_glide_size(0)
+	TEST_ASSERT_EQUAL(thing.glide_size, 0, "an instant move (glide_size 0) must be preserved")
+
+/// Stabilizers must cancel drift (hold position) only when the mech has functional, powered thrusters.
+/datum/unit_test/mecha_stabilizer/Run()
+	var/turf/center = locate(run_loc_floor_bottom_left.x + 2, run_loc_floor_bottom_left.y + 2, run_loc_floor_bottom_left.z)
+	var/obj/vehicle/sealed/mecha/working/ripley/ripley = allocate(/obj/vehicle/sealed/mecha/working/ripley, center)
+	ripley.AddElement(/datum/element/forced_gravity, 0) // weightless, so the base Process_Spacemove reports "still drifting"
+	ripley.step_energy_drain = 10
+	TEST_ASSERT_NOTNULL(ripley.cell, "test mech should spawn with a power cell")
+	ripley.cell.charge = ripley.cell.maxcharge
+
+	var/obj/item/mecha_parts/mecha_equipment/thrusters/rcs = new /obj/item/mecha_parts/mecha_equipment/thrusters(ripley)
+	rcs.attach(ripley)
+	TEST_ASSERT_EQUAL(ripley.active_thrusters, rcs, "the attached thruster should become the active set")
+
+	ripley.stabilizers = FALSE
+	TEST_ASSERT(!ripley.Process_Spacemove(NORTH, continuous_move = TRUE), "stabilizers off: the mech must keep drifting (Process_Spacemove returns FALSE)")
+
+	ripley.stabilizers = TRUE
+	TEST_ASSERT(ripley.Process_Spacemove(NORTH, continuous_move = TRUE), "stabilizers on + thrusters + power: drift must be cancelled (Process_Spacemove returns TRUE)")
+
+	ripley.cell.charge = 0
+	TEST_ASSERT(!ripley.Process_Spacemove(NORTH, continuous_move = TRUE), "stabilizers must fail without power")
+
+/// #6: a mech must be able to rotate even when it cannot move, and rotating must not consume the move cooldown.
+/datum/unit_test/mecha_turn_decoupled/Run()
+	var/turf/center = locate(run_loc_floor_bottom_left.x + 2, run_loc_floor_bottom_left.y + 2, run_loc_floor_bottom_left.z)
+	var/obj/vehicle/sealed/mecha/working/ripley/ripley = allocate(/obj/vehicle/sealed/mecha/working/ripley, center)
+	ripley.AddElement(/datum/element/forced_gravity, 0) // weightless and (below) thruster-less: voluntary movement is impossible here
+	ripley.active_thrusters = null
+	ripley.strafe = FALSE
+	ripley.setDir(NORTH)
+
+	// Core fix: the turn happens even though Process_Spacemove would block any actual movement.
+	TEST_ASSERT(ripley.vehicle_move(EAST), "a non-strafe turn must succeed even when the mech cannot move")
+	TEST_ASSERT_EQUAL(ripley.dir, EAST, "the mech should have rotated to face EAST")
+	TEST_ASSERT(COOLDOWN_FINISHED(ripley, cooldown_vehicle_move), "turning must not start the movement cooldown")
+
+	// The turn uses its own (separate) cooldown: an immediate second turn is blocked, facing unchanged.
+	ripley.vehicle_move(SOUTH)
+	TEST_ASSERT_EQUAL(ripley.dir, EAST, "a second turn within the turn cooldown must be blocked")
+
+	// Strafe mode without a held Alt must NOT rotate: the mech keeps its facing while trying to strafe.
+	ripley.cooldown_vehicle_turn = 0
+	ripley.strafe = TRUE
+	ripley.setDir(NORTH)
+	ripley.vehicle_move(EAST)
+	TEST_ASSERT_EQUAL(ripley.dir, NORTH, "strafe mode without Alt must not rotate the mech")

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -27,7 +27,7 @@
 	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	movedelay = 1 SECONDS
 	/// Cooldown between in-place rotations. Kept short and separate from movedelay so turning stays responsive and isn't blocked by inability to move.
-	var/turn_delay = 2
+	var/turn_delay = 0.2 SECONDS
 	anchored = TRUE
 	emulate_door_bumps = TRUE
 	COOLDOWN_DECLARE(mecha_bump_smash)
@@ -657,7 +657,7 @@
 		return TRUE
 	if(continuous_move)
 		// Drift tick: engaged stabilizers cancel residual drift (like a jetpack's) as long as we have powered, functional thrusters.
-		if(stabilizers && active_thrusters && has_charge(step_energy_drain))
+		if(stabilizers && active_thrusters && !equipment_disabled && has_charge(step_energy_drain))
 			return TRUE
 		return FALSE
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -635,8 +635,15 @@
 ///Plays the mech step sound effect. Split from movement procs so that other mechs (HONK) can override this one specific part.
 /obj/vehicle/sealed/mecha/proc/play_stepsound()
 	SIGNAL_HANDLER
+	// step_silent is set for thrust / push-off; inertia_moving is set while the drift loop is carrying us.
+	// Neither is a footstep, so don't play the walk sound (it was firing on every space-drift tick).
+	if(step_silent)
+		step_silent = FALSE
+		return
+	if(inertia_moving)
+		return
 	if(stepsound)
-		playsound(src,stepsound,40,1)
+		playsound(src, stepsound, 40, TRUE)
 
 /obj/vehicle/sealed/mecha/proc/disconnect_air()
 	SIGNAL_HANDLER
@@ -682,6 +689,10 @@
 		return FALSE
 	if(!direction)
 		return FALSE
+
+	// Cleared each call: Process_Spacemove sets this when we thrust / push off, and play_stepsound consumes it.
+	// Resetting here keeps a thrust that didn't end in a step from silencing the next genuine footstep.
+	step_silent = FALSE
 
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		direction = pick(GLOB.alldirs)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -26,9 +26,12 @@
 	max_integrity = 300
 	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	movedelay = 1 SECONDS
+	/// Cooldown between in-place rotations. Kept short and separate from movedelay so turning stays responsive and isn't blocked by inability to move.
+	var/turn_delay = 2
 	anchored = TRUE
 	emulate_door_bumps = TRUE
 	COOLDOWN_DECLARE(mecha_bump_smash)
+	COOLDOWN_DECLARE(cooldown_vehicle_turn)
 	var/light_on = FALSE
 	///What direction will the mech face when entered/powered on? Defaults to South.
 	var/dir_in = SOUTH
@@ -156,6 +159,15 @@
 
 	///Wether we are strafing
 	var/strafe = FALSE
+
+	///Whether thruster stabilizers are engaged (cancels space drift to hold position, like a jetpack's). Needs functional, powered thrusters.
+	var/stabilizers = FALSE
+
+	// Space-drift mass model: a multi-ton exosuit should resist being nudged and should not reach human EVA drift speeds.
+	/// Higher = harder for impulses (steps, recoil, push-off) to build drift.
+	inertia_force_weight = 8
+	/// Multiplies the drift move delay, capping the mech's top drift speed well below a human's.
+	inertia_move_multiplier = 3
 
 	///Cooldown length between bumpsmashes
 	var/smashcooldown = 3
@@ -637,6 +649,9 @@
 	if(.)
 		return TRUE
 	if(continuous_move)
+		// Drift tick: engaged stabilizers cancel residual drift (like a jetpack's) as long as we have powered, functional thrusters.
+		if(stabilizers && active_thrusters && has_charge(step_energy_drain))
+			return TRUE
 		return FALSE
 
 	var/atom/movable/backup = get_spacemove_backup()
@@ -663,13 +678,42 @@
 
 
 /obj/vehicle/sealed/mecha/vehicle_move(direction, forcerotate = FALSE)
-	if(!COOLDOWN_FINISHED(src, cooldown_vehicle_move))
-		return FALSE
-	COOLDOWN_START(src, cooldown_vehicle_move, movedelay)
 	if(completely_disabled)
 		return FALSE
 	if(!direction)
 		return FALSE
+
+	if(internal_damage & MECHA_INT_CONTROL_LOST)
+		direction = pick(GLOB.alldirs)
+
+	//only mechs with diagonal movement may move/turn diagonally
+	if(!allow_diagonal_movement && ISDIAGONALDIR(direction))
+		return TRUE
+
+	// Rotation is decoupled from movement: turning must NOT be blocked by the inability to move (zero-g, no power)
+	// nor share/consume the move cooldown, otherwise the mech "can't turn" in space and Alt-strafe turns get eaten.
+	if(dir != direction || forcerotate)
+		var/should_turn = forcerotate || !strafe
+		if(!should_turn) // strafe mode: a driver holding Alt converts the strafe into an in-place rotation
+			for(var/mob/driver in return_drivers())
+				if(driver.client?.keys_held["Alt"])
+					should_turn = TRUE
+					break
+		if(should_turn)
+			if(!COOLDOWN_FINISHED(src, cooldown_vehicle_turn))
+				return FALSE
+			COOLDOWN_START(src, cooldown_vehicle_turn, turn_delay)
+			setDir(direction)
+			if(turnsound)
+				playsound(src, turnsound, 40, TRUE)
+			return TRUE
+
+	// In strafe mode, a direction != facing without Alt means strafe-move: travel that way while keeping our facing.
+	var/strafing = strafe && (dir != direction)
+
+	if(!COOLDOWN_FINISHED(src, cooldown_vehicle_move))
+		return FALSE
+	COOLDOWN_START(src, cooldown_vehicle_move, movedelay)
 	if(internal_tank?.connected_port)
 		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_MECHA_MESSAGE))
 			to_chat(occupants, "[icon2html(src, occupants)]<span class='warning'>Unable to move while connected to the air system port!</span>")
@@ -703,31 +747,6 @@
 
 	var/olddir = dir
 
-	if(internal_damage & MECHA_INT_CONTROL_LOST)
-		direction = pick(GLOB.alldirs)
-
-	//only mechs with diagonal movement may move diagonally
-	if(!allow_diagonal_movement && ISDIAGONALDIR(direction))
-		return TRUE
-
-	//if we're not facing the way we're going rotate us
-	var/no_strafe = FALSE
-	if(dir != direction || forcerotate)
-		if(strafe)
-			for(var/D in return_drivers())
-				var/mob/driver = D
-				if(driver.client?.keys_held["Alt"])
-					no_strafe = TRUE
-					setDir(direction)
-					if(turnsound)
-						playsound(src,turnsound,40,TRUE)
-					return TRUE
-		else
-			setDir(direction)
-			if(turnsound)
-				playsound(src,turnsound,40,TRUE)
-			return TRUE
-
 	set_glide_size(DELAY_TO_GLIDE_SIZE(movedelay))
 	use_power(step_energy_drain)
 
@@ -736,7 +755,7 @@
 		//Otherwise just walk normally
 		. = step(src,direction, dir)
 
-	if(strafe && !no_strafe)
+	if(strafing)
 		setDir(olddir)
 
 
@@ -1027,6 +1046,7 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/mech_toggle_lights, VEHICLE_CONTROL_SETTINGS)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/mech_view_stats, VEHICLE_CONTROL_SETTINGS)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/strafe, VEHICLE_CONTROL_DRIVE)
+	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/toggle_stabilizers, VEHICLE_CONTROL_DRIVE)
 	if(max_occupants > 1)
 		initialize_passenger_action_type(/datum/action/vehicle/sealed/mecha/swap_seat)
 

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -26,8 +26,8 @@
 	max_integrity = 300
 	armor = list(MELEE = 20, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	movedelay = 1 SECONDS
-	/// Cooldown between in-place rotations. Kept short and separate from movedelay so turning stays responsive and isn't blocked by inability to move.
-	var/turn_delay = 0.2 SECONDS
+	/// Cooldown between in-place rotations. Kept shorter than movedelay so turning stays responsive and isn't blocked by inability to move, but slow enough not to spin on the spot.
+	var/turn_delay = 0.4 SECONDS
 	anchored = TRUE
 	emulate_door_bumps = TRUE
 	COOLDOWN_DECLARE(mecha_bump_smash)
@@ -701,23 +701,29 @@
 	if(!allow_diagonal_movement && ISDIAGONALDIR(direction))
 		return TRUE
 
+	// In strafe mode, a driver holding Alt turns directional input into a PURE in-place rotation: the mech turns
+	// toward the input and must never step - not even once it already faces that way (otherwise it walks off after turning).
+	var/strafe_rotate = FALSE
+	if(strafe && !forcerotate)
+		for(var/mob/driver in return_drivers())
+			if(driver.client?.keys_held["Alt"])
+				strafe_rotate = TRUE
+				break
+
 	// Rotation is decoupled from movement: turning must NOT be blocked by the inability to move (zero-g, no power)
 	// nor share/consume the move cooldown, otherwise the mech "can't turn" in space and Alt-strafe turns get eaten.
-	if(dir != direction || forcerotate)
-		var/should_turn = forcerotate || !strafe
-		if(!should_turn) // strafe mode: a driver holding Alt converts the strafe into an in-place rotation
-			for(var/mob/driver in return_drivers())
-				if(driver.client?.keys_held["Alt"])
-					should_turn = TRUE
-					break
-		if(should_turn)
-			if(!COOLDOWN_FINISHED(src, cooldown_vehicle_turn))
-				return FALSE
-			COOLDOWN_START(src, cooldown_vehicle_turn, turn_delay)
-			setDir(direction)
-			if(turnsound)
-				playsound(src, turnsound, 40, TRUE)
-			return TRUE
+	if((dir != direction || forcerotate) && (forcerotate || !strafe || strafe_rotate))
+		if(!COOLDOWN_FINISHED(src, cooldown_vehicle_turn))
+			return FALSE
+		COOLDOWN_START(src, cooldown_vehicle_turn, turn_delay)
+		setDir(direction)
+		if(turnsound)
+			playsound(src, turnsound, 40, TRUE)
+		return TRUE
+
+	// Alt-strafe is rotation-only: if we already face the requested direction, hold position instead of stepping forward.
+	if(strafe_rotate)
+		return TRUE
 
 	// In strafe mode, a direction != facing without Alt means strafe-move: travel that way while keeping our facing.
 	var/strafing = strafe && (dir != direction)

--- a/code/modules/vehicles/mecha/combat/honker.dm
+++ b/code/modules/vehicles/mecha/combat/honker.dm
@@ -130,6 +130,12 @@
 	return output
 
 /obj/vehicle/sealed/mecha/combat/honker/play_stepsound()
+	// Same as the base: thrust / push-off and drift-loop moves aren't footsteps, so don't squeak on them.
+	if(step_silent)
+		step_silent = FALSE
+		return
+	if(inertia_moving)
+		return
 	if(squeak)
 		playsound(src, "clownstep", 70, 1)
 	squeak = !squeak

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -401,6 +401,7 @@
 	N.dna_lock = M.dna_lock
 	N.mecha_flags = M.mecha_flags
 	N.strafe = M.strafe
+	N.stabilizers = M.stabilizers
 	N.obj_integrity = M.obj_integrity //This is not a repair tool
 	if (M.name != "\improper APLU MK-I \"Ripley\"")
 		N.name = M.name

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -53,9 +53,9 @@
 		sleep(max(0, projectile_delay))
 		if(!chassis)
 			break
-
-		if(kickback)
-			chassis.newtonian_move(newtonian_target)
+	// Recoil once per volley (not once per pellet) and capped, so spam-firing can't ratchet drift toward the global cap.
+	if(kickback && chassis)
+		chassis.newtonian_move(newtonian_target, controlled_cap = INERTIA_FORCE_RECOIL_CAP)
 	if(chassis)
 		chassis.log_message("Fired from [src], targeting [target].", LOG_MECHA)
 

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -142,6 +142,26 @@
 		var/datum/action/action = LAZYACCESSASSOC(occupant_actions, occupant, /datum/action/vehicle/sealed/mecha/strafe)
 		action?.UpdateButtons()
 
+/datum/action/vehicle/sealed/mecha/toggle_stabilizers
+	name = "Toggle thruster stabilizers. Cancels space drift so the mech can hold position. Needs powered thrusters."
+	button_icon_state = "mech_thrusters_off"
+
+/datum/action/vehicle/sealed/mecha/toggle_stabilizers/Trigger()
+	if(!owner || !chassis || !(owner in chassis.occupants))
+		return
+	chassis.toggle_stabilizers()
+
+/obj/vehicle/sealed/mecha/proc/toggle_stabilizers()
+	stabilizers = !stabilizers
+	to_chat(occupants, "[icon2html(src, occupants)]<span class='notice'>Toggled thruster stabilizers [stabilizers ? "on" : "off"].</span>")
+	log_message("Toggled thruster stabilizers [stabilizers ? "on" : "off"].", LOG_MECHA)
+
+	for(var/occupant in occupants)
+		var/datum/action/vehicle/sealed/mecha/toggle_stabilizers/action = LAZYACCESSASSOC(occupant_actions, occupant, /datum/action/vehicle/sealed/mecha/toggle_stabilizers)
+		if(action)
+			action.button_icon_state = "mech_thrusters_[stabilizers ? "on" : "off"]"
+			action.UpdateButtons()
+
 //////////////////////////////////////// Specific Ability Actions  ///////////////////////////////////////////////
 //Need to be granted by the mech type, Not default abilities.
 

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -47,6 +47,7 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/mech_toggle_lights, VEHICLE_CONTROL_SETTINGS)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/mech_view_stats, VEHICLE_CONTROL_SETTINGS)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/strafe, VEHICLE_CONTROL_DRIVE)
+	initialize_controller_action_type(/datum/action/vehicle/sealed/mecha/toggle_stabilizers, VEHICLE_CONTROL_DRIVE)
 	if(max_occupants > 1)
 		initialize_passenger_action_type(/datum/action/vehicle/sealed/mecha/swap_seat)
 


### PR DESCRIPTION
# Описание

Переработка космического дрейфа и поведения мехов в невесомости

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

Коротко по пунктам:
- Мехи теперь имеют массу: больше не разгоняются в космосе как человек в скафандре и имеют низкий потолок скорости дрейфа.
- Добавил стабилизаторы тяги (кнопка в управлении): гасят дрейф и держат меха на месте, если есть запитанные рабочие движки.
- Отвязал поворот меха от движения: можно крутиться в невесомости/без энергии, и поворот больше не съедает кулдаун шага (свой отдельный кулдаун).
- Стрельбой больше нельзя разгоняться ("клик = ускорение") и нельзя тормозить уже набранный дрейф. Отдача упёрта в свой потолок.
- Меховое оружие даёт отдачу раз за залп, а не за каждую дробину (спамом ствола до глобального капа уже не разогнаться).
- Быстрый дрейф больше не "телепортирует" спрайт при лагах MC (glide_size упёрт сверху).
- Попутно: SSmovement больше не runtime-ит на удалённых луупах, просто их пропускает.
- Накинул регрессионные юнит-тесты на всё перечисленное.

## Причина изменений

Космический дрейф был сломан и эксплуатабелен: мех весом в несколько тонн летал как человек, стрельбой можно было разгоняться и тормозить (фактически бесплатные тормоза/реверс), а на быстром дрейфе спрайты визуально телепортировались. Плюс меха нельзя было нормально развернуть в невесомости

## Changelog

:cl:
balance: мехи теперь имеют массу в космосе и не разгоняются как человек
add: стабилизаторы тяги для мехов, держат позицию в невесомости
fix: мех можно поворачивать в невесомости, поворот больше не съедает кулдаун движения
fix: стрельбой в космосе больше нельзя разгоняться или тормозить дрейф
balance: меховое оружие даёт отдачу раз за залп, а не за каждую пулю
fix: быстрый дрейф больше не телепортирует спрайт при лагах
fix: убран рантайм в сабсистеме движения на удалённых луупах
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Стабилизаторы для мехов (отменяют дрейф в невесомости) и кнопка переключения в интерфейсе.
  * Отдача от оружия ограничена верхним пределом и не изменяет уже накопленный дрейф.

* **Исправления ошибок**
  * Подсистема движения пропускает уже удалённые элементы очереди, предотвращая рантаймы.
  * Разделён кулдаун поворота меха; улучшено поведение поворота и ограничение glide_size.
  * Подавление шаговых звуков при инерционном дрейфе.

* **Тесты**
  * Добавлены регрессионные тесты для механики дрейфа, отдачи и стабилизаторов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->