### PR TITLE
Фикс фона на фотографиях

### DIFF
--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -30,6 +30,12 @@
 				atoms += new /obj/effect/appearance_clone(newT, T.loc)
 			for(var/i in T.contents)
 				var/atom/A = i
+				// Lighting objects live in turf.contents (new /atom/movable/lighting_object(turf)
+				// assigns loc=turf) and carry the per-turf darkness color matrix. Cloning one
+				// renders it as a solid black tile on LIGHTING_LAYER, painting the floor black in
+				// any shaded area. Skip it - the photo is intentionally unlit.
+				if(istype(A, /atom/movable/lighting_object))
+					continue
 				if(!A.invisibility || (see_ghosts && isobserver(A)))
 					atoms += new /obj/effect/appearance_clone(newT, A)
 		skip_normal = TRUE
@@ -41,6 +47,8 @@
 			var/turf/T = i
 			atoms += T
 			for(var/atom/movable/A in T)
+				if(istype(A, /atom/movable/lighting_object))
+					continue // see clone path above - lighting objects paint the floor black
 				if(A.invisibility)
 					if(!(see_ghosts && isobserver(A)))
 						continue

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -156,6 +156,7 @@
 #include "auto_cryo.dm"
 #include "bad_defines_defined.dm"
 #include "bugfix_coverage.dm"
+#include "camera_photo_probe.dm"
 #include "can_inject_clothing.dm"
 #include "disposal_holder.dm"
 #include "ghost_role_limbs.dm"

--- a/code/modules/unit_tests/camera_photo_probe.dm
+++ b/code/modules/unit_tests/camera_photo_probe.dm
@@ -1,0 +1,68 @@
+// Regression test for the camera "no background" bug: a photo taken in a shaded
+// (dynamic-lit, non-fully-bright) area must still render the floor/scene, not a
+// solid black tile. Root cause was camera_get_icon cloning the turf's
+// lighting_object (which lives in turf.contents) — its dark color matrix painted
+// every floor tile black. See camera_image_capturing.dm.
+
+/// Returns TRUE if the pixel at (px,py) is present and not pure/near-black.
+/datum/unit_test/proc/camera_pixel_is_lit(icon/ico, px, py)
+	if(!ico)
+		return FALSE
+	var/col = ico.GetPixel(px, py)
+	if(isnull(col))
+		return FALSE
+	var/list/rgb = ReadRGB(col)
+	return (rgb[1] + rgb[2] + rgb[3]) > 12 // > ~#040404, i.e. not the dark-lighting fill
+
+/datum/unit_test/camera_photo_shaded_background/Run()
+	TEST_ASSERT(SSlighting.initialized, "SSlighting was not initialized")
+
+	var/turf/bl = run_loc_floor_bottom_left
+	var/turf/center = locate(bl.x + 1, bl.y + 1, bl.z)
+	TEST_ASSERT_NOTNULL(center, "no center turf for camera test")
+
+	// Build a 3x3 of floor turfs, each driven to a dark lighting state — exactly
+	// the condition under which the bug manifested ("slightly shaded breaks").
+	var/list/turfs = list()
+	var/list/created_los = list()
+	for(var/dx = -1 to 1)
+		for(var/dy = -1 to 1)
+			var/turf/T = locate(center.x + dx, center.y + dy, center.z)
+			if(!isturf(T))
+				continue
+			if(!isfloorturf(T))
+				T = T.ChangeTurf(/turf/open/floor/plasteel)
+			if(!T.lighting_object)
+				new /atom/movable/lighting_object(T)
+				created_los += T.lighting_object
+			T.lighting_object.color = LIGHTING_DARK_MATRIX
+			T.lighting_object.update(animate_time = 0, use_animate = FALSE)
+			turfs += T
+
+	var/obj/item/camera/cam = allocate(/obj/item/camera, center)
+	var/datum/turf_reservation/clone_area = SSmapping.RequestBlockReservation(3, 3)
+	var/psize = 3 * world.icon_size
+	var/icon/result = cam.camera_get_icon(turfs, center, psize, psize, clone_area, 1, 1, 3, 3)
+
+	TEST_ASSERT_NOTNULL(result, "camera_get_icon returned null")
+
+	// Sample the 9 tile centers. Every background floor tile must be lit (not black).
+	var/black_tiles = 0
+	var/list/report = list()
+	for(var/ty = 0 to 2)
+		for(var/tx = 0 to 2)
+			var/px = tx * world.icon_size + round(world.icon_size / 2)
+			var/py = ty * world.icon_size + round(world.icon_size / 2)
+			var/lit = camera_pixel_is_lit(result, px, py)
+			if(!lit)
+				black_tiles++
+			report += "[tx],[ty]=[isnull(result.GetPixel(px, py)) ? "EMPTY" : result.GetPixel(px, py)]"
+
+	log_test("camera_photo_shaded_background: tiles=[report.Join(" | ")]")
+
+	qdel(clone_area)
+	for(var/atom/movable/lighting_object/lo as anything in created_los)
+		if(!QDELETED(lo))
+			qdel(lo, force = TRUE)
+
+	TEST_ASSERT_EQUAL(black_tiles, 0, "Shaded camera photo lost [black_tiles]/9 background floor tiles to black (lighting_object cloned into the photo)")


### PR DESCRIPTION
# Описание

Чиню баг с фотоаппаратами, на который жаловались в дискорде: на фотках пропадал фон, оставался только сам объект съёмки на чёрном поле. Нормально снимало только на ЦК и админ-арене.

Причина оказалась в обновлении света (#2827). Раньше затенение было подложкой (underlay) прямо на тайле и в фото никогда не попадало. После переезда движка света затенение стало отдельным объектом `/atom/movable/lighting_object`, и из-за вызова `new(turf)` он лежит не только в `vis_contents` (как написано в комментарии его New), но и в `turf.contents`. А камера при съёмке клонирует всё содержимое тайла, поэтому клонировала и объект света с его тёмной матрицей (BLEND_MULTIPLY) - он-то и закрашивал пол в чёрный. На полном свете матрица белая и ничего не портит, поэтому баг и вылезал только при затенении; а на ЦК динамического света нет вообще, вот там и работало.

Фикс точечный: при съёмке пропускаю `lighting_object`, его на фото быть не должно. Выбор тайлов через `view()` не трогаю, AI-камеры чинятся тем же кодом. Добавил регресс-тест `camera_photo_shaded_background`.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Баг-репорт из дискорда: https://discord.com/channels/875735187449847830/1502904633553715240. Фотоаппараты не делают нормальные снимки нигде, кроме ЦК - у фоток нет фона, и зависит это от уровня освещения тайла.

## Changelog

:cl:
fix: Фотоаппараты снова снимают с фоном в затенённых зонах (раньше пол на фото становился чёрным везде, кроме ЦК)
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Bug Fixes**
  * Исправлена проблема с камерой, при которой фотографии в затемнённых областях отображались полностью чёрными. Теперь фотографии корректно показывают фон независимо от уровня освещённости.

* **Tests**
  * Добавлены тесты для проверки корректности работы камеры в различных условиях освещения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->