### PR TITLE
тайп индикатор в тикеты, фиксы хендла.

### DIFF
--- a/code/modules/admin/admin_ticket_panel.dm
+++ b/code/modules/admin/admin_ticket_panel.dm
@@ -22,6 +22,7 @@
 
 /datum/admin_ticket_panel/ui_data(mob/user)
 	. = list()
+	.["ckey"] = user?.ckey
 
 	var/list/tickets_data = list()
 
@@ -73,6 +74,14 @@
 	.["handler"] = AH.handler
 	.["ticket_ping_stop"] = AH.ticket_ping_stop
 	.["ticket_ping"] = AH.ticket_ping
+	var/list/typing = list()
+	for(var/typing_ckey in AH.typing_admins)
+		if(world.time - AH.typing_admins[typing_ckey] < 5 SECONDS)
+			typing += typing_ckey
+		else
+			AH.typing_admins -= typing_ckey
+	.["typing_admins"] = typing
+	.["initiator_typing"] = (AH.initiator_typing_time != null && world.time - AH.initiator_typing_time < 5 SECONDS)
 	.["interactions"] = AH._interactions.Copy()
 
 /datum/admin_ticket_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -109,6 +118,10 @@
 			message = trim(message)
 			if(!message)
 				return TRUE
+			//auto-assign
+			if(!selected_ticket.handler)
+				selected_ticket.handle_issue()
+			selected_ticket.typing_admins -= usr.ckey
 			usr.client.cmd_admin_pm(selected_ticket.initiator, message)
 			. = TRUE
 
@@ -240,6 +253,18 @@
 			if(!istype(O))
 				return TRUE
 			O.ManualFollow(sender)
+			. = TRUE
+
+		if("typing_start")
+			if(!selected_ticket || selected_ticket.state != AHELP_ACTIVE)
+				return TRUE
+			selected_ticket.typing_admins[usr.ckey] = world.time
+			. = TRUE
+
+		if("typing_stop")
+			if(!selected_ticket)
+				return TRUE
+			selected_ticket.typing_admins -= usr.ckey
 			. = TRUE
 
 	SStgui.update_uis(src)

--- a/code/modules/admin/admin_ticket_panel.dm
+++ b/code/modules/admin/admin_ticket_panel.dm
@@ -79,9 +79,17 @@
 		if(world.time - AH.typing_admins[typing_ckey] < 5 SECONDS)
 			typing += typing_ckey
 		else
-			AH.typing_admins -= typing_ckey
+			var/client/C = GLOB.directory[typing_ckey]
+			if(C?.reply_modal_open)
+				typing += typing_ckey
+			else
+				AH.typing_admins -= typing_ckey
 	.["typing_admins"] = typing
 	.["initiator_typing"] = (AH.initiator_typing_time != null && world.time - AH.initiator_typing_time < 5 SECONDS)
+	if(!.["initiator_typing"] && AH.initiator_ckey)
+		var/client/C = GLOB.directory[AH.initiator_ckey]
+		if(C?.reply_modal_open)
+			.["initiator_typing"] = TRUE
 	.["interactions"] = AH._interactions.Copy()
 
 /datum/admin_ticket_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -174,6 +174,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	/// Who is handling this admin help?
 	var/handler
 	var/suppress_ticket_panel = FALSE
+	/// Admin-shnir typing in ticket
+	var/list/typing_admins
+	/// ticket initiator
+	var/initiator_typing_time
 
 //call this on its own to create a ticket, don't manually assign current_ticket
 //msg is the title of the ticket: usually the ahelp text
@@ -203,6 +207,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	statclick = new(null, src)
 	_interactions = list()
+	typing_admins = list()
 
 	addtimer(CALLBACK(src, PROC_REF(add_to_ping_ss), 2 MINUTES)) // Ticket Ping | this is not responsible for the notification itself, but only for adding the ticket to the list of those to notify.
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -55,10 +55,13 @@
 	if(AH)
 		message_admins("[key_name_admin(src, FALSE)] [ADMIN_FLW(src.mob)] начал отвечать на админхелп [key_name_admin(C, FALSE)] [ADMIN_FLW(C.mob)].",\
 		islog = FALSE, prefix = "AHELP")
+		AH.typing_admins[usr.ckey] = world.time
 	var/msg = input(src,"Сообщение:", "Приватное сообщение [C.holder?.fakekey ? "администрации" : key_name(C, FALSE)].") as message|null
 	if (!msg)
 		message_admins("[key_name_admin(src, FALSE)] [ADMIN_FLW(src.mob)] прекратил отвечать на admin help [key_name_admin(C, FALSE)] [ADMIN_FLW(C.mob)].",\
 		islog = FALSE, prefix = "AHELP")
+		if(AH)
+			AH.typing_admins -= usr.ckey
 		return
 	if(!C) //We lost the client during input, disconnected or relogged.
 		if(GLOB.directory[AH.initiator_ckey]) // Client has reconnected, lets try to recover
@@ -67,7 +70,15 @@
 			to_chat(src, "<span class='danger'>Ошибка: Admin-PM: Клиент не найден.</span>", confidential = TRUE)
 			to_chat(src, "<span class='danger'><b>Сообщение не отправлено:</b></span><br>[msg]", confidential = TRUE)
 			AH.AddInteraction("<b>Клиент не найден, сообщение не отправлено:</b><br>[msg]")
+			if(AH)
+				AH.typing_admins -= usr.ckey
 			return
+	if(AH && !AH.handler && holder)
+		AH.handle_issue()
+
+	if(AH)
+		AH.typing_admins -= usr.ckey
+
 	cmd_admin_pm(whom, msg)
 
 //takes input from cmd_admin_pm_context, cmd_admin_pm_panel or /client/Topic and sends them a PM.
@@ -118,9 +129,23 @@
 	else
 		//get message text, limit it's length.and clean/escape html
 		if(!msg)
+			//track typing indicator
+			var/datum/admin_help/typing_ticket
+			if(!holder && current_ticket)
+				typing_ticket = current_ticket
+				typing_ticket.initiator_typing_time = world.time
+			else if(holder && recipient?.current_ticket)
+				typing_ticket = recipient.current_ticket
+				typing_ticket.typing_admins[src.ckey] = world.time
+
 			msg = input(src,"Сообщение:", "Приватное сообщение для [recipient.holder?.fakekey ? "администрации" : key_name(recipient, 0, 0)].") as message|null
 			msg = trim(msg)
 			if(!msg)
+				if(typing_ticket)
+					if(!holder)
+						typing_ticket.initiator_typing_time = null
+					else
+						typing_ticket.typing_admins -= src.ckey
 				return
 
 		if(!recipient)
@@ -138,7 +163,11 @@
 					if(!check_rights(R_SERVER|R_DEBUG,0)||external)//no sending html to the poor bots
 						msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
 						if(!msg)
+							if(!holder && current_ticket)
+								current_ticket.initiator_typing_time = null
 							return
+					if(!holder && current_ticket)
+						current_ticket.initiator_typing_time = null
 					current_ticket.MessageNoRecipient(msg)
 					return
 
@@ -188,6 +217,10 @@
 				if(current_ticket)
 					SSblackbox.LogAhelp(current_ticket.id, "Reply", msg, recipient.ckey, src.ckey)
 			else		//recipient is an admin but sender is not
+				//clear initiator
+				if(!holder && current_ticket)
+					current_ticket.initiator_typing_time = null
+
 				var/replymsg = "PM-ответ от <b>[key_name(src, recipient, 1)]</b>: <span class='linkify'>[keywordparsedmsg]</span>"
 				admin_ticket_log(src, "<font color='#f87171'>[replymsg]</font>")
 				to_chat(recipient, "<span class='danger'>[replymsg]</span>", confidential = TRUE)
@@ -204,6 +237,14 @@
 					new /datum/admin_help(msg, recipient, TRUE)
 					already_logged = TRUE //BLUEMOON EDIT, enable ticket logging
 					SSblackbox.LogAhelp(recipient.current_ticket.id, "Ticket Opened", msg, recipient.ckey, src.ckey)
+
+				//auto-assign ticket
+				if(recipient.current_ticket && !recipient.current_ticket.handler)
+					recipient.current_ticket.handle_issue()
+
+				//clear typing
+				if(recipient.current_ticket)
+					recipient.current_ticket.typing_admins -= src.ckey
 
 				var/recipient_message = ""
 				recipient_message += "<br><center><font color='red' size='4'><b>-- Administrator private message --</b></font></center>"

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -56,7 +56,9 @@
 		message_admins("[key_name_admin(src, FALSE)] [ADMIN_FLW(src.mob)] начал отвечать на админхелп [key_name_admin(C, FALSE)] [ADMIN_FLW(C.mob)].",\
 		islog = FALSE, prefix = "AHELP")
 		AH.typing_admins[usr.ckey] = world.time
+		reply_modal_open = TRUE
 	var/msg = input(src,"Сообщение:", "Приватное сообщение [C.holder?.fakekey ? "администрации" : key_name(C, FALSE)].") as message|null
+	reply_modal_open = FALSE
 	if (!msg)
 		message_admins("[key_name_admin(src, FALSE)] [ADMIN_FLW(src.mob)] прекратил отвечать на admin help [key_name_admin(C, FALSE)] [ADMIN_FLW(C.mob)].",\
 		islog = FALSE, prefix = "AHELP")
@@ -137,8 +139,11 @@
 			else if(holder && recipient?.current_ticket)
 				typing_ticket = recipient.current_ticket
 				typing_ticket.typing_admins[src.ckey] = world.time
+			if(typing_ticket)
+				reply_modal_open = TRUE
 
 			msg = input(src,"Сообщение:", "Приватное сообщение для [recipient.holder?.fakekey ? "администрации" : key_name(recipient, 0, 0)].") as message|null
+			reply_modal_open = FALSE
 			msg = trim(msg)
 			if(!msg)
 				if(typing_ticket)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -21,6 +21,8 @@
 	show_verb_panel = FALSE
 	///Contains admin info. Null if client is not an admin.
 	var/datum/admins/holder = null
+	/// TRUE while blocking input() modal open
+	var/reply_modal_open = FALSE
 	/// If TRUE, this admin receives GC leak notifications (warnfail/softcheck alerts). Toggle via GC Health Panel.
 	var/gc_leak_notify = FALSE
 	var/datum/click_intercept = null // Needs to implement InterceptClickOn(user,params,atom) proc

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -742,8 +742,7 @@
 		var/list/skin_data = GLOB.pda_reskins[new_skin]
 		if(skin_data && skin_data["icon"])
 			icon = skin_data["icon"]
-			if(skin_data["overlays_icon"])
-				overlays_icon = skin_data["overlays_icon"]
+			overlays_icon = skin_data["icon"]
 			icon_state = base_icon_state
 			if(job_icon_state)
 				icon_state = job_icon_state
@@ -818,8 +817,7 @@
 	if(!skin_data || !skin_data["icon"])
 		return
 	icon = skin_data["icon"]
-	if(skin_data["overlays_icon"])
-		overlays_icon = skin_data["overlays_icon"]
+	overlays_icon = skin_data["icon"]
 	icon_state = base_icon_state
 	if(job_icon_state)
 		icon_state = job_icon_state

--- a/tgui/packages/tgui/interfaces/AdminTicketPanel.js
+++ b/tgui/packages/tgui/interfaces/AdminTicketPanel.js
@@ -400,6 +400,7 @@ const TicketDetailPanel = (props, context) => {
 
   const stopTyping = () => {
     act('typing_stop');
+    setLastTypingPing(0);
   };
 
   const sendReply = () => {

--- a/tgui/packages/tgui/interfaces/AdminTicketPanel.js
+++ b/tgui/packages/tgui/interfaces/AdminTicketPanel.js
@@ -231,6 +231,7 @@ export const AdminTicketPanel = (props, context) => {
                       <TicketListItem
                         key={ticket.ref}
                         ticket={ticket}
+                        ckey={data.ckey}
                         selected={ticket.ref === selected_ticket_ref}
                         onSelect={() => {
                           setTab(ticket.state);
@@ -288,8 +289,10 @@ export const AdminTicketPanel = (props, context) => {
 };
 
 const TicketListItem = (props) => {
-  const { ticket, selected, onSelect } = props;
+  const { ticket, selected, onSelect, ckey } = props;
   const color = STATE_COLORS[ticket.state] || '#94a3b8';
+  const listTypingAdmins = (ticket.typing_admins || []).filter(Boolean);
+  const hasListInitiatorTyping = !!ticket.initiator_typing;
 
   return (
     <Box
@@ -329,21 +332,40 @@ const TicketListItem = (props) => {
           >
             {ticket.name}
           </Box>
+            {(listTypingAdmins.length > 0 || !!hasListInitiatorTyping) && (
+            <Box
+              fontSize="10px"
+              color="#ffcc00"
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              ✎ {listTypingAdmins.concat(
+                hasListInitiatorTyping
+                  ? [ticket.initiator_ckey || 'игрок']
+                  : []
+              ).join(', ')} {(listTypingAdmins.length + (hasListInitiatorTyping ? 1 : 0)) === 1 ? 'печатает' : 'печатают'}...
+            </Box>
+          )}
         </Flex.Item>
         <Flex.Item shrink={0}>
-          <Box
-            fontSize="9px"
-            px={0.8}
-            py={0.2}
-            style={{
-              backgroundColor: color,
-              color: '#fff',
-              borderRadius: '3px',
-              fontWeight: 'bold',
-            }}
-          >
-            {STATE_LABELS[ticket.state]}
-          </Box>
+          <Flex align="center">
+            <Box
+              fontSize="9px"
+              px={0.8}
+              py={0.2}
+              style={{
+                backgroundColor: color,
+                color: '#fff',
+                borderRadius: '3px',
+                fontWeight: 'bold',
+              }}
+            >
+              {STATE_LABELS[ticket.state]}
+            </Box>
+          </Flex>
         </Flex.Item>
       </Flex>
     </Box>
@@ -357,17 +379,46 @@ const TicketDetailPanel = (props, context) => {
     'replyMessage',
     ''
   );
+  const [lastTypingPing, setLastTypingPing] = useLocalState(
+    context,
+    'lastTypingPing_' + ticket.ref,
+    0
+  );
   const isActive = ticket.state === 1;
   const color = STATE_COLORS[ticket.state] || '#94a3b8';
   const canReply = isActive && ticket.has_initiator;
+
+  const typingAdmins = (ticket.typing_admins || []).filter(Boolean);
+
+  const pingTyping = () => {
+    const now = Date.now();
+    if (now - lastTypingPing > 2000) {
+      act('typing_start');
+      setLastTypingPing(now);
+    }
+  };
+
+  const stopTyping = () => {
+    act('typing_stop');
+  };
 
   const sendReply = () => {
     const message = replyMessage.trim();
     if (!message || !canReply) {
       return;
     }
+    stopTyping();
     act('send_reply', { message });
     setReplyMessage('');
+  };
+
+  const handleTypingInput = (e, value) => {
+    setReplyMessage(value);
+    if (value) {
+      pingTyping();
+    } else {
+      stopTyping();
+    }
   };
 
   return (
@@ -450,11 +501,18 @@ const TicketDetailPanel = (props, context) => {
                 </Box>
               )}
             </Flex.Item>
-            {ticket.handler && (
-              <Flex.Item mr={3}>
-                <b>Взят:</b> {ticket.handler}
-              </Flex.Item>
-            )}
+            <Flex.Item mr={3}>
+              <b>Взят:</b>{' '}
+              {ticket.handler ? (
+                <Box as="span" color="#ffcc00" fontWeight="bold">
+                  {ticket.handler}
+                </Box>
+              ) : (
+                <Box as="span" color="#666">
+                  Не взят
+                </Box>
+              )}
+            </Flex.Item>
             <Flex.Item mr={3}>
               <b>Открыт:</b> {ticket.opened_at_text || '—'}{' '}
               <Box as="span" color="label">
@@ -648,6 +706,19 @@ const TicketDetailPanel = (props, context) => {
       </Stack.Item>
       {isActive && (
         <Stack.Item>
+          {(typingAdmins.length > 0 || !!ticket.initiator_typing) && (
+            <Box fontSize="11px" color="#ffcc00" textAlign="left" py={0.5} style={{fontWeight: 'bold'}}>
+              <Icon name="pencil-alt" mr={0.5} />
+              {typingAdmins.concat(
+                ticket.initiator_typing
+                  ? [ticket.initiator_ckey || 'игрок']
+                  : []
+              ).join(', ')}{' '}
+              {(typingAdmins.length + (ticket.initiator_typing ? 1 : 0)) === 1
+                ? 'печатает'
+                : 'печатают'}...
+            </Box>
+          )}
           <Section title={'Ответить ' + (ticket.initiator_ckey || 'ckey')}>
             <Flex>
               <Flex.Item grow>
@@ -660,7 +731,7 @@ const TicketDetailPanel = (props, context) => {
                       : 'Игрок отключён, ответ невозможен'
                   }
                   value={replyMessage}
-                  onInput={(e, value) => setReplyMessage(value)}
+                  onInput={handleTypingInput}
                   onEnter={sendReply}
                 />
               </Flex.Item>


### PR DESCRIPTION
# Описание
Статус в окне тикета. 

## Changelog

:cl:

admin: Статус ответа в тикет панели.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Добавлены индикаторы набора текста в панели тикетов и в личных сообщениях: видно, кто сейчас печатает.
  * В карточке тикета теперь отображается вариант **«Не взят»** и бейдж назначенного исполнителя, если он есть.

* **Bug Fixes**
  * Ответ в тикете теперь автоматически закрепляет его за отвечающим, если тикет не был взят.
  * Индикаторы набора текста корректно очищаются при пустом сообщении, отмене ввода и перед отправкой.
  * Оверлеи PDA при смене скина теперь отображаются согласованно.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->