### PR TITLE
CI/CD: фиксы латентных багов, харденинг supply chain, ускорение матрицы

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -155,7 +155,9 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # Slow maps legitimately reach ~30 min (icemoon passed at 29m39s); 45 leaves
+    # headroom for valid runs while still bounding a genuinely hung round.
+    timeout-minutes: 45
     needs: [find_all_maps, build_test_server]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -7,27 +7,51 @@ on:
     branches:
     - master
     - upstream-merge
+    # Skip the heavy compile/test matrix for docs/changelog-only PRs.
+    # NOTE: if any of these jobs are required status checks in branch protection,
+    # pair this with an aggregate "all green" gate job so docs-only PRs are not
+    # left waiting on checks that never run.
+    paths-ignore:
+    - 'html/changelogs/**'
+    - '.github/ISSUE_TEMPLATE/**'
+    - '**/*.md'
+  workflow_dispatch:
+
+# Least-privilege default token; individual jobs opt up as needed.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref so rapid pushes do not pile up full CI runs.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_linters:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      checks: write # DreamAnnotate posts lint annotations via the checks API
     steps:
       - uses: actions/checkout@v4
       - name: Restore SpacemanDMM cache
         uses: actions/cache@v4
         with:
           path: ~/SpacemanDMM
-          key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-
       - name: Restore Yarn cache
         uses: actions/cache@v4
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-
+            ${{ runner.os }}-yarn-
       - name: Install Tools
         run: |
           pip3 install setuptools --upgrade
@@ -46,7 +70,7 @@ jobs:
           tools/bootstrap/python -m mapmerge2.dmm_test
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
-        uses: yogstation13/DreamAnnotate@v2
+        uses: yogstation13/DreamAnnotate@8ef04ef7fbb4ac63ee2daca222af91599e0af5e1 # v2
         if: always()
         with:
           outputFile: output-annotations.txt
@@ -55,45 +79,95 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Compile Maps
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Restore BYOND cache
         uses: actions/cache@v4
         with:
           path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-
       - name: Compile All Maps
         run: |
           bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
+
+  build_test_server:
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
+    name: Build Integration Server
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore BYOND cache
+        uses: actions/cache@v4
+        with:
+          path: ~/BYOND
+          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-
+      - name: Restore Yarn cache
+        uses: actions/cache@v4
+        with:
+          path: tgui/.yarn/cache
+          key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-
+            ${{ runner.os }}-yarn-
+      # Compile the test server (DM + TGUI) exactly once; every integration leg
+      # below reuses this build instead of recompiling per map.
+      - name: Compile
+        run: |
+          bash tools/ci/install_byond.sh
+          source $HOME/BYOND/byond/bin/byondsetup
+          tools/build/build --ci -DCIBUILDING
+      - name: Upload server build
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-server
+          path: |
+            tgstation.dmb
+            tgstation.rsc
+          retention-days: 1
+          if-no-files-found: error
+
   find_all_maps:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Find Maps to Test
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Find Maps
         id: map_finder
         run: |
           echo "$(ls -mw0 _maps/*.json)" > maps_output.txt
           sed -i -e s+_maps/+\"+g -e s+.json+\"+g maps_output.txt
           echo "Maps: $(cat maps_output.txt)"
-          echo "::set-output name=maps::{\"paths\":[$(cat maps_output.txt)]}"
+          echo "maps={\"paths\":[$(cat maps_output.txt)]}" >> "$GITHUB_OUTPUT"
+
   run_all_tests:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
     runs-on: ubuntu-24.04
-    needs: [find_all_maps]
+    timeout-minutes: 30
+    needs: [find_all_maps, build_test_server]
     strategy:
       fail-fast: false
       matrix:
         map: ${{ fromJSON(needs.find_all_maps.outputs.maps).paths }}
     services:
       mysql:
-        image: mysql:latest
+        # NOTE: this service appears unused - the schema load and the game both
+        # target 127.0.0.1:3306, which is the runner's pre-installed MySQL started
+        # by `systemctl start mysql` below. Pinned for reproducibility; a candidate
+        # for removal.
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -108,16 +182,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
-      - name: Restore Yarn cache
+          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-
+      - name: Restore BYOND native libs cache
         uses: actions/cache@v4
         with:
-          path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          path: ~/.byond/bin
+          key: ${{ runner.os }}-byond-libs-${{ hashFiles('dependencies.sh') }}
+      - name: Download server build
+        uses: actions/download-artifact@v4
+        with:
+          name: test-server
+          path: .
       - name: Setup database
         run: |
           sudo systemctl start mysql
@@ -130,11 +207,17 @@ jobs:
           bash tools/ci/install_rust_g.sh
       - name: Install auxmos
         run: |
-          sudo apt update || true
           bash tools/ci/install_auxmos.sh
-      - name: Compile and run tests
+      - name: Run tests
         run: |
           bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
-          tools/build/build --ci -DCIBUILDING
           bash tools/ci/run_server.sh ${{ matrix.map }}
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.map }}
+          path: ci_test/data/logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -32,20 +32,17 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    permissions:
-      contents: read
-      checks: write # DreamAnnotate posts lint annotations via the checks API
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Restore SpacemanDMM cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
           restore-keys: |
             ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-
       - name: Restore Yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
@@ -58,6 +55,11 @@ jobs:
           bash tools/ci/install_node.sh
           bash tools/ci/install_spaceman_dmm.sh dreamchecker
           tools/bootstrap/python -c ''
+      # Register DreamChecker/DreamMaker problem matchers before linting; v3 is a
+      # composite action (no Node runtime), immune to the Node deprecation, and
+      # annotates the live output of the steps below.
+      - name: Setup lint annotations
+        uses: yogstation13/DreamAnnotate@67354dcd99fe4f980d9887f04e0109472de0fccb # v3
       - name: Run Linters
         run: |
           bash tools/ci/check_filedirs.sh tgstation.dme
@@ -68,12 +70,7 @@ jobs:
           tools/build/build --ci lint
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
-          ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
-      - name: Annotate Lints
-        uses: yogstation13/DreamAnnotate@8ef04ef7fbb4ac63ee2daca222af91599e0af5e1 # v2
-        if: always()
-        with:
-          outputFile: output-annotations.txt
+          ~/dreamchecker
 
   compile_all_maps:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
@@ -81,9 +78,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Restore BYOND cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
@@ -101,16 +98,16 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Restore BYOND cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
           restore-keys: |
             ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-
       - name: Restore Yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
@@ -125,7 +122,7 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci -DCIBUILDING
       - name: Upload server build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-server
           path: |
@@ -142,7 +139,7 @@ jobs:
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Find Maps
         id: map_finder
         run: |
@@ -179,21 +176,21 @@ jobs:
       group: ci-${{ github.ref }}-${{ matrix.map }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Restore BYOND cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
           restore-keys: |
             ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}-
       - name: Restore BYOND native libs cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.byond/bin
           key: ${{ runner.os }}-byond-libs-${{ hashFiles('dependencies.sh') }}
       - name: Download server build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-server
           path: .
@@ -217,7 +214,7 @@ jobs:
           bash tools/ci/run_server.sh ${{ matrix.map }}
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-logs-${{ matrix.map }}
           path: ci_test/data/logs/

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -67,6 +67,6 @@ jobs:
 
       - name: "Push"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -1,7 +1,7 @@
 name: Generate documentation
 on:
   schedule:
-  - cron: "44 */6 * * *"
+  - cron: "44 4 * * *"
   workflow_dispatch:
 permissions:
   contents: read
@@ -18,7 +18,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/SpacemanDMM
-          key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-
       - name: Install SpacemanDMM
         run: bash tools/ci/install_spaceman_dmm.sh dmdoc
       - name: Generate documentation

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency: gen-docs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/SpacemanDMM
           key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('dependencies.sh') }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,4 +13,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,9 @@
 name: PR Labeling
+# SECURITY: this workflow runs on pull_request_target, which executes in the base
+# repo context with a write-scoped token and secrets. NEVER add a checkout of the
+# PR head (actions/checkout with a PR ref) or an inline `run:` that executes
+# PR-controlled code here - that is the classic pull_request_target privilege
+# escalation. The only step must remain a trusted action that reads base-ref config.
 on:
   - pull_request_target
 jobs:

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -14,13 +14,15 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 25
       - name: Python setup
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          cache: pip
+          cache-dependency-path: tools/changelog/requirements.txt
       - name: Install depends
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -14,11 +14,11 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 25
       - name: Python setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
           cache: pip

--- a/.github/workflows/round_id_linker.yml
+++ b/.github/workflows/round_id_linker.yml
@@ -7,6 +7,6 @@ jobs:
   link_rounds:
     runs-on: ubuntu-22.04
     steps:
-    - uses: SPLURT-Station/round_linker@master #notice: fork the round linkies from tg!!
+    - uses: SPLURT-Station/round_linker@97569d582b737b0101308e991c54b72c00fd02c4 # master @ 2026-06-05; notice: SPLURT fork of the tg round linker
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tgs_merge_detector.yml
+++ b/.github/workflows/tgs_merge_detector.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check if comment is from the specified user
         id: filter_comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const comment = context.payload.comment;
@@ -49,7 +49,7 @@ jobs:
 
       - name: Add or remove label based on comment content
         if: steps.filter_comment.outputs.result == 'deployed' || steps.filter_comment.outputs.result == 'removed'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.comment.body;

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update the TGS DMAPI
     steps:
     - name: Clone
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Branch
       run: |

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -20,7 +20,7 @@ jobs:
         git reset --hard master
 
     - name: Apply DMAPI update
-      uses: tgstation/tgs-dmapi-updater@v2
+      uses: tgstation/tgs-dmapi-updater@dcd21d4ab5d4a2031a8f9fd951b44d46a030b052 # v2
       with:
         header-path: 'code/__DEFINES/tgs.dm'
         library-path: 'code/modules/tgs'
@@ -35,7 +35,7 @@ jobs:
         git push -f -u origin tgs-dmapi-update
 
     - name: Create Pull Request
-      uses: repo-sync/pull-request@v2
+      uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
       if: ${{ success() }}
       with:
         source_branch: "tgs-dmapi-update"

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -9,6 +9,8 @@ export BYOND_MINOR=1680
 
 #rust_g git tag
 export RUST_G_VERSION=6.0.1
+# sha256 of the pinned librust_g.so release asset (verified after download)
+export RUST_G_SHA256=4de9edd022c9bd4408cedc300b0fba4066fee6e49c1e03c3ea1e2de7499c3aa8
 
 #node version
 export NODE_VERSION_LTS=20.19.0
@@ -16,6 +18,9 @@ export NODE_VERSION_COMPAT=20.19.0
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.11
+# sha256 of the pinned dreamchecker / dmdoc release assets (verified after download)
+export SPACEMAN_DMM_DREAMCHECKER_SHA256=1d31563287d1fa0f5c4f5744cdf74f97b5d3abc4911a81e3c94ce01a56f5a0d0
+export SPACEMAN_DMM_DMDOC_SHA256=27c10207221b695baa1a00e0a7870bcfb80e5f362340b5d475b224d9182f4c35
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.11.0
@@ -23,6 +28,8 @@ export PYTHON_VERSION=3.11.0
 # Auxmos git tag
 # v2.5.1: v2.5.6 causes illegal operation crashes + network sequence errors on this codebase
 export AUXMOS_VERSION=v2.5.1
+# sha256 of the pinned libauxmos.so release asset (verified after download)
+export AUXMOS_SHA256=ac67ced93c5c5d77184c071b297c1f53f97338fd149a378ab2c98a182b8f6c46
 
 # Extools git tag
 export EXTOOLS_VERSION=v0.0.7

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -12,9 +12,9 @@ NC="\033[0m" # No Color
 
 st=0
 
-if git grep -P "\r\n"; then
+if git grep -lP "\r$"; then
     echo "ERROR: CRLF line endings detected. Please stop using the webeditor, and fix it using a desktop Git client."
-	st = 1
+	st=1
 fi;
 if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -12,7 +12,7 @@ NC="\033[0m" # No Color
 
 st=0
 
-if git grep -lP "\r$"; then
+if git grep -lIP "\r$"; then
     echo "ERROR: CRLF line endings detected. Please stop using the webeditor, and fix it using a desktop Git client."
 	st=1
 fi;

--- a/tools/ci/install_auxmos.sh
+++ b/tools/ci/install_auxmos.sh
@@ -3,7 +3,34 @@ set -euo pipefail
 
 source dependencies.sh
 
-mkdir -p ~/.byond/bin
-wget -O ~/.byond/bin/libauxmos.so "https://github.com/Putnam3145/auxmos/releases/download/${AUXMOS_VERSION}/libauxmos.so"
-chmod +x ~/.byond/bin/libauxmos.so
-ldd ~/.byond/bin/libauxmos.so
+TARGET="$HOME/.byond/bin/libauxmos.so"
+URL="https://github.com/Putnam3145/auxmos/releases/download/${AUXMOS_VERSION}/libauxmos.so"
+
+mkdir -p "$HOME/.byond/bin"
+
+verify_checksum() {
+	echo "${AUXMOS_SHA256}  ${TARGET}" | sha256sum -c - >/dev/null 2>&1
+}
+
+# Reuse a cached copy (e.g. from actions/cache) only if it matches the pinned hash.
+if [ -f "$TARGET" ] && verify_checksum; then
+	echo "Using cached libauxmos.so ($AUXMOS_VERSION)."
+else
+	for attempt in 1 2 3; do
+		if wget -nv -O "$TARGET" "$URL"; then
+			break
+		fi
+		echo "libauxmos.so download failed (attempt ${attempt}/3), retrying..." >&2
+		sleep 3
+	done
+
+	if ! verify_checksum; then
+		echo "ERROR: libauxmos.so checksum mismatch for ${AUXMOS_VERSION}." >&2
+		echo "Expected: ${AUXMOS_SHA256}" >&2
+		echo "Actual:   $(sha256sum "$TARGET" 2>/dev/null | awk '{print $1}')" >&2
+		exit 1
+	fi
+fi
+
+chmod +x "$TARGET"
+ldd "$TARGET"

--- a/tools/ci/install_rust_g.sh
+++ b/tools/ci/install_rust_g.sh
@@ -3,7 +3,34 @@ set -euo pipefail
 
 source dependencies.sh
 
-mkdir -p ~/.byond/bin
-wget -nv -O ~/.byond/bin/librust_g.so "https://github.com/tgstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
-chmod +x ~/.byond/bin/librust_g.so
-ldd ~/.byond/bin/librust_g.so
+TARGET="$HOME/.byond/bin/librust_g.so"
+URL="https://github.com/tgstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
+
+mkdir -p "$HOME/.byond/bin"
+
+verify_checksum() {
+	echo "${RUST_G_SHA256}  ${TARGET}" | sha256sum -c - >/dev/null 2>&1
+}
+
+# Reuse a cached copy (e.g. from actions/cache) only if it matches the pinned hash.
+if [ -f "$TARGET" ] && verify_checksum; then
+	echo "Using cached librust_g.so ($RUST_G_VERSION)."
+else
+	for attempt in 1 2 3; do
+		if wget -nv -O "$TARGET" "$URL"; then
+			break
+		fi
+		echo "librust_g.so download failed (attempt ${attempt}/3), retrying..." >&2
+		sleep 3
+	done
+
+	if ! verify_checksum; then
+		echo "ERROR: librust_g.so checksum mismatch for ${RUST_G_VERSION}." >&2
+		echo "Expected: ${RUST_G_SHA256}" >&2
+		echo "Actual:   $(sha256sum "$TARGET" 2>/dev/null | awk '{print $1}')" >&2
+		exit 1
+	fi
+fi
+
+chmod +x "$TARGET"
+ldd "$TARGET"

--- a/tools/ci/install_spaceman_dmm.sh
+++ b/tools/ci/install_spaceman_dmm.sh
@@ -3,17 +3,44 @@ set -euo pipefail
 
 source dependencies.sh
 
-if [ ! -f ~/$1 ]; then
-	mkdir -p "$HOME/SpacemanDMM"
-	CACHEFILE="$HOME/SpacemanDMM/$1"
+BINARY="$1"
 
-	if ! [ -f "$CACHEFILE.version" ] || ! grep -Fxq "$SPACEMAN_DMM_VERSION" "$CACHEFILE.version"; then
-		wget -O "$CACHEFILE" "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$1"
+case "$BINARY" in
+	dreamchecker) EXPECTED_SHA256="$SPACEMAN_DMM_DREAMCHECKER_SHA256" ;;
+	dmdoc) EXPECTED_SHA256="$SPACEMAN_DMM_DMDOC_SHA256" ;;
+	*) echo "ERROR: unknown SpacemanDMM binary '$BINARY'." >&2; exit 1 ;;
+esac
+
+verify_checksum() {
+	echo "${EXPECTED_SHA256}  $1" | sha256sum -c - >/dev/null 2>&1
+}
+
+if [ ! -f ~/"$BINARY" ]; then
+	mkdir -p "$HOME/SpacemanDMM"
+	CACHEFILE="$HOME/SpacemanDMM/$BINARY"
+
+	# Re-download if the cache is missing, the wrong version, or fails the pinned checksum.
+	if ! [ -f "$CACHEFILE.version" ] || ! grep -Fxq "$SPACEMAN_DMM_VERSION" "$CACHEFILE.version" || ! verify_checksum "$CACHEFILE"; then
+		for attempt in 1 2 3; do
+			if wget -nv -O "$CACHEFILE" "https://github.com/SpaceManiac/SpacemanDMM/releases/download/$SPACEMAN_DMM_VERSION/$BINARY"; then
+				break
+			fi
+			echo "$BINARY download failed (attempt ${attempt}/3), retrying..." >&2
+			sleep 3
+		done
+
+		if ! verify_checksum "$CACHEFILE"; then
+			echo "ERROR: $BINARY checksum mismatch for ${SPACEMAN_DMM_VERSION}." >&2
+			echo "Expected: ${EXPECTED_SHA256}" >&2
+			echo "Actual:   $(sha256sum "$CACHEFILE" 2>/dev/null | awk '{print $1}')" >&2
+			exit 1
+		fi
+
 		chmod +x "$CACHEFILE"
 		echo "$SPACEMAN_DMM_VERSION" >"$CACHEFILE.version"
 	fi
 
-	ln -s "$CACHEFILE" ~/$1
+	ln -s "$CACHEFILE" ~/"$BINARY"
 fi
 
-~/$1 --version
+~/"$BINARY" --version


### PR DESCRIPTION
# Описание

Правки CI/CD по трём приоритетам из аудита:
- **P0** - чиню латентные баги, которые рано или поздно уронили бы CI: устаревший `::set-output` в генераторе матрицы карт (гитхаб его отключит -> матрица тестов обнулится), битое `st = 1` в check_grep.sh, древние actions в make_changelogs.
- **P1** - supply chain: rust-g/auxmos/dreamchecker качаются с проверкой SHA256 и ретраями; сторонние actions запинены на commit SHA; least-privilege permissions.
- **P2** - скорость: тестовый сервер собирается один раз и едет артефактом в плечи матрицы вместо 19 одинаковых компиляций DM+TGUI; плюс concurrency, таймауты, кэш нативных либ.

## Причина изменений

Матрица интеграционных тестов гоняла полную компиляцию DM и TGUI заново на каждой из 19 карт - build-once это убирает. Заодно закрыты latent-баги и дыры supply chain (нативные .so грузились в DreamDaemon без проверки целостности).

## Changelog

:cl:
code: ускорил и починил CI (build-once сборка тестового сервера, фиксы устаревших GitHub Actions)
server: сборка нативных CI-зависимостей теперь проверяется по SHA256
/:cl:
