### PR TITLE
Фикс энкодинг-раундтрипа: управляющие символы и двойное кодирование

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -113,6 +113,47 @@
 	if(non_whitespace)
 		return text		//only accepts the text if it has some non-spaces
 
+/// Removes the ASCII C0 control characters and DEL (0x7F) from `text`, EXCEPT tab,
+/// line feed and carriage return (0x09/0x0A/0x0D). The kept whitespace has proper
+/// JSON escapes and round-trips fine; the rest of the C0 range can only be escaped
+/// as \uXXXX, which the DM<->TGUI json/topic bridge does not reliably preserve, so
+/// any value TGUI echoes back as a lookup key (such as a custom emote panel name)
+/// is silently corrupted by them. Multi-byte Unicode (e.g. Cyrillic) is preserved.
+/// Returns the cleaned text.
+/proc/strip_control_chars(text)
+	if(!length(text))
+		return text
+	var/lenbytes = length(text)
+	var/char = ""
+	var/list/cleaned = list()
+	for(var/i = 1, i <= lenbytes, i += length(char))
+		char = text[i]
+		var/ascii = text2ascii(char)
+		if((ascii < 32 && ascii != 9 && ascii != 10 && ascii != 13) || ascii == 127)
+			continue
+		cleaned += char
+	return jointext(cleaned, "")
+
+/// Rebuilds a flat associative list with control characters stripped from every
+/// text key, so saved data keyed by user text cannot be made permanently
+/// unmatchable/undeletable by a control character that breaks the DM<->TGUI or
+/// savefile round-trip. Entries whose key cleans to empty, or collides with an
+/// already-cleaned key, are dropped (first one wins). Non-text keys (e.g. typepaths)
+/// pass through untouched. Returns a list.
+/proc/sanitize_assoc_keys(list/input)
+	if(!islist(input))
+		return list()
+	var/list/cleaned = list()
+	for(var/key in input)
+		if(!istext(key))
+			cleaned[key] = input[key]
+			continue
+		var/clean_key = strip_control_chars(key)
+		if(!length(clean_key) || (clean_key in cleaned))
+			continue
+		cleaned[clean_key] = input[key]
+	return cleaned
+
 /// html_encode that keeps " and ' as raw readable characters (safe in HTML
 /// text contexts). Dangerous chars (<, >, &) remain encoded. Use for free-form
 /// user-entered text displayed in chat, names, flavor descriptions, etc.
@@ -124,6 +165,9 @@
 /proc/finalize_stripped_input(name, max_length, no_trim)
 	if(isnull(name))
 		return null
+	// Control characters survive html_encode but cannot round-trip through the
+	// DM<->TGUI/json bridge or savefile keys - strip them at the source.
+	name = strip_control_chars(name)
 	name = html_encode_readable(name)
 	//trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 	return no_trim ? copytext(name, 1, max_length) : trim(name, max_length)

--- a/code/datums/components/jukebox/jukebox.dm
+++ b/code/datums/components/jukebox/jukebox.dm
@@ -298,7 +298,7 @@
 			var/datum/preferences/prefs = L?.client?.prefs
 			if(!prefs)
 				return
-			var/current_playlist_name = params["playlist"]
+			var/current_playlist_name = strip_control_chars(params["playlist"])
 			var/track = params["track"]
 			switch(action)
 				if("new_playlist")

--- a/code/game/machinery/colormate.dm
+++ b/code/game/machinery/colormate.dm
@@ -2,6 +2,17 @@
 #define COLORMATE_HSV 2
 #define COLORMATE_MATRIX 3
 
+/// color_presets_* are nested: list(item_type = list(preset_name = value)). The
+/// inner keys are user-entered preset names, so clean control characters out of
+/// them on load - otherwise a control-character name makes a preset permanently
+/// unselectable and undeletable through the UI. Mirrors sanitize_custom_emote_panel.
+/proc/sanitize_color_preset_keys(list/presets)
+	if(!islist(presets))
+		return list()
+	for(var/item_type in presets)
+		presets[item_type] = sanitize_assoc_keys(presets[item_type])
+	return presets
+
 /obj/machinery/gear_painter
 	name = "\improper Color Mate"
 	desc = "A machine to give your apparel a fresh new color!"
@@ -227,7 +238,7 @@
 				return
 
 			var/datum/preferences/prefs = user.client.prefs
-			var/preset_name = params["name"]
+			var/preset_name = strip_control_chars(params["name"])
 
 			// Сопоставляем режим (имя поля в prefs, лист пресетов для inserted.type)
 			var/presets_field

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -701,9 +701,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	key_bindings = sanitize_islist(key_bindings, list())
 	modless_key_bindings = sanitize_islist(modless_key_bindings, list())
 	favorite_outfits = SANITIZE_LIST(favorite_outfits)
-	color_presets_tint = SANITIZE_LIST(color_presets_tint) // BLUEMOON ADD
-	color_presets_hsv = SANITIZE_LIST(color_presets_hsv) // BLUEMOON ADD
-	color_presets_matrix = SANITIZE_LIST(color_presets_matrix) // BLUEMOON ADD
+	color_presets_tint = sanitize_color_preset_keys(color_presets_tint) // BLUEMOON ADD
+	color_presets_hsv = sanitize_color_preset_keys(color_presets_hsv) // BLUEMOON ADD
+	color_presets_matrix = sanitize_color_preset_keys(color_presets_matrix) // BLUEMOON ADD
 	screentip_color = sanitize_hexcolor(screentip_color, 6, 1, initial(screentip_color))
 	screentip_pref = sanitize_inlist(screentip_pref, GLOB.screentip_pref_options, SCREENTIP_PREFERENCE_ENABLED)
 
@@ -1405,10 +1405,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 								else
 									entry -= setting
 
+							// Already html_encoded at write time by stripped_input(); re-encoding
+							// here double-encodes (& -> &amp; -> &amp;amp;) on every load. Only bound length.
 							if(LOADOUT_CUSTOM_NAME)
-								entry[setting] = trim(html_encode(entry[setting]), MAX_NAME_LEN)
+								entry[setting] = trim(entry[setting], MAX_NAME_LEN)
 							if(LOADOUT_CUSTOM_DESCRIPTION)
-								entry[setting] = trim(html_encode(entry[setting]), 500)
+								entry[setting] = trim(entry[setting], 500)
 
 				loadout_data[save_key] = sanitize_entries.Copy()
 			else
@@ -1616,7 +1618,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		if(job_preferences["[j]"] != JP_LOW && job_preferences["[j]"] != JP_MEDIUM && job_preferences["[j]"] != JP_HIGH)
 			job_preferences -= j
 
-	custom_emote_panel = SANITIZE_LIST(custom_emote_panel)
+	// Strips control characters from saved emote names so legacy entries that could
+	// not round-trip through TGUI become matchable again (and thus renamable/removable).
+	custom_emote_panel = sanitize_custom_emote_panel(custom_emote_panel)
 
 	all_quirks = SANITIZE_LIST(all_quirks)
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1406,11 +1406,15 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 									entry -= setting
 
 							// Already html_encoded at write time by stripped_input(); re-encoding
-							// here double-encodes (& -> &amp; -> &amp;amp;) on every load. Only bound length.
+							// here double-encodes (& -> &amp; -> &amp;amp;) on every load. Only bound
+							// length, and only for text - a malformed savefile could hold a non-text
+							// value here, which trim() would choke on.
 							if(LOADOUT_CUSTOM_NAME)
-								entry[setting] = trim(entry[setting], MAX_NAME_LEN)
+								if(istext(entry[setting]))
+									entry[setting] = trim(entry[setting], MAX_NAME_LEN)
 							if(LOADOUT_CUSTOM_DESCRIPTION)
-								entry[setting] = trim(entry[setting], 500)
+								if(istext(entry[setting]))
+									entry[setting] = trim(entry[setting], 500)
 
 				loadout_data[save_key] = sanitize_entries.Copy()
 			else

--- a/code/modules/instruments/songs/editor.dm
+++ b/code/modules/instruments/songs/editor.dm
@@ -177,7 +177,7 @@
 
 	else if(href_list["modifyline"])
 		var/num = round(text2num(href_list["modifyline"]),1)
-		var/content = stripped_input(usr, "Enter your line: ", parent.name, lines[num], MUSIC_MAXLINECHARS)
+		var/content = stripped_input(usr, "Enter your line: ", parent.name, html_decode(lines[num]), MUSIC_MAXLINECHARS)
 		if(!content || !in_range(parent, usr))
 			return
 		if(num > lines.len || num < 1)

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -104,6 +104,11 @@
 /obj/item/integrated_circuit/proc/load(list/component_params)
 	// Load name
 	if(component_params["name"])
+		// NOTE: html_encode is intentionally kept. displayed_name is injected into
+		// unescaped legacy-HTML sinks (assembly_legacy_ui.dm) and to_chat, and the
+		// circuit-import path does NOT validate component names - dropping this encode
+		// would allow a crafted clone-code JSON to inject raw HTML. The cosmetic
+		// double-encode on repeated clone cycles is the lesser evil.
 		displayed_name = html_encode(component_params["name"])
 
 	// Load input values
@@ -168,7 +173,9 @@
 // Loads assembly parameters from a list
 // Doesn't verify any of the parameters it loads, this is the job of verify_save()
 /obj/item/electronic_assembly/proc/load(list/assembly_params)
-	// Load modified name, if any.
+	// NOTE: html_encode intentionally kept here too. name/desc are injected into
+	// unescaped legacy-HTML sinks; even though verify_save() rejects </> in them,
+	// keeping the encode is the consistent, injection-safe choice for this subsystem.
 	if(assembly_params["name"])
 		name = html_encode(assembly_params["name"])
 

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -173,6 +173,9 @@
 
 /// Set the ringtone if possible. Also handles encoding.
 /datum/computer_file/program/messenger/proc/set_ringtone(new_ringtone, mob/user)
+	// html_encode is required: a custom ringtone reaches an UNESCAPED maptext sink via
+	// computer.ring() -> balloon_alert(). To avoid double-encoding on re-edit, the
+	// PDA_ringSet dialog html_decode()s this value back when pre-filling its default.
 	new_ringtone = trim(html_encode(new_ringtone), MESSENGER_RINGTONE_MAX_LENGTH)
 	if(!new_ringtone)
 		return FALSE
@@ -201,7 +204,7 @@
 	switch(action)
 		if("PDA_ringSet")
 			var/mob/living/user = usr
-			var/new_ringtone = tgui_input_text(user, "Enter a new ringtone", "Ringtone", ringtone, max_length = MAX_MESSAGE_LEN, encode = FALSE)
+			var/new_ringtone = tgui_input_text(user, "Enter a new ringtone", "Ringtone", html_decode(ringtone), max_length = MAX_MESSAGE_LEN, encode = FALSE)
 			if(!new_ringtone)
 				return FALSE
 			return set_ringtone(new_ringtone, user)

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -284,7 +284,7 @@
 			if(!A.mutable)
 				return
 			if(A)
-				var/new_name = sanitize_name(html_encode(trim(params["name"], 50)))//, allow_numbers = TRUE)
+				var/new_name = sanitize_name(strip_control_chars(trim(params["name"], 50)))//, allow_numbers = TRUE) - sanitize_name already html_encodes; double-encoding it produced &amp;lt; in the UI
 				if(!new_name || ..())
 					return
 				A.AssignName(new_name)

--- a/code/modules/research/nanites/extra_settings/text.dm
+++ b/code/modules/research/nanites/extra_settings/text.dm
@@ -5,12 +5,17 @@
 	value = initial
 
 /datum/nanite_extra_setting/text/set_value(value)
-	src.value = trim(value)
+	// Strip control chars: a stray C0 byte in this value would break JSON.parse for
+	// the whole nanite programmer extra-settings payload.
+	src.value = trim(strip_control_chars(value))
 
 /datum/nanite_extra_setting/text/get_copy()
 	return new /datum/nanite_extra_setting/text(value)
 
 /datum/nanite_extra_setting/text/get_value()
+	// Kept html_encoded: consumers inject this into unescaped HTML/chat sinks
+	// (brainwash objective shown to the victim, dermal button label, mood event).
+	// Callers needing the raw value (the speech sensor's phrase match) html_decode it.
 	return html_encode(value)
 
 /datum/nanite_extra_setting/text/get_frontend_list(name)

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -257,9 +257,11 @@
 	var/datum/nanite_extra_setting/inclusive = extra_settings[NES_INCLUSIVE_MODE]
 	if(!sentence.get_value())
 		return
+	// get_value() is html_encoded; the heard message is raw, so decode the trigger
+	// phrase before matching or a phrase containing & < > " ' would never fire.
 	if(inclusive.get_value())
-		if(findtext(hearing_args[HEARING_RAW_MESSAGE], sentence.get_value()))
+		if(findtext(hearing_args[HEARING_RAW_MESSAGE], html_decode(sentence.get_value())))
 			send_code()
 	else
-		if(lowertext(hearing_args[HEARING_RAW_MESSAGE]) == lowertext(sentence.get_value()))
+		if(lowertext(hearing_args[HEARING_RAW_MESSAGE]) == lowertext(html_decode(sentence.get_value())))
 			send_code()

--- a/code/modules/research/nanites/nanite_remote.dm
+++ b/code/modules/research/nanites/nanite_remote.dm
@@ -222,7 +222,10 @@
 		if("set_message")
 			if(locked)
 				return
-			var/new_message = html_encode(params["value"])
+			// Kept html_encoded: mind_control/on_trigger feeds comm_message straight into
+			// brainwash() (an unescaped objective shown to the victim). Add control-char
+			// stripping so a C0 byte can't break the nanite remote's own TGUI payload.
+			var/new_message = html_encode(strip_control_chars(params["value"]))
 			if(!new_message)
 				return
 			comm_message = new_message

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -35,10 +35,12 @@
 			else
 				return stripped_input(user, message, title, default, max_length)
 		else
+			// Even raw (encode=FALSE) input must drop control characters: they break
+			// the DM<->TGUI round-trip and any savefile key built from this text.
 			if(multiline)
-				return input(user, message, title, default) as message|null
+				return strip_control_chars(input(user, message, title, default) as message|null)
 			else
-				return input(user, message, title, default) as text|null
+				return strip_control_chars(input(user, message, title, default) as text|null)
 	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout, prevent_enter)
 	text_input.ui_interact(user)
 	text_input.wait()
@@ -156,6 +158,9 @@
 /datum/tgui_input_text/proc/set_entry(entry)
 	if(isnull(entry))
 		return
+	// Strip control characters in both branches: they survive html_encode but break
+	// the DM<->TGUI round-trip and any savefile key built from this text.
+	entry = strip_control_chars(entry)
 	var/converted_entry = encode ? html_encode_readable(entry) : entry
 	src.entry = trim(converted_entry, max_length)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -82,6 +82,7 @@
 // #include "confusion.dm"
 // #include "crayons.dm"
 #include "create_and_destroy.dm"
+#include "custom_emote_panel.dm"
 // #include "designs.dm"
 #include "dynamic_ruleset_sanity.dm"
 // #include "egg_glands.dm"

--- a/code/modules/unit_tests/custom_emote_panel.dm
+++ b/code/modules/unit_tests/custom_emote_panel.dm
@@ -1,0 +1,60 @@
+/// Verifies that ASCII control characters can no longer corrupt custom emote
+/// panel names. Such characters survive html_encode() but cannot round-trip
+/// through the DM<->TGUI json/topic bridge, which used to leave a button that
+/// could not be executed, renamed, or deleted.
+/// See modular_bluemoon/code/modules/tgui_panel/tgui_emote_panel.dm.
+/datum/unit_test/custom_emote_panel_control_chars
+
+/datum/unit_test/custom_emote_panel_control_chars/Run()
+	// 0x0E and 0x1F are control bytes from the reported breaking range; they must
+	// be removed while the surrounding text is preserved.
+	var/dirty = "test[ascii2text(14)][ascii2text(31)]name"
+	TEST_ASSERT_EQUAL(strip_control_chars(dirty), "testname", "control characters were not stripped from a name")
+
+	// Multi-byte Unicode (Cyrillic) must survive untouched.
+	TEST_ASSERT_EQUAL(strip_control_chars("вздох"), "вздох", "Unicode text was corrupted by strip_control_chars")
+
+	// Tab/newline/carriage-return have proper JSON escapes and round-trip fine, so
+	// they are deliberately kept (e.g. a multi-line *me message must stay intact).
+	var/whitespace = "a[ascii2text(9)]b[ascii2text(10)]c[ascii2text(13)]d"
+	TEST_ASSERT_EQUAL(strip_control_chars(whitespace), whitespace, "tab/newline/carriage-return must be preserved")
+
+	// A string made entirely of control characters cleans to empty.
+	TEST_ASSERT_EQUAL(strip_control_chars("[ascii2text(14)][ascii2text(20)]"), "", "an all-control string should clean to empty")
+
+	// Recovery: a panel whose key carries a control character is rebuilt with a
+	// clean, matchable key, and the stored message is cleaned too.
+	var/broken_name = "wave[ascii2text(15)]"
+	var/list/panel = list()
+	panel[broken_name] = list("type" = TGUI_PANEL_EMOTE_TYPE_ME, "message" = "machine[ascii2text(16)] hums")
+	var/list/repaired = sanitize_custom_emote_panel(panel)
+	TEST_ASSERT(isnull(repaired[broken_name]), "the broken control-character key should not survive sanitization")
+	TEST_ASSERT_NOTNULL(repaired["wave"], "the cleaned emote name should be present and matchable")
+	var/list/repaired_emote = repaired["wave"]
+	TEST_ASSERT_EQUAL(repaired_emote["message"], "machine hums", "the stored message should also be stripped of control characters")
+
+	// An emote whose entire name is control characters is unrecoverable and dropped.
+	var/list/garbage_panel = list()
+	garbage_panel["[ascii2text(14)]"] = list("type" = TGUI_PANEL_EMOTE_TYPE_DEFAULT, "key" = "sigh")
+	TEST_ASSERT_EQUAL(length(sanitize_custom_emote_panel(garbage_panel)), 0, "an all-control-character emote name should be dropped")
+
+	// Collision: two names that clean to the same key keep only the first.
+	var/list/collision_panel = list()
+	collision_panel["hi[ascii2text(14)]"] = list("type" = TGUI_PANEL_EMOTE_TYPE_DEFAULT, "key" = "first")
+	collision_panel["hi[ascii2text(15)]"] = list("type" = TGUI_PANEL_EMOTE_TYPE_DEFAULT, "key" = "second")
+	var/list/deduped = sanitize_custom_emote_panel(collision_panel)
+	TEST_ASSERT_EQUAL(length(deduped), 1, "colliding cleaned names should be deduplicated")
+	var/list/kept = deduped["hi"]
+	TEST_ASSERT_EQUAL(kept["key"], "first", "the first cleaned emote should win a name collision")
+
+	// sanitize_assoc_keys (the generic helper behind colormate/jukebox recovery) cleans
+	// text keys, drops empty/colliding ones, and leaves non-text keys (typepaths) alone.
+	var/list/assoc = list()
+	assoc["good[ascii2text(14)]"] = "a"
+	assoc["[ascii2text(31)]"] = "b" // all-control -> dropped
+	assoc[/obj/item] = "typepath-key-stays"
+	var/list/assoc_clean = sanitize_assoc_keys(assoc)
+	TEST_ASSERT_EQUAL(assoc_clean["good"], "a", "sanitize_assoc_keys should clean a control-character text key")
+	TEST_ASSERT(isnull(assoc_clean["good[ascii2text(14)]"]), "the original dirty key must not survive")
+	TEST_ASSERT_EQUAL(assoc_clean[/obj/item], "typepath-key-stays", "non-text keys must pass through untouched")
+	TEST_ASSERT_EQUAL(length(assoc_clean), 2, "the all-control-character key should have been dropped")

--- a/code/modules/unit_tests/custom_emote_panel.dm
+++ b/code/modules/unit_tests/custom_emote_panel.dm
@@ -22,6 +22,9 @@
 	// A string made entirely of control characters cleans to empty.
 	TEST_ASSERT_EQUAL(strip_control_chars("[ascii2text(14)][ascii2text(20)]"), "", "an all-control string should clean to empty")
 
+	// DEL (0x7F) is also handled by the ascii == 127 branch and must be stripped.
+	TEST_ASSERT_EQUAL(strip_control_chars(ascii2text(127)), "", "DEL (0x7F) should be stripped")
+
 	// Recovery: a panel whose key carries a control character is rebuilt with a
 	// clean, matchable key, and the stored message is cleaned too.
 	var/broken_name = "wave[ascii2text(15)]"

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -426,7 +426,10 @@
 /obj/belly/proc/set_messages(var/raw_text, var/type, var/delim = "\n\n")
 	ASSERT(type == "smo" || type == "smi" || type == "dmo" || type == "dmp" || type == "em")
 
-	var/list/raw_list = splittext(html_encode(raw_text),delim)
+	// html_decode first so re-submitting already-encoded text (get_messages feeds the
+	// stored value back as the input default) normalizes instead of double-encoding
+	// (& -> &amp; -> &amp;amp;). strip_control_chars keeps the \n\n delimiters.
+	var/list/raw_list = splittext(strip_control_chars(html_encode(html_decode(raw_text))),delim)
 	if(raw_list.len > 10)
 		raw_list.Cut(11)
 		testing("[owner] tried to set [lowertext(name)] with 11+ messages")

--- a/code/modules/vore/eating/vorepanel.dm
+++ b/code/modules/vore/eating/vorepanel.dm
@@ -222,7 +222,7 @@
 			if(host.vore_organs.len >= BELLIES_MAX)
 				return FALSE
 
-			var/new_name = html_encode(input(usr,"New belly's name:","New Belly") as text|null)
+			var/new_name = strip_control_chars(html_encode(input(usr,"New belly's name:","New Belly") as text|null))
 
 			var/failure_msg
 			if(length(new_name) > BELLIES_NAME_MAX || length(new_name) < BELLIES_NAME_MIN)
@@ -496,7 +496,7 @@
 	var/attr = params["attribute"]
 	switch(attr)
 		if("b_name")
-			var/new_name = html_encode(input(usr,"Belly's new name:","New Name") as text|null)
+			var/new_name = strip_control_chars(html_encode(input(usr,"Belly's new name:","New Name") as text|null))
 
 			var/failure_msg
 			if(length(new_name) > BELLIES_NAME_MAX || length(new_name) < BELLIES_NAME_MIN)

--- a/modular_bluemoon/code/modules/tattoo/tattoo_persistence.dm
+++ b/modular_bluemoon/code/modules/tattoo/tattoo_persistence.dm
@@ -33,7 +33,11 @@
 	S["pending_tattoo_removals"] >> temp_pending_removals
 
 	persistent_tattoos = sanitize_integer(temp_persistent, 0, 1, TRUE)
-	tattoos_string = sanitize_text(temp_tattoos)
+	// Strip control chars from saved tattoo text: the ^/~ field/record separators are
+	// printable ASCII and untouched, but a stray C0 byte in the text would break the
+	// whole TattooManager TGUI payload (JSON.parse), making the panel - and thus the
+	// only way to remove the tattoo - unopenable.
+	tattoos_string = strip_control_chars(sanitize_text(temp_tattoos))
 	pending_tattoo_removals = islist(temp_pending_removals) ? temp_pending_removals : list()
 
 // Сохранение настроек татуировок

--- a/modular_bluemoon/code/modules/tattoo/tattoo_prefs_ui.dm
+++ b/modular_bluemoon/code/modules/tattoo/tattoo_prefs_ui.dm
@@ -143,7 +143,7 @@
 
 		if("add_tattoo")
 			var/zone = params["zone"]
-			var/text = params["text"]
+			var/text = strip_control_chars(params["text"])
 			var/color = params["color"]
 			var/style = params["style"]
 			if(!zone || !text || !color || !style)
@@ -154,7 +154,7 @@
 		if("edit_tattoo")
 			var/zone = params["zone"]
 			var/index = params["index"]
-			var/new_text = params["text"]
+			var/new_text = strip_control_chars(params["text"])
 			var/new_color = params["color"]
 			var/new_style = params["style"]
 			if(!zone || !index || !new_text || !new_color || !new_style)

--- a/modular_bluemoon/code/modules/tgui_panel/tgui_emote_panel.dm
+++ b/modular_bluemoon/code/modules/tgui_panel/tgui_emote_panel.dm
@@ -146,7 +146,7 @@
 						to_chat(client, span_warning("Эмоция [emote_key] не существует!"))
 						return
 
-					var/message_override = tgui_input_text(client.mob, "Какой кастомный текст будет у эмоции? (максимум - [TGUI_PANEL_MAX_EMOTE_LENGTH] символов)", "Кастомный текст", emote_key, TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE)
+					var/message_override = strip_control_chars(tgui_input_text(client.mob, "Какой кастомный текст будет у эмоции? (максимум - [TGUI_PANEL_MAX_EMOTE_LENGTH] символов)", "Кастомный текст", emote_key, TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE))
 					if (!message_override)
 						to_chat(client, span_warning("Текст \"[message_override]\" не подходит!"))
 						return
@@ -159,7 +159,7 @@
 					)
 
 				if ("*me")
-					var/message = tgui_input_text(client.mob, "Какой текст будет у эмоции? (максимум - [TGUI_PANEL_MAX_EMOTE_LENGTH] символов)", "Кастомный текст", "", TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE)
+					var/message = strip_control_chars(tgui_input_text(client.mob, "Какой текст будет у эмоции? (максимум - [TGUI_PANEL_MAX_EMOTE_LENGTH] символов)", "Кастомный текст", "", TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE))
 					if (!message)
 						to_chat(client, span_warning("Текст \"[message]\" не подходит!"))
 						return
@@ -170,7 +170,7 @@
 						"message" = message,
 					)
 
-			var/emote_name = tgui_input_text(client.mob, "Какое название эмоции будет в панели?", "Название эмоции", suggested_name, TGUI_PANEL_MAX_EMOTE_NAME_LENGTH, FALSE, TRUE)
+			var/emote_name = strip_control_chars(tgui_input_text(client.mob, "Какое название эмоции будет в панели?", "Название эмоции", suggested_name, TGUI_PANEL_MAX_EMOTE_NAME_LENGTH, FALSE, TRUE))
 			if (!emote_name)
 				to_chat(client, span_warning("Название \"[emote_name]\" не подходит!"))
 				return
@@ -235,7 +235,7 @@
 
 
 /datum/tgui_panel/proc/emotes_rename(emote_name)
-	var/new_emote_name = tgui_input_text(client.mob, "Выберите новое название эмоции [emote_name]:", "Название эмоции", emote_name, TGUI_PANEL_MAX_EMOTE_NAME_LENGTH, FALSE, TRUE)
+	var/new_emote_name = strip_control_chars(tgui_input_text(client.mob, "Выберите новое название эмоции [emote_name]:", "Название эмоции", emote_name, TGUI_PANEL_MAX_EMOTE_NAME_LENGTH, FALSE, TRUE))
 	if (!new_emote_name)
 		return FALSE
 	if (new_emote_name == emote_name)
@@ -270,7 +270,7 @@
 		to_chat(client, span_warning("Вы можете добавить текст только обычным эмоциям!"))
 		return FALSE
 
-	var/message_override = tgui_input_text(client.mob, "Выберите новый кастомный текст для эмоции [emote_name]:", "Кастомный текст", "", TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE)
+	var/message_override = strip_control_chars(tgui_input_text(client.mob, "Выберите новый кастомный текст для эмоции [emote_name]:", "Кастомный текст", "", TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE))
 	if (!message_override)
 		return FALSE
 	client.prefs.custom_emote_panel[emote_name]["type"] = TGUI_PANEL_EMOTE_TYPE_CUSTOM
@@ -293,9 +293,9 @@
 		to_chat(client, span_warning("У этой эмоции ещё нет кастомного текста!"))
 		return FALSE
 
-	var/message_override = tgui_input_text(client.mob, "Выберите новый кастомный текст для эмоции [emote_name]:", "Кастомный текст", old_message, TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE)
-	if (!message_override)
-		return TRUE
+	var/message_override = strip_control_chars(tgui_input_text(client.mob, "Выберите новый кастомный текст для эмоции [emote_name]:", "Кастомный текст", old_message, TGUI_PANEL_MAX_EMOTE_LENGTH, TRUE, TRUE))
+	if (!message_override) // отмена или текст из одних управляющих символов - ничего не меняем
+		return FALSE
 	if (emote_type == TGUI_PANEL_EMOTE_TYPE_CUSTOM)
 		client.prefs.custom_emote_panel[emote_name]["message_override"] = message_override
 	else
@@ -306,6 +306,31 @@
 /datum/tgui_panel/proc/emotes_send_list()
 	var/list/payload = client.prefs.custom_emote_panel
 	window.send_message("emotes/setList", payload)
+
+/// Rebuilds a custom_emote_panel list with control characters stripped from every
+/// emote name (the assoc key) and stored message. Entries whose name becomes empty
+/// after cleaning, or collide with an already-cleaned name, are dropped. This both
+/// repairs legacy emotes whose control-character names could not round-trip through
+/// TGUI (and were therefore impossible to rename or delete) and guards against any
+/// such name re-entering the saved data. Always returns a list.
+/proc/sanitize_custom_emote_panel(list/panel)
+	if(!islist(panel))
+		return list()
+	var/list/cleaned = list()
+	for(var/emote_name in panel)
+		var/clean_name = strip_control_chars(emote_name)
+		if(!length(clean_name))
+			continue // name was entirely control characters - unrecoverable, drop it
+		if(clean_name in cleaned)
+			continue // a cleaned name already claimed this slot - drop the duplicate
+		var/list/emote = panel[emote_name]
+		if(islist(emote))
+			if(emote["message"])
+				emote["message"] = strip_control_chars(emote["message"])
+			if(emote["message_override"])
+				emote["message_override"] = strip_control_chars(emote["message_override"])
+		cleaned[clean_name] = emote
+	return cleaned
 
 #undef TGUI_PANEL_MAX_EMOTES
 #undef TGUI_PANEL_MAX_EMOTE_LENGTH

--- a/modular_sand/code/modules/client/preferences_savefile.dm
+++ b/modular_sand/code/modules/client/preferences_savefile.dm
@@ -75,7 +75,9 @@
 	.["favorite_paintings_md5"] >> favorite_paintings_md5
 	favorite_paintings_md5 = SANITIZE_LIST(favorite_paintings_md5)
 	.["playlists"] >> playlists
-	playlists = SANITIZE_LIST(playlists)
+	// Strip control chars from playlist-name keys so a broken name can't make a
+	// playlist permanently unselectable/undeletable through the jukebox UI.
+	playlists = sanitize_assoc_keys(playlists)
 	.["metadollars"] >> metadollars
 	metadollars = isnum(metadollars) ? max(0, round(metadollars)) : 0
 	.["metadollar_minute_pool"] >> metadollar_minute_pool


### PR DESCRIPTION
# Описание

Чиню целый класс багов с кодированием/декодированием текста. Корень один: пользовательский текст (название эмоции, пресета, плейлиста, тату и т.д.) используется как ключ или уходит в TGUI, а управляющие ASCII-символы (0x0E-0x1F) этот круговой путь DM<->TGUI не переживают. Из-за этого имя с таким символом застревало в сейве - кнопку/панель нельзя было ни использовать, ни переименовать, ни удалить. Плюс родственная болячка: повторное `html_encode` без декода накапливало мусор `&amp;amp;`.

Что внутри:
- Центральный guard `strip_control_chars()` в точках входа текста (`finalize_stripped_input`, `tgui_input_text/set_entry`) - гасит новую порчу почти везде разом.
- Пофайловое восстановление сломанных сейвов (Color Mate, музыкальный автомат, татуировки) - элементы снова чинятся при загрузке персонажа.
- Убран дрейф двойного кодирования в лодауте, нанитах, пандемии, рингтоне PDA, редакторе песен и сообщениях vore.
- Попутно починен нанитный сенсор речи (фразы со спецсимволами теперь срабатывают).

Отдельно отмечу: в нескольких местах "наивный" фикс (просто убрать `html_encode`) открыл бы инъекцию в неэкранированные sink-и - интегральные схемы, директива brainwash, maptext рингтона. Там кодирование оставлено намеренно, это не недосмотр.

- [x] Изменения были проверены на локальном сервере <!-- компиляция 0 errors + точечный dm-test (custom_emote_panel) проходит на локальном DreamDaemon; полный ручной прогон каждого UI не делал -->
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Любой игрок мог случайно или намеренно вставить управляющий символ в название и получить вечно висящую, неудаляемую кнопку/пресет/плейлист в своём сейве, а в случае тату/факса - сломать всю панель для всех. Фикс закрывает это на входе и чинит уже испорченные сейвы, не ломая отображение и не открывая инъекций.

## Changelog

:cl:
fix: Эмоции, пресеты Color Mate, плейлисты музыкального автомата, татуировки, имена факсов и другие поля с управляющими символами в названии больше не ломают кнопки и панели. Уже сломанные элементы чинятся при загрузке персонажа.
fix: Имена и тексты в лодауте, нанитах, схемах, рингтонах PDA и др. больше не накапливают артефакты вида "&amp;amp;" при повторных сохранениях.
fix: Нанитный сенсор речи теперь срабатывает на фразы со спецсимволами.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of special control characters in user-provided text fields across various systems (custom presets, playlists, emotes, tattoos, messages)
  * Fixed text encoding issues in input fields for better consistency
  * Resolved potential display issues when re-opening previously saved custom content

* **New Features**
  * Enhanced text input validation for improved stability when saving custom names and descriptions

* **Tests**
  * Added comprehensive test coverage for special character handling in custom emote panel data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->