### PR TITLE
Фикс ошибок линтера или СМАЙЛИ НАЧНИ УЖЕ ИСПОЛЬЗОВАТЬ ПРЫ И ПРОВЕРЯТЬ ТО, ЧТО ТЫ ДЕЛАЕШЬ, ОНО ОШИБКАМИ СРЁТ ДАЖЕ В VSC, НУ СЕРЬЁЗНО

### DIFF
--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -272,7 +272,7 @@
 		if(L.stat != DEAD)
 			attacksuccess = TRUE
 		blobstrain.attack_living(L)
-	var/spreadsuccess = FALSE
+//	var/spreadsuccess = FALSE
 	var/obj/structure/blob/B = locate() in T
 	if(B)
 		if(attacksuccess)
@@ -292,7 +292,7 @@
 		if(cardinalblobs.len)
 			OB = pick(cardinalblobs)
 			if(OB.expand(T, src))
-				spreadsuccess = TRUE
+//				spreadsuccess = TRUE
 				add_points(-BLOB_SPREAD_COST)
 		else
 			OB = pick(diagonalblobs)

--- a/modular_bluemoon/code/game/objects/structures/safe.dm
+++ b/modular_bluemoon/code/game/objects/structures/safe.dm
@@ -102,7 +102,7 @@ GLOBAL_DATUM_INIT(spare_id_safe, /obj/structure/safe/spare_id, null)
 		code_opening()
 
 /obj/structure/safe/floor/syndi/armory/code_opening(datum/source, level)
-	SIGNAL_HANDLER
+	. = ..()
 	if(!security_level_opens_safe(level) || open)
 		return
 	playsound(src, 'modular_bluemoon/sound/effects/opening-gears.ogg', 200, ignore_walls = TRUE)


### PR DESCRIPTION
# Описание
1) закомментирована переменная которая нигде не используется
2) переведён сингнал хандлер на взятие его с родителя, чтобы не жаловался линтер

## Причина изменений
Красный крестик ОТ ТОГО, ЧТО СМАЙЛИ АКТИВНО ОТРИЦАЕТ СУЩЕСТВОВАНИЕ ЛИНТЕРА И ПРОВЕРКИ КОДА ЧЕРЕЗ ЮНИТ ТЕСТЫ
<img width="765" height="105" alt="image" src="https://github.com/user-attachments/assets/64a3776e-9931-44eb-b7b4-fbeb8339e0ba" />
<img width="1419" height="398" alt="image" src="https://github.com/user-attachments/assets/8ff6c931-d023-4e68-bb5f-f36d4ca3fb61" />
<img width="1320" height="63" alt="image" src="https://github.com/user-attachments/assets/7715ff78-f5c7-49fd-adb2-a8bb342cc512" />

## Демонстрация изменений
<img width="516" height="127" alt="image" src="https://github.com/user-attachments/assets/4aa4748a-410c-4191-9416-18812f122fa3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Refactor**
  * Оптимизированы внутренние процедуры механик игры для улучшения кода и надёжности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->