### PR TITLE
Пачка фиксов по багрепортам: сикеи боргов, health sensor, воксы, цели антагов и другое

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -555,7 +555,7 @@
 			var/mob/living/silicon/ai/aiPlayer = i
 			if(aiPlayer.mind)
 				count_ai++
-				parts += "▶ \[[count_ai]/[total_ai]\] <b><font color=\"#60b6ff\">[aiPlayer.name]</font></b> (игрок: <b>[aiPlayer.mind.key]</b>)"
+				parts += "▶ \[[count_ai]/[total_ai]\] <b><font color=\"#60b6ff\">[aiPlayer.name]</font></b>[aiPlayer.mind.hide_ckey ? "" : " (игрок: <b>[aiPlayer.mind.key]</b>)"]"
 				parts += "[FOURSPACES]├ Статус: [aiPlayer.stat != DEAD ? "<b>активен</b>" : span_redtext("деактивирован") ]"
 				parts += "[FOURSPACES]├ Суммарное кол-во изменений законов: <b>[aiPlayer.law_change_counter == 0 ? span_greentext("изменения отсутствуют")  : span_redtext("[aiPlayer.law_change_counter]") ]</b>"
 				parts += "[FOURSPACES]└ <font color=\"#60b6ff\">ЗАКОНЫ ИИ //</font>"
@@ -573,7 +573,7 @@
 					count_minion++
 					count_minion_spacer--
 					if(connected_minion.mind)
-						parts += "[FOURSPACES][FOURSPACES] — ([count_minion]/[total_ai_minion]) <b>[connected_minion.name]</b> (игрок: <b>[connected_minion.mind.key]</b>) [connected_minion.stat != DEAD ? "(<span class='greentext'>активен</span>)" : "(<span class='redtext'>деактивирован</span>)"] (законы синхронизируются)[count_minion_spacer ? ", " : "."]"
+						parts += "[FOURSPACES][FOURSPACES] — ([count_minion]/[total_ai_minion]) <b>[connected_minion.name]</b>[connected_minion.mind.hide_ckey ? "" : " (игрок: <b>[connected_minion.mind.key]</b>)"] [connected_minion.stat != DEAD ? "(<span class='greentext'>активен</span>)" : "(<span class='redtext'>деактивирован</span>)"] (законы синхронизируются)[count_minion_spacer ? ", " : "."]"
 			else
 				parts += "[FOURSPACES][FOURSPACES] — \[0/0\] <i>Миньоны отсутствуют</i>."
 
@@ -588,7 +588,7 @@
 		for(var/mob/living/silicon/robot/standalone_silicon in GLOB.silicon_mobs)
 			count_silicon++
 			if (!standalone_silicon.connected_ai && standalone_silicon.mind)
-				parts += "▶ ([count_silicon]/[total_silicon]) [minion_spacer ? "<br>" : ""]<b><font color=\"#60b6ff\">[standalone_silicon.name]</font></b> (игрок: <b>[standalone_silicon.mind.key]</b>)"
+				parts += "▶ ([count_silicon]/[total_silicon]) [minion_spacer ? "<br>" : ""]<b><font color=\"#60b6ff\">[standalone_silicon.name]</font></b>[standalone_silicon.mind.hide_ckey ? "" : " (игрок: <b>[standalone_silicon.mind.key]</b>)"]"
 				parts += "[FOURSPACES]├ Статус: [(standalone_silicon.stat != DEAD) ? "<span class='greentext'>выжил</span> как самостоятельный киборг без связи с ИИ!" : "<span class='redtext'>не смог выжить</span> в суровых условиях, будучи самостоятельным киборгом без связи с ИИ."]"
 				parts += "[FOURSPACES]├ Суммарное кол-во изменений законов: <b>[standalone_silicon.law_change_counter == 0 ? span_greentext("изменения отсутствуют")  : span_redtext("[standalone_silicon.law_change_counter]") ]</b>"
 				parts += "[FOURSPACES]└ <font color=\"#60b6ff\">ЗАКОНЫ КИБОРГА //</font>"

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -48,6 +48,10 @@
 		if (cyborg_user.a_intent == INTENT_HARM)
 			return
 
+	// No hands - no stripping: keeps carp/swarmers/roaches and other handless fauna from undressing people.
+	if (!user.can_hold_items() && !IsAdminGhost(user))
+		return
+
 	if (!isnull(should_strip_proc_path) && !call(source, should_strip_proc_path)(user))
 		return
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -49,7 +49,8 @@
 			return
 
 	// No hands - no stripping: keeps carp/swarmers/roaches and other handless fauna from undressing people.
-	if (!user.can_hold_items() && !IsAdminGhost(user))
+	// TRAIT_CAN_STRIP covers mobs with manipulators instead of hands (cyborgs, adult xenomorphs).
+	if (!user.can_hold_items() && !HAS_TRAIT(user, TRAIT_CAN_STRIP) && !IsAdminGhost(user))
 		return
 
 	if (!isnull(should_strip_proc_path) && !call(source, should_strip_proc_path)(user))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -293,6 +293,16 @@
 		else if(A.type == datum_type)
 			return A
 
+///Is this character an offstation ghost role (hotel, ghost cafe, CentCom intern, ERT etc.)? Such characters must not be picked as antag objective targets.
+/datum/mind/proc/is_ghost_role()
+	if(has_antag_datum(/datum/antagonist/ghost_role))
+		return TRUE
+	if(assigned_role in GLOB.exp_specialmap[EXP_TYPE_SPECIAL])
+		return TRUE
+	if(current && HAS_TRAIT(current, TRAIT_NO_MIDROUND_ANTAG))
+		return TRUE
+	return FALSE
+
 /*
 	Removes antag type's references from a mind.
 	objectives, uplinks, powers etc are all handled.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -116,7 +116,7 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 		if(O.late_joiner)
 			try_target_late_joiners = TRUE
 	for(var/datum/mind/possible_target in get_crewmember_minds())
-		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target))
+		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target) && !possible_target.is_ghost_role())
 			if(!(possible_target in blacklist))
 				// BLUEMOON ADD START - если персонаж сверхтяжёлый и установлена настройка, что сверхтяжёлые персонажи не могут быть по заданию, персонажа не добавляет в пулл
 				if(!(!include_superheavy_character && possible_target.current.mob_weight > MOB_WEIGHT_HEAVY))
@@ -140,7 +140,7 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 /datum/objective/proc/find_target_by_role(role, role_type=0, invert=0)//Option sets either to check assigned role or special role. Default to assigned., invert inverts the check, eg: "Don't choose a Ling"
 	var/list/datum/mind/owners = get_owners()
 	for(var/datum/mind/possible_target in get_crewmember_minds())
-		if(!(possible_target in owners) && ishuman(possible_target.current))
+		if(!(possible_target in owners) && ishuman(possible_target.current) && !possible_target.is_ghost_role())
 			var/is_role = 0
 			if(role_type)
 				if(possible_target.special_role == role)

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -233,9 +233,11 @@
 	if(do_message)
 		owner.visible_message("<span class='warning'>Strange armor appears on [owner]!</span>", "<span class='heavy_brass'>A bright shimmer runs down your body, equipping you with Ratvarian armor.</span>")
 		playsound(owner, 'sound/magic/clockwork/fellowship_armory.ogg', 15 * do_message, TRUE) //get sound loudness based on how much we equipped
-	cooldown = CLOCKWORK_ARMOR_COOLDOWN + world.time
-	owner.update_action_buttons_icon()
-	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob, update_action_buttons_icon)), CLOCKWORK_ARMOR_COOLDOWN)
+		cooldown = CLOCKWORK_ARMOR_COOLDOWN + world.time //no cooldown if nothing was equipped, so a failed attempt (e.g. undroppable equipment) can be retried
+		owner.update_action_buttons_icon()
+		addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob, update_action_buttons_icon)), CLOCKWORK_ARMOR_COOLDOWN)
+	else
+		to_chat(owner, "<span class='warning'>Ваше снаряжение невозможно заменить бронёй Ратвара! Снимите его и попробуйте снова.</span>")
 	return TRUE
 
 /datum/action/innate/clockwork_armaments/proc/remove_item_if_better(obj/item/I, mob/user)

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -28,6 +28,7 @@
 	. = ..()
 	if(is_servant_of_ratvar(user))
 		. += "<span class='nzcrentr_small'>Generates <b>[DisplayPower(STARGAZER_POWER)]</b> per second while viewing starlight within [STARGAZER_RANGE] tiles.</span>"
+		. += "<span class='nzcrentr_small'>It only functions wrenched inside a room with a view of space - it can not operate in open space or outdoors.</span>"
 	if(star_light_star_bright)
 		. += "[is_servant_of_ratvar(user) ? "<span class='nzcrentr_small'>It can see starlight!</span>" : "It's shining brilliantly!"]"
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -405,13 +405,13 @@
 		sac_objective.team = src
 
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD)
+		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD && !player.mind.is_ghost_role())
 			target_candidates += player.mind
 
 	if(!length(target_candidates))
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
+			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD && !player.mind.is_ghost_role())
 				target_candidates += player.mind
 
 	listclearnulls(target_candidates)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -273,12 +273,9 @@
 				LH.sac_targetter.sac_targetted.Remove(H.real_name)
 			LH.sac_targetter = null
 			EC.total_sacrifices++
-			for(var/X in carbon_user.get_all_gear())
-				if(!istype(X,/obj/item/forbidden_book))
-					continue
-				var/obj/item/forbidden_book/FB = X
-				FB.charge++
-				FB.charge++
+			//deep contents search: get_all_gear() can't see inside MOD storage modules and the like, eating the sacrifice reward
+			for(var/obj/item/forbidden_book/FB in carbon_user.GetAllContents(/obj/item/forbidden_book))
+				FB.charge += 2
 				break
 
 		if(!LH.target)

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -22,10 +22,9 @@
 
 /obj/item/assembly/health/toggle_secure()
 	secured = !secured
-	if(secured && scanning)
+	if(secured && scanning) //scanning state survives the unsecure/attach cycle, processing just pauses while unsecured
 		START_PROCESSING(SSobj, src)
 	else
-		scanning = FALSE
 		STOP_PROCESSING(SSobj, src)
 	update_icon()
 	return secured

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	set_genital = new(null) //BLUEMOON ADD
 	AddAbility(regurg)
 	AddAbility(set_genital) //BLUEMOON ADD
+	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) // adult xenomorphs have claws dexterous enough to undress prey
 	. = ..()
 
 /mob/living/carbon/alien/humanoid/Destroy()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -16,6 +16,7 @@
 	spark_system.attach(src)
 
 	set_wires(new /datum/wires/robot(src))
+	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) // manipulators are good enough to strip and search
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 	// AddElement(/datum/element/ridable, /datum/component/riding/creature/cyborg)
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge))

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -82,6 +82,8 @@
 /obj/structure/disposalholder/proc/start_moving()
 	cleanup_movement_loop()
 	var/delay = world.tick_lag
+	if(hasmob) //mobs should visibly fly through the pipes instead of near-instantly arriving at the exit
+		delay = max(delay, 1)
 	var/datum/move_loop/disposal_holder/our_loop = SSmove_manager.move_disposals(src, delay = delay, timeout = delay * count)
 	if(our_loop)
 		movement_loop = our_loop

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -113,6 +113,11 @@
 /obj/item/organ/proc/can_decay()
 	if(organ_flags & (ORGAN_NO_SPOIL | ORGAN_SYNTHETIC | ORGAN_FAILING))
 		return FALSE
+	if(owner) //species/effects with stabilized organs (vox, skeletons etc.) keep them from rotting inside the body
+		if(slot == ORGAN_SLOT_HEART && HAS_TRAIT(owner, TRAIT_STABLEHEART))
+			return FALSE
+		if(slot == ORGAN_SLOT_LIVER && HAS_TRAIT(owner, TRAIT_STABLELIVER))
+			return FALSE
 	return TRUE
 
 //Checks to see if the organ is frozen from temperature

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -132,6 +132,7 @@
 // #include "species_whitelists.dm"
 // #include "stomach.dm"
 // #include "strippable.dm"
+#include "strippable_hands_gate.dm"
 #include "subsystem_init.dm"
 #include "surgeries.dm"
 #include "teleporters.dm"

--- a/code/modules/unit_tests/strippable_hands_gate.dm
+++ b/code/modules/unit_tests/strippable_hands_gate.dm
@@ -1,0 +1,21 @@
+/// Tests the "no hands - no stripping" gate on the strip menu:
+/// handless fauna can't open it, while cyborgs and adult xenomorphs
+/// (manipulators/claws via TRAIT_CAN_STRIP) still can.
+/datum/unit_test/strippable_hands_gate
+
+/datum/unit_test/strippable_hands_gate/proc/can_open_strip_menu(mob/living/stripper)
+	var/mob/living/carbon/human/victim = allocate(/mob/living/carbon/human)
+	var/datum/element/strippable/strippable = SSdcs.GetElement(list(/datum/element/strippable, GLOB.strippable_human_items, TYPE_PROC_REF(/mob/living/carbon/human, should_strip)))
+	strippable.mouse_drop_onto(victim, stripper, stripper)
+	return !isnull(LAZYACCESS(strippable.strip_menus, victim))
+
+/datum/unit_test/strippable_hands_gate/Run()
+	var/mob/living/simple_animal/hostile/carp/carp = allocate(/mob/living/simple_animal/hostile/carp)
+	TEST_ASSERT(!can_open_strip_menu(carp), "A carp (no hands) was able to open the strip menu")
+
+	var/mob/living/silicon/robot/borg = allocate(/mob/living/silicon/robot)
+	borg.a_intent = INTENT_HELP
+	TEST_ASSERT(can_open_strip_menu(borg), "A cyborg was unable to open the strip menu")
+
+	var/mob/living/carbon/alien/humanoid/hunter/xeno = allocate(/mob/living/carbon/alien/humanoid/hunter)
+	TEST_ASSERT(can_open_strip_menu(xeno), "An adult xenomorph was unable to open the strip menu")

--- a/modular_bluemoon/code/game/objects/items/fleshlight.dm
+++ b/modular_bluemoon/code/game/objects/items/fleshlight.dm
@@ -632,6 +632,15 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 		if(fl_eq?.holder_genital?.owner == G.owner)
 			to_chat(user, span_warning("Сопряжённый фонарик уже внутри этого человека! Это создаст портальную петлю."))
 			return FALSE
+	// No silent stealth insertion: announce the attempt and take time, like other insertable toys
+	if(user == G.owner)
+		G.owner.visible_message(span_warning("<b>[user]</b> пытается вставить [src] в себя!"),\
+			span_warning("Вы пытаетесь вставить [src] в себя!"))
+	else
+		G.owner.visible_message(span_warning("<b>[user]</b> пытается вставить [src] в <b>[G.owner]</b>!"),\
+			span_warning("<b>[user]</b> пытается вставить [src] в вас!"))
+	if(!do_mob(user, G.owner, 5 SECONDS))
+		return FALSE
 	return TRUE
 
 /obj/item/clothing/underwear/briefs/panties/portalpanties/proc/genital_inserted(datum/source, obj/item/organ/genital/G, mob/user)
@@ -646,6 +655,8 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 	// Update connected fleshlights
 	update_portal()
 	playsound(src, 'sound/machines/ping.ogg', 50, FALSE)
+	if(G.owner && G.owner != user)
+		to_chat(G.owner, span_userlove("Вы чувствуете, как [src] оказывается внутри!"))
 	// Grant control action to the genital owner and register signals
 	if(G.owner)
 		inserted_control_action = new /datum/action/portal_device_control(src)
@@ -765,6 +776,15 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 		if(pp_eq?.holder_genital?.owner == G.owner)
 			to_chat(user, span_warning("Сопряжённые трусики уже внутри этого человека! Это создаст портальную петлю."))
 			return FALSE
+	// No silent stealth insertion: announce the attempt and take time, like other insertable toys
+	if(user == G.owner)
+		G.owner.visible_message(span_warning("<b>[user]</b> пытается вставить [src] в себя!"),\
+			span_warning("Вы пытаетесь вставить [src] в себя!"))
+	else
+		G.owner.visible_message(span_warning("<b>[user]</b> пытается вставить [src] в <b>[G.owner]</b>!"),\
+			span_warning("<b>[user]</b> пытается вставить [src] в вас!"))
+	if(!do_mob(user, G.owner, 5 SECONDS))
+		return FALSE
 	return TRUE
 
 /obj/item/portallight/proc/genital_inserted(datum/source, obj/item/organ/genital/G, mob/user)
@@ -778,6 +798,8 @@ GLOBAL_LIST_EMPTY(public_portal_panties)
 			targetting = CUM_TARGET_PENIS
 	update_appearance()
 	playsound(src, 'sound/machines/ping.ogg', 50, FALSE)
+	if(G.owner && G.owner != user)
+		to_chat(G.owner, span_userlove("Вы чувствуете, как [src] оказывается внутри!"))
 	// Grant control action to the genital owner and register signals
 	if(G.owner)
 		inserted_control_action = new /datum/action/portal_device_control(src)

--- a/modular_splurt/code/modules/clothing/neck/_neck.dm
+++ b/modular_splurt/code/modules/clothing/neck/_neck.dm
@@ -43,7 +43,7 @@
 	icon = 'modular_splurt/icons/obj/clothing/neck/collars.dmi'
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/neck.dmi'
 	icon_state = "collar_holo"
-	poly_states = 0
+	poly_colors = list("#33FFFF")
 	is_edible = 0
 
 /obj/item/clothing/neck/petcollar/casino


### PR DESCRIPTION
# Описание

Пачка фиксов по багрепортам из дискорда:

- Раундэнд больше не палит сикеи ИИ и боргов, если у игрока включён Hide ckey
- Health sensor больше не вырубается при сборке: раскрутил, собрал с игнитером, вставил в гранату - триггерится от смерти/крита носителя
- Сердце и печень воксов больше не гниют (трейты стабильных органов теперь реально работают, заодно у скелетов/зомби)
- Гостроли (отель, гост-кафе, ЦК, ERT) больше не выбираются целями антагов и жертвой НарСи
- Holo-collar с замком снова красится альт-кликом, как обычный
- Карпы, свармеры и тараканы больше не умеют раздевать тушки - раздевание требует рук. Борги (манипуляторы) и взрослые ксеноморфы (когти) считаются рукастыми и раздевать/обыскивать умеют - на это добавлен юнит-тест
- Кловорк-броня не уходит в кулдаун, если из-за неснимаемой шмотки ничего не надето, и говорит об этом
- По мусоропроводу теперь летишь видимо (1 труба за 0.1с), а не телепортируешься в конец; предметы и почта летают с прежней скоростью
- Портальные фонарик и трусики больше не вставляются в людей мгновенно и молча: попытка объявляется в чат, занимает 5 секунд, цель получает уведомление
- Еретику начисляются заряды кодекса за жертву, даже если кодекс лежит в хранилище МОДа
- Стратогейзер кловорков теперь поясняет в осмотре, что не работает в открытом космосе

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Накопившиеся багрепорты, часть висит давно. Меньше сломанных механик - меньше нытиков

## Changelog

:cl:
fix: настройка Hide ckey теперь скрывает сикеи ИИ и боргов в раундэнд-отчёте
fix: health sensor не выключается при сборке с игнитером, граната с ним снова триггерится от смерти носителя
fix: сердце и печень воксов больше не гниют
fix: гостроли больше не становятся целями антагов и жертвой Нар-Си
fix: holo-collar с замком снова меняет цвет
fix: фауна без рук больше не может раздевать тела; манипуляторы боргов и когти взрослых ксеноморфов считаются за руки
fix: кловорк-броня не тратит кулдаун при провале надевания
fix: еретик получает заряды кодекса за жертву, даже если кодекс в хранилище МОДа
fix: портальные фонарик и трусики вставляются с объявлением в чат, задержкой и уведомлением цели
tweak: полёт по мусоропроводу для мобов замедлен до видимого (предметы летают как раньше)
qol: стратогейзер кловорков поясняет в осмотре, почему не работает в космосе
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления и улучшения**
  * Скрытие идентификаторов игроков для ИИ/миньонов при соответствующей настройке
  * Блокировка доступа к панели раздевания для сущностей без рук
  * Исключение призрачных ролей из выбора целей антагонистов и жертв
  * Более понятная обратная связь и корректный кулдаун при смене брони
  * Уточнённый текст для устройства stargazer
  * Задержки при транспортировке с содержимым, устойчивость органов к разложению, учёт вложенных книг для зарядов
  * Ксеноморфам и роботам добавлена врождённая возможность раздевать

* **Новые возможности**
  * Система выявления специальных (ghost) ролей для игрового баланса

* **Тесты**
  * Добавлен юнит-тест проверки правила «нет рук — нет стрип-меню»
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
