### PR TITLE
Pdaupd2

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -146,16 +146,6 @@
 	static_inventory += using
 	robit.thruster_button = using
 
-//PDA message
-	using = new /atom/movable/screen/robot/pda_msg_send(null, src)
-	using.screen_loc = ui_borg_pda_send
-	static_inventory += using
-
-//PDA log
-	using = new /atom/movable/screen/robot/pda_msg_show(null, src)
-	using.screen_loc = ui_borg_pda_log
-	static_inventory += using
-
 //Intent
 	action_intent = new /atom/movable/screen/act_intent/robot(null, src)
 	action_intent.icon_state = mymob.a_intent
@@ -387,24 +377,4 @@
 		return
 	robot.modularInterface?.interact(robot)
 
-/atom/movable/screen/robot/pda_msg_send
-	name = "PDA - Send Message"
-	icon = 'icons/mob/screen_ai.dmi'
-	icon_state = "pda_send"
 
-/atom/movable/screen/robot/pda_msg_send/Click()
-	if(..())
-		return
-	var/mob/living/silicon/robot/R = usr
-	R.cmd_send_pdamesg(usr)
-
-/atom/movable/screen/robot/pda_msg_show
-	name = "PDA - Show Message Log"
-	icon = 'icons/mob/screen_ai.dmi'
-	icon_state = "pda_receive"
-
-/atom/movable/screen/robot/pda_msg_show/Click()
-	if(..())
-		return
-	var/mob/living/silicon/robot/R = usr
-	R.cmd_show_message_log(usr)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -239,6 +239,14 @@ GLOBAL_LIST_EMPTY(uplinks)
 	. = ..()
 	if(.)
 		return
+	switch(action)
+		if("lock")
+			active = FALSE
+			locked = TRUE
+			telecrystals += hidden_crystals
+			hidden_crystals = 0
+			SStgui.close_uis(src)
+			return TRUE
 	if(!active)
 		return
 	switch(action)
@@ -251,12 +259,6 @@ GLOBAL_LIST_EMPTY(uplinks)
 				var/datum/uplink_item/I = buyable_items[item_name]
 				MakePurchase(usr, I)
 				return TRUE
-		if("lock")
-			active = FALSE
-			locked = TRUE
-			telecrystals += hidden_crystals
-			hidden_crystals = 0
-			SStgui.close_uis(src)
 		if("select")
 			selected_cat = params["category"]
 			return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -693,7 +693,7 @@
 		if(!silent)
 			to_chat(src, "<span class='warning'>You can't do that right now!</span>")
 		return FALSE
-	if(!Adjacent(M) && (M.loc != src))
+	if(!Adjacent(M) && (M.loc != src) && !(M in src.GetAllContents()))
 		if((be_close == 0) || (!no_tk && (dna.check_mutation(TK) && tkMaxRangeCheck(src, M))))
 			return TRUE
 		if(!silent)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -604,15 +604,6 @@
 	data["emitterhealth"] = emitterhealth
 	data["emittermaxhealth"] = emittermaxhealth
 	data["holoform"] = holoform
-	// Unread messages from PDA messenger
-	data["messenger_unread"] = 0
-	if(pda)
-		var/datum/computer_file/program/messenger/messenger = locate() in pda.get_all_files()
-		if(messenger)
-			for(var/chat_ref in messenger.saved_chats)
-				var/datum/pda_chat/chat = messenger.saved_chats[chat_ref]
-				data["messenger_unread"] += chat.unread_messages
-
 	var/datum/language_holder/H = get_language_holder()
 	data["translator_on"] = H?.omnitongue ? TRUE : FALSE
 	data["encoder_active"] = encoder_active
@@ -1008,27 +999,6 @@
 					messenger.run_program(src)
 					pda.active_program = messenger
 					messenger.ui_interact(src)
-				else
-					to_chat(src, "<span class='warning'>Мессенджер не найден!</span>")
-			else
-				to_chat(src, "<span class='warning'>PDA не установлен!</span>")
-			return TRUE
-		if("quick_reply")
-			if(pda)
-				var/datum/computer_file/program/messenger/messenger = locate() in pda.get_all_files()
-				if(messenger)
-					var/datum/pda_chat/target_chat = null
-					for(var/chat_ref in messenger.saved_chats)
-						var/datum/pda_chat/chat = messenger.saved_chats[chat_ref]
-						if(chat.unread_messages > 0)
-							target_chat = chat
-							break
-					if(target_chat)
-						messenger.quick_reply_prompt(src, target_chat)
-					else
-						messenger.run_program(src)
-						pda.active_program = messenger
-						messenger.ui_interact(src)
 				else
 					to_chat(src, "<span class='warning'>Мессенджер не найден!</span>")
 			else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -100,6 +100,8 @@
 /mob/living/silicon/robot/proc/create_modularInterface()
 	if(!modularInterface)
 		modularInterface = new /obj/item/modular_computer/tablet/integrated(src)
+		modularInterface.saved_identification = real_name
+		modularInterface.saved_job = designation || "Cyborg"
 	modularInterface.layer = ABOVE_HUD_PLANE
 	modularInterface.plane = ABOVE_HUD_PLANE
 
@@ -192,6 +194,9 @@
 		builtInCamera.c_tag = real_name	//update the camera name too
 	if(aiPDA && !shell)
 		aiPDA.imprint_id(real_name, aiPDA.saved_job)
+	if(modularInterface)
+		modularInterface.saved_identification = real_name
+		modularInterface.saved_job = designation || "Cyborg"
 
 /mob/living/silicon/robot/proc/get_standard_name()
 	return "[(designation ? "[designation] " : "")][mmi.braintype]-[ident]"

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -284,7 +284,7 @@
 	else
 		turn_on(user)
 
-/obj/item/modular_computer/proc/turn_on(mob/user)
+/obj/item/modular_computer/proc/turn_on(mob/user, open_ui = TRUE)
 	var/issynth = issilicon(user) // Robots and AIs get different activation messages.
 	if(obj_integrity <= integrity_failure * max_integrity)
 		if(issynth)
@@ -307,7 +307,8 @@
 			soundloop.start()
 		enabled = 1
 		update_appearance()
-		ui_interact(user)
+		if(open_ui)
+			ui_interact(user)
 		return TRUE
 	else // Unpowered
 		if(issynth)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -513,7 +513,7 @@
 	if(new_alert)
 		new_alert = FALSE
 		update_appearance()
-	if(user.client)
+	if(user.client && !equipped)
 		update_pda_prefs(user.client)
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_PDA_MESSAGE_MENU_RIGGED))

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -950,7 +950,7 @@
 
 /obj/item/modular_computer/pda/silicon/turn_on(mob/user, open_ui = FALSE)
 	if(silicon_owner?.stat != DEAD)
-		return ..()
+		return ..(user, open_ui)
 	return FALSE
 
 // pAI PDA

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -175,9 +175,9 @@
 	borgo = null
 	return ..()
 
-/obj/item/modular_computer/tablet/integrated/turn_on(mob/user)
+/obj/item/modular_computer/tablet/integrated/turn_on(mob/user, open_ui = TRUE)
 	if(borgo?.stat != DEAD)
-		return ..()
+		return ..(user, open_ui)
 	return FALSE
 
 /**

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -22,11 +22,11 @@
 
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
 	var/obj/item/computer_hardware/printer/printer = computer.all_components[MC_PRINT]
-	var/obj/item/card/id/id_card = card_slot ? card_slot.stored_card : null
-	data["has_id_slot"] = !!card_slot
+	var/obj/item/card/id/id_card = computer.GetID()
+	data["has_id_slot"] = !!(id_card || card_slot)
 	data["has_printer"] = !!printer
 	data["paperamt"] = printer ? "[printer.stored_paper] / [printer.max_paper]" : null
-	data["card_owner"] = card_slot?.stored_card ? id_card.registered_name : "No Card Inserted."
+	data["card_owner"] = id_card ? id_card.registered_name : "No Card Inserted."
 	data["current_user"] = payments_acc ? payments_acc.account_holder : null
 	data["barcode_split"] = cut_multiplier * 100
 	return data
@@ -38,17 +38,22 @@
 	if(!computer)
 		return
 
-	// Get components
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
 	var/obj/item/computer_hardware/printer/printer = computer.all_components[MC_PRINT]
-	var/obj/item/card/id/id_card = card_slot ? card_slot.stored_card : null
-	if(!card_slot || !printer) //We need both to successfully use this app.
+	var/obj/item/card/id/id_card = computer.GetID()
+	if(!printer)
 		return
 
 	switch(action)
 		if("ejectid")
-			if(id_card)
+			if(card_slot?.stored_card)
 				card_slot.try_eject(usr, TRUE)
+			else if(istype(computer, /obj/item/modular_computer/pda))
+				var/obj/item/modular_computer/pda/pda = computer
+				if(pda.stored_id)
+					var/obj/item/card/id/removed = pda.RemoveID()
+					if(removed)
+						usr.put_in_hands(removed)
 		if("selectid")
 			if(!id_card)
 				return

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -41,8 +41,6 @@
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
 	var/obj/item/computer_hardware/printer/printer = computer.all_components[MC_PRINT]
 	var/obj/item/card/id/id_card = computer.GetID()
-	if(!printer)
-		return
 
 	switch(action)
 		if("ejectid")

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -396,7 +396,7 @@
 	var/list/static_data = list()
 	static_data["can_spam"] = spam_mode
 	static_data["is_silicon"] = issilicon(user)
-	static_data["remote_silicon"] = (isAI(user) || iscyborg(user)) && !istype(computer, /obj/item/modular_computer/pda/silicon)
+	static_data["remote_silicon"] = (isAI(user) || iscyborg(user)) && !computer.get_ntnet_status()
 	static_data["alert_able"] = alert_able
 	return static_data
 

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -193,8 +193,6 @@
 	return TRUE
 
 /datum/computer_file/program/messenger/ui_state(mob/user)
-	if(issilicon(user))
-		return GLOB.deep_inventory_state
 	return GLOB.default_state
 
 /datum/computer_file/program/messenger/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -832,7 +832,7 @@
 
 	// Ensure computer is on
 	if(!computer.enabled)
-		computer.turn_on(usr)
+		computer.turn_on(usr, FALSE)
 		if(!computer.enabled)
 			return
 

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -30,6 +30,11 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 	if(. <= UI_DISABLED)
 		return
 
+	if(istype(src_object, /datum/computer_file/program))
+		var/datum/computer_file/program/prog = src_object
+		if(prog.computer == aiPDA && !stat)
+			return UI_INTERACTIVE
+
 	// Robots can interact with anything they can see.
 	var/list/clientviewlist = getviewsize(client.view)
 	if(get_dist(src, src_object) <= min(clientviewlist[1],clientviewlist[2]))
@@ -40,6 +45,11 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 	. = shared_ui_interaction(src_object)
 	if(. < UI_INTERACTIVE)
 		return
+
+	if(istype(src_object, /datum/computer_file/program))
+		var/datum/computer_file/program/prog = src_object
+		if(prog.computer == aiPDA && !stat)
+			return UI_INTERACTIVE
 
 	// The AI can interact with anything it can see nearby, or with cameras while wireless control is enabled.
 	if(!control_disabled && can_see(src_object))

--- a/tgui/packages/tgui/interfaces/NtosMessenger.js
+++ b/tgui/packages/tgui/interfaces/NtosMessenger.js
@@ -638,6 +638,14 @@ const ChatScreen = (props, context) => {
               </>
             )}
             {filteredMessages}
+            <div ref={(node) => {
+              if (node) {
+                const parent = node.parentElement?.closest('.Section__content');
+                if (parent) {
+                  parent.scrollTop = parent.scrollHeight;
+                }
+              }
+            }} key={messages.length} />
           </Stack>
         </Section>
       </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PaiSoftware.js
+++ b/tgui/packages/tgui/interfaces/PaiSoftware.js
@@ -9,7 +9,6 @@ export const PaiSoftware = (props, context) => {
     stat,
     temp,
     software,
-    messenger_unread,
   } = data;
 
   if (stat === 4) {
@@ -83,20 +82,6 @@ export const PaiSoftware = (props, context) => {
                     icon="comment-alt"
                     onClick={() => act('messenger')}>
                     Мессенджер
-                  </Button>
-                </Stack.Item>
-                <Stack.Item>
-                  <Button
-                    fluid
-                    icon="reply"
-                    color={messenger_unread > 0 ? 'good' : null}
-                    onClick={() => act('quick_reply')}>
-                    Быстрый ответ
-                    {messenger_unread > 0 && (
-                      <Box inline ml={1}>
-                        ({messenger_unread})
-                      </Box>
-                    )}
                   </Button>
                 </Stack.Item>
                 <Stack.Item mt={1}>


### PR DESCRIPTION
# Описание

фикс кучи багов.

## Changelog

:cl:
fix: fixed a few things
fix: У боргов убраны кнопки с мессенджером (быстрый ответ, последний лог). 
fix: Мессенджер боргов теперь работает.
fix: Попытка пофиксить автооткрытие апплинка.
fix: При ответе на сообщение открывается только импут текста.
fix: Чат теперь имеет якорь, что прокручивает сразу к актуальным сообщениям.
fix: Пда теперь можно использовать находясь на руках.
fix: Автообновление при эквипе теперь работает адекватно, не дергая каждый раз настройки.
fix: Show massage log ии теперь работает.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Удалены функции**
  * Убраны элементы PDA в интерфейсе робота: отправка сообщений и просмотр логов.
  * Удалён счётчик непрочитанных сообщений и кнопка «Быстрый ответ» в PAI.

* **Улучшения / Поведение UI**
  * Чат теперь автопрокручивается к последним сообщениям.
  * Имя и должность робота синхронизируются с его интерфейсом.
  * Блокировка аплинка теперь закрывает UI немедленно.
  * Включение некоторых устройств может не открывать интерфейс по умолчанию; улучшено определение владельца ID и поведение извлечения/удаления карт.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->