### PR TITLE
Микрофиксик рантайма аплинка

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -69,7 +69,7 @@
 	if(viewing_category && market)
 		if(market.available_items[viewing_category])
 			for(var/datum/blackmarket_item/I in market.available_items[viewing_category])
-				if(user.mind.has_antag_datum(/datum/antagonist/rev/head))
+				if(user.mind?.has_antag_datum(/datum/antagonist/rev/head))
 					data["items"] += list(list(
 						"id" = I.type,
 						"name" = I.name,

--- a/code/modules/unit_tests/bugfix_coverage.dm
+++ b/code/modules/unit_tests/bugfix_coverage.dm
@@ -111,3 +111,48 @@
 
 	if(eyes.active)
 		eyes.toggle(silent = TRUE)
+
+// Test: black market uplink ui_data tolerates a viewer with no mind (e.g. a ghost
+// opening it through attack_ghost). The head-rev discount check used to deref
+// user.mind directly and runtimed ("Cannot execute null.has_antag_datum()") on
+// every UI refresh tick. The mindless viewer must fall through to the full price.
+/datum/unit_test/blackmarket_uplink_mindless_viewer/Run()
+	var/obj/item/blackmarket_uplink/uplink = allocate(/obj/item/blackmarket_uplink)
+
+	var/datum/blackmarket_market/market = SSblackmarket.markets[uplink.viewing_market]
+	TEST_ASSERT_NOTNULL(market, "Uplink should resolve to a real market after Initialize")
+
+	// Deterministically place a known item in the viewed category so the ui_data
+	// loop actually reaches the guarded discount check (init item rolls are RNG).
+	var/test_category = "unit test wares"
+	var/list/category_items = list()
+	market.available_items[test_category] = category_items
+	uplink.viewing_category = test_category
+
+	var/datum/blackmarket_item/probe = new()
+	probe.name = "unit test contraband"
+	probe.category = test_category
+	probe.price = 100
+	probe.stock = 1
+	category_items += probe
+
+	// A freshly created mob has no mind, mirroring the reported observer.
+	var/mob/living/carbon/human/viewer = allocate(/mob/living/carbon/human)
+	TEST_ASSERT_NULL(viewer.mind, "Test precondition: viewer must be mindless to reproduce the bug")
+
+	// Old code: user.mind.has_antag_datum(...) -> runtime caught by the error handler.
+	// The ?. guard avoids it; the mindless viewer takes the non-headrev branch.
+	var/list/data = uplink.ui_data(viewer)
+	TEST_ASSERT_NOTNULL(data, "ui_data should return data for a mindless viewer")
+
+	var/found_cost
+	for(var/list/entry as anything in data["items"])
+		if(entry["name"] == "unit test contraband")
+			found_cost = entry["cost"]
+			break
+	TEST_ASSERT_NOTNULL(found_cost, "Injected item should be present in ui_data output")
+	TEST_ASSERT_EQUAL(found_cost, 100, "Mindless viewer should be charged full price (no head-rev discount)")
+
+	// Cleanup: don't leave the probe/category lingering in the global market.
+	market.available_items -= test_category
+	qdel(probe)


### PR DESCRIPTION
# Описание

Призраки могли открыть Black Market Uplink через клик (attack_ghost), а у них нет mind. Код проверял скидку для хедрева напрямую через `user.mind.has_antag_datum()`, поэтому ловил рантайм на каждом тике обновления UI - в логах капал по разу в секунду, пока окно открыто. Поменял на null-безопасный `user.mind?.has_antag_datum()`, как и везде в кодбазе

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Спам рантаймов в логах от любого призрака, заглянувшего в аплинк. Чистый однострочный фикс, поведение для живых не меняется.

## Changelog

:cl:
fix: исправлен спам рантаймов при открытии Black Market Uplink призраком
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлена ошибка при просмотре черного рынка наблюдателями без единицы разума.

* **Тестирование**
  * Добавлен новый тест для проверки работоспособности в данном случае.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->