### PR TITLE
pda state qol

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -898,6 +898,9 @@
 		/datum/computer_file/program/secureye,
 	)
 
+/obj/item/modular_computer/pda/ui_state(mob/user)
+	return GLOB.human_adjacent_state_no_view
+
 /**
  * Silicon PDA — built-in to Silicons.
  */

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -93,6 +93,9 @@
 		QDEL_NULL(inserted_item)
 	return ..()
 
+/obj/item/modular_computer/tablet/ui_state(mob/user)
+	return GLOB.human_adjacent_state_no_view
+
 /obj/item/modular_computer/tablet/ui_act(action, params)
 	. = ..()
 	if(.)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -17,6 +17,7 @@
 	comp_light_luminosity = 2.3 //Same as the PDA
 	looping_sound = FALSE
 	allow_chunky = TRUE
+	var/default_ui_state = FALSE
 	var/has_variants = TRUE
 	var/finish_color = null
 
@@ -94,6 +95,8 @@
 	return ..()
 
 /obj/item/modular_computer/tablet/ui_state(mob/user)
+	if(default_ui_state)
+		return ..()
 	return GLOB.human_adjacent_state_no_view
 
 /obj/item/modular_computer/tablet/ui_act(action, params)
@@ -165,6 +168,7 @@
 	///IC log that borgs can view in their personal management app
 	var/list/borglog = list()
 	can_have_pen = FALSE
+	default_ui_state = TRUE
 
 /obj/item/modular_computer/tablet/integrated/Initialize(mapload)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -470,7 +470,15 @@
 		chat.can_reply = FALSE
 		return
 	var/target_name = target.computer.saved_identification
-	var/input_message = tgui_input_text(user, "Enter [mime_mode ? "emojis":"a message"].", "NT Messaging[target_name ? " ([target_name])" : ""]", max_length = MAX_MESSAGE_LEN, encode = FALSE)
+	var/input_message
+	var/input_title = "NT Messaging[target_name ? " ([target_name])" : ""]"
+	var/input_desc = "Enter [mime_mode ? "emojis":"a message"]."
+	if(user.client?.prefs.tgui_input_verbs)
+		input_message = tgui_input_text(user, input_desc, input_title, max_length = MAX_MESSAGE_LEN, encode = FALSE)
+	else
+		input_message = stripped_input(user, input_desc, input_title)
+	if(!input_message)
+		return
 	send_message(user, input_message, list(chat))
 
 /// Helper that sends a message to everyone

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -192,9 +192,6 @@
 
 	return TRUE
 
-/datum/computer_file/program/messenger/ui_state(mob/user)
-	return GLOB.default_state
-
 /datum/computer_file/program/messenger/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(isobserver(usr))
@@ -767,8 +764,10 @@
 	var/list/mob/living/receivers = list()
 	if(computer.inserted_pai && computer.inserted_pai.pai)
 		receivers += computer.inserted_pai.pai
-	if(computer.loc && isliving(computer.loc))
+	if(isliving(computer.loc))
 		receivers += computer.loc
+	else if(isliving(computer.loc?.loc))
+		receivers += computer.loc.loc
 
 	var/datum/computer_file/program/messenger/sender_messenger = chat?.recipient?.resolve()
 

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -141,6 +141,9 @@
  * This is a proc over a var for memory reasons
  */
 /datum/proc/ui_state(mob/user)
+	var/datum/host = ui_host(user)
+	if(host && host != src)
+		return host.ui_state(user)
 	return GLOB.default_state
 
 /**

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -15,17 +15,17 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 /datum/ui_state/default/can_use_topic(src_object, mob/user)
 	return user.default_can_use_topic(src_object) // Call the individual mob-overridden procs.
 
-/mob/proc/default_can_use_topic(src_object)
+/mob/proc/default_can_use_topic(src_object, viewcheck = TRUE)
 	return UI_CLOSE // Don't allow interaction by default.
 
-/mob/living/default_can_use_topic(src_object)
+/mob/living/default_can_use_topic(src_object, viewcheck)
 	. = shared_ui_interaction(src_object)
 	if(. > UI_CLOSE && loc) //must not be in nullspace.
-		. = min(., shared_living_ui_distance(src_object)) // Check the distance...
+		. = min(., shared_living_ui_distance(src_object, viewcheck)) // Check the distance...
 	if(. == UI_INTERACTIVE && !IsAdvancedToolUser(src)) // unhandy living mobs can only look, not touch.
 		return UI_UPDATE
 
-/mob/living/silicon/robot/default_can_use_topic(src_object)
+/mob/living/silicon/robot/default_can_use_topic(src_object, viewcheck)
 	. = shared_ui_interaction(src_object)
 	if(. <= UI_DISABLED)
 		return
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 		return UI_INTERACTIVE
 	return UI_DISABLED // Otherwise they can keep the UI open.
 
-/mob/living/silicon/ai/default_can_use_topic(src_object)
+/mob/living/silicon/ai/default_can_use_topic(src_object, viewcheck)
 	. = shared_ui_interaction(src_object)
 	if(. < UI_INTERACTIVE)
 		return
@@ -56,7 +56,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 		return UI_INTERACTIVE
 	return UI_CLOSE
 
-/mob/living/silicon/pai/default_can_use_topic(src_object)
+/mob/living/silicon/pai/default_can_use_topic(src_object, viewcheck)
 	// pAIs can only use themselves and the owner's radio.
 	if((src_object == src || src_object == radio || src_object == pda || src_object == card || src_object == internal_instrument) && !stat)
 		return UI_INTERACTIVE

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -15,7 +15,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/ui_state/default, new)
 /datum/ui_state/default/can_use_topic(src_object, mob/user)
 	return user.default_can_use_topic(src_object) // Call the individual mob-overridden procs.
 
-/mob/proc/default_can_use_topic(src_object, viewcheck = TRUE)
+/mob/proc/default_can_use_topic(src_object, viewcheck)
 	return UI_CLOSE // Don't allow interaction by default.
 
 /mob/living/default_can_use_topic(src_object, viewcheck)

--- a/code/modules/tgui/states/human_adjacent.dm
+++ b/code/modules/tgui/states/human_adjacent.dm
@@ -12,10 +12,22 @@
 
 GLOBAL_DATUM_INIT(human_adjacent_state, /datum/ui_state/human_adjacent_state, new)
 
+/datum/ui_state/human_adjacent_state
+	var/viewcheck = TRUE
+
 /datum/ui_state/human_adjacent_state/can_use_topic(src_object, mob/user)
-	. = user.default_can_use_topic(src_object)
+	. = user.default_can_use_topic(src_object, viewcheck)
+	if(!viewcheck && isatom(src_object))
+		var/atom/A = src_object
+		if(!isturf(A.loc) && !user.contains(A))
+			return UI_CLOSE
 
 	var/dist = get_dist(src_object, user)
 	if((dist > 1) || (!ishuman(user)))
 		// Can't be used unless adjacent and human, even with TK
 		. = min(., UI_UPDATE)
+
+/datum/ui_state/human_adjacent_state/no_view
+	viewcheck = FALSE
+
+GLOBAL_DATUM_INIT(human_adjacent_state_no_view, /datum/ui_state/human_adjacent_state/no_view, new)


### PR DESCRIPTION
# Описание
- ПДА, планшетами теперь нормально можно пользоваться в том числе на руках, vore и т.д.
- Можно отвечать на сообщения, пока ПДА в tailbag и т.д.

МОЖЕТ ЧТО-ТО СЛОМАТЬСЯ, НУЖЕН ТМ
## Причина изменений
QoL

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: ПДА, планшетами теперь нормально можно пользоваться в том числе на руках, vore и т.д.
qol: Можно отвечать на сообщения, пока ПДА в tailbag и т.д.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Улучшения**
  * Единое поведение интерфейса для портативных PDA и опция вернуть дефолтное поведение для встроенных планшетов — предсказуемое открытие/закрытие UI.
  * Сообщения и уведомления доставляются точнее — расширен набор получателей.
  * Усилены проверки доступа к интерфейсам: добавлен режим «без проверки вида», влияющий на взаимодействие на близкой дистанции.
  * Обновлён поток открытия UI и способ ввода в быстром ответе для более надёжной работы.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->