### PR TITLE
Bump BYOND to 516.1682

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1634"
+byond: "516.1682"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -25,7 +25,7 @@
  * since it calls on process rather than instantly which handles spamming.
  */
 /datum/proc/ui_update()
-	for(var/datum/tgui/ui as() in SStgui.get_all_open_uis(src))
+	for(var/datum/tgui/ui as anything in SStgui.get_all_open_uis(src))
 		ui.needs_update = TRUE
 
 /**

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=516
-export BYOND_MINOR=1680
+export BYOND_MINOR=1682
 
 #rust_g git tag
 export RUST_G_VERSION=6.0.1


### PR DESCRIPTION
# Описание

Поднял BYOND до 516.1682. По чейнджлогу версии нам ничего полезного - только мелкие фиксы движка (краш `dm.exe` без `.dme`, краш на пустых выражениях перед `::`, MouseDrop за пределами окна, мелочь в пейджере). Чисто гигиенический бамп пина.

Что в PR:
- `dependencies.sh` - пин 516.1680 -> 516.1682
- `.tgs.yml` - синхрон, отставал на 515.1634
- `external.dm` - новый компилятор ругается на пустые скобки, падал `for(... as() in ...)`. Заменил `as()` на `as anything`, семантика та же

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Выравниваем версию компилятора в CI/Docker/TGS с продом.

## Changelog

:cl:
server: поднят BYOND до 516.1682
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Chores**
  * Обновлена версия BYOND с 515.1634 на 516.1682 для совместимости с текущим окружением.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->