### PR TITLE
фачка пиксов

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon2.dmm
@@ -3184,11 +3184,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/storage)
-"qi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel/cult,
-/area/ruin/space/has_grav/bluemoon/port_tarkon/mining)
 "qk" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4946,6 +4941,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/mineral/equipment_vendor/golem,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/mining)
 "Bp" = (
@@ -8737,8 +8733,10 @@
 /obj/item/storage/box/firingpins,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
-/obj/item/ammo_box/magazine/m357/dumdum,
-/obj/item/ammo_box/magazine/m357/dumdum,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
 /turf/open/floor/plasteel/cult,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/comms)
 "WE" = (
@@ -13484,7 +13482,7 @@ zh
 BU
 jo
 TQ
-qi
+BU
 Bo
 Vy
 BU

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon3.dmm
@@ -4703,7 +4703,7 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
-/obj/machinery/mineral/equipment_vendor,
+/obj/machinery/mineral/equipment_vendor/golem,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/mining)
 "Bp" = (
@@ -8353,8 +8353,10 @@
 /obj/item/storage/box/firingpins,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
-/obj/item/ammo_box/magazine/m357/dumdum,
-/obj/item/ammo_box/magazine/m357/dumdum,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/storage)
 "Xg" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon4.dmm
@@ -1022,8 +1022,10 @@
 /obj/item/storage/box/firingpins,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
-/obj/item/ammo_box/magazine/m357/dumdum,
-/obj/item/ammo_box/magazine/m357/dumdum,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/storage)
 "fU" = (
@@ -1735,7 +1737,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/mineral/equipment_vendor,
+/obj/machinery/mineral/equipment_vendor/golem,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/mining)
 "kf" = (

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/defcon5.dmm
@@ -3744,6 +3744,10 @@
 /obj/item/storage/box/firingpins,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/storage)
 "wa" = (
@@ -4842,7 +4846,6 @@
 	},
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/mineral/equipment_vendor,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/mining)
@@ -6388,6 +6391,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/port_tarkon/trauma)
+"Lw" = (
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/mineral/equipment_vendor/golem,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/bluemoon/port_tarkon/mining)
 "Ly" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
@@ -13180,7 +13191,7 @@ cq
 jo
 TQ
 CZ
-gS
+Lw
 Vy
 gS
 IK

--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/forgotten_ship.dmm
@@ -399,11 +399,6 @@
 /turf/open/floor/wood/wood_parquet,
 /area/ruin/space/has_grav/bluemoon/inteq_forgotten_ship)
 "bL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	pixel_y = 23;
-	pixel_x = 37
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},


### PR DESCRIPTION
# Описание

Пачка фиксов мапинга, включающих: 
- Замена всех патрон для дигла на всех версиях таркона с магазина .357 dum dum на .50 AE (потому что диглы там .50)
- Замена всех шахтёрских вендоматов на шахтёрские вендоматы големов
- Удаление криво поставленного ни подключённого ни к чему скрубера
## Причина изменений

По запросу игроков

## Changelog


:cl:
map: пофикшен тип магазинов на тарконах, вендоры заменены на вендоры големов



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Изменения

* **Игровой баланс**
  * Обновлены торговые точки на картах космических развалин с добавлением специализированного оборудования.
  * Переработан состав боеприпасов в нескольких локациях.
  * Внесены корректировки в распределение лута и оборудования на картах космических руин.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->