### PR TITLE
loadout copy

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -80,7 +80,7 @@
 #define LOADOUT_LIMBS		 		list(LOADOUT_LIMB_NORMAL,LOADOUT_LIMB_PROSTHETIC,LOADOUT_LIMB_AMPUTATED) //you can amputate your legs/arms though
 
 //loadout saving/loading specific defines
-#define MAXIMUM_LOADOUT_SAVES		5
+#define MAXIMUM_LOADOUT_SAVES		10
 #define LOADOUT_ITEM				"loadout_item"
 #define LOADOUT_COLOR				"loadout_color"
 #define LOADOUT_CUSTOM_NAME			"loadout_custom_name"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -6375,10 +6375,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			loadout_data["SAVE_[where_copy]"] = LAZYCOPY(loadout_to_copy)
 			save_preferences()
 		if(href_list["clear_loadout"])
-			loadout_data["SAVE_[loadout_slot]"] = list()
-			var/confirm = tgui_alert(user, "Вы уверены, что хотите очистить лодаут?", "Очистка лодаута!", list("Нет", "Да"))
+			var/confirm = tgui_alert(user, "Вы уверены, что хотите сбросить [loadout_slot] лодаут слот?", "Очистка лодаута!", list("Нет", "Да"))
 			if(confirm != "Да")
 				return
+			loadout_data["SAVE_[loadout_slot]"] = list()
 			save_preferences()
 		// BLUEMOON ADD - переключатель лодаута
 		if(href_list["toggle_loadout_enabled"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1124,6 +1124,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/loadout_points_label = src.use_modern_translations ? get_modern_text("loadout_points", src) : "loadout point"
 				var/loadout_points_remaining_label = src.use_modern_translations ? get_modern_text("loadout_points_remaining", src) : "remaining"
 				var/clear_loadout_label = src.use_modern_translations ? get_modern_text("clear_loadout", src) : "Clear Loadout"
+				var/copy_loadout_label = src.use_modern_translations ? get_modern_text("copy_loadout", src) : "Copy Loadout"
 				var/loadout_points_word = loadout_points_label
 				if(!src.use_modern_translations && gear_points != 1)
 					loadout_points_word = "[loadout_points_label]s"
@@ -1150,7 +1151,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/loadout_toggle_text = loadout_enabled ? (src.use_modern_translations ? get_modern_text("enabled", src) : "ON") : (src.use_modern_translations ? get_modern_text("disabled", src) : "OFF")
 				dat += "<center>[loadout_enabled_label]: <a href='?_src_=prefs;preference=gear;toggle_loadout_enabled=1'><font color='[loadout_toggle_color]'><b>[loadout_toggle_text]</b></font></a></center><br>"
 				// BLUEMOON ADD END
-				dat += "<center><a href='?_src_=prefs;preference=gear;clear_loadout=1'>[clear_loadout_label]</a></center>"
+				dat += "<center style=\"line-height:20px\">"
+				dat += "<a href='?_src_=prefs;preference=gear;clear_loadout=1'>[clear_loadout_label]</a>"
+				dat += "<a href='?_src_=prefs;preference=gear;copy_loadout=1'>[copy_loadout_label]</a>"
+				dat += "</center>"
 				dat += "</td>"
 			else
 				// Modern uses colspan=2 for the Preview cell above, so there is no right column here.
@@ -6358,8 +6362,23 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(chosen > MAXIMUM_LOADOUT_SAVES || chosen < 1)
 				return
 			loadout_slot = chosen
+		if(href_list["copy_loadout"])
+			var/list/lod_slots = list()
+			for(var/i = 1, i <= MAXIMUM_LOADOUT_SAVES, i++)
+				if(i == loadout_slot)
+					continue
+				lod_slots += i
+			var/where_copy = tgui_input_list(user, "Выбери в какой слот скопировать текущий лодаут.", "Копирование лодаута", lod_slots)
+			if(!where_copy)
+				return
+			var/list/loadout_to_copy = loadout_data["SAVE_[loadout_slot]"]
+			loadout_data["SAVE_[where_copy]"] = LAZYCOPY(loadout_to_copy)
+			save_preferences()
 		if(href_list["clear_loadout"])
 			loadout_data["SAVE_[loadout_slot]"] = list()
+			var/confirm = tgui_alert(user, "Вы уверены, что хотите очистить лодаут?", "Очистка лодаута!", list("Нет", "Да"))
+			if(confirm != "Да")
+				return
 			save_preferences()
 		// BLUEMOON ADD - переключатель лодаута
 		if(href_list["toggle_loadout_enabled"])

--- a/modular_bluemoon/code/modules/client/modern_ru.dm
+++ b/modular_bluemoon/code/modules/client/modern_ru.dm
@@ -39,7 +39,7 @@ var/list/ru_strings = list(
 	// Character preview options
 	"preview_title" = "Предпросмотр",
 	"preview_job" = "Работа",
-	"preview_loadout" = "Снаряжение",
+	"preview_loadout" = "Лодаут",
 	"preview_naked" = "Нагота",
 	"preview_naked_aroused" = "Возбужденный",
 
@@ -49,7 +49,7 @@ var/list/ru_strings = list(
 	"char_tab_appearance" = "Внешность",
 	"char_tab_markings" = "Отметины",
 	"char_tab_speech" = "Речь",
-	"char_tab_loadout" = "Снаряжение",
+	"char_tab_loadout" = "Лодаут",
 	"char_tab_quirks" = "Особенности",
 
 	// Quirks tab labels
@@ -146,10 +146,10 @@ var/list/ru_strings = list(
 	"pregnancy_preferences" = "Предпочтения беременности",
 
 	// Loadout tab labels
-	"loadout" = "Снаряжение",
-	"loadout_points" = "Очки снаряжения",
+	"loadout" = "Лодаут",
+	"loadout_points" = "Очки лодаута",
 	"points_remaining" = "очков осталось",
-	"clear_loadout" = "Очистить снаряжение",
+	"clear_loadout" = "Очистить лодаут",
 
 	// Markings tab labels
 	"character_tattoos" = "Татуировки персонажа",
@@ -249,9 +249,10 @@ var/list/ru_strings = list(
 	"cycle_background" = "Фон",
 
 	// Loadout
-	"loadout_points" = "очков снаряжения",
+	"loadout_points" = "очков лодаута",
 	"loadout_points_remaining" = "осталось",
-	"clear_loadout" = "Очистить снаряжение",
+	"clear_loadout" = "Очистить лодаут",
+	"copy_loadout" = "Скопировать лодаут",
 	"loadout_enabled_label" = "Заменять одежду лодаутом",
 
 	// Quirks
@@ -569,11 +570,11 @@ var/list/ru_strings = list(
 	"set_speech_style" = "Установить стиль речи",
 
 	// Loadout tab (already partially covered)
-	"gear_points" = "Очки снаряжения",
+	"gear_points" = "Очки лодаут",
 	"choose_items" = "Выбрать предметы",
-	"loadout_slot" = "Слот снаряжения",
+	"loadout_slot" = "Слот лодаута",
 	"loadout_slot_hint" = "Можно выбрать только один предмет на категорию, кроме предметов, которые появляются в рюкзаке или руках.",
-	"loadout_no_categories" = "ОШИБКА: Нет категорий снаряжения — что-то пошло совсем не так!",
+	"loadout_no_categories" = "ОШИБКА: Нет категорий лодаута — что-то пошло совсем не так!",
 	"loadout_no_subcategories" = "Подкатегории не найдены. Что-то пошло совсем не так!",
 	"no_items_in_category" = "В этой категории нет доступных предметов.",
 	"cost" = "Стоимость",
@@ -1103,6 +1104,7 @@ var/list/en_strings = list(
 	"loadout_points" = "loadout point",
 	"loadout_points_remaining" = "remaining",
 	"clear_loadout" = "Clear Loadout",
+	"copy_loadout" = "Copy Loadout",
 	"loadout_enabled_label" = "Replace clothing with loadout",
 
 	// Quirks

--- a/modular_splurt/code/modules/client/preferences.dm
+++ b/modular_splurt/code/modules/client/preferences.dm
@@ -1091,7 +1091,7 @@
 				chosen_gear = list()
 
 			dat += "<table align='center' width='100%'>"
-			dat += "<tr><td colspan=4><center><b><font color='[gear_points == 0 ? "#E62100" : "#CCDDFF"]'>[gear_points]</font> loadout points remaining.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
+			dat += "<tr><td colspan=4><center><b><font color='[gear_points == 0 ? "#E62100" : "#CCDDFF"]'>[gear_points]</font> loadout points remaining.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\]\[<a href='?_src_=prefs;preference=gear;copy_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
 			// BLUEMOON ADD - переключатель спавна с лодаутом
 			var/loadout_toggle_color = loadout_enabled ? "#6ABF6A" : "#E62100"
 			var/loadout_toggle_text = loadout_enabled ? "ON" : "OFF"

--- a/modular_splurt/code/modules/client/preferences.dm
+++ b/modular_splurt/code/modules/client/preferences.dm
@@ -1091,7 +1091,7 @@
 				chosen_gear = list()
 
 			dat += "<table align='center' width='100%'>"
-			dat += "<tr><td colspan=4><center><b><font color='[gear_points == 0 ? "#E62100" : "#CCDDFF"]'>[gear_points]</font> loadout points remaining.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\]\[<a href='?_src_=prefs;preference=gear;copy_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
+			dat += "<tr><td colspan=4><center><b><font color='[gear_points == 0 ? "#E62100" : "#CCDDFF"]'>[gear_points]</font> loadout points remaining.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\] \[<a href='?_src_=prefs;preference=gear;copy_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
 			// BLUEMOON ADD - переключатель спавна с лодаутом
 			var/loadout_toggle_color = loadout_enabled ? "#6ABF6A" : "#E62100"
 			var/loadout_toggle_text = loadout_enabled ? "ON" : "OFF"


### PR DESCRIPTION
# Описание
- Добавлена кнопка копирования лодаута из слота в слот
- Слоты лодаута расширены до 10
- В переводе частично использовалось слово Снаряжение, частично Лодаут, я лично считаю, что лодаут это уже сленг, поэтому заменил на него

## Причина изменений
Сейчас легче персонажа в новый слот скопировать, если тебе нужен другой лодаут, чем переносить уже готовый руками.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Добавлена кнопка копирования лодаута из слота в слот
qol: Слоты лодаута расширены до 10
/:cl:
