### PR TITLE
Автоотстегивание с опер столов при грабе

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -356,6 +356,8 @@
 
 /mob/living/carbon/human/CtrlClick(mob/user)
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated())
+		if(buckled && (istype(buckled, /obj/structure/table/optable) || istype(buckled, /obj/machinery/stasis)))
+			buckled.user_unbuckle_mob(src, user)
 		if(!user.CheckActionCooldown())
 			return FALSE
 		var/mob/living/carbon/human/H = user

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1800,6 +1800,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			to_chat(user, "<span class='notice'>You do not breathe, so you cannot perform CPR.</span>")
 
 /datum/species/proc/grab(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+	// BLUEMOON ADD START отстегавание с опер стола.
+	if(target.buckled && (istype(target.buckled, /obj/structure/table/optable) || istype(target.buckled, /obj/machinery/stasis)))
+		target.buckled.user_unbuckle_mob(target, user)
+	// BLUEMOON ADD END
 	if(target.check_martial_melee_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s grab attempt!</span>", target = user, \
 			target_message = "<span class='warning'>[target] blocks your grab attempt!</span>")


### PR DESCRIPTION
# Описание

Дорогой дневник, мне не описать ту боль и унижение которое я сегодня пережила. Мое мертвое тело лежит на операционном столе, а над телом хирург. Я знаю что у него 700 отработанных часов в этом секторе, я точно могу доверить ему свою жизнь, но каково мое удивление, когда он начинает жестоко тупить, не понимая как перенести мое тело к слипперу. Дорогой дневник, я не видела более грустного лица мед работника, чем то. которое с соплями не может нажать на стол, чтобы отстегнуть меня. Спустя 20 минут зашла другая медсестричка, которая с легким вздохом ловко открепила ремни, сказав что второй врач лоускил ебучий. 

Дорогой дневник, мне не описать ту боль и унижение которое я сегодня пережила.

## Причина изменений

выше.

## Changelog

:cl:
qol: Теперь при грабе тела с операционного стола оно будет автоматически открепляться.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * При Ctrl+Click на пристёгнутом персонаже происходит его отстёгивание от хирургического стола или стазис-механизма
  * При захвате пристёгнутого персонажа на указанных устройствах выполняется предварительное отстёгивание перед захватом

<!-- end of auto-generated comment: release notes by coderabbit.ai -->