### PR TITLE
Много вещичек на праздники в кустики. 

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -377,47 +377,9 @@
 	. = ..()
 	if(!mapload)
 		return
-	var/static/list/random_stuff = list(
-		/obj/item/reagent_containers/syringe/heroin = WEIGHT_UNCOMMON,
-		/obj/item/toy/plush/teddybear = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/pill/labebium = WEIGHT_SECRET,
-		/obj/item/reagent_containers/food/snacks/grown/mushroom/schizoshroom = WEIGHT_UNCOMMON,
-		/obj/item/toy/plush/bm/millie = WEIGHT_UNCOMMON,
-		/obj/item/genital_equipment/condom = WEIGHT_UNCOMMON,
-		/obj/item/genital_equipment/condom/open/used = WEIGHT_COMMON,
-		/obj/item/assembly/mousetrap/armed = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/food/snacks/special_candy = WEIGHT_UNCOMMON,
-		/obj/item/buttplug/small = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/food/snacks/donut/semen = WEIGHT_COMMON,
-		/obj/item/reagent_containers/glass/bottle/semen = WEIGHT_SECRET,
-		/obj/item/restraints/handcuffs/fake/kinky = WEIGHT_COMMON,
-		/obj/item/reagent_containers/pill/pendosovka = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/pill/zvezdochka = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/food/snacks/cube/tentacles = WEIGHT_UNCOMMON,
-		/obj/item/clothing/underwear/briefs/tentacle/female = WEIGHT_SECRET,
-		/obj/item/seeds/cannabis = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/syringe/contraband/methamphetamine = WEIGHT_SECRET,
-		/obj/item/reagent_containers/pill/lsd = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/pill/mdma = WEIGHT_UNCOMMON,
-		/obj/item/mod/construction/broken_core = WEIGHT_UNCOMMON,
-		/obj/item/trash/candy = WEIGHT_COMMON,
-		/obj/item/trash/syndi_cakes = WEIGHT_UNCOMMON,
-		/obj/item/trash/candle = WEIGHT_COMMON,
-		/obj/item/soap = WEIGHT_COMMON,
-		/mob/living/simple_animal/pet/dog/corgi/puppy/slime = WEIGHT_SECRET,
-		/obj/item/slime_cookie/pink = WEIGHT_UNCOMMON,
-		/obj/item/clothing/mask/cigarette/shadyjims = WEIGHT_UNCOMMON,
-		/obj/item/clothing/head/kitty = WEIGHT_UNCOMMON,
-		/obj/item/reagent_containers/food/snacks/intecookies = WEIGHT_UNCOMMON,
-		/obj/item/binoculars = WEIGHT_SECRET,
-		/obj/structure/sign/poster/contraband/paws = WEIGHT_UNCOMMON,
-		/obj/item/restraints/legcuffs/bola/energy = WEIGHT_SECRET,
-		/obj/item/stack/medical/suture/five = WEIGHT_UNCOMMON,
-		/obj/item/sign/flag/rus = WEIGHT_SECRET, // Пасхалко
-		/obj/item/toy/figure/inteq = WEIGHT_SECRET,
-		/obj/item/reagent_containers/food/snacks/chips = WEIGHT_UNCOMMON)
 	if(prob(40))
-		var/picked = pickweight(random_stuff)
+		var/list/pool = get_plant_loot_pool()
+		var/picked = pickweight(pool)
 		new picked(src)
 
 #undef WEIGHT_COMMON

--- a/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
+++ b/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
@@ -180,6 +180,7 @@ GLOBAL_LIST_INIT(plant_loot_patriotic_usa, list(
 	/obj/item/clothing/head/that = WEIGHT_UNCOMMON,
 	/obj/item/toy/spinningtoy = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/snacks/burger = WEIGHT_UNCOMMON,
+	/obj/item/sign/flag/usa = WEIGHT_UNCOMMON,
 ))
 
 GLOBAL_LIST_INIT(plant_loot_pirate, list(

--- a/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
+++ b/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
@@ -198,8 +198,6 @@ GLOBAL_LIST_INIT(plant_loot_animal, list(
 	// WEIGHT_UNCOMMON
 	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
 	/obj/item/toy/plush/bubbleplush = WEIGHT_UNCOMMON,
-	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
-	/obj/item/toy/plush/bubbleplush = WEIGHT_UNCOMMON,
 	/obj/item/clothing/head/kitty = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/snacks/cube = WEIGHT_UNCOMMON,
 ))

--- a/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
+++ b/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
@@ -10,9 +10,8 @@ GLOBAL_LIST_INIT(plant_loot_common, list(
 	/obj/item/binoculars = WEIGHT_SECRET,
 	/obj/item/clothing/underwear/briefs/tentacle/female = WEIGHT_SECRET,
 	/obj/item/disk/nuclear/fake = WEIGHT_SECRET,
-	/obj/item/card/emag = WEIGHT_SECRET,
 	/obj/item/restraints/legcuffs/bola/energy = WEIGHT_SECRET,
-	/obj/item/sign/flag/rus = WEIGHT_SECRET,
+	/obj/item/sign/flag/rus = WEIGHT_SECRET, // пасхалко
 	/obj/item/toy/figure/inteq = WEIGHT_SECRET,
 	// WEIGHT_UNCOMMON
 	/obj/item/trash/syndi_cakes = WEIGHT_UNCOMMON,
@@ -63,7 +62,7 @@ GLOBAL_LIST_INIT(plant_loot_winter, list(
 	/obj/item/clothing/head/helmet/space/santahat = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/drinks/mug/coco = WEIGHT_UNCOMMON,
 	/obj/item/toy/spinningtoy = WEIGHT_UNCOMMON,
-	/obj/item/a_gift = WEIGHT_UNCOMMON,
+	/obj/item/a_gift = WEIGHT_UNCOMMON, // на рассмотрение
 	/obj/item/decoration/garland = WEIGHT_UNCOMMON,
 	/obj/item/decoration/tinsel = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/drinks/bottle/champagne = WEIGHT_UNCOMMON,
@@ -81,6 +80,7 @@ GLOBAL_LIST_INIT(plant_loot_valentines, list(
 	/obj/item/reagent_containers/spray = WEIGHT_UNCOMMON,
 	/obj/item/clothing/neck/petcollar = WEIGHT_UNCOMMON,
 	/obj/item/lipstick/random = WEIGHT_UNCOMMON,
+	/obj/item/lipstick/crocin = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/snacks/pie/cream = WEIGHT_UNCOMMON,
 	// WEIGHT_COMMON
 	/obj/item/reagent_containers/food/snacks/candyheart = WEIGHT_COMMON,
@@ -167,7 +167,7 @@ GLOBAL_LIST_INIT(plant_loot_patriotic_ru, list(
 	/obj/item/sign/flag/rus = WEIGHT_UNCOMMON,
 	/obj/item/clothing/head/ushanka = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/snacks/meat/slab = WEIGHT_UNCOMMON,
-	/obj/item/reagent_containers/food/snacks/cheesewedge = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cheesewedge = WEIGHT_UNCOMMON, // сюда бы еще медведя друна закинуть
 	// WEIGHT_COMMON
 	/obj/item/reagent_containers/food/drinks/bottle/vodka = WEIGHT_COMMON,
 ))
@@ -184,7 +184,7 @@ GLOBAL_LIST_INIT(plant_loot_patriotic_usa, list(
 
 GLOBAL_LIST_INIT(plant_loot_pirate, list(
 	// WEIGHT_SECRET
-	/obj/item/melee/sabre = WEIGHT_SECRET,
+	/obj/item/melee/sabre = WEIGHT_SECRET, // Под вопросом
 	// WEIGHT_UNCOMMON
 	/obj/item/clothing/head/pirate = WEIGHT_UNCOMMON,
 	/obj/item/clothing/glasses/sunglasses = WEIGHT_UNCOMMON,
@@ -247,7 +247,7 @@ GLOBAL_LIST_INIT(plant_loot_birthday, list(
 	/obj/item/reagent_containers/food/snacks/cakeslice/birthday = WEIGHT_UNCOMMON,
 	/obj/item/toy/plush = WEIGHT_UNCOMMON,
 	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_UNCOMMON,
-	/obj/item/a_gift = WEIGHT_UNCOMMON,
+	/obj/item/a_gift = WEIGHT_UNCOMMON, // под вопросом
 	/obj/item/clothing/head/festive = WEIGHT_UNCOMMON,
 ))
 

--- a/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
+++ b/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
@@ -1,0 +1,480 @@
+// Полный список пуллов для kirbyplants
+
+#define WEIGHT_COMMON 10
+#define WEIGHT_UNCOMMON 5
+#define WEIGHT_SECRET 1
+
+// Обычный пулл
+GLOBAL_LIST_INIT(plant_loot_common, list(
+	// WEIGHT_SECRET
+	/obj/item/binoculars = WEIGHT_SECRET,
+	/obj/item/clothing/underwear/briefs/tentacle/female = WEIGHT_SECRET,
+	/obj/item/disk/nuclear/fake = WEIGHT_SECRET,
+	/obj/item/card/emag = WEIGHT_SECRET,
+	/obj/item/restraints/legcuffs/bola/energy = WEIGHT_SECRET,
+	/obj/item/sign/flag/rus = WEIGHT_SECRET,
+	/obj/item/toy/figure/inteq = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/trash/syndi_cakes = WEIGHT_UNCOMMON,
+	/obj/item/trash/can = WEIGHT_UNCOMMON,
+	/obj/item/trash/raisins = WEIGHT_UNCOMMON,
+	/obj/item/broken_bottle = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/teddybear = WEIGHT_UNCOMMON,
+	/obj/item/toy/figure = WEIGHT_UNCOMMON,
+	/obj/item/toy/cards/deck = WEIGHT_UNCOMMON,
+	/obj/item/coin/silver = WEIGHT_UNCOMMON,
+	/obj/item/stack/spacecash/c1 = WEIGHT_UNCOMMON,
+	/obj/item/lighter = WEIGHT_UNCOMMON,
+	/obj/item/clothing/mask/cigarette = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/chips = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/special_candy = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/intecookies = WEIGHT_UNCOMMON,
+	/obj/item/genital_equipment/condom = WEIGHT_UNCOMMON,
+	/obj/item/buttplug/small = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cube/tentacles = WEIGHT_UNCOMMON,
+	/obj/item/seeds/cannabis = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/pill/lsd = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/pill/mdma = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/mushroom/schizoshroom = WEIGHT_UNCOMMON,
+	/obj/item/mod/construction/broken_core = WEIGHT_UNCOMMON,
+	/obj/item/slime_cookie/pink = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/kitty = WEIGHT_UNCOMMON,
+	/obj/item/clothing/mask/cigarette/shadyjims = WEIGHT_UNCOMMON,
+	/obj/item/stack/medical/suture/five = WEIGHT_UNCOMMON,
+	/obj/item/assembly/mousetrap/armed = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/bm/millie = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/trash/candy = WEIGHT_COMMON,
+	/obj/item/trash/candle = WEIGHT_COMMON,
+	/obj/item/soap = WEIGHT_COMMON,
+	/obj/item/reagent_containers/food/snacks/donut/semen = WEIGHT_COMMON,
+	/obj/item/genital_equipment/condom/open/used = WEIGHT_COMMON,
+	/obj/item/restraints/handcuffs/fake/kinky = WEIGHT_COMMON,
+))
+
+// Смотреть значения списков в самом низу таблицы.
+GLOBAL_LIST_INIT(plant_loot_winter, list(
+	// WEIGHT_SECRET
+	/obj/item/clothing/neck/petcollar = WEIGHT_SECRET,
+	/obj/item/clothing/head/festive = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/head/santa = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/helmet/space/santahat = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/mug/coco = WEIGHT_UNCOMMON,
+	/obj/item/toy/spinningtoy = WEIGHT_UNCOMMON,
+	/obj/item/a_gift = WEIGHT_UNCOMMON,
+	/obj/item/decoration/garland = WEIGHT_UNCOMMON,
+	/obj/item/decoration/tinsel = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/bottle/champagne = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_valentines, list(
+	// WEIGHT_SECRET
+	/obj/item/storage/fancy/ringbox = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/chocolatebar = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
+	/obj/item/grown/rose = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/spray = WEIGHT_UNCOMMON,
+	/obj/item/clothing/neck/petcollar = WEIGHT_UNCOMMON,
+	/obj/item/lipstick/random = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/pie/cream = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/snacks/candyheart = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_april_fools, list(
+	// WEIGHT_SECRET
+	/obj/item/clothing/mask/gas/clown_hat = WEIGHT_SECRET,
+	/obj/item/extendohand = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/grown/banana = WEIGHT_UNCOMMON,
+	/obj/item/bikehorn = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/spray/cleaner = WEIGHT_UNCOMMON,
+	/obj/item/grown/bananapeel = WEIGHT_UNCOMMON,
+	/obj/item/toy/crayon/rainbow = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/pie/cream = WEIGHT_UNCOMMON,
+	/obj/item/restraints/handcuffs/fake = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_easter, list(
+	// WEIGHT_SECRET
+	/obj/item/storage/bag/easterbasket = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/egg/loaded = WEIGHT_UNCOMMON,
+	/obj/item/toy/figure = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/rabbitears = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/chocolateegg = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/carrot = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_halloween, list(
+	// WEIGHT_SECRET
+	/obj/item/clothing/mask/gas = WEIGHT_SECRET,
+	/obj/item/toy/plush/bubbleplush = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/chocolatebar = WEIGHT_UNCOMMON,
+	/obj/item/candle = WEIGHT_UNCOMMON,
+	/obj/item/weapon/carved_pumpkin = WEIGHT_UNCOMMON,
+	/obj/item/decoration/garland/halloween = WEIGHT_UNCOMMON,
+	/obj/item/decoration/tinsel/halloween = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/pill/lsd = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/snacks/candy_corn = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_pride, list(
+	// WEIGHT_SECRET
+	/obj/item/sign/flag = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/gloves/color/rainbow = WEIGHT_UNCOMMON,
+	/obj/item/clothing/under/color/rainbow = WEIGHT_UNCOMMON,
+	/obj/item/flashlight/glowstick = WEIGHT_UNCOMMON,
+	/obj/item/lipstick = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/soft/green = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_420, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/lighter = WEIGHT_UNCOMMON,
+	/obj/item/clothing/mask/cigarette/rollie/cannabis = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/chocolatebar = WEIGHT_UNCOMMON,
+	/obj/item/bong = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/seeds/cannabis = WEIGHT_COMMON,
+	/obj/item/reagent_containers/food/snacks/grown/cannabis = WEIGHT_COMMON,
+	/obj/item/rollingpaper = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_st_patrick, list(
+	// WEIGHT_SECRET
+	/obj/item/coin/gold = WEIGHT_SECRET,
+	/obj/item/storage/bag/money = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/drinks/beer = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/soft/green = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/grass = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_patriotic_ru, list(
+	// WEIGHT_SECRET
+	/obj/item/kitchen/knife = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/sign/flag/rus = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/ushanka = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/meat/slab = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cheesewedge = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/drinks/bottle/vodka = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_patriotic_usa, list(
+	// WEIGHT_SECRET
+	/obj/item/clothing/head/helmet/space/syndicate/blue = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/drinks/bottle/whiskey = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/that = WEIGHT_UNCOMMON,
+	/obj/item/toy/spinningtoy = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/burger = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_pirate, list(
+	// WEIGHT_SECRET
+	/obj/item/melee/sabre = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/head/pirate = WEIGHT_UNCOMMON,
+	/obj/item/clothing/glasses/sunglasses = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/bottle/rum = WEIGHT_UNCOMMON,
+	/obj/item/coin/gold = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_animal, list(
+	// WEIGHT_SECRET
+	/obj/item/clothing/mask/gas = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/bubbleplush = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/bubbleplush = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/kitty = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cube = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_space, list(
+	// WEIGHT_SECRET
+	/obj/item/stack/sheet/mineral/plasma = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/head/syndicatefake = WEIGHT_UNCOMMON,
+	/obj/item/toy/spinningtoy = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/soda_cans/cola = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_bee, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/mask/rat/bee = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/honeybar = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/honeybar = WEIGHT_UNCOMMON,
+	/obj/item/clothing/suit/beekeeper_suit = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_nature, list(
+	// WEIGHT_SECRET
+	/obj/item/cultivator = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/seeds/random = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/ambrosia = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/poppy = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/peaceflower = WEIGHT_UNCOMMON,
+	/obj/item/grown/sunflower = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_french, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/head/beret = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/grapes = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/baguette = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/bottle/wine = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/store/cheesewheel = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_birthday, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/cakeslice/birthday = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_UNCOMMON,
+	/obj/item/a_gift = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/festive = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_spooky, list(
+	// WEIGHT_SECRET
+	/obj/item/clothing/head/helmet/space/santahat = WEIGHT_SECRET,
+	/obj/item/clothing/mask/gas/monkeymask = WEIGHT_SECRET,
+	/obj/item/restraints/legcuffs/bola/energy = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/candy_corn = WEIGHT_UNCOMMON,
+	/obj/item/candle = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/bubbleplush = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/pill/lsd = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_historical, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/grown/poppy = WEIGHT_UNCOMMON,
+	/obj/item/clothing/accessory/medal = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/bottle/wine = WEIGHT_UNCOMMON,
+	/obj/item/candle = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_labor, list(
+	// WEIGHT_SECRET
+	/obj/item/stack/rods/ten = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/head/hardhat = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/hardhat/red = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/nursehat = WEIGHT_UNCOMMON,
+	/obj/item/wrench = WEIGHT_UNCOMMON,
+	/obj/item/crowbar = WEIGHT_UNCOMMON,
+	/obj/item/screwdriver = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_kindness, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON,
+	/obj/item/grown/rose = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/teddybear = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/pie/cream = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_ramadan, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/grown/banana = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/sugarcookie = WEIGHT_UNCOMMON,
+	/obj/item/clothing/head/fedora = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/glass/beaker/waterbottle/large = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_programmers, list(
+	// WEIGHT_SECRET
+	/obj/item/circuitboard = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/computer_hardware/hard_drive = WEIGHT_UNCOMMON,
+	/obj/item/disk/data = WEIGHT_UNCOMMON,
+	/obj/item/stack/cable_coil/random = WEIGHT_UNCOMMON,
+	/obj/item/toy/figure = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/chips = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_tea, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/drinks/mug = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/donut = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/drinks/mug/tea = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_hotdog, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/meatball = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/drinks/soda_cans/cola = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/fries = WEIGHT_UNCOMMON,
+	// WEIGHT_COMMON
+	/obj/item/reagent_containers/food/snacks/hotdog = WEIGHT_COMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_indigenous, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/clothing/head/kitty = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/corn = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/tortilla = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_vegan, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/seeds/random = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/tofu = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/salad = WEIGHT_UNCOMMON,
+	/obj/item/reagent_containers/food/snacks/grown/apple = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_parent, list(
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_UNCOMMON,
+	/obj/item/grown/rose = WEIGHT_UNCOMMON,
+	/obj/item/toy/plush/teddybear = WEIGHT_UNCOMMON,
+	/obj/item/toy/figure = WEIGHT_UNCOMMON,
+))
+
+GLOBAL_LIST_INIT(plant_loot_dynamic, list(
+	// WEIGHT_SECRET
+	/obj/item/grenade/smokebomb = WEIGHT_SECRET,
+	/obj/item/melee/baton = WEIGHT_SECRET,
+	/obj/item/clothing/mask/gas/syndicate = WEIGHT_SECRET,
+	// WEIGHT_UNCOMMON
+	/obj/item/reagent_containers/glass/bottle/plasma = WEIGHT_UNCOMMON,
+))
+
+/proc/add_pool(var/list/pool, var/list/addition)
+	for(var/item in addition)
+		if(pool[item])
+			pool[item] += addition[item]
+		else
+			pool[item] = addition[item]
+
+/proc/get_plant_loot_pool()
+	var/list/pool = list()
+	if(SSevents.holidays)
+		for(var/holiday_name in SSevents.holidays)
+			switch(holiday_name)
+				if(NEW_YEAR, CHRISTMAS, FESTIVE_SEASON)
+					add_pool(pool, GLOB.plant_loot_winter)
+				if(VALENTINES)
+					add_pool(pool, GLOB.plant_loot_valentines)
+				if(APRIL_FOOLS)
+					add_pool(pool, GLOB.plant_loot_april_fools)
+				if(EASTER)
+					add_pool(pool, GLOB.plant_loot_easter)
+				if(HALLOWEEN)
+					add_pool(pool, GLOB.plant_loot_halloween)
+				if(PRIDE_MONTH, "Pride Week |", "Lesbian Visibility Day |", "Bisexual Visibility Day |",
+				   "Intersex Awareness Day |", "Transgender Awareness Week |", "Transgender Day of Remembrance |",
+				   "Asexual Awareness Week |", "Pansexual and Panromantic Awareness Day |",
+				   "Stonewall Riots Anniversary")
+					add_pool(pool, GLOB.plant_loot_pride)
+				if("День Четыре Двадцать |")
+					add_pool(pool, GLOB.plant_loot_420)
+				if("День Святого Патрика |")
+					add_pool(pool, GLOB.plant_loot_st_patrick)
+				if("день Победы", "Russian Day |", "день, когда ебанные коммунисты взяли эту страну.")
+					add_pool(pool, GLOB.plant_loot_patriotic_ru)
+				if("день Независимости США", "День Колумба")
+					add_pool(pool, GLOB.plant_loot_patriotic_usa)
+				if("день Говорения-как-пират")
+					add_pool(pool, GLOB.plant_loot_pirate)
+				if("день Животных", MONKEYDAY, "день Рождения Яна", "Moth Week")
+					add_pool(pool, GLOB.plant_loot_animal)
+				if("День Космонавта |", "день НЛО")
+					add_pool(pool, GLOB.plant_loot_space)
+				if("день пчёл")
+					add_pool(pool, GLOB.plant_loot_bee)
+				if("День Земли |", "день цветов")
+					add_pool(pool, GLOB.plant_loot_nature)
+				if("день взятия Бастилии")
+					add_pool(pool, GLOB.plant_loot_french)
+				if("день рождения Space Station 13", "Birthday of S.P.L.U.R.T.")
+					add_pool(pool, GLOB.plant_loot_birthday)
+				if("Пятница 13-е", "день Сурка", "Годовщина Судного Дня Майя")
+					add_pool(pool, GLOB.plant_loot_spooky)
+				if("ANZAC Day", "Waitangi Day", "Международный День Коренных Народов Мира")
+					add_pool(pool, GLOB.plant_loot_historical)
+				if("День Труда |", "День Пожарника |", "день Доктора", "День Матери", "День Отца")
+					add_pool(pool, GLOB.plant_loot_labor)
+				if("Случайные Акты Дня Доброты |", "день доброты", "день дружбы")
+					add_pool(pool, GLOB.plant_loot_kindness)
+				if("Начало Рамадана", "Конец Рамадана")
+					add_pool(pool, GLOB.plant_loot_ramadan)
+				if("день Программиста")
+					add_pool(pool, GLOB.plant_loot_programmers)
+				if("Национальный День Чая |")
+					add_pool(pool, GLOB.plant_loot_tea)
+				if("Национальный день Хот-Дога!")
+					add_pool(pool, GLOB.plant_loot_hotdog)
+				if("Международный День Коренных Народов Мира")
+					add_pool(pool, GLOB.plant_loot_indigenous)
+				if("день Вегана")
+					add_pool(pool, GLOB.plant_loot_vegan)
+				if("День Матери", "День Отца")
+					add_pool(pool, GLOB.plant_loot_parent)
+				if("Dynamic Day")
+					add_pool(pool, GLOB.plant_loot_dynamic)
+				// Single-item holidays (unique tiny additions)
+				if("день Сурка")
+					add_pool(pool, list(/obj/item/clothing/head/helmet/space/chronos = WEIGHT_SECRET))
+				if("Високосный день |")
+					add_pool(pool, list(/obj/item/stack/sheet/metal/fifty = WEIGHT_SECRET))
+				if("День Пи |")
+					add_pool(pool, list(/obj/item/reagent_containers/food/snacks/pie = WEIGHT_UNCOMMON))
+				if("день Случайных Актов Дня Доброты |")
+					add_pool(pool, list(/obj/item/reagent_containers/food/snacks/cookie = WEIGHT_COMMON))
+				if("День Земли |")
+					add_pool(pool, list(/obj/item/seeds/random = WEIGHT_UNCOMMON))
+				if("Любовный Сектор |")
+					add_pool(pool, list(/obj/item/toy/plush/carpplushie = WEIGHT_UNCOMMON))
+				if("день Улыбок")
+					add_pool(pool, list(/obj/item/toy/plush/bubbleplush = WEIGHT_UNCOMMON))
+				if("день Босса")
+					add_pool(pool, list(/obj/item/clothing/head/that = WEIGHT_UNCOMMON))
+				if("день ПРИВЕТОВ")
+					add_pool(pool, list(/obj/item/toy/plush = WEIGHT_UNCOMMON))
+				if("День Прав Человека |")
+					add_pool(pool, list(/obj/item/book/manual/wiki/security_space_law = WEIGHT_SECRET))
+				if("день подарков")
+					add_pool(pool, list(/obj/item/a_gift = WEIGHT_UNCOMMON))
+				if("день Жизни")
+					add_pool(pool, list(/obj/item/clothing/mask/gas/monkeymask = WEIGHT_SECRET))
+				if("день Опьянения")
+					add_pool(pool, list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = WEIGHT_UNCOMMON))
+				if("Garbage Day")
+					add_pool(pool, list(/obj/item/trash = WEIGHT_COMMON))
+	if(!pool.len)
+		return GLOB.plant_loot_common
+	// Микс с обычным листом 30%
+	for(var/item in GLOB.plant_loot_common)
+		if(pool[item])
+			pool[item] += max(1, round(GLOB.plant_loot_common[item] * 0.3))
+		else
+			pool[item] = max(1, round(GLOB.plant_loot_common[item] * 0.3))
+	return pool
+
+#undef WEIGHT_COMMON
+#undef WEIGHT_UNCOMMON
+#undef WEIGHT_SECRET

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4504,6 +4504,7 @@
 #include "modular_bluemoon\code\game\objects\structures\extinguisher.dm"
 #include "modular_bluemoon\code\game\objects\structures\ghost_role_spawners.dm"
 #include "modular_bluemoon\code\game\objects\structures\inflatable.dm"
+#include "modular_bluemoon\code\game\objects\structures\kirbyplants_holiday_loot.dm"
 #include "modular_bluemoon\code\game\objects\structures\safe.dm"
 #include "modular_bluemoon\code\game\objects\structures\statues.dm"
 #include "modular_bluemoon\code\game\objects\structures\wallmount.dm"


### PR DESCRIPTION
# Описание

43 праздника получили пулл предметов, которые могут заспавнится в кустиках. 

## Причина изменений

давно хотелось + давно лежит.

## Changelog

:cl:
add: Больше предметов в кустах, связанные с текущими праздниками.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Kirby-растения теперь дропают лут в зависимости от активных праздничных событий и сезонов.
  * Генерация добычи растений переработана: пул возможных предметов формируется динамически с учётом текущих событий, а итоговый набор смешивается с базовым пулом.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->