### PR TITLE
Фиксы одежды, лечения и вилянья хвоста

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -236,8 +236,8 @@
 				if(!silent)
 					patient.balloon_alert(user, "[ru_parse_zone(healed_zone)] закрыта скафандром!")
 				return FALSE
-		return patient.can_inject(user, !silent, healed_zone, TRUE)
-	return patient.can_inject(user, !silent, healed_zone)
+		return patient.can_inject(user, !silent, healed_zone, penetrate_thick = TRUE, bypass_immunity = TRUE)
+	return patient.can_inject(user, !silent, healed_zone, bypass_immunity = TRUE)
 
 /obj/item/stack/medical/proc/has_healable_damage(mob/living/carbon/patient)
 	if(heal_brute && patient.getBruteLoss_nonProsthetic() > 0)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -436,7 +436,7 @@
 		var/obj/item/clothing/chest_clothes = null
 		if(w_uniform)
 			chest_clothes = w_uniform
-		if(wear_suit)
+		if(wear_suit && (wear_suit.body_parts_covered & CHEST))
 			chest_clothes = wear_suit
 		if(chest_clothes)
 			if(!(chest_clothes.resistance_flags & UNACIDABLE))
@@ -462,10 +462,10 @@
 	//ARMS & HANDS//
 	if(!bodyzone_hit || bodyzone_hit == BODY_ZONE_L_ARM || bodyzone_hit == BODY_ZONE_R_ARM)
 		var/obj/item/clothing/arm_clothes = null
-		if(gloves)
-			arm_clothes = gloves
 		if(w_uniform && ((w_uniform.body_parts_covered & HANDS) || (w_uniform.body_parts_covered & ARMS)))
 			arm_clothes = w_uniform
+		if(gloves && ((gloves.body_parts_covered & HANDS) || (gloves.body_parts_covered & ARMS)))
+			arm_clothes = gloves //gloves (incl. MOD gauntlets) are the outer layer over the uniform's arms
 		if(wear_suit && ((wear_suit.body_parts_covered & HANDS) || (wear_suit.body_parts_covered & ARMS)))
 			arm_clothes = wear_suit
 
@@ -489,10 +489,10 @@
 	//LEGS & FEET//
 	if(!bodyzone_hit || bodyzone_hit == BODY_ZONE_L_LEG || bodyzone_hit == BODY_ZONE_R_LEG || bodyzone_hit == "feet")
 		var/obj/item/clothing/leg_clothes = null
-		if(shoes)
-			leg_clothes = shoes
 		if(w_uniform && ((w_uniform.body_parts_covered & FEET) || (bodyzone_hit != "feet" && (w_uniform.body_parts_covered & LEGS))))
 			leg_clothes = w_uniform
+		if(shoes && ((shoes.body_parts_covered & FEET) || (bodyzone_hit != "feet" && (shoes.body_parts_covered & LEGS))))
+			leg_clothes = shoes //shoes (incl. MOD boots) are the outer layer over the uniform's legs
 		if(wear_suit && ((wear_suit.body_parts_covered & FEET) || (bodyzone_hit != "feet" && (wear_suit.body_parts_covered & LEGS))))
 			leg_clothes = wear_suit
 		if(leg_clothes)
@@ -905,7 +905,7 @@
 		var/obj/item/clothing/chest_clothes = null
 		if(w_uniform)
 			chest_clothes = w_uniform
-		if(wear_suit)
+		if(wear_suit && (wear_suit.body_parts_covered & CHEST))
 			chest_clothes = wear_suit
 		if(chest_clothes)
 			torn_items += chest_clothes
@@ -913,10 +913,10 @@
 	//ARMS & HANDS//
 	if(!def_zone || def_zone == BODY_ZONE_L_ARM || def_zone == BODY_ZONE_R_ARM)
 		var/obj/item/clothing/arm_clothes = null
-		if(gloves)
-			arm_clothes = gloves
 		if(w_uniform && ((w_uniform.body_parts_covered & HANDS) || (w_uniform.body_parts_covered & ARMS)))
 			arm_clothes = w_uniform
+		if(gloves && ((gloves.body_parts_covered & HANDS) || (gloves.body_parts_covered & ARMS)))
+			arm_clothes = gloves //gloves (incl. MOD gauntlets) are the outer layer over the uniform's arms
 		if(wear_suit && ((wear_suit.body_parts_covered & HANDS) || (wear_suit.body_parts_covered & ARMS)))
 			arm_clothes = wear_suit
 		if(arm_clothes)
@@ -925,10 +925,10 @@
 	//LEGS & FEET//
 	if(!def_zone || def_zone == BODY_ZONE_L_LEG || def_zone == BODY_ZONE_R_LEG)
 		var/obj/item/clothing/leg_clothes = null
-		if(shoes)
-			leg_clothes = shoes
 		if(w_uniform && ((w_uniform.body_parts_covered & FEET) || (w_uniform.body_parts_covered & LEGS)))
 			leg_clothes = w_uniform
+		if(shoes && ((shoes.body_parts_covered & FEET) || (shoes.body_parts_covered & LEGS)))
+			leg_clothes = shoes //shoes (incl. MOD boots) are the outer layer over the uniform's legs
 		if(wear_suit && ((wear_suit.body_parts_covered & FEET) || (wear_suit.body_parts_covered & LEGS)))
 			leg_clothes = wear_suit
 		if(leg_clothes)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2737,7 +2737,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		//
 		if(H.w_uniform)
 			chest_clothes = H.w_uniform
-		if(H.wear_suit)
+		if(H.wear_suit && (H.wear_suit.body_parts_covered & CHEST))
 			chest_clothes = H.wear_suit
 
 		if(chest_clothes)
@@ -2755,10 +2755,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		if(H.w_shirt && (H.w_shirt.body_parts_covered & ARMS))
 			arm_clothes = H.w_shirt
 		//
-		if(H.gloves)
-			arm_clothes = H.gloves
 		if(H.w_uniform && ((H.w_uniform.body_parts_covered & HANDS) || (H.w_uniform.body_parts_covered & ARMS)))
 			arm_clothes = H.w_uniform
+		if(H.gloves && ((H.gloves.body_parts_covered & HANDS) || (H.gloves.body_parts_covered & ARMS)))
+			arm_clothes = H.gloves //gloves (incl. MOD gauntlets) are worn over the uniform's arms, so they are the outer layer that takes the fire
 		if(H.wear_suit && ((H.wear_suit.body_parts_covered & HANDS) || (H.wear_suit.body_parts_covered & ARMS)))
 			arm_clothes = H.wear_suit
 		if(arm_clothes)
@@ -2774,10 +2774,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		if(H.w_shirt && (H.w_shirt.body_parts_covered & LEGS))
 			leg_clothes = H.w_shirt
 		//
-		if(H.shoes)
-			leg_clothes = H.shoes
 		if(H.w_uniform && ((H.w_uniform.body_parts_covered & FEET) || (H.w_uniform.body_parts_covered & LEGS)))
 			leg_clothes = H.w_uniform
+		if(H.shoes && ((H.shoes.body_parts_covered & FEET) || (H.shoes.body_parts_covered & LEGS)))
+			leg_clothes = H.shoes //shoes (incl. MOD boots) are worn over the uniform's legs, so they are the outer layer that takes the fire
 		if(H.wear_suit && ((H.wear_suit.body_parts_covered & FEET) || (H.wear_suit.body_parts_covered & LEGS)))
 			leg_clothes = H.wear_suit
 		if(leg_clothes)
@@ -2857,24 +2857,38 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 /datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)
 	return mutant_bodyparts[wagging_type]
 
+/// Replaces an associative key in mutant_bodyparts in-place, keeping its original position.
+/// handle_mutant_bodyparts decides intra-layer overlay draw order from the iteration order of
+/// mutant_bodyparts (every part in a layer shares the same numeric layer, so later entries draw
+/// on top). A plain delete+add would move the tail entry to the end of the list, past insect_wings,
+/// flipping the wagging tail in front of the wings. Renaming in place preserves draw order.
+/// Returns TRUE if the key was found and replaced.
+/datum/species/proc/swap_mutant_bodypart_key(old_key, new_key)
+	if(!(old_key in mutant_bodyparts))
+		return FALSE
+	var/list/rebuilt = list()
+	for(var/key in mutant_bodyparts)
+		if(key == old_key)
+			rebuilt[new_key] = mutant_bodyparts[old_key]
+		else
+			rebuilt[key] = mutant_bodyparts[key]
+	mutant_bodyparts = rebuilt
+	return TRUE
+
 /datum/species/proc/start_wagging_tail(mob/living/carbon/human/H)
 	if(tail_type && wagging_type)
 		if(mutant_bodyparts[tail_type])
-			mutant_bodyparts[wagging_type] = mutant_bodyparts[tail_type]
-			mutant_bodyparts -= tail_type
+			swap_mutant_bodypart_key(tail_type, wagging_type)
 			if(tail_type == "tail_lizard") //special lizard thing
-				mutant_bodyparts["waggingspines"] = mutant_bodyparts["spines"]
-				mutant_bodyparts -= "spines"
+				swap_mutant_bodypart_key("spines", "waggingspines")
 			H.update_body()
 
 /datum/species/proc/stop_wagging_tail(mob/living/carbon/human/H)
 	if(tail_type && wagging_type)
 		if(mutant_bodyparts[wagging_type])
-			mutant_bodyparts[tail_type] = mutant_bodyparts[wagging_type]
-			mutant_bodyparts -= wagging_type
+			swap_mutant_bodypart_key(wagging_type, tail_type)
 			if(tail_type == "tail_lizard") //special lizard thing
-				mutant_bodyparts["spines"] = mutant_bodyparts["waggingspines"]
-				mutant_bodyparts -= "waggingspines"
+				swap_mutant_bodypart_key("waggingspines", "spines")
 			H.update_body()
 
 ///////////////


### PR DESCRIPTION
# Описание

Пофиксил три бажки из багрепортов:
- хвост мольки больше не торчит поверх крыльев после поглаживания (виляние ломало порядок слоёв)
- моды теперь защищают надетую одежду от огня/кислоты/разрыва, как харды (раньше комбез под модом сгорал)
- карп (и другие pierce-immune) снова чинятся нитками/сетками, а не только медипенами

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Три бага из репортов: хвост сквозь крылья, мод не спасает одежду от огня, и карп вытекает с царапины потому что не зашить

## Changelog

:cl:
fix: Хвост инсектоидов больше не отображается поверх крыльев после поглаживания
fix: Моды защищают надетую одежду от огня, кислоты и разрыва так же, как хардсьюты
fix: Карп и другие существа с твёрдой кожей снова лечатся нитками и сетками
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Улучшена точность взаимодействия кислоты с одеждой персонажа при расчёте урона по разным частям тела
* Исправлена логика повреждения одежды при воздействии огня, учитывая правильные слои защиты
* Оптимизирована система определения защитного слоя в зависимости от типа одежды

## New Features
* Добавлены улучшения для механики анимации хвостов персонажа

<!-- end of auto-generated comment: release notes by coderabbit.ai -->