### PR TITLE
Фикс бага и немного баланса

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -634,6 +634,9 @@
 	var/mob/living/parent
 	var/selfdeleting = FALSE
 
+/obj/item/riding_offhand/attack_hand()
+	return
+
 /obj/item/riding_offhand/dropped(mob/user)
 	selfdeleting = TRUE
 	. = ..()

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -292,7 +292,7 @@
 	и можете вбивать людей в столы с нечеловеческой силой. \
 	К сожалению, из-за размера перчаток вы не сможете пользоваться огнестрельным оружием."
 	item = /obj/item/clothing/gloves/fingerless/pugilist/mauler
-	cost = 8
+	cost = 4
 
 /datum/uplink_item/dangerous/powerfist
 	name = "Power Fist"

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -301,7 +301,7 @@
 		Гаечным ключом можно регулировать расход газа для дополнительного урона и отбрасывания целей. \
 		Отвёрткой можно извлечь присоединённый баллон."
 	item = /obj/item/melee/powerfist
-	cost = 5
+	cost = 4
 
 /datum/uplink_item/dangerous/death_lipstick
 	name = "Kiss of Death"


### PR DESCRIPTION
# Описание

Пофиксил баг, который позволял смешно кидать любых хуманов на расстоянии. Шаги воспроизведения бага:

- Хватаем хумана на плечи
- Получаем offhand в руку, тыкаем **свободной** рукой по offhand 
- хуман падает на пол, offhand становиться невидимкой, но кидаться им всё ещё можно
- Поздравляю, теперь вы можете бесконечно кидаться этим хуманом на расстоянии

Смысл баг-фикса заключается в невозможности тыкнуть свободной рукой по offhand

Уменьшил цену перчаток-маулерок тритора и поверфиста, потому что они крайне непопулярные оружия ближнего боя.

Маулерки     8 ТК --> 4 ТК
Поверфисты 5 ТК --> 4 ТК

## Причина изменений

баланс это круто, баги это плохо

## Changelog

:cl:
balance: Снижена стоимость powerfist и Mauler Gauntlets до 4 ТК
fix: пофикшен баг с броском хуманов на расстоянии
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Исправления ошибок**
  * Исправлено взаимодействие с вспомогательным снаряжением райдера.

* **Балансировка**
  * Снижена стоимость двух опасных предметов апстрима, сделав их более доступными для приобретения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->