### PR TITLE
Латексный замок для всей латексной кинк-одежды

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -9,29 +9,22 @@
 	equip_delay_other = 20
 	equip_delay_self = 20
 	mutantrace_variation = STYLE_MUZZLE
-	var/seamless = FALSE
+
+/obj/item/clothing/mask/muzzle/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
 
 /obj/item/clothing/mask/muzzle/attack_paw(mob/user, act_intent, attackchain_flags)
     if(iscarbon(user))
         var/mob/living/carbon/C = user
         if(src == C.wear_mask)
-            if(seamless)
+            if(HAS_TRAIT(src, TRAIT_NODROP))
                 to_chat(user, span_warning("You need help taking this off!"))
                 return
             else
                 if(!do_after(C, 60, target = src))
                     return
     ..()
-
-/obj/item/clothing/mask/muzzle/attackby(obj/item/K, mob/user, params)
-    if(istype(K, /obj/item/key/latex))
-        if(seamless != FALSE)
-            to_chat(user, span_notice("The latches suddenly loosen!"))
-            seamless = FALSE
-        else
-            to_chat(user, span_warning("The latches suddenly tighten!"))
-            seamless = TRUE
-    return
 
 /obj/item/clothing/mask/surgical
 	name = "sterile mask"

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -166,6 +166,7 @@
 #include "hallucination_stationmessage.dm"
 #include "memory_leak_limits.dm"
 #include "human_mob_gc.dm"
+#include "latex_lockable.dm"
 #include "parallax_position.dm"
 #include "perf_optimizations.dm"
 #include "psychosis_pools.dm"

--- a/code/modules/unit_tests/latex_lockable.dm
+++ b/code/modules/unit_tests/latex_lockable.dm
@@ -10,7 +10,7 @@
 	TEST_ASSERT(suit.GetComponent(/datum/component/latex_lockable), "latex jumpsuit is missing the latex_lockable component")
 
 	// Надеваем - незаперто, снимается.
-	TEST_ASSERT(wearer.equip_to_slot_or_del(suit, ITEM_SLOT_ICLOTHING, TRUE), "failed to equip latex jumpsuit")
+	TEST_ASSERT(wearer.equip_to_slot_or_del(suit, ITEM_SLOT_ICLOTHING), "failed to equip latex jumpsuit")
 	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "unlocked latex item must not have TRAIT_NODROP")
 	TEST_ASSERT(wearer.canUnEquip(suit), "unlocked latex item must be removable")
 
@@ -29,7 +29,7 @@
 	TEST_ASSERT(HAS_TRAIT(suit, TRAIT_NODROP), "re-locking should set NODROP")
 	wearer.dropItemToGround(suit, TRUE)
 	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "a dropped latex item must lose NODROP")
-	TEST_ASSERT(wearer.equip_to_slot_or_del(suit, ITEM_SLOT_ICLOTHING, TRUE), "failed to re-equip latex jumpsuit")
+	TEST_ASSERT(wearer.equip_to_slot_or_del(suit, ITEM_SLOT_ICLOTHING), "failed to re-equip latex jumpsuit")
 	TEST_ASSERT(HAS_TRAIT(suit, TRAIT_NODROP), "re-equipping a still-locked latex item must restore NODROP")
 
 	// Чистим состояние для проверки согласия.
@@ -40,6 +40,26 @@
 	// У allocate()'нутых мобов нет client -> нет согласия -> запирание отклоняется.
 	suit.attackby(key, other)
 	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "locking another's worn latex without consent must be refused")
+
+	// Достижимость надетого замка: другой игрок отпирает чужой запертый предмет
+	// латексным ключом через меню стрипа (use_item_on_strippable -> attackby).
+	// Это путь, который воспроизводит реальный баг "запертое снять/отпереть нельзя".
+	suit.attackby(key, wearer)
+	TEST_ASSERT(HAS_TRAIT(suit, TRAIT_NODROP), "re-locking before strip-menu test failed")
+	TEST_ASSERT(suit.interactable_in_strip_menu, "latex item must be interactable in the strip menu so the key is reachable while worn")
+	suit.use_item_on_strippable(other, wearer, key)
+	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "another player must be able to unlock a worn latex item with the key via the strip menu")
+
+	// Карман-ловушка: запертый предмет, убранный не в штатный слот, не должен
+	// получать NODROP (иначе его не достать обратно). Берём намордник - он мелкий
+	// и влезает в карман, в отличие от комбинезона.
+	var/obj/item/clothing/mask/muzzle/muzzle = allocate(/obj/item/clothing/mask/muzzle)
+	TEST_ASSERT(wearer.equip_to_slot_or_del(muzzle, ITEM_SLOT_MASK), "failed to equip muzzle")
+	muzzle.attackby(key, wearer)
+	TEST_ASSERT(HAS_TRAIT(muzzle, TRAIT_NODROP), "locking a worn muzzle must apply NODROP")
+	wearer.dropItemToGround(muzzle, TRUE)
+	TEST_ASSERT(wearer.equip_to_slot_or_del(muzzle, ITEM_SLOT_LPOCKET), "failed to put muzzle into a pocket")
+	TEST_ASSERT(!HAS_TRAIT(muzzle, TRAIT_NODROP), "a locked muzzle stashed in a pocket must not be NODROP")
 
 /// Каждый кинк-латексный предмет должен получить компонент латексного замка.
 /// Ловит опечатки и пропущенные AddComponent при добавлении новых вещей.
@@ -58,7 +78,12 @@
 		/obj/item/clothing/under/latex,
 		/obj/item/clothing/under/latex/half,
 		/obj/item/clothing/under/latex_bodysuit,
+		/obj/item/clothing/underwear/socks/latex,
+		/obj/item/clothing/underwear/socks/thigh/l_stockings,
 	)
 	for(var/item_type in latex_types)
 		var/obj/item/item = allocate(item_type)
 		TEST_ASSERT(item.GetComponent(/datum/component/latex_lockable), "[item_type] is missing the latex_lockable component")
+		// Без этого флага латексным ключом не дотянуться до надетого предмета через
+		// меню стрипа - запертое нечем разблокировать (см. /datum/unit_test/latex_lockable).
+		TEST_ASSERT(item.interactable_in_strip_menu, "[item_type] must be interactable in the strip menu")

--- a/code/modules/unit_tests/latex_lockable.dm
+++ b/code/modules/unit_tests/latex_lockable.dm
@@ -1,0 +1,64 @@
+/// Латексный замок (/datum/component/latex_lockable): запирание латексной
+/// кинк-одежды латексным ключом. Заперто -> TRAIT_NODROP, снять нельзя.
+/// Запереть чужой надетый предмет можно только с согласия (VERB_CONSENT).
+/datum/unit_test/latex_lockable/Run()
+	var/mob/living/carbon/human/wearer = allocate(/mob/living/carbon/human)
+	var/mob/living/carbon/human/other = allocate(/mob/living/carbon/human)
+	var/obj/item/key/latex/key = allocate(/obj/item/key/latex)
+	var/obj/item/clothing/under/latex/suit = allocate(/obj/item/clothing/under/latex)
+
+	TEST_ASSERT(suit.GetComponent(/datum/component/latex_lockable), "latex jumpsuit is missing the latex_lockable component")
+
+	// Надеваем - незаперто, снимается.
+	TEST_ASSERT(wearer.equip_to_slot_or_del(suit, ITEM_SLOT_ICLOTHING, TRUE), "failed to equip latex jumpsuit")
+	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "unlocked latex item must not have TRAIT_NODROP")
+	TEST_ASSERT(wearer.canUnEquip(suit), "unlocked latex item must be removable")
+
+	// Запираем своим ключом - вешается NODROP, снять нельзя.
+	suit.attackby(key, wearer)
+	TEST_ASSERT(HAS_TRAIT(suit, TRAIT_NODROP), "locking a worn latex item must apply TRAIT_NODROP")
+	TEST_ASSERT(!wearer.canUnEquip(suit), "locked latex item must not be removable")
+
+	// Отпираем - NODROP снят, снимается.
+	suit.attackby(key, wearer)
+	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "unlocking must remove TRAIT_NODROP")
+	TEST_ASSERT(wearer.canUnEquip(suit), "unlocked latex item must be removable again")
+
+	// Состояние замка переживает снятие: заперт -> уронили (NODROP ушёл) -> надели (NODROP вернулся).
+	suit.attackby(key, wearer)
+	TEST_ASSERT(HAS_TRAIT(suit, TRAIT_NODROP), "re-locking should set NODROP")
+	wearer.dropItemToGround(suit, TRUE)
+	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "a dropped latex item must lose NODROP")
+	TEST_ASSERT(wearer.equip_to_slot_or_del(suit, ITEM_SLOT_ICLOTHING, TRUE), "failed to re-equip latex jumpsuit")
+	TEST_ASSERT(HAS_TRAIT(suit, TRAIT_NODROP), "re-equipping a still-locked latex item must restore NODROP")
+
+	// Чистим состояние для проверки согласия.
+	suit.attackby(key, wearer)
+	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "cleanup unlock failed")
+
+	// Согласие: другой игрок не может запереть наш надетый латекс без VERB_CONSENT.
+	// У allocate()'нутых мобов нет client -> нет согласия -> запирание отклоняется.
+	suit.attackby(key, other)
+	TEST_ASSERT(!HAS_TRAIT(suit, TRAIT_NODROP), "locking another's worn latex without consent must be refused")
+
+/// Каждый кинк-латексный предмет должен получить компонент латексного замка.
+/// Ловит опечатки и пропущенные AddComponent при добавлении новых вещей.
+/datum/unit_test/latex_lockable_coverage/Run()
+	var/static/list/latex_types = list(
+		/obj/item/clothing/under/misc/latex_catsuit,
+		/obj/item/clothing/gloves/latex_gloves,
+		/obj/item/clothing/shoes/latexheels,
+		/obj/item/clothing/shoes/latex_socks,
+		/obj/item/clothing/head/helmet/space/deprivation_helmet,
+		/obj/item/clothing/neck/mind_collar,
+		/obj/item/clothing/mask/muzzle,
+		/obj/item/clothing/mask/muzzle/ballgag,
+		/obj/item/clothing/gloves/latexsleeves,
+		/obj/item/clothing/gloves/latexsleeves/security,
+		/obj/item/clothing/under/latex,
+		/obj/item/clothing/under/latex/half,
+		/obj/item/clothing/under/latex_bodysuit,
+	)
+	for(var/item_type in latex_types)
+		var/obj/item/item = allocate(item_type)
+		TEST_ASSERT(item.GetComponent(/datum/component/latex_lockable), "[item_type] is missing the latex_lockable component")

--- a/modular_bluemoon/code/datums/components/latex_lockable.dm
+++ b/modular_bluemoon/code/datums/components/latex_lockable.dm
@@ -38,6 +38,12 @@ GLOBAL_LIST_INIT(latex_lock_default_messages, list(
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equipped))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_dropped))
 	RegisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_ATTACK_PAW), PROC_REF(on_attack_hand))
+	// Чтобы латексным ключом можно было щёлкнуть по предмету, пока он надет на
+	// ДРУГОМ игроке - через меню стрипа (use_item_on_strippable -> attackby). Без
+	// этого надетый запертый предмет нечем разблокировать. Заодно даёт зелёную
+	// подсветку слота в меню стрипа.
+	var/obj/item/item = parent
+	item.interactable_in_strip_menu = TRUE
 	// На случай, если предмет создан уже надетым и запертым.
 	refresh_nodrop()
 
@@ -50,6 +56,8 @@ GLOBAL_LIST_INIT(latex_lock_default_messages, list(
 		COMSIG_ATOM_ATTACK_PAW,
 	))
 	REMOVE_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+	var/obj/item/item = parent
+	item.interactable_in_strip_menu = initial(item.interactable_in_strip_menu)
 
 /// Человек, на ком предмет НАДЕТ в слоте (не в руках), иначе null.
 /datum/component/latex_lockable/proc/get_wearer()
@@ -86,10 +94,13 @@ GLOBAL_LIST_INIT(latex_lock_default_messages, list(
 
 /datum/component/latex_lockable/proc/on_equipped(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
-	if(slot == ITEM_SLOT_HANDS)
-		return
-	if(locked)
+	var/obj/item/item = parent
+	// NODROP вешаем только когда предмет надет в свой штатный слот. Иначе запертый
+	// предмет, убранный в карман/рюкзак/подсумок, оказался бы заперт там навсегда.
+	if(locked && (slot & item.slot_flags))
 		ADD_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+	else
+		REMOVE_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
 
 /datum/component/latex_lockable/proc/on_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/modular_bluemoon/code/datums/components/latex_lockable.dm
+++ b/modular_bluemoon/code/datums/components/latex_lockable.dm
@@ -1,0 +1,107 @@
+// Латексный замок.
+// Даёт латексной кинк-одежде возможность запираться латексным ключом
+// (/obj/item/key/latex, "Latex Adjustment Override").
+//
+// Заперто -> на предмет вешается TRAIT_NODROP: его нельзя снять ни самому,
+// ни стрипом другим игроком (force-снятие админом/раздеванием обходит, как и
+// любой NODROP). Открывает только тот же ключ.
+//
+// Запереть предмет, надетый на ДРУГОМ игроке, можно только если у него включён
+// VERB_CONSENT. Отпереть (разблокировать) - всегда.
+
+/// Источник трейта NODROP от латексного замка. Отдельный, чтобы не конфликтовать
+/// с другими источниками NODROP на том же предмете.
+#define LATEX_LOCK_TRAIT "latex_lock"
+
+/// Дефолтный флейвор при безуспешной попытке стянуть запертый предмет с себя.
+GLOBAL_LIST_INIT(latex_lock_default_messages, list(
+	"Вы безуспешно шарите руками по латексу в поисках застёжки.",
+	"Вы не можете подцепить край - материал словно прилип к коже.",
+	"Чем сильнее вы тянете, тем плотнее оно облегает.",
+))
+
+/datum/component/latex_lockable
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// Заперт ли замок.
+	var/locked = FALSE
+	/// Пул сообщений при попытке самоснятия запертого предмета.
+	var/list/lock_messages
+
+/datum/component/latex_lockable/Initialize(locked = FALSE, list/lock_messages)
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+	src.locked = locked
+	src.lock_messages = lock_messages || GLOB.latex_lock_default_messages
+
+/datum/component/latex_lockable/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attackby))
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equipped))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_dropped))
+	RegisterSignal(parent, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_ATTACK_PAW), PROC_REF(on_attack_hand))
+	// На случай, если предмет создан уже надетым и запертым.
+	refresh_nodrop()
+
+/datum/component/latex_lockable/UnregisterFromParent()
+	UnregisterSignal(parent, list(
+		COMSIG_PARENT_ATTACKBY,
+		COMSIG_ITEM_EQUIPPED,
+		COMSIG_ITEM_DROPPED,
+		COMSIG_ATOM_ATTACK_HAND,
+		COMSIG_ATOM_ATTACK_PAW,
+	))
+	REMOVE_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+
+/// Человек, на ком предмет НАДЕТ в слоте (не в руках), иначе null.
+/datum/component/latex_lockable/proc/get_wearer()
+	var/obj/item/item = parent
+	if(!ishuman(item.loc))
+		return null
+	var/mob/living/carbon/human/wearer = item.loc
+	if(wearer.is_holding(item))
+		return null
+	return wearer
+
+/// Выдать/снять NODROP по текущему состоянию замка и того, надет ли предмет.
+/datum/component/latex_lockable/proc/refresh_nodrop()
+	if(locked && get_wearer())
+		ADD_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+	else
+		REMOVE_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+
+/datum/component/latex_lockable/proc/on_attackby(datum/source, obj/item/weapon, mob/user, params)
+	SIGNAL_HANDLER
+	if(!istype(weapon, /obj/item/key/latex))
+		return
+	var/obj/item/item = parent
+	var/mob/living/carbon/human/wearer = get_wearer()
+	// Согласие нужно только при ЗАПИРАНИИ чужого надетого предмета.
+	if(!locked && wearer && wearer != user)
+		if(!(wearer.client?.prefs?.toggles & VERB_CONSENT))
+			to_chat(user, span_warning("Они не хотят, чтобы вы это делали!"))
+			return COMPONENT_NO_AFTERATTACK
+	locked = !locked
+	refresh_nodrop()
+	to_chat(user, span_warning("[item] внезапно [locked ? "затягивается" : "ослабляется"]!"))
+	return COMPONENT_NO_AFTERATTACK
+
+/datum/component/latex_lockable/proc/on_equipped(datum/source, mob/equipper, slot)
+	SIGNAL_HANDLER
+	if(slot == ITEM_SLOT_HANDS)
+		return
+	if(locked)
+		ADD_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+
+/datum/component/latex_lockable/proc/on_dropped(datum/source, mob/user)
+	SIGNAL_HANDLER
+	REMOVE_TRAIT(parent, TRAIT_NODROP, LATEX_LOCK_TRAIT)
+
+/datum/component/latex_lockable/proc/on_attack_hand(datum/source, mob/user)
+	SIGNAL_HANDLER
+	if(!locked)
+		return
+	if(get_wearer() != user)
+		return
+	to_chat(user, span_purple(pick(lock_messages)))
+	return COMPONENT_NO_ATTACK_HAND
+
+#undef LATEX_LOCK_TRAIT

--- a/modular_sand/code/modules/clothing/underwear/socks.dm
+++ b/modular_sand/code/modules/clothing/underwear/socks.dm
@@ -84,6 +84,10 @@
 	desc = "A pair of latex socks."
 	icon_state = "socks_latex"
 
+/obj/item/clothing/underwear/socks/latex/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
+
 /obj/item/clothing/underwear/socks/pantyhose
 	name = "pantyhose"
 	desc = "Pantyhose."
@@ -256,6 +260,10 @@
 	desc = "A pair of stockings."
 	body_parts_covered = LEGS | FEET
 	icon_state = "stockings_latex"
+
+/obj/item/clothing/underwear/socks/thigh/l_stockings/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
 
 /obj/item/clothing/underwear/socks/thigh/leggings_stir
 	name = "Thigh-high Stirrups (Black)"

--- a/modular_splurt/code/modules/clothing/kinkyclothes.dm
+++ b/modular_splurt/code/modules/clothing/kinkyclothes.dm
@@ -8,6 +8,10 @@
 	mob_overlay_icon = 'modular_splurt/icons/mobs/gloves.dmi'
 	mutantrace_variation = NONE
 
+/obj/item/clothing/gloves/latexsleeves/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
+
 /obj/item/clothing/gloves/latexsleeves/security
 	name = "security sleeves"
 	desc = "A pair of latex sleeves, with a band of red above the elbows denoting that the wearer is part of the security team."

--- a/modular_splurt/code/modules/clothing/lewd_clothing/collar/kink_collars.dm
+++ b/modular_splurt/code/modules/clothing/lewd_clothing/collar/kink_collars.dm
@@ -36,12 +36,16 @@
 	var/obj/item/mind_controller/remote = null
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/collar/mind_collar
 	var/emoting = "Shivers"
-	var/seamless = FALSE
 
 /obj/item/clothing/neck/mind_collar/Initialize()
 	. = ..()
 	remote = new /obj/item/mind_controller(src, src)
 	remote.forceMove(src)
+	AddComponent(/datum/component/latex_lockable, FALSE, list(
+		"You can't seem to find the release latch for the collar!",
+		"The collar refuses to budge while you tug at it.",
+		"Your hands uselessly roam along the strange device.",
+	))
 
 /obj/item/clothing/neck/mind_collar/proc/emoting_proc()
 	var/mob/living/carbon/human/U = src.loc
@@ -53,22 +57,3 @@
 		remote.collar = null
 		remote = null
 	return ..()
-/obj/item/clothing/neck/mind_collar/attack_hand(mob/living/carbon/human/user)
-	var/mob/living/carbon/human/C = user
-	if(iscarbon(user) && seamless && (user.get_item_by_slot(ITEM_SLOT_NECK)))
-		to_chat(C, span_purple(pick("You can't seem to find the release latch for the collar!",
-									"The collar refuses to budge while you tug at it.",
-									"Your hands uselessly roam along the strange device.")))
-		return
-	. = ..()
-/obj/item/clothing/neck/mind_collar/MouseDrop(atom/over_object)
-
-/obj/item/clothing/neck/mind_collar/attackby(obj/item/K, mob/user, params)
-	if(istype(K, /obj/item/key/latex))
-		if(seamless != FALSE)
-			to_chat(user, span_warning("The collar latches loosen!"))
-			seamless = FALSE
-		else
-			to_chat(user, span_warning("The collar latches tighten!"))
-			seamless = TRUE
-	return

--- a/modular_splurt/code/modules/clothing/lewd_clothing/foot/lewd_shoes.dm
+++ b/modular_splurt/code/modules/clothing/lewd_clothing/foot/lewd_shoes.dm
@@ -11,14 +11,13 @@
 	slowdown = 0
 	strip_delay = 120
 	mutantrace_variation = STYLE_DIGITIGRADE
-	var/seamless = FALSE
 
 
 //it takes time to put them off, do not touch
 /obj/item/clothing/shoes/latexheels/attack_hand(mob/user)
 	var/mob/living/carbon/C = user
 	if(iscarbon(user) && (user.get_item_by_slot(ITEM_SLOT_FEET) == src))
-		if(seamless)
+		if(HAS_TRAIT(src, TRAIT_NODROP))
 			to_chat(C, span_purple(pick("You slide your heels against each other in a failed attempt at kicking them off.",
 										"The heels refuse to budge no matter how much you tug.",
 										"The heels are tight around your ankles and the laces refuse to loosen.")))
@@ -28,20 +27,9 @@
 				return
 	. = ..()
 
-/obj/item/clothing/shoes/latexheels/MouseDrop(atom/over_object)
-
-/obj/item/clothing/shoes/latexheels/attackby(obj/item/K, mob/user, params)
-	if(istype(K, /obj/item/key/latex))
-		if(seamless != FALSE)
-			to_chat(user, span_warning("The heels suddenly loosen!"))
-			seamless = FALSE
-		else
-			to_chat(user, span_warning("The heels suddenly tighten!"))
-			seamless = TRUE
-	return
-
 /obj/item/clothing/shoes/latexheels/Initialize()
 	. = ..()
+	AddComponent(/datum/component/latex_lockable)
 	AddComponent(/datum/component/squeak, list('modular_splurt/sound/lewd/highheel1.ogg' = 1,'modular_splurt/sound/lewd/highheel2.ogg' = 1), 70)
 
 /////////////////
@@ -57,6 +45,10 @@
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/lewd_clothing/feet/lewd_shoes.dmi'
 	anthro_mob_worn_overlay = 'modular_splurt/icons/mob/clothing/lewd_clothing/feet/lewd_shoes_digi.dmi'
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/clothing/shoes/latex_socks/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
 
 //start processing
 /obj/item/clothing/shoes/latex_socks/equipped(mob/user, slot)

--- a/modular_splurt/code/modules/clothing/lewd_clothing/gloves/lewd_gloves.dm
+++ b/modular_splurt/code/modules/clothing/lewd_clothing/gloves/lewd_gloves.dm
@@ -7,26 +7,11 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'modular_splurt/icons/obj/clothing/lewd_clothes/gloves/lewd_gloves.dmi'
 	mob_overlay_icon = 'modular_splurt/icons/mob/clothing/lewd_clothing/gloves/lewd_gloves.dmi'
-	var/seamless = FALSE
 
-
-/obj/item/clothing/gloves/latex_gloves/attack_hand(mob/living/carbon/human/user)
-	var/mob/living/carbon/human/C = user
-	if(iscarbon(user) && seamless && (user.get_item_by_slot(ITEM_SLOT_GLOVES) == src))
-		to_chat(C, span_purple(pick("You rub your gloved fingers together as you search for some sort of escape.",
-									"You can't find any leverage to remove these gloves!",
-									"Your pointless clawing seems to only make things more skin tight")))
-		return
+/obj/item/clothing/gloves/latex_gloves/Initialize()
 	. = ..()
-
-/obj/item/clothing/gloves/latex_gloves/MouseDrop(atom/over_object)
-
-/obj/item/clothing/gloves/latex_gloves/attackby(obj/item/K, mob/user, params)
-	if(istype(K, /obj/item/key/latex))
-		if(seamless != FALSE)
-			to_chat(user, span_warning("The gloves suddenly loosen!"))
-			seamless = FALSE
-		else
-			to_chat(user, span_warning("The gloves suddenly tighten!"))
-			seamless = TRUE
-	return
+	AddComponent(/datum/component/latex_lockable, FALSE, list(
+		"You rub your gloved fingers together as you search for some sort of escape.",
+		"You can't find any leverage to remove these gloves!",
+		"Your pointless clawing seems to only make things more skin tight",
+	))

--- a/modular_splurt/code/modules/clothing/lewd_clothing/head/deprivation_helmet.dm
+++ b/modular_splurt/code/modules/clothing/lewd_clothing/head/deprivation_helmet.dm
@@ -24,7 +24,6 @@
 	var/earmuffs = FALSE
 	var/prevent_vision = FALSE
 	var/color_changed = FALSE
-	var/seamless = FALSE
 
 	var/static/list/helmet_designs
 	actions_types = list(/datum/action/item_action/toggle_vision, /datum/action/item_action/toggle_hearing, /datum/action/item_action/toggle_speech)
@@ -189,6 +188,11 @@
 	update_action_buttons_icons()
 	if(!length(helmet_designs))
 		populate_helmet_designs()
+	AddComponent(/datum/component/latex_lockable, FALSE, list(
+		"You roam your hands around the helmet for some sort of release!",
+		"You find it impossible to leverage your fingers underneath the helmet",
+		"The durable material seems to reflect your pointless force.",
+	))
 
 //updating both and icon in hands and icon worn
 /obj/item/clothing/head/helmet/space/deprivation_helmet/update_icon_state()
@@ -238,26 +242,6 @@
 			to_chat(user, span_purple("Finally you can hear the world around you once more."))
 		if(prevent_vision == TRUE)
 			to_chat(user, span_purple("The helmet no longer restricts your vision."))
-
-/obj/item/clothing/head/helmet/space/deprivation_helmet/attack_hand(mob/living/carbon/human/user)
-	if(iscarbon(user) && seamless && (user.get_item_by_slot(ITEM_SLOT_HEAD) == src))
-		to_chat(user, span_purple(pick("You roam your hands around the helmet for some sort of release!",
-									"You find it impossible to leverage your fingers underneath the helmet",
-									"The durable material seems to reflect your pointless force.")))
-		return
-	. = ..()
-
-/obj/item/clothing/head/helmet/space/deprivation_helmet/MouseDrop(atom/over_object)
-
-/obj/item/clothing/head/helmet/space/deprivation_helmet/attackby(obj/item/K, mob/user, params)
-	if(istype(K, /obj/item/key/latex))
-		if(seamless != FALSE)
-			to_chat(user, span_warning("The latches suddenly loosen"))
-			seamless = FALSE
-		else
-			to_chat(user, span_warning("The latches suddenly tighten!"))
-			seamless = TRUE
-	return
 
 #undef NO_MUZZLE
 #undef HALF_MUZZLE

--- a/modular_splurt/code/modules/clothing/lewd_clothing/uniform/latex_catsuit.dm
+++ b/modular_splurt/code/modules/clothing/lewd_clothing/uniform/latex_catsuit.dm
@@ -11,11 +11,14 @@
 	can_adjust = FALSE
 	strip_delay = 80
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_ALL_TAURIC
-	var/seamless = FALSE
+
+/obj/item/clothing/under/misc/latex_catsuit/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
 
 /obj/item/clothing/under/misc/latex_catsuit/attack_hand(mob/living/carbon/human/user)
 	var/mob/living/carbon/human/C = user
-	if(iscarbon(user) && seamless && (src == C.w_uniform))
+	if(iscarbon(user) && HAS_TRAIT(src, TRAIT_NODROP) && (src == C.w_uniform))
 		to_chat(C, span_purple(pick("Your hands uselessly roam across your rubber predicament and you fail to find a seam",
 									"You find it impossible to leverage your fingers beneath the suit.",
 									"The suit almost seems to be tightening away from your pointless clawing")))
@@ -83,15 +86,3 @@
 		C.apply_overlay(BODY_FRONT_LAYER)
 		C.apply_overlay(BODY_ADJ_UPPER_LAYER)
 	C.regenerate_icons() //Just in case
-
-/obj/item/clothing/under/misc/latex_catsuit/MouseDrop(atom/over_object)
-
-/obj/item/clothing/under/misc/latex_catsuit/attackby(obj/item/K, mob/user, params)
-	if(istype(K, /obj/item/key/latex))
-		if(seamless != FALSE)
-			to_chat(user, span_warning("The suit suddenly loosens!"))
-			seamless = FALSE
-		else
-			to_chat(user, span_warning("The suit suddenly tighten!"))
-			seamless = TRUE
-	return

--- a/modular_splurt/code/modules/clothing/masks/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/masks/miscellaneous.dm
@@ -3,7 +3,7 @@
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(src == C.wear_mask)
-			if(seamless)
+			if(HAS_TRAIT(src, TRAIT_NODROP))
 				to_chat(user, span_warning("Тебе нужна помощь, чтобы снять ЭТО!"))
 				return
 			else

--- a/modular_splurt/code/modules/clothing/under/miscellaneous.dm
+++ b/modular_splurt/code/modules/clothing/under/miscellaneous.dm
@@ -18,6 +18,10 @@
 	anthro_mob_worn_overlay = 'modular_splurt/icons/mob/clothing/uniform_digi.dmi'
 	can_adjust = FALSE
 
+/obj/item/clothing/under/latex/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)
+
 /obj/item/clothing/under/latex/half
 	name = "latex bodysuit"
 	desc = "A tight fitting outfit made of latex, that covers the wearers torso."
@@ -624,3 +628,7 @@
 	icon_state = "latexbodysuit"
 	item_state = "latexbodysuit"
 	body_parts_covered = CHEST|ARMS|LEGS|GROIN
+
+/obj/item/clothing/under/latex_bodysuit/Initialize()
+	. = ..()
+	AddComponent(/datum/component/latex_lockable)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4356,6 +4356,7 @@
 #include "modular_bluemoon\code\datums\brain_damage\imaginary_friend.dm"
 #include "modular_bluemoon\code\datums\components\demoraliser.dm"
 #include "modular_bluemoon\code\datums\components\follow_component.dm"
+#include "modular_bluemoon\code\datums\components\latex_lockable.dm"
 #include "modular_bluemoon\code\datums\components\mood_events.dm"
 #include "modular_bluemoon\code\datums\components\crafting\recipes\guncrafting.dm"
 #include "modular_bluemoon\code\datums\components\crafting\recipes\guncrafting_recipes.dm"


### PR DESCRIPTION
# Описание

Латексный замок (seamless) был только на паре вещей и тупо копипастой по файлам. Вынес в один компонент и повесил на весь латекс: костюм, перчатки, каблуки, носки, шлем-депривации, минд-ошейник, намордник, кляп, комбез, боди, рукава, чулки. Запирается латексным ключом, заперто = не снять (ни себе, ни стрипом), тем же ключом отпирается. Чужой надетый запереть можно только с его согласия (галка Verb Consent)

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Ласка попросил. Нахуя - хз, я не спрашивал

## Changelog

:cl:
add: Вся латексная кинк-одежда теперь запирается латексным ключом.
tweak: Запереть надетый на другом игроке латекс можно только с его согласия.
refactor: Логика латексного замка вынесена в переиспользуемый компонент.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Новые функции**
  * Добавлена унифицированная система блокировки для латексной одежды. Маски, воротники, перчатки, ботинки, шлемы и другие латексные предметы теперь поддерживают механику запирания через латексный ключ с единообразным поведением.

* **Тесты**
  * Добавлены модульные тесты для проверки функциональности и надёжности системы блокировки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->