### PR TITLE
Теперь для снятия КК требуется авторизация через терминал

### DIFF
--- a/code/__DEFINES/security_levels.dm
+++ b/code/__DEFINES/security_levels.dm
@@ -10,9 +10,12 @@
 #define SEC_LEVEL_EPSILON 9
 #define SEC_LEVEL_DELTA 10
 
+/// Security levels at or above lambda require keycard auth to set or change.
+#define IS_HIGH_SECURITY_LEVEL(L) ((L) >= SEC_LEVEL_LAMBDA)
+
 GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
-/// When TRUE, red alert was set via keycard auth and cannot be lowered except by keycard auth, emagged comms, or admin bypass.
-GLOBAL_VAR_INIT(red_alert_keycard_locked, FALSE)
+/// Lowest level that cannot be lowered/changed without keycard auth (or bypass). 0 = unlocked.
+GLOBAL_VAR_INIT(keycard_secured_level, 0)
 
 /*
 * All security levels, per ascending alert. Nothing too fancy, really.

--- a/code/__DEFINES/security_levels.dm
+++ b/code/__DEFINES/security_levels.dm
@@ -11,6 +11,8 @@
 #define SEC_LEVEL_DELTA 10
 
 GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
+/// When TRUE, red alert was set via keycard auth and cannot be lowered except by keycard auth, emagged comms, or admin bypass.
+GLOBAL_VAR_INIT(red_alert_keycard_locked, FALSE)
 
 /*
 * All security levels, per ascending alert. Nothing too fancy, really.
@@ -72,8 +74,8 @@ GLOBAL_LIST_INIT(sec_level_colors, list(
 /// Engineering Override Access manual toggle
 //#define COMSIG_GLOB_FORCE_AIRLOCK_OVERRIDE "force_airlock_override"
 
-/proc/set_security_level(level, secret_variant_override = null)
-	SSsecurity_level.set_level(level, secret_variant_override)
+/proc/set_security_level(level, secret_variant_override = null, bypass_keycard_lock = FALSE)
+	SSsecurity_level.set_level(level, secret_variant_override, bypass_keycard_lock)
 
 /proc/get_security_level_notice_theme(level)
 	if(!isnum(level))

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -28,9 +28,15 @@ SUBSYSTEM_DEF(security_level)
 		return null
 	return emergency_shuttle
 
-/datum/controller/subsystem/security_level/proc/set_level(new_level, secret_variant_override)
+/datum/controller/subsystem/security_level/proc/set_level(new_level, secret_variant_override, bypass_keycard_lock = FALSE)
 	if(!isnum(new_level))
 		new_level = SECLEVEL2NUM(new_level)
+
+	var/current_level = isnum(GLOB.security_level) ? GLOB.security_level : SECLEVEL2NUM(GLOB.security_level)
+	if(GLOB.red_alert_keycard_locked && current_level >= SEC_LEVEL_RED && new_level < SEC_LEVEL_RED)
+		if(!bypass_keycard_lock)
+			return
+		GLOB.red_alert_keycard_locked = FALSE
 
 	//Will not be announced if you try to set to the same level as it already is
 	if(new_level >= SEC_LEVEL_GREEN && new_level <= SEC_LEVEL_DELTA && new_level != GLOB.security_level)
@@ -47,6 +53,7 @@ SUBSYSTEM_DEF(security_level)
 					else
 						emergency_shuttle.modTimer(1.66)
 				GLOB.security_level = SEC_LEVEL_GREEN
+				GLOB.red_alert_keycard_locked = FALSE
 				var/obj/machinery/computer/communications/C = locate() in GLOB.machines
 				if(C)
 					C.post_status("alert", "greenalert")

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -34,6 +34,8 @@ SUBSYSTEM_DEF(security_level)
 
 	var/current_level = isnum(GLOB.security_level) ? GLOB.security_level : SECLEVEL2NUM(GLOB.security_level)
 	if(!bypass_keycard_lock && new_level != current_level)
+		if(IS_HIGH_SECURITY_LEVEL(current_level) && new_level < SEC_LEVEL_RED)
+			return
 		if(GLOB.keycard_secured_level && new_level < GLOB.keycard_secured_level)
 			return
 		if(IS_HIGH_SECURITY_LEVEL(current_level) && IS_HIGH_SECURITY_LEVEL(new_level) && new_level != current_level)

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -33,10 +33,14 @@ SUBSYSTEM_DEF(security_level)
 		new_level = SECLEVEL2NUM(new_level)
 
 	var/current_level = isnum(GLOB.security_level) ? GLOB.security_level : SECLEVEL2NUM(GLOB.security_level)
-	if(GLOB.red_alert_keycard_locked && current_level >= SEC_LEVEL_RED && new_level < SEC_LEVEL_RED)
-		if(!bypass_keycard_lock)
+	if(!bypass_keycard_lock && new_level != current_level)
+		if(GLOB.keycard_secured_level && new_level < GLOB.keycard_secured_level)
 			return
-		GLOB.red_alert_keycard_locked = FALSE
+		if(IS_HIGH_SECURITY_LEVEL(current_level) && IS_HIGH_SECURITY_LEVEL(new_level) && new_level != current_level)
+			return
+
+	if(bypass_keycard_lock && GLOB.keycard_secured_level && new_level < GLOB.keycard_secured_level)
+		GLOB.keycard_secured_level = 0
 
 	//Will not be announced if you try to set to the same level as it already is
 	if(new_level >= SEC_LEVEL_GREEN && new_level <= SEC_LEVEL_DELTA && new_level != GLOB.security_level)
@@ -53,7 +57,7 @@ SUBSYSTEM_DEF(security_level)
 					else
 						emergency_shuttle.modTimer(1.66)
 				GLOB.security_level = SEC_LEVEL_GREEN
-				GLOB.red_alert_keycard_locked = FALSE
+				GLOB.keycard_secured_level = 0
 				var/obj/machinery/computer/communications/C = locate() in GLOB.machines
 				if(C)
 					C.post_status("alert", "greenalert")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -189,7 +189,7 @@
 
 			var/current_level = isnum(GLOB.security_level) ? GLOB.security_level : SECLEVEL2NUM(GLOB.security_level)
 			var/emagged_bypass = (obj_flags & EMAGGED)
-			if(GLOB.red_alert_keycard_locked && current_level >= SEC_LEVEL_RED && new_sec_level < SEC_LEVEL_RED && !emagged_bypass)
+			if(GLOB.keycard_secured_level >= SEC_LEVEL_RED && current_level >= SEC_LEVEL_RED && new_sec_level < SEC_LEVEL_RED && !emagged_bypass)
 				to_chat(usr, span_warning("Красный код может быть снят только через устройства двойной авторизации ключ-карт."))
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 				return
@@ -631,7 +631,7 @@
 					data["alertLevelTick"] = alert_level_tick
 					data["canMakeAnnouncement"] = TRUE
 					data["canSetAlertLevel"] = issilicon(user) ? "NO_SWIPE_NEEDED" : "SWIPE_NEEDED"
-					data["redAlertKeycardLocked"] = GLOB.red_alert_keycard_locked && GLOB.security_level >= SEC_LEVEL_RED && !(obj_flags & EMAGGED)
+					data["redAlertKeycardLocked"] = GLOB.keycard_secured_level >= SEC_LEVEL_RED && GLOB.security_level >= SEC_LEVEL_RED && !(obj_flags & EMAGGED)
 				else if(syndicate)
 					data["canMakeAnnouncement"] = TRUE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -189,12 +189,17 @@
 
 			var/current_level = isnum(GLOB.security_level) ? GLOB.security_level : SECLEVEL2NUM(GLOB.security_level)
 			var/emagged_bypass = (obj_flags & EMAGGED)
+			if(IS_HIGH_SECURITY_LEVEL(current_level) && new_sec_level < SEC_LEVEL_RED)
+				to_chat(usr, span_warning("С высокого кода тревоги можно перейти только на красный — через устройства двойной авторизации ключ-карт."))
+				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
+				return
 			if(GLOB.keycard_secured_level >= SEC_LEVEL_RED && current_level >= SEC_LEVEL_RED && new_sec_level < SEC_LEVEL_RED && !emagged_bypass)
 				to_chat(usr, span_warning("Красный код может быть снят только через устройства двойной авторизации ключ-карт."))
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 				return
 
-			set_security_level(new_sec_level, null, emagged_bypass)
+			var/bypass_red_lock = emagged_bypass && !IS_HIGH_SECURITY_LEVEL(current_level)
+			set_security_level(new_sec_level, null, bypass_red_lock)
 
 			to_chat(usr, span_notice("Доступ разрешён. Обновляю уровень угрозы."))
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
@@ -632,6 +637,7 @@
 					data["canMakeAnnouncement"] = TRUE
 					data["canSetAlertLevel"] = issilicon(user) ? "NO_SWIPE_NEEDED" : "SWIPE_NEEDED"
 					data["redAlertKeycardLocked"] = GLOB.keycard_secured_level >= SEC_LEVEL_RED && GLOB.security_level >= SEC_LEVEL_RED && !(obj_flags & EMAGGED)
+					data["highAlertKeycardLocked"] = GLOB.security_level >= SEC_LEVEL_LAMBDA
 				else if(syndicate)
 					data["canMakeAnnouncement"] = TRUE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -187,7 +187,14 @@
 			if (GLOB.security_level == new_sec_level)
 				return
 
-			set_security_level(new_sec_level)
+			var/current_level = isnum(GLOB.security_level) ? GLOB.security_level : SECLEVEL2NUM(GLOB.security_level)
+			var/emagged_bypass = (obj_flags & EMAGGED)
+			if(GLOB.red_alert_keycard_locked && current_level >= SEC_LEVEL_RED && new_sec_level < SEC_LEVEL_RED && !emagged_bypass)
+				to_chat(usr, span_warning("Красный код может быть снят только через устройства двойной авторизации ключ-карт."))
+				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
+				return
+
+			set_security_level(new_sec_level, null, emagged_bypass)
 
 			to_chat(usr, span_notice("Доступ разрешён. Обновляю уровень угрозы."))
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
@@ -624,6 +631,7 @@
 					data["alertLevelTick"] = alert_level_tick
 					data["canMakeAnnouncement"] = TRUE
 					data["canSetAlertLevel"] = issilicon(user) ? "NO_SWIPE_NEEDED" : "SWIPE_NEEDED"
+					data["redAlertKeycardLocked"] = GLOB.red_alert_keycard_locked && GLOB.security_level >= SEC_LEVEL_RED && !(obj_flags & EMAGGED)
 				else if(syndicate)
 					data["canMakeAnnouncement"] = TRUE
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -953,7 +953,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				secret_variant_override = TRUE
 			if("Случайно (90% обычные)")
 				secret_variant_override = null
-	set_security_level(level, secret_variant_override)
+	set_security_level(level, secret_variant_override, TRUE)
 
 	var/extra_log = ""
 	if(level in list("violet", "amber", "red", "delta"))

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -457,7 +457,7 @@
 	safety = !safety
 	if(safety)
 		if(timing)
-			set_security_level(previous_level)
+			set_security_level(previous_level, null, TRUE)
 			revert_syndicate_nuke_pinpointers_disk()
 		timing = FALSE
 		detonation_timer = null
@@ -478,7 +478,7 @@
 		set_security_level("delta")
 	else
 		detonation_timer = null
-		set_security_level(previous_level)
+		set_security_level(previous_level, null, TRUE)
 		revert_syndicate_nuke_pinpointers_disk()
 		countdown.stop()
 	update_icon()
@@ -604,7 +604,7 @@
 	detonation_timer = null
 	exploding = FALSE
 	exploded = TRUE
-	set_security_level(previous_level)
+	set_security_level(previous_level, null, TRUE)
 	revert_syndicate_nuke_pinpointers_disk()
 	countdown.stop()
 	update_icon()

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -2,6 +2,11 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 
 #define KEYCARD_RED_ALERT "Red Alert"
 #define KEYCARD_CLEAR_RED_ALERT "Clear Red Alert"
+#define KEYCARD_CLEAR_HIGH_ALERT "Clear High Alert"
+#define KEYCARD_LAMBDA_ALERT "Lambda Alert"
+#define KEYCARD_GAMMA_ALERT "Gamma Alert"
+#define KEYCARD_EPSILON_ALERT "Epsilon Alert"
+#define KEYCARD_DELTA_ALERT "Delta Alert"
 #define KEYCARD_EMERGENCY_MAINTENANCE_ACCESS "Emergency Maintenance Access"
 #define KEYCARD_BSA_UNLOCK "Bluespace Artillery Unlock"
 #define KEYCARD_BSMINER_PROTOCOLS "Bluespace Miner Protocols"
@@ -29,6 +34,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	var/mob/triggerer = null
 	var/obj/item/card/id/first_id = null
 	var/waiting = 0
+	var/pending_security_level = 0
 
 	COOLDOWN_DECLARE(access_grant_cooldown)
 
@@ -54,8 +60,11 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	var/list/data = list()
 	data["waiting"] = waiting
 	data["auth_required"] = event_source ? event_source.event : 0
-	data["red_alert"] = (SECLEVEL2NUM(NUM2SECLEVEL(GLOB.security_level)) >= SEC_LEVEL_RED) ? 1 : 0
-	data["red_alert_keycard_locked"] = GLOB.red_alert_keycard_locked
+	data["security_level"] = NUM2SECLEVEL(GLOB.security_level)
+	data["can_set_red_alert"] = (GLOB.security_level < SEC_LEVEL_RED && GLOB.keycard_secured_level < SEC_LEVEL_RED)
+	data["can_clear_red_alert"] = (GLOB.keycard_secured_level == SEC_LEVEL_RED && GLOB.security_level == SEC_LEVEL_RED)
+	data["can_clear_high_alert"] = (GLOB.security_level >= SEC_LEVEL_LAMBDA)
+	data["high_alert_levels"] = list("lambda", "gamma", "epsilon", "delta")
 	data["emergency_maint"] = GLOB.emergency_access
 	data["bsa_unlock"] = GLOB.bsa_unlock
 	return data
@@ -78,13 +87,39 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 		return
 	switch(action)
 		if("red_alert")
-			if(!event_source && !GLOB.red_alert_keycard_locked)
-				sendEvent(KEYCARD_RED_ALERT, ID)
+			if(!event_source && GLOB.security_level < SEC_LEVEL_RED && GLOB.keycard_secured_level < SEC_LEVEL_RED)
+				sendSecurityLevelEvent(SEC_LEVEL_RED, KEYCARD_RED_ALERT, ID)
 				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
 				. = TRUE
 		if("clear_red_alert")
-			if(!event_source && GLOB.red_alert_keycard_locked)
-				sendEvent(KEYCARD_CLEAR_RED_ALERT, ID)
+			if(!event_source && GLOB.keycard_secured_level == SEC_LEVEL_RED && GLOB.security_level == SEC_LEVEL_RED)
+				sendSecurityLevelEvent(SEC_LEVEL_BLUE, KEYCARD_CLEAR_RED_ALERT, ID)
+				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
+				. = TRUE
+		if("clear_high_alert")
+			if(!event_source && GLOB.security_level >= SEC_LEVEL_LAMBDA)
+				sendSecurityLevelEvent(SEC_LEVEL_RED, KEYCARD_CLEAR_HIGH_ALERT, ID)
+				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
+				. = TRUE
+		if("set_high_alert")
+			if(!event_source)
+				var/level_name = params["level"]
+				var/level_num = SECLEVEL2NUM(level_name)
+				if(!IS_HIGH_SECURITY_LEVEL(level_num) || GLOB.security_level == level_num)
+					return
+				var/event_name
+				switch(level_num)
+					if(SEC_LEVEL_LAMBDA)
+						event_name = KEYCARD_LAMBDA_ALERT
+					if(SEC_LEVEL_GAMMA)
+						event_name = KEYCARD_GAMMA_ALERT
+					if(SEC_LEVEL_EPSILON)
+						event_name = KEYCARD_EPSILON_ALERT
+					if(SEC_LEVEL_DELTA)
+						event_name = KEYCARD_DELTA_ALERT
+					else
+						return
+				sendSecurityLevelEvent(level_num, event_name, ID)
 				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
 				. = TRUE
 		if("emergency_maint")
@@ -127,6 +162,10 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 				balloon_alert(usr, "key access sent")
 			return
 
+/obj/machinery/keycard_auth/proc/sendSecurityLevelEvent(level_num, event_type, trigger_id)
+	pending_security_level = level_num
+	sendEvent(event_type, trigger_id)
+
 /obj/machinery/keycard_auth/proc/sendEvent(event_type, trigger_id)
 	triggerer = usr
 	event = event_type
@@ -137,6 +176,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 /obj/machinery/keycard_auth/proc/eventSent()
 	triggerer = null
 	event = ""
+	pending_security_level = 0
 	waiting = 0
 
 /obj/machinery/keycard_auth/proc/triggerEvent(source, trigger_id)
@@ -149,6 +189,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	icon_state = "auth_off"
 	event_source = null
 	first_id = null
+	pending_security_level = 0
 
 /obj/machinery/keycard_auth/proc/trigger_event(confirmer)
 	log_game("[key_name(triggerer)] triggered and [key_name(confirmer)] confirmed event [event]")
@@ -161,10 +202,18 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	deadchat_broadcast(" confirmed [event] at [span_name("[A2.name]")].", span_name("[confirmer]"), confirmer, message_type=DEADCHAT_ANNOUNCEMENT)
 	switch(event)
 		if(KEYCARD_RED_ALERT)
-			GLOB.red_alert_keycard_locked = TRUE
-			set_security_level(SEC_LEVEL_RED)
+			set_security_level(SEC_LEVEL_RED, null, TRUE)
+			GLOB.keycard_secured_level = SEC_LEVEL_RED
 		if(KEYCARD_CLEAR_RED_ALERT)
 			set_security_level(SEC_LEVEL_BLUE, null, TRUE)
+			GLOB.keycard_secured_level = 0
+		if(KEYCARD_CLEAR_HIGH_ALERT)
+			set_security_level(SEC_LEVEL_RED, null, TRUE)
+			GLOB.keycard_secured_level = SEC_LEVEL_RED
+		if(KEYCARD_LAMBDA_ALERT, KEYCARD_GAMMA_ALERT, KEYCARD_EPSILON_ALERT, KEYCARD_DELTA_ALERT)
+			set_security_level(pending_security_level, null, TRUE)
+			GLOB.keycard_secured_level = pending_security_level
+			pending_security_level = 0
 		if(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 			make_maint_all_access()
 		if(KEYCARD_BSA_UNLOCK)
@@ -204,6 +253,11 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 #undef ACCESS_GRANTING_COOLDOWN
 #undef KEYCARD_RED_ALERT
 #undef KEYCARD_CLEAR_RED_ALERT
+#undef KEYCARD_CLEAR_HIGH_ALERT
+#undef KEYCARD_LAMBDA_ALERT
+#undef KEYCARD_GAMMA_ALERT
+#undef KEYCARD_EPSILON_ALERT
+#undef KEYCARD_DELTA_ALERT
 #undef KEYCARD_EMERGENCY_MAINTENANCE_ACCESS
 #undef KEYCARD_BSA_UNLOCK
 #undef KEYCARD_BSMINER_PROTOCOLS

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -1,6 +1,7 @@
 GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 
 #define KEYCARD_RED_ALERT "Red Alert"
+#define KEYCARD_CLEAR_RED_ALERT "Clear Red Alert"
 #define KEYCARD_EMERGENCY_MAINTENANCE_ACCESS "Emergency Maintenance Access"
 #define KEYCARD_BSA_UNLOCK "Bluespace Artillery Unlock"
 #define KEYCARD_BSMINER_PROTOCOLS "Bluespace Miner Protocols"
@@ -54,6 +55,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	data["waiting"] = waiting
 	data["auth_required"] = event_source ? event_source.event : 0
 	data["red_alert"] = (SECLEVEL2NUM(NUM2SECLEVEL(GLOB.security_level)) >= SEC_LEVEL_RED) ? 1 : 0
+	data["red_alert_keycard_locked"] = GLOB.red_alert_keycard_locked
 	data["emergency_maint"] = GLOB.emergency_access
 	data["bsa_unlock"] = GLOB.bsa_unlock
 	return data
@@ -76,8 +78,13 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 		return
 	switch(action)
 		if("red_alert")
-			if(!event_source)
+			if(!event_source && !GLOB.red_alert_keycard_locked)
 				sendEvent(KEYCARD_RED_ALERT, ID)
+				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
+				. = TRUE
+		if("clear_red_alert")
+			if(!event_source && GLOB.red_alert_keycard_locked)
+				sendEvent(KEYCARD_CLEAR_RED_ALERT, ID)
 				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
 				. = TRUE
 		if("emergency_maint")
@@ -154,7 +161,10 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	deadchat_broadcast(" confirmed [event] at [span_name("[A2.name]")].", span_name("[confirmer]"), confirmer, message_type=DEADCHAT_ANNOUNCEMENT)
 	switch(event)
 		if(KEYCARD_RED_ALERT)
+			GLOB.red_alert_keycard_locked = TRUE
 			set_security_level(SEC_LEVEL_RED)
+		if(KEYCARD_CLEAR_RED_ALERT)
+			set_security_level(SEC_LEVEL_BLUE, null, TRUE)
 		if(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 			make_maint_all_access()
 		if(KEYCARD_BSA_UNLOCK)
@@ -193,6 +203,7 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 
 #undef ACCESS_GRANTING_COOLDOWN
 #undef KEYCARD_RED_ALERT
+#undef KEYCARD_CLEAR_RED_ALERT
 #undef KEYCARD_EMERGENCY_MAINTENANCE_ACCESS
 #undef KEYCARD_BSA_UNLOCK
 #undef KEYCARD_BSMINER_PROTOCOLS

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -3,10 +3,6 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 #define KEYCARD_RED_ALERT "Red Alert"
 #define KEYCARD_CLEAR_RED_ALERT "Clear Red Alert"
 #define KEYCARD_CLEAR_HIGH_ALERT "Clear High Alert"
-#define KEYCARD_LAMBDA_ALERT "Lambda Alert"
-#define KEYCARD_GAMMA_ALERT "Gamma Alert"
-#define KEYCARD_EPSILON_ALERT "Epsilon Alert"
-#define KEYCARD_DELTA_ALERT "Delta Alert"
 #define KEYCARD_EMERGENCY_MAINTENANCE_ACCESS "Emergency Maintenance Access"
 #define KEYCARD_BSA_UNLOCK "Bluespace Artillery Unlock"
 #define KEYCARD_BSMINER_PROTOCOLS "Bluespace Miner Protocols"
@@ -60,11 +56,9 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	var/list/data = list()
 	data["waiting"] = waiting
 	data["auth_required"] = event_source ? event_source.event : 0
-	data["security_level"] = NUM2SECLEVEL(GLOB.security_level)
 	data["can_set_red_alert"] = (GLOB.security_level < SEC_LEVEL_RED && GLOB.keycard_secured_level < SEC_LEVEL_RED)
 	data["can_clear_red_alert"] = (GLOB.keycard_secured_level == SEC_LEVEL_RED && GLOB.security_level == SEC_LEVEL_RED)
 	data["can_clear_high_alert"] = (GLOB.security_level >= SEC_LEVEL_LAMBDA)
-	data["high_alert_levels"] = list("lambda", "gamma", "epsilon", "delta")
 	data["emergency_maint"] = GLOB.emergency_access
 	data["bsa_unlock"] = GLOB.bsa_unlock
 	return data
@@ -99,27 +93,6 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 		if("clear_high_alert")
 			if(!event_source && GLOB.security_level >= SEC_LEVEL_LAMBDA)
 				sendSecurityLevelEvent(SEC_LEVEL_RED, KEYCARD_CLEAR_HIGH_ALERT, ID)
-				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
-				. = TRUE
-		if("set_high_alert")
-			if(!event_source)
-				var/level_name = params["level"]
-				var/level_num = SECLEVEL2NUM(level_name)
-				if(!IS_HIGH_SECURITY_LEVEL(level_num) || GLOB.security_level == level_num)
-					return
-				var/event_name
-				switch(level_num)
-					if(SEC_LEVEL_LAMBDA)
-						event_name = KEYCARD_LAMBDA_ALERT
-					if(SEC_LEVEL_GAMMA)
-						event_name = KEYCARD_GAMMA_ALERT
-					if(SEC_LEVEL_EPSILON)
-						event_name = KEYCARD_EPSILON_ALERT
-					if(SEC_LEVEL_DELTA)
-						event_name = KEYCARD_DELTA_ALERT
-					else
-						return
-				sendSecurityLevelEvent(level_num, event_name, ID)
 				playsound(get_turf(user), 'sound/machines/auth.ogg', 75, 1, 1)
 				. = TRUE
 		if("emergency_maint")
@@ -210,10 +183,6 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 		if(KEYCARD_CLEAR_HIGH_ALERT)
 			set_security_level(SEC_LEVEL_RED, null, TRUE)
 			GLOB.keycard_secured_level = SEC_LEVEL_RED
-		if(KEYCARD_LAMBDA_ALERT, KEYCARD_GAMMA_ALERT, KEYCARD_EPSILON_ALERT, KEYCARD_DELTA_ALERT)
-			set_security_level(pending_security_level, null, TRUE)
-			GLOB.keycard_secured_level = pending_security_level
-			pending_security_level = 0
 		if(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 			make_maint_all_access()
 		if(KEYCARD_BSA_UNLOCK)
@@ -254,10 +223,6 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 #undef KEYCARD_RED_ALERT
 #undef KEYCARD_CLEAR_RED_ALERT
 #undef KEYCARD_CLEAR_HIGH_ALERT
-#undef KEYCARD_LAMBDA_ALERT
-#undef KEYCARD_GAMMA_ALERT
-#undef KEYCARD_EPSILON_ALERT
-#undef KEYCARD_DELTA_ALERT
 #undef KEYCARD_EMERGENCY_MAINTENANCE_ACCESS
 #undef KEYCARD_BSA_UNLOCK
 #undef KEYCARD_BSMINER_PROTOCOLS

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -16,23 +16,40 @@ const STATE_MESSAGES = "messages";
 // Used for whether or not you need to swipe to confirm an alert level change
 const SWIPE_NEEDED = "SWIPE_NEEDED";
 
+const ALERT_LEVEL_ORDER = {
+  green: 0,
+  blue: 1,
+  orange: 2,
+  violet: 3,
+  amber: 4,
+  red: 5,
+  lambda: 6,
+  gamma: 7,
+  epsilon: 8,
+  delta: 9,
+};
+
 const sortByCreditCost = sortBy(shuttle => shuttle.creditCost);
 const sortByCreditCostERT = sortBy(ert => ert.creditCost);
 
 const AlertButton = (props, context) => {
   const { act, data } = useBackend(context);
-  const { alertLevelTick, canSetAlertLevel } = data;
+  const { alertLevelTick, canSetAlertLevel, redAlertKeycardLocked } = data;
   const { alertLevel, setShowAlertLevelConfirm } = props;
 
   const thisIsCurrent = data.alertLevel === alertLevel;
+  const currentOrder = ALERT_LEVEL_ORDER[data.alertLevel] ?? 0;
+  const targetOrder = ALERT_LEVEL_ORDER[alertLevel] ?? 0;
+  const lockedFromLowering = redAlertKeycardLocked && targetOrder < currentOrder;
 
   return (
     <Button
       icon="exclamation-triangle"
       color={thisIsCurrent && "good"}
       content={capitalize(alertLevel)}
+      disabled={lockedFromLowering}
       onClick={() => {
-        if (thisIsCurrent) {
+        if (thisIsCurrent || lockedFromLowering) {
           return;
         }
 
@@ -368,6 +385,7 @@ const PageMain = (props, context) => {
     emagged,
     emergencyAccess,
     importantActionReady,
+    redAlertKeycardLocked,
     sectors,
     shuttleCalled,
     shuttleCalledPreviously,
@@ -439,6 +457,12 @@ const PageMain = (props, context) => {
 
       {!!canSetAlertLevel && (
         <Section title="Уровень тревоги">
+          {!!redAlertKeycardLocked && (
+            <NoticeBox mb={1}>
+              Красный код заблокирован. Снять его можно только через
+              устройства двойной авторизации ключ-карт.
+            </NoticeBox>
+          )}
           <Flex justify="space-between">
             <Flex.Item>
               <Box>

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -34,13 +34,14 @@ const sortByCreditCostERT = sortBy(ert => ert.creditCost);
 
 const AlertButton = (props, context) => {
   const { act, data } = useBackend(context);
-  const { alertLevelTick, canSetAlertLevel, redAlertKeycardLocked } = data;
+  const { alertLevelTick, canSetAlertLevel, redAlertKeycardLocked, highAlertKeycardLocked } = data;
   const { alertLevel, setShowAlertLevelConfirm } = props;
 
   const thisIsCurrent = data.alertLevel === alertLevel;
   const currentOrder = ALERT_LEVEL_ORDER[data.alertLevel] ?? 0;
   const targetOrder = ALERT_LEVEL_ORDER[alertLevel] ?? 0;
-  const lockedFromLowering = redAlertKeycardLocked && targetOrder < currentOrder;
+  const lockedFromLowering = (redAlertKeycardLocked && targetOrder < currentOrder)
+    || (highAlertKeycardLocked && targetOrder < ALERT_LEVEL_ORDER.red);
 
   return (
     <Button
@@ -386,6 +387,7 @@ const PageMain = (props, context) => {
     emergencyAccess,
     importantActionReady,
     redAlertKeycardLocked,
+    highAlertKeycardLocked,
     sectors,
     shuttleCalled,
     shuttleCalledPreviously,
@@ -457,6 +459,12 @@ const PageMain = (props, context) => {
 
       {!!canSetAlertLevel && (
         <Section title="Уровень тревоги">
+          {!!highAlertKeycardLocked && (
+            <NoticeBox mb={1}>
+              Активен высокий код тревоги. Понизить его можно только до
+              красного через устройства двойной авторизации ключ-карт.
+            </NoticeBox>
+          )}
           {!!redAlertKeycardLocked && (
             <NoticeBox mb={1}>
               Красный код заблокирован. Снять его можно только через

--- a/tgui/packages/tgui/interfaces/KeycardAuth.js
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.js
@@ -33,11 +33,20 @@ export const KeycardAuth = (props, context) => {
                 )}
                 {data.auth_required === 0 && (
                   <>
-                    <Button
-                      icon="exclamation-triangle"
-                      fluid
-                      onClick={() => act('red_alert')}
-                      content="Красный код" />
+                    {!data.red_alert_keycard_locked && (
+                      <Button
+                        icon="exclamation-triangle"
+                        fluid
+                        onClick={() => act('red_alert')}
+                        content="Красный код" />
+                    )}
+                    {!!data.red_alert_keycard_locked && (
+                      <Button
+                        icon="check"
+                        fluid
+                        onClick={() => act('clear_red_alert')}
+                        content="Снять красный код" />
+                    )}
                     <Button
                       icon="wrench"
                       fluid

--- a/tgui/packages/tgui/interfaces/KeycardAuth.js
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.js
@@ -1,17 +1,35 @@
+import { capitalize } from 'common/string';
 import { useBackend } from '../backend';
 import { Box, Button, Section } from '../components';
 import { Window } from '../layouts';
 
+const HIGH_ALERT_LABELS = {
+  lambda: 'Код Лямбда',
+  gamma: 'Код Гамма',
+  epsilon: 'Код Эпсилон',
+  delta: 'Код Дельта',
+};
+
 export const KeycardAuth = (props, context) => {
   const { act, data } = useBackend(context);
+  const {
+    waiting,
+    auth_required,
+    security_level,
+    can_set_red_alert,
+    can_clear_red_alert,
+    can_clear_high_alert,
+    high_alert_levels = [],
+  } = data;
+
   return (
     <Window
       width={375}
-      height={165}>
-      <Window.Content>
+      height={340}>
+      <Window.Content scrollable>
         <Section>
           <Box>
-            {data.waiting === 1 && (
+            {waiting === 1 && (
               <span>
                 Ожидайте подтверждения запроса
                 на втором устройстве...
@@ -19,9 +37,9 @@ export const KeycardAuth = (props, context) => {
             )}
           </Box>
           <Box>
-            {data.waiting === 0 && (
+            {waiting === 0 && (
               <>
-                {!!data.auth_required && (
+                {!!auth_required && (
                   <Button
                     icon="check-square"
                     color="red"
@@ -31,22 +49,38 @@ export const KeycardAuth = (props, context) => {
                     onClick={() => act('auth_swipe')}
                     content="Авторизовать" />
                 )}
-                {data.auth_required === 0 && (
+                {auth_required === 0 && (
                   <>
-                    {!data.red_alert_keycard_locked && (
+                    {!!can_set_red_alert && (
                       <Button
                         icon="exclamation-triangle"
                         fluid
                         onClick={() => act('red_alert')}
                         content="Красный код" />
                     )}
-                    {!!data.red_alert_keycard_locked && (
+                    {!!can_clear_red_alert && (
                       <Button
                         icon="check"
                         fluid
                         onClick={() => act('clear_red_alert')}
                         content="Снять красный код" />
                     )}
+                    {!!can_clear_high_alert && (
+                      <Button
+                        icon="check"
+                        fluid
+                        onClick={() => act('clear_high_alert')}
+                        content="Снизить код (до красного)" />
+                    )}
+                    {high_alert_levels.map(level => (
+                      <Button
+                        key={level}
+                        icon="radiation"
+                        fluid
+                        disabled={security_level === level}
+                        onClick={() => act('set_high_alert', { level })}
+                        content={HIGH_ALERT_LABELS[level] || capitalize(level)} />
+                    ))}
                     <Button
                       icon="wrench"
                       fluid

--- a/tgui/packages/tgui/interfaces/KeycardAuth.js
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.js
@@ -1,32 +1,22 @@
-import { capitalize } from 'common/string';
 import { useBackend } from '../backend';
 import { Box, Button, Section } from '../components';
 import { Window } from '../layouts';
-
-const HIGH_ALERT_LABELS = {
-  lambda: 'Код Лямбда',
-  gamma: 'Код Гамма',
-  epsilon: 'Код Эпсилон',
-  delta: 'Код Дельта',
-};
 
 export const KeycardAuth = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     waiting,
     auth_required,
-    security_level,
     can_set_red_alert,
     can_clear_red_alert,
     can_clear_high_alert,
-    high_alert_levels = [],
   } = data;
 
   return (
     <Window
       width={375}
-      height={340}>
-      <Window.Content scrollable>
+      height={165}>
+      <Window.Content>
         <Section>
           <Box>
             {waiting === 1 && (
@@ -72,15 +62,6 @@ export const KeycardAuth = (props, context) => {
                         onClick={() => act('clear_high_alert')}
                         content="Снизить код (до красного)" />
                     )}
-                    {high_alert_levels.map(level => (
-                      <Button
-                        key={level}
-                        icon="radiation"
-                        fluid
-                        disabled={security_level === level}
-                        onClick={() => act('set_high_alert', { level })}
-                        content={HIGH_ALERT_LABELS[level] || capitalize(level)} />
-                    ))}
                     <Button
                       icon="wrench"
                       fluid


### PR DESCRIPTION
# Описание
Теперь для снятия КК требуется авторизация через терминал, коды выше(дельта и эпсилон не требуют это
<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [ ] Изменения были проверены на локальном сервере
- [ ] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений
<img width="477" height="647" alt="изображение" src="https://github.com/user-attachments/assets/90b45dcf-3d06-4f6e-a272-8d9e2b10efdf" />

<!-- Тут напиши причину, по которой твой пулл-реквест будет полезен для игры. -->

## Демонстрация изменений
<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/4bfc711a-6d3d-4f0e-a802-09d3143fdf82" />
<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/af3f73b9-e0ef-40ce-a942-3ecdda87f9be" />

<!-- Можешь вставить тут видео или скриншоты изменений, если они будут полезны для проверяющего пулл-реквест.
	 Вставлять их можно Ctr+C, Ctr+V. -->

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Теперь для снятия КК требуется авторизация через терминал
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена keycard-блокировка тревог: при активации уровень тревоги нельзя понизить/снять без соответствующей keycard-авторизации или предусмотренного обхода.
  * В устройствах keycard auth появились действия для очистки тревог: можно очистить красную тревогу и (при доступе) снизить до красного.
* **Изменения в интерфейсе**
  * Communications Console теперь отображает предупреждения и блокирует попытки снижения при keycard-локах (включая логику для “high” и “red” тревог).
  * Кнопки уровня тревоги учитывают порядок уровней и корректно отключаются при недоступности действий.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->