### PR TITLE
Доработка стилей чата

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -9,7 +9,7 @@ import DOMPurify from 'dompurify';
 
 import { flushSaveToServer, getLastSavedAt, scheduleSaveToServer } from '../serverState';
 import { loadSettings, updateSettings } from '../settings/actions';
-import { CHAT_ANIM_SPEEDS } from '../settings/constants';
+import { CHAT_ANIM_SPEEDS, MESSAGE_STYLES } from '../settings/constants';
 import { selectSettings } from '../settings/selectors';
 import { addChatPage, changeChatPage, changeScrollTracking, loadChat, rebuildChat, removeChatPage, saveChatToDisk, toggleAcceptedType, updateChatPage, updateMessageCount } from './actions';
 import { MAX_PERSISTED_MESSAGES, MESSAGE_SAVE_INTERVAL } from './constants';
@@ -140,6 +140,17 @@ const createApplySettings = () => {
         settings.chatBgColor,
         settings.chatTextColor,
         settings.chatAccentColor);
+    }
+    if (anyChanged(prev, settings, ['styleOverrides', 'spanAnimations'])) {
+      // Normalize so the renderer always sees every known style id and
+      // clears stale properties for styles that lost their override.
+      const normalized = {};
+      for (const style of MESSAGE_STYLES) {
+        normalized[style.id] = settings.styleOverrides?.[style.id] || {};
+      }
+      chatRenderer.setStyleOverrides(
+        normalized,
+        settings.spanAnimations !== false);
     }
 
     // Animation speed

--- a/tgui/packages/tgui-panel/chat/middleware.test.js
+++ b/tgui/packages/tgui-panel/chat/middleware.test.js
@@ -17,6 +17,7 @@ const mockChatRenderer = {
   setBgAnimation: jest.fn(),
   setCustomColors: jest.fn(),
   setCustomProperties: jest.fn(),
+  setStyleOverrides: jest.fn(),
   setTimestamps: jest.fn(),
   setTimeDividers: jest.fn(),
   changePage: jest.fn(),
@@ -109,6 +110,7 @@ describe('chatMiddleware applySettings diffing', () => {
     expect(mockChatRenderer.setBgAnimation).toHaveBeenCalledTimes(1);
     expect(mockChatRenderer.setCustomColors).toHaveBeenCalledTimes(1);
     expect(mockChatRenderer.setCustomProperties).toHaveBeenCalledTimes(1);
+    expect(mockChatRenderer.setStyleOverrides).toHaveBeenCalledTimes(1);
     expect(mockChatRenderer.setTimestamps).toHaveBeenCalledTimes(1);
     expect(mockChatRenderer.setTimeDividers).toHaveBeenCalledTimes(1);
   });
@@ -134,6 +136,7 @@ describe('chatMiddleware applySettings diffing', () => {
     expect(mockChatRenderer.setBgAnimation).not.toHaveBeenCalled();
     expect(mockChatRenderer.setCustomColors).not.toHaveBeenCalled();
     expect(mockChatRenderer.setCustomProperties).not.toHaveBeenCalled();
+    expect(mockChatRenderer.setStyleOverrides).not.toHaveBeenCalled();
     expect(mockChatRenderer.setTimestamps).not.toHaveBeenCalled();
     expect(mockChatRenderer.setTimeDividers).not.toHaveBeenCalled();
   });
@@ -249,6 +252,45 @@ describe('chatMiddleware applySettings diffing', () => {
     expect(mockChatRenderer.setTimestamps).not.toHaveBeenCalled();
   });
 
+  test('styleOverrides change triggers setStyleOverrides only', async () => {
+    const store = createTestStore();
+    store.dispatch(updateSettings({ highlightText: '' }));
+    await flushPromises();
+    clearRendererSpies();
+
+    store.dispatch(updateSettings({
+      styleOverrides: {
+        emote: { color: '#ff0000', disabled: false },
+      },
+    }));
+    await flushPromises();
+
+    expect(mockChatRenderer.setStyleOverrides).toHaveBeenCalledTimes(1);
+    const [overrides, spanAnimations]
+      = mockChatRenderer.setStyleOverrides.mock.calls[0];
+    // Normalized map always contains every known style id
+    expect(overrides.emote).toEqual({ color: '#ff0000', disabled: false });
+    expect(overrides.whisper).toEqual({});
+    expect(spanAnimations).toBe(true);
+    expect(mockChatRenderer.setHighlight).not.toHaveBeenCalled();
+    expect(mockChatRenderer.setCustomProperties).not.toHaveBeenCalled();
+  });
+
+  test('spanAnimations toggle propagates to setStyleOverrides', async () => {
+    const store = createTestStore();
+    store.dispatch(updateSettings({ highlightText: '' }));
+    await flushPromises();
+    clearRendererSpies();
+
+    store.dispatch(updateSettings({ spanAnimations: false }));
+    await flushPromises();
+
+    expect(mockChatRenderer.setStyleOverrides).toHaveBeenCalledTimes(1);
+    const [, spanAnimations]
+      = mockChatRenderer.setStyleOverrides.mock.calls[0];
+    expect(spanAnimations).toBe(false);
+  });
+
   test('matchWord toggle re-runs setHighlight', async () => {
     const store = createTestStore();
     store.dispatch(updateSettings({ highlightText: 'foo' }));
@@ -280,6 +322,7 @@ describe('chatMiddleware applySettings diffing', () => {
     expect(mockChatRenderer.setBgAnimation).not.toHaveBeenCalled();
     expect(mockChatRenderer.setCustomColors).not.toHaveBeenCalled();
     expect(mockChatRenderer.setCustomProperties).not.toHaveBeenCalled();
+    expect(mockChatRenderer.setStyleOverrides).not.toHaveBeenCalled();
     expect(mockChatRenderer.setTimestamps).not.toHaveBeenCalled();
     expect(mockChatRenderer.setTimeDividers).not.toHaveBeenCalled();
   });

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -795,8 +795,12 @@ export class ChatRenderer {
     if (!spanAnimations) {
       root.classList.add('Chat--fxAnimOff');
     }
-    for (const [styleId, override] of Object.entries(overrides)) {
-      const prop = '--cs-' + styleId + '-color';
+    // Iterate the full known style list rather than the passed map,
+    // so a partial or empty overrides object still clears every stale
+    // --cs-* variable from previous calls.
+    for (const style of MESSAGE_STYLES) {
+      const override = overrides[style.id];
+      const prop = '--cs-' + style.id + '-color';
       if (override?.color) {
         root.style.setProperty(prop, override.color);
       }
@@ -804,7 +808,7 @@ export class ChatRenderer {
         root.style.removeProperty(prop);
       }
       if (override?.disabled) {
-        root.classList.add('Chat--plain-' + styleId);
+        root.classList.add('Chat--plain-' + style.id);
       }
     }
     updateStyleOverrideSheet(buildStyleOverrideCss(overrides));

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -10,6 +10,7 @@ import { classes } from 'common/react';
 import { createLogger } from 'tgui/logging';
 
 import highlightSoundUrl from '../assets/chat_notify.ogg';
+import { MESSAGE_STYLE_ANIMATIONS, MESSAGE_STYLES } from '../settings/constants';
 import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MAX_PERSISTED_MESSAGES, MAX_VISIBLE_MESSAGES, MESSAGE_PRUNE_INTERVAL, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN, MESSAGE_TYPES } from './constants';
 import { canPageAcceptType, createMessage, isSameMessage } from './model';
 import { highlightNode, linkifyNode } from './replaceInTextNode';
@@ -57,6 +58,70 @@ const getDistanceFromBottom = node => (
 const isScrollTracked = node => (
   getDistanceFromBottom(node) <= SCROLL_TRACKING_TOLERANCE
 );
+
+const STYLE_OVERRIDE_SHEET_ID = 'cs-style-overrides';
+
+const FONT_OVERRIDE_CSS = {
+  normal: 'font-weight: normal; font-style: normal;',
+  italic: 'font-weight: normal; font-style: italic;',
+  bold: 'font-weight: bold; font-style: normal;',
+  bolditalic: 'font-weight: bold; font-style: italic;',
+};
+
+/**
+ * Builds CSS text for font/size/animation overrides of message styles.
+ * Colors go through CSS custom properties instead (see setStyleOverrides),
+ * because their theme defaults differ between dark and light.
+ */
+const buildStyleOverrideCss = (overrides) => {
+  let css = '';
+  for (const style of MESSAGE_STYLES) {
+    const override = overrides[style.id];
+    if (!override || override.disabled) {
+      continue;
+    }
+    const classNames = [style.id, ...(style.extraClasses || [])];
+    const decls = [];
+    if (FONT_OVERRIDE_CSS[override.font]) {
+      decls.push(FONT_OVERRIDE_CSS[override.font]);
+    }
+    const size = parseFloat(override.size);
+    if (size && size !== 100) {
+      const clamped = Math.min(200, Math.max(50, size));
+      decls.push('font-size: ' + clamped + '%;');
+    }
+    if (decls.length > 0) {
+      css += classNames.map(cls => '.Chat .' + cls).join(', ')
+        + ' { ' + decls.join(' ') + ' }\n';
+    }
+    const anim = MESSAGE_STYLE_ANIMATIONS.find(a => a.id === override.anim);
+    if (anim?.css) {
+      // :not() держит специфичность выше темы, но уступает глобальному
+      // тумблеру Chat--fxAnimOff.
+      css += classNames
+        .map(cls => '.Chat:not(.Chat--fxAnimOff) .' + cls)
+        .join(', ')
+        + ' { animation: ' + anim.css + '; }\n';
+    }
+  }
+  return css;
+};
+
+const updateStyleOverrideSheet = (cssText) => {
+  let node = document.getElementById(STYLE_OVERRIDE_SHEET_ID);
+  if (!cssText) {
+    node?.remove();
+    return;
+  }
+  if (!node) {
+    node = document.createElement('style');
+    node.id = STYLE_OVERRIDE_SHEET_ID;
+    document.head.appendChild(node);
+  }
+  if (node.textContent !== cssText) {
+    node.textContent = cssText;
+  }
+};
 
 const createHighlightNode = (text, color) => {
   const node = document.createElement('span');
@@ -699,6 +764,52 @@ export class ChatRenderer {
     }
   }
 
+  /**
+   * Applies per-style customization: color overrides via CSS custom
+   * properties (--cs-<id>-color), "plain look" via Chat--plain-<id>
+   * classes, font/size/animation via a dynamic stylesheet, plus the
+   * global span animation toggle (Chat--fxAnimOff).
+   * @param {Object} overrides map of styleId ->
+   *   { color, disabled, font, size, anim }
+   * @param {boolean} spanAnimations
+   */
+  setStyleOverrides(overrides = {}, spanAnimations = true) {
+    this._pendingAppearance = {
+      ...this._pendingAppearance,
+      styleOverrides: overrides,
+      spanAnimations,
+    };
+    if (!this.rootNode) {
+      return;
+    }
+    const root = this.rootNode;
+    const toRemove = [];
+    for (const cls of root.classList) {
+      if (cls.startsWith('Chat--plain-') || cls === 'Chat--fxAnimOff') {
+        toRemove.push(cls);
+      }
+    }
+    for (const cls of toRemove) {
+      root.classList.remove(cls);
+    }
+    if (!spanAnimations) {
+      root.classList.add('Chat--fxAnimOff');
+    }
+    for (const [styleId, override] of Object.entries(overrides)) {
+      const prop = '--cs-' + styleId + '-color';
+      if (override?.color) {
+        root.style.setProperty(prop, override.color);
+      }
+      else {
+        root.style.removeProperty(prop);
+      }
+      if (override?.disabled) {
+        root.classList.add('Chat--plain-' + styleId);
+      }
+    }
+    updateStyleOverrideSheet(buildStyleOverrideCss(overrides));
+  }
+
   setCustomProperties(props) {
     this._pendingAppearance = {
       ...this._pendingAppearance,
@@ -739,6 +850,9 @@ export class ChatRenderer {
     }
     if (p._customProps) {
       this.setCustomProperties(p._customProps);
+    }
+    if (p.styleOverrides !== undefined) {
+      this.setStyleOverrides(p.styleOverrides, p.spanAnimations);
     }
     this._pendingAppearance = null;
   }

--- a/tgui/packages/tgui-panel/chat/renderer.test.js
+++ b/tgui/packages/tgui-panel/chat/renderer.test.js
@@ -936,6 +936,22 @@ describe('ChatRenderer', () => {
       expect(root.classList.contains('Chat--fxAnimOff')).toBe(false);
     });
 
+    test('empty overrides map fully resets root state', () => {
+      const renderer = createReadyRenderer();
+      renderer.setStyleOverrides({
+        emote: { color: '#ff0000', disabled: true },
+        whisper: { color: '#00ff00' },
+      }, false);
+
+      renderer.setStyleOverrides({}, true);
+
+      const root = renderer.rootNode;
+      expect(root.style.getPropertyValue('--cs-emote-color')).toBe('');
+      expect(root.style.getPropertyValue('--cs-whisper-color')).toBe('');
+      expect(root.classList.contains('Chat--plain-emote')).toBe(false);
+      expect(root.classList.contains('Chat--fxAnimOff')).toBe(false);
+    });
+
     test('queues overrides until mount via pending appearance', () => {
       const renderer = new ChatRenderer();
       renderer.setStyleOverrides({

--- a/tgui/packages/tgui-panel/chat/renderer.test.js
+++ b/tgui/packages/tgui-panel/chat/renderer.test.js
@@ -898,6 +898,104 @@ describe('ChatRenderer', () => {
     });
   });
 
+  // ---- setStyleOverrides ----
+
+  describe('setStyleOverrides', () => {
+    test('sets color custom properties and plain classes', () => {
+      const renderer = createReadyRenderer();
+      renderer.setStyleOverrides({
+        emote: { color: '#ff0000', disabled: false },
+        whisper: { color: '', disabled: true },
+        lewd: {},
+      }, true);
+
+      const root = renderer.rootNode;
+      expect(root.style.getPropertyValue('--cs-emote-color'))
+        .toBe('#ff0000');
+      expect(root.style.getPropertyValue('--cs-whisper-color')).toBe('');
+      expect(root.classList.contains('Chat--plain-whisper')).toBe(true);
+      expect(root.classList.contains('Chat--plain-emote')).toBe(false);
+      expect(root.classList.contains('Chat--fxAnimOff')).toBe(false);
+    });
+
+    test('clears stale properties and classes on re-apply', () => {
+      const renderer = createReadyRenderer();
+      renderer.setStyleOverrides({
+        emote: { color: '#ff0000', disabled: true },
+      }, false);
+      expect(renderer.rootNode.classList.contains('Chat--fxAnimOff'))
+        .toBe(true);
+
+      renderer.setStyleOverrides({
+        emote: {},
+      }, true);
+
+      const root = renderer.rootNode;
+      expect(root.style.getPropertyValue('--cs-emote-color')).toBe('');
+      expect(root.classList.contains('Chat--plain-emote')).toBe(false);
+      expect(root.classList.contains('Chat--fxAnimOff')).toBe(false);
+    });
+
+    test('queues overrides until mount via pending appearance', () => {
+      const renderer = new ChatRenderer();
+      renderer.setStyleOverrides({
+        emote: { color: '#00ff00' },
+      }, false);
+
+      const rootNode = document.createElement('div');
+      renderer.rootNode = rootNode;
+      renderer.applyPendingAppearance();
+
+      expect(rootNode.style.getPropertyValue('--cs-emote-color'))
+        .toBe('#00ff00');
+      expect(rootNode.classList.contains('Chat--fxAnimOff')).toBe(true);
+    });
+
+    test('font/size/anim overrides emit a dynamic stylesheet', () => {
+      const renderer = createReadyRenderer();
+      renderer.setStyleOverrides({
+        emote: { font: 'bold', size: 130, anim: 'pulse' },
+        telepathy: { font: 'bolditalic' },
+      }, true);
+
+      const sheet = document.getElementById('cs-style-overrides');
+      expect(sheet).not.toBeNull();
+      const css = sheet.textContent;
+      expect(css).toContain(
+        '.Chat .emote { font-weight: bold; font-style: normal; '
+        + 'font-size: 130%; }');
+      expect(css).toContain(
+        '.Chat:not(.Chat--fxAnimOff) .emote { animation: cs-pulse');
+      // extraClasses получают те же правила
+      expect(css).toContain('.Chat .telepathy, .Chat .telepathybold');
+    });
+
+    test('size is clamped and disabled styles emit no rules', () => {
+      const renderer = createReadyRenderer();
+      renderer.setStyleOverrides({
+        emote: { size: 500 },
+        whisper: { font: 'bold', size: 150, anim: 'glow', disabled: true },
+      }, true);
+
+      const css = document.getElementById('cs-style-overrides').textContent;
+      expect(css).toContain('font-size: 200%');
+      expect(css).not.toContain('whisper');
+    });
+
+    test('stylesheet is removed when no rules remain', () => {
+      const renderer = createReadyRenderer();
+      renderer.setStyleOverrides({
+        emote: { font: 'bold' },
+      }, true);
+      expect(document.getElementById('cs-style-overrides')).not.toBeNull();
+
+      renderer.setStyleOverrides({
+        emote: { color: '#ff0000' },
+      }, true);
+      expect(document.getElementById('cs-style-overrides')).toBeNull();
+    });
+  });
+
   // ---- Events ----
 
   describe('events', () => {

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -332,7 +332,7 @@ export const SettingsGeneral = (props, context) => {
 // Инлайн-стиль превью: настройки применяются к чату через переменные
 // и динамическую таблицу на корне .Chat, панель настроек ими не
 // покрывается, поэтому превью собирает те же значения инлайном.
-const getStylePreviewStyle = (override) => {
+const getStylePreviewStyle = (override, spanAnimations) => {
   if (!override || override.disabled) {
     return undefined;
   }
@@ -360,15 +360,19 @@ const getStylePreviewStyle = (override) => {
   if (size && size !== 100) {
     style['font-size'] = Math.min(200, Math.max(50, size)) + '%';
   }
-  const anim = MESSAGE_STYLE_ANIMATIONS.find(a => a.id === override.anim);
-  if (anim?.css) {
-    style['animation'] = anim.css;
+  // Как и в чате (.Chat--fxAnimOff), глобальный тумблер гасит
+  // пользовательские анимации и в превью.
+  if (spanAnimations !== false) {
+    const anim = MESSAGE_STYLE_ANIMATIONS.find(a => a.id === override.anim);
+    if (anim?.css) {
+      style['animation'] = anim.css;
+    }
   }
   return Object.keys(style).length > 0 ? style : undefined;
 };
 
 const MessageStyleRow = (props, context) => {
-  const { style, override, setOverride } = props;
+  const { style, override, setOverride, spanAnimations } = props;
   const selectedFont = MESSAGE_STYLE_FONTS.find(
     f => f.id === (override.font || ''));
   const selectedAnim = MESSAGE_STYLE_ANIMATIONS.find(
@@ -384,7 +388,7 @@ const MessageStyleRow = (props, context) => {
             <Box
               as="span"
               className={style.id}
-              style={getStylePreviewStyle(override)}>
+              style={getStylePreviewStyle(override, spanAnimations)}>
               {style.example}
             </Box>
           ) || (
@@ -497,6 +501,7 @@ export const SettingsTextStyles = (props, context) => {
           style={style}
           override={styleOverrides?.[style.id] || {}}
           setOverride={setOverride}
+          spanAnimations={spanAnimations}
         />
       ))}
       <Divider />

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -13,7 +13,7 @@ import { ChatPageSettings } from '../chat';
 import { rebuildChat, saveChatToDisk } from '../chat/actions';
 import { THEMES } from '../themes';
 import { changeSettingsTab, updateSettings } from './actions';
-import { CHAT_ANIM_SPEEDS, CHAT_ANIMATIONS, CHAT_BG_ANIMATIONS, CHAT_STYLES, FONTS, SETTINGS_TABS, TEXT_GLOW_OPTIONS, TIME_DIVIDER_INTERVALS, TIMESTAMP_FORMATS } from './constants';
+import { CHAT_ANIM_SPEEDS, CHAT_ANIMATIONS, CHAT_BG_ANIMATIONS, CHAT_STYLES, FONTS, MESSAGE_STYLE_ANIMATIONS, MESSAGE_STYLE_FONTS, MESSAGE_STYLES, SETTINGS_TABS, TEXT_GLOW_OPTIONS, TIME_DIVIDER_INTERVALS, TIMESTAMP_FORMATS } from './constants';
 import { selectActiveTab, selectSettings } from './selectors';
 
 /**
@@ -93,6 +93,9 @@ export const SettingsPanel = (props, context) => {
         )}
         {activeTab === 'appearance' && (
           <SettingsAppearance />
+        )}
+        {activeTab === 'textStyles' && (
+          <SettingsTextStyles />
         )}
         {activeTab === 'chatPage' && (
           <ChatPageSettings />
@@ -321,6 +324,198 @@ export const SettingsGeneral = (props, context) => {
         icon="save"
         onClick={() => dispatch(saveChatToDisk())}>
         Сохранить лог чата
+      </Button>
+    </Section>
+  );
+};
+
+// Инлайн-стиль превью: настройки применяются к чату через переменные
+// и динамическую таблицу на корне .Chat, панель настроек ими не
+// покрывается, поэтому превью собирает те же значения инлайном.
+const getStylePreviewStyle = (override) => {
+  if (!override || override.disabled) {
+    return undefined;
+  }
+  const style = {};
+  if (override.color) {
+    style['color'] = override.color;
+  }
+  if (override.font === 'normal') {
+    style['font-weight'] = 'normal';
+    style['font-style'] = 'normal';
+  }
+  else if (override.font === 'italic') {
+    style['font-weight'] = 'normal';
+    style['font-style'] = 'italic';
+  }
+  else if (override.font === 'bold') {
+    style['font-weight'] = 'bold';
+    style['font-style'] = 'normal';
+  }
+  else if (override.font === 'bolditalic') {
+    style['font-weight'] = 'bold';
+    style['font-style'] = 'italic';
+  }
+  const size = parseFloat(override.size);
+  if (size && size !== 100) {
+    style['font-size'] = Math.min(200, Math.max(50, size)) + '%';
+  }
+  const anim = MESSAGE_STYLE_ANIMATIONS.find(a => a.id === override.anim);
+  if (anim?.css) {
+    style['animation'] = anim.css;
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+};
+
+const MessageStyleRow = (props, context) => {
+  const { style, override, setOverride } = props;
+  const selectedFont = MESSAGE_STYLE_FONTS.find(
+    f => f.id === (override.font || ''));
+  const selectedAnim = MESSAGE_STYLE_ANIMATIONS.find(
+    a => a.id === (override.anim || ''));
+  return (
+    <Box mb={1.5}>
+      <Stack align="center" mb={0.5}>
+        <Stack.Item grow>
+          <Box as="span" bold color="label" mr={1}>
+            {style.name}:
+          </Box>
+          {!override.disabled && (
+            <Box
+              as="span"
+              className={style.id}
+              style={getStylePreviewStyle(override)}>
+              {style.example}
+            </Box>
+          ) || (
+            <Box as="span">
+              {style.example}
+            </Box>
+          )}
+        </Stack.Item>
+        <Stack.Item shrink={0}>
+          <Button.Checkbox
+            checked={!!override.disabled}
+            tooltip="Показывать как обычный текст"
+            onClick={() => setOverride(style.id, {
+              disabled: !override.disabled,
+            })}>
+            Откл.
+          </Button.Checkbox>
+        </Stack.Item>
+      </Stack>
+      {!override.disabled && (
+        <Flex wrap align="center">
+          <Flex.Item mr={1} mb={0.5}>
+            <ColorInput
+              value={override.color || ''}
+              placeholder="авто"
+              onChange={v => setOverride(style.id, {
+                color: v,
+              })}
+              onClear={() => setOverride(style.id, {
+                color: '',
+              })}
+            />
+          </Flex.Item>
+          <Flex.Item mr={1} mb={0.5}>
+            <Dropdown
+              width="8em"
+              selected={selectedFont?.name || MESSAGE_STYLE_FONTS[0].name}
+              options={MESSAGE_STYLE_FONTS.map(f => f.name)}
+              onSelected={value => {
+                const font = MESSAGE_STYLE_FONTS.find(f => f.name === value);
+                setOverride(style.id, {
+                  font: font?.id || '',
+                });
+              }}
+            />
+          </Flex.Item>
+          <Flex.Item mr={1} mb={0.5}>
+            <NumberInput
+              width="5.5em"
+              step={5}
+              stepPixelSize={4}
+              minValue={50}
+              maxValue={200}
+              unit="%"
+              value={parseFloat(override.size) || 100}
+              format={value => toFixed(value)}
+              onChange={(e, value) => setOverride(style.id, {
+                size: value,
+              })}
+            />
+          </Flex.Item>
+          <Flex.Item mb={0.5}>
+            <Dropdown
+              width="8em"
+              selected={selectedAnim?.name || MESSAGE_STYLE_ANIMATIONS[0].name}
+              options={MESSAGE_STYLE_ANIMATIONS.map(a => a.name)}
+              onSelected={value => {
+                const anim = MESSAGE_STYLE_ANIMATIONS.find(
+                  a => a.name === value);
+                setOverride(style.id, {
+                  anim: anim?.id || '',
+                });
+              }}
+            />
+          </Flex.Item>
+        </Flex>
+      )}
+    </Box>
+  );
+};
+
+export const SettingsTextStyles = (props, context) => {
+  const {
+    styleOverrides,
+    spanAnimations,
+  } = useSelector(context, selectSettings);
+  const dispatch = useDispatch(context);
+  const setOverride = (styleId, patch) => {
+    const prevEntry = styleOverrides?.[styleId] || {};
+    dispatch(updateSettings({
+      styleOverrides: {
+        ...styleOverrides,
+        [styleId]: {
+          ...prevEntry,
+          ...patch,
+        },
+      },
+    }));
+  };
+  return (
+    <Section>
+      <Box color="label" mb={1}>
+        Настройте вид частых стилей сообщений под себя: цвет,
+        начертание, размер и анимацию - или полностью стандартный
+        текст. Пустой цвет и вариант Тема = как в оформлении темы.
+      </Box>
+      {MESSAGE_STYLES.map(style => (
+        <MessageStyleRow
+          key={style.id}
+          style={style}
+          override={styleOverrides?.[style.id] || {}}
+          setOverride={setOverride}
+        />
+      ))}
+      <Divider />
+      <Button.Checkbox
+        checked={spanAnimations !== false}
+        tooltip="Мерцание и пульсация особых стилей: гипноз, глитч ИИ, помехи, делам и т.п. Выключает и ваши анимации выше."
+        onClick={() => dispatch(updateSettings({
+          spanAnimations: spanAnimations === false,
+        }))}>
+        Анимации особых стилей
+      </Button.Checkbox>
+      <Divider />
+      <Button
+        icon="undo"
+        onClick={() => dispatch(updateSettings({
+          styleOverrides: {},
+          spanAnimations: true,
+        }))}>
+        Сбросить стили текста
       </Button>
     </Section>
   );

--- a/tgui/packages/tgui-panel/settings/constants.js
+++ b/tgui/packages/tgui-panel/settings/constants.js
@@ -14,8 +14,71 @@ export const SETTINGS_TABS = [
     name: 'Оформление',
   },
   {
+    id: 'textStyles',
+    name: 'Стили текста',
+  },
+  {
     id: 'chatPage',
     name: 'Вкладки чата',
+  },
+];
+
+// Стили сообщений, доступные для кастомизации игроком.
+// id совпадает с CSS-классом спана и именем переменной --cs-<id>-color.
+// extraClasses - дополнительные спаны, которые красятся той же переменной
+// и сбрасываются тем же plain-классом.
+export const MESSAGE_STYLES = [
+  { id: 'emote', name: 'Эмоции', example: '* Пример эмоции персонажа' },
+  { id: 'whisper', name: 'Шёпот', example: 'Пример шёпота' },
+  { id: 'singing', name: 'Пение', example: 'Пример песни ~' },
+  { id: 'lewd', name: 'НСФВ', example: 'Пример непристойной фразы' },
+  { id: 'purr', name: 'Мурчание', example: 'Пример мурчания' },
+  { id: 'croon', name: 'Воркование', example: 'Пример воркования' },
+  { id: 'deadsay', name: 'Мёртвые', example: 'Пример речи призрака' },
+  {
+    id: 'telepathy',
+    name: 'Телепатия',
+    example: 'Пример телепатии',
+    extraClasses: ['telepathybold'],
+  },
+  { id: 'signlang', name: 'Жесты', example: 'Пример жестовой речи' },
+  { id: 'thought', name: 'Мысли', example: 'Пример мысли' },
+  { id: 'dream', name: 'Сны', example: 'Пример сна' },
+];
+
+// Начертание текста стиля: пусто = как в теме.
+export const MESSAGE_STYLE_FONTS = [
+  { id: '', name: 'Тема' },
+  { id: 'normal', name: 'Обычный' },
+  { id: 'italic', name: 'Курсив' },
+  { id: 'bold', name: 'Жирный' },
+  { id: 'bolditalic', name: 'Жирный курсив' },
+];
+
+// Декоративные анимации стиля: пусто = как в теме.
+// css - значение свойства animation; кейфреймы cs-* лежат в Chat.scss.
+export const MESSAGE_STYLE_ANIMATIONS = [
+  { id: '', name: 'Тема', css: null },
+  { id: 'none', name: 'Нет', css: 'none' },
+  {
+    id: 'pulse',
+    name: 'Пульс',
+    css: 'cs-pulse 2000ms ease-in-out infinite alternate',
+  },
+  {
+    id: 'glow',
+    name: 'Свечение',
+    css: 'cs-glow 2400ms ease-in-out infinite alternate',
+  },
+  {
+    id: 'flicker',
+    name: 'Мерцание',
+    css: 'cs-flicker 1600ms steps(4) infinite',
+  },
+  {
+    id: 'rainbow',
+    name: 'Радуга',
+    css: 'cs-rainbow 6000ms linear infinite',
   },
 ];
 

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -35,6 +35,9 @@ const initialState = {
   fontWeight: 400,
   letterSpacing: 0,
   borderRadius: 8,
+  // Кастомизация стилей сообщений: { [styleId]: { color, disabled } }
+  styleOverrides: {},
+  spanAnimations: true,
   // Timestamps & time dividers
   enableTimestamps: false,
   timestampFormat: 'hm',

--- a/tgui/packages/tgui-panel/styles/components/Chat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Chat.scss
@@ -84,10 +84,16 @@ $color-bg-section: base.$color-bg-section !default;
 
 .Chat__highlight {
   color: #000;
+  // Спаны с background-clip: text делают текст прозрачным через
+  // наследуемый -webkit-text-fill-color; без сброса подсветка
+  // превращается в нечитаемую цветную плашку.
+  -webkit-text-fill-color: #000;
+  text-shadow: none;
 }
 
 .Chat__highlight--restricted {
   color: #fff;
+  -webkit-text-fill-color: #fff;
   background-color: #a00;
   font-weight: bold;
 }
@@ -153,4 +159,161 @@ hr {
   margin-right: 2em;
   margin-bottom: 0.3em;
   margin-top: 0.3em;
+}
+
+// Кастомизация стилей сообщений (вкладка настроек "Стили текста").
+// Классы Chat--plain-<стиль> вешаются на корень чата и возвращают
+// выбранному спану вид обычного текста. Цвета переопределяются через
+// CSS-переменные --cs-<стиль>-color в темах goon/chat-dark|light.
+@mixin plain-message-style {
+  color: inherit;
+  font-family: inherit;
+  font-style: normal;
+  font-weight: inherit;
+  font-size: 100%;
+  letter-spacing: inherit;
+  opacity: 1;
+  text-shadow: none;
+  border-left: none;
+  padding-left: 0;
+  animation: none;
+  transform: none;
+}
+
+.Chat--plain-emote .emote {
+  @include plain-message-style;
+}
+
+.Chat--plain-whisper .whisper {
+  @include plain-message-style;
+}
+
+.Chat--plain-singing .singing {
+  @include plain-message-style;
+}
+
+.Chat--plain-lewd .lewd {
+  @include plain-message-style;
+}
+
+.Chat--plain-purr .purr {
+  @include plain-message-style;
+}
+
+.Chat--plain-croon .croon {
+  @include plain-message-style;
+}
+
+.Chat--plain-deadsay .deadsay {
+  @include plain-message-style;
+}
+
+.Chat--plain-telepathy .telepathy,
+.Chat--plain-telepathy .telepathybold {
+  @include plain-message-style;
+}
+
+.Chat--plain-signlang .signlang {
+  @include plain-message-style;
+}
+
+.Chat--plain-signlang .signlang::before {
+  content: none;
+}
+
+.Chat--plain-thought .thought {
+  @include plain-message-style;
+}
+
+.Chat--plain-thought .thought::before {
+  content: none;
+}
+
+.Chat--plain-dream .dream {
+  @include plain-message-style;
+}
+
+// Глобальный тумблер декоративных анимаций особых стилей чата.
+.Chat--fxAnimOff .mesmerize,
+.Chat--fxAnimOff .infernal_ascension,
+.Chat--fxAnimOff .supermatter_delam,
+.Chat--fxAnimOff .ai_corruption,
+.Chat--fxAnimOff .broadcast_static,
+.Chat--fxAnimOff .glitch,
+.Chat--fxAnimOff .dream,
+.Chat--fxAnimOff .last_breath {
+  animation: none;
+}
+
+// Библиотека анимаций для кастомизации стилей игроком.
+// Только opacity/text-shadow/color - transform ломает перенос строк,
+// а на длинных сообщениях это критично.
+@keyframes cs-pulse {
+  0% {
+    opacity: 0.6;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+// text-shadow без цвета = currentColor, свечение подстраивается
+// под выбранный игроком цвет стиля.
+@keyframes cs-glow {
+  0% {
+    text-shadow: 0 0 1px;
+  }
+
+  100% {
+    text-shadow: 0 0 7px;
+  }
+}
+
+@keyframes cs-flicker {
+  0% {
+    opacity: 0.95;
+  }
+
+  25% {
+    opacity: 0.7;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  75% {
+    opacity: 0.8;
+  }
+
+  100% {
+    opacity: 0.95;
+  }
+}
+
+@keyframes cs-rainbow {
+  0%, 100% {
+    color: #f06a6a;
+  }
+
+  17% {
+    color: #e8a13c;
+  }
+
+  33% {
+    color: #c9c93e;
+  }
+
+  50% {
+    color: #5cc95c;
+  }
+
+  67% {
+    color: #5aa8e8;
+  }
+
+  83% {
+    color: #b06ae0;
+  }
 }

--- a/tgui/packages/tgui-panel/styles/components/Chat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Chat.scss
@@ -84,6 +84,7 @@ $color-bg-section: base.$color-bg-section !default;
 
 .Chat__highlight {
   color: #000;
+
   // Спаны с background-clip: text делают текст прозрачным через
   // наследуемый -webkit-text-fill-color; без сброса подсветка
   // превращается в нечитаемую цветную плашку.
@@ -178,6 +179,10 @@ hr {
   padding-left: 0;
   animation: none;
   transform: none;
+  background: none;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
+  -webkit-text-fill-color: currentColor;
 }
 
 .Chat--plain-emote .emote {

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -341,14 +341,14 @@ em {
 }
 
 .emote {
-  color: #c8c8d2;
+  color: var(--cs-emote-color, #d6d6e0);
   font-style: italic;
   padding-left: 0.6em;
-  border-left: 2px solid rgba(150, 150, 170, 0.25);
+  border-left: 2px solid rgba(160, 160, 185, 0.4);
 }
 
 .deadsay {
-  color: #e2c1ff;
+  color: var(--cs-deadsay-color, #e2c1ff);
 }
 
 .binarysay {
@@ -1057,11 +1057,7 @@ blockquote.nicegreen {
 
 .lewd {
   font-style: italic;
-  background: linear-gradient(90deg, #ff5ea8, #c14bd6);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: #b14fd0;
-  -webkit-text-fill-color: transparent;
+  color: var(--cs-lewd-color, #e06bbe);
 }
 
 /* BLUEMOON ADD START - напитки для синтетиков */
@@ -1430,23 +1426,7 @@ blockquote.brass {
 .singing {
   font-family: "Trebuchet MS", cursive, sans-serif;
   font-style: italic;
-  letter-spacing: 0.6px;
-  background: linear-gradient(90deg, #7fd4ff, #c79cff, #ffa6d6);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: #c79cff;
-  -webkit-text-fill-color: transparent;
-  animation: song-drift 6000ms ease-in-out infinite alternate;
-}
-
-@keyframes song-drift {
-  0% {
-    filter: hue-rotate(0deg);
-  }
-
-  100% {
-    filter: hue-rotate(20deg);
-  }
+  color: var(--cs-singing-color, #c79cff);
 }
 
 .his_grace {
@@ -1766,19 +1746,15 @@ li {
 /* Голоса видов и существ */
 .ember {
   color: #c8753a;
-  font-family: Georgia, "Times New Roman", serif;
   text-shadow: 0 0 2px rgba(120, 45, 10, 0.55);
 }
 
 .felinspeak {
   color: #e58fce;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
 }
 
 .voxshriek {
   color: #4f9e8c;
-  font-family: "Consolas", "Courier New", monospace;
-  letter-spacing: -0.04em;
   font-weight: bold;
 }
 
@@ -1789,32 +1765,29 @@ li {
 
 .plasmavoice {
   color: #b58cff;
-  font-family: "Consolas", "Courier New", monospace;
   text-shadow: 0 0 2px rgba(150, 100, 255, 0.35);
 }
 
 .chitvoice {
   color: #8a9a32;
-  font-family: "Verdana", sans-serif;
-  letter-spacing: 0.02em;
 }
 
 .shadekinvoice {
-  color: #6b6f7a;
+  color: #767b87;
   font-style: italic;
   text-shadow: 0 0 3px rgba(40, 30, 70, 0.7);
 }
 
 .frostvoice {
   color: #9fd6e8;
-  font-size: 310%;
+  font-size: 185%;
   font-weight: bold;
   text-shadow: 0 0 4px rgba(120, 200, 230, 0.5);
 }
 
 .bloodmad {
   color: #c41010;
-  font-size: 310%;
+  font-size: 185%;
   font-weight: bold;
   font-style: italic;
   text-shadow: 0 0 3px rgba(120, 0, 0, 0.6);
@@ -1864,20 +1837,20 @@ li {
 .infernal_ascension {
   color: #ff5a1f;
   font-weight: bold;
-  font-size: 245%;
+  font-size: 185%;
   text-shadow: 0 0 8px rgba(255, 90, 0, 0.7);
-  animation: infernoflicker 220ms infinite alternate;
+  animation: infernoflicker 1400ms ease-in-out infinite alternate;
 }
 
 @keyframes infernoflicker {
   0% {
-    opacity: 0.82;
+    opacity: 0.92;
     text-shadow: 0 0 6px rgba(255, 80, 0, 0.55);
   }
 
   100% {
     opacity: 1;
-    text-shadow: 0 0 11px rgba(255, 140, 40, 0.85);
+    text-shadow: 0 0 10px rgba(255, 140, 40, 0.75);
   }
 }
 
@@ -1909,22 +1882,22 @@ li {
 }
 
 .mesmerize {
-  color: #b5103a;
+  color: #d42a52;
   font-style: italic;
   font-weight: bold;
-  text-shadow: 0 0 7px rgba(120, 0, 30, 0.7);
+  text-shadow: 0 0 6px rgba(120, 0, 30, 0.6);
   animation: mesmer-pulse 2600ms ease-in-out infinite alternate;
 }
 
 @keyframes mesmer-pulse {
   0% {
-    color: #7a0020;
-    text-shadow: 0 0 4px rgba(90, 0, 20, 0.6);
+    color: #b01840;
+    text-shadow: 0 0 4px rgba(90, 0, 20, 0.5);
   }
 
   100% {
-    color: #ff385f;
-    text-shadow: 0 0 11px rgba(180, 20, 60, 0.9);
+    color: #f04568;
+    text-shadow: 0 0 9px rgba(180, 20, 60, 0.7);
   }
 }
 
@@ -1959,28 +1932,21 @@ li {
   font-weight: bold;
   letter-spacing: 0.04em;
   color: #38e0e0;
-  animation: ai_glitch 900ms steps(2) infinite;
+  text-shadow: 1px 0 rgba(255, 43, 77, 0.6), -1px 0 rgba(26, 255, 255, 0.6);
+  animation: ai_glitch 2400ms steps(2) infinite;
 }
 
 @keyframes ai_glitch {
   0% {
-    color: #38e0e0;
-    text-shadow: 1px 0 #ff2b4d, -1px 0 #1affff;
+    text-shadow: 1px 0 rgba(255, 43, 77, 0.6), -1px 0 rgba(26, 255, 255, 0.6);
   }
 
-  45% {
-    color: #ff3b5c;
-    text-shadow: -1px 0 #38e0e0, 1px 0 #ff2b4d;
-  }
-
-  55% {
-    color: #9ef7f7;
-    text-shadow: 1px 0 #ff2b4d, -1px 0 #1affff;
+  50% {
+    text-shadow: -1px 0 rgba(255, 43, 77, 0.6), 1px 0 rgba(26, 255, 255, 0.6);
   }
 
   100% {
-    color: #38e0e0;
-    text-shadow: -1px 0 #ff2b4d, 1px 0 #1affff;
+    text-shadow: 1px 0 rgba(255, 43, 77, 0.6), -1px 0 rgba(26, 255, 255, 0.6);
   }
 }
 
@@ -1995,26 +1961,24 @@ li {
   color: #9aa0a3;
   font-family: Consolas, "Courier New", monospace;
   letter-spacing: 0.03em;
-  transform: skewX(-3deg);
-  display: inline-block;
-  animation: bcast_flicker 1600ms steps(3) infinite;
+  animation: bcast_flicker 2400ms steps(3) infinite;
 }
 
 @keyframes bcast_flicker {
   0% {
-    opacity: 0.85;
+    opacity: 0.95;
   }
 
   30% {
-    opacity: 0.55;
+    opacity: 0.75;
   }
 
   60% {
-    opacity: 0.92;
+    opacity: 1;
   }
 
   100% {
-    opacity: 0.7;
+    opacity: 0.85;
   }
 }
 
@@ -2026,10 +1990,9 @@ li {
 
 /* Коммуникационные режимы и состояния персонажа */
 .whisper {
-  color: #8f9bb3;
+  color: var(--cs-whisper-color, #97a3bd);
   font-style: italic;
-  font-size: 92%;
-  opacity: 0.82;
+  opacity: 0.92;
   letter-spacing: 0.02em;
 }
 
@@ -2037,7 +2000,7 @@ li {
   color: #9bb0d6;
   font-style: italic;
   letter-spacing: 1px;
-  opacity: 0.78;
+  opacity: 0.85;
   text-shadow: 0 0 5px rgba(155, 176, 214, 0.45);
   animation: last-fade 2200ms ease-out 1 both;
 }
@@ -2049,25 +2012,22 @@ li {
   }
 
   100% {
-    opacity: 0.6;
-    letter-spacing: 1.4px;
+    opacity: 0.78;
+    letter-spacing: 1.2px;
   }
 }
 
 .slurring {
   display: inline-block;
-  filter: blur(0.35px);
   letter-spacing: 0.4px;
   transform: skewX(-3deg);
-  opacity: 0.9;
 }
 
 .glitch {
   display: inline-block;
-  font-family: "Courier New", monospace;
   color: #6fe3ff;
-  text-shadow: -1px 0 rgba(255, 0, 90, 0.7), 1px 0 rgba(0, 255, 160, 0.7);
-  animation: glitch-jit 400ms steps(3) infinite;
+  text-shadow: -1px 0 rgba(255, 0, 90, 0.6), 1px 0 rgba(0, 255, 160, 0.6);
+  animation: glitch-jit 700ms steps(3) infinite;
 }
 
 @keyframes glitch-jit {
@@ -2089,21 +2049,20 @@ li {
 }
 
 .telepathy {
-  color: #6fd0e0;
+  color: var(--cs-telepathy-color, #6fd0e0);
   font-style: italic;
   text-shadow: 0 0 5px rgba(80, 180, 210, 0.45);
 }
 
 .telepathybold {
-  color: #6fd0e0;
+  color: var(--cs-telepathy-color, #6fd0e0);
   font-style: italic;
   font-weight: bold;
   text-shadow: 0 0 6px rgba(80, 180, 210, 0.55);
 }
 
 .signlang {
-  color: #c2a86a;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
+  color: var(--cs-signlang-color, #c2a86a);
   font-style: italic;
 }
 
@@ -2114,7 +2073,7 @@ li {
 }
 
 .thought {
-  color: #9d8fc4;
+  color: var(--cs-thought-color, #9d8fc4);
   font-style: italic;
   opacity: 0.9;
 }
@@ -2126,7 +2085,7 @@ li {
 }
 
 .dream {
-  color: #8a86b8;
+  color: var(--cs-dream-color, #8a86b8);
   font-style: italic;
   letter-spacing: 0.08em;
   animation: dreamhaze 5000ms infinite alternate;
@@ -2134,7 +2093,7 @@ li {
 
 @keyframes dreamhaze {
   0% {
-    opacity: 0.55;
+    opacity: 0.75;
   }
 
   100% {
@@ -2150,14 +2109,14 @@ li {
 }
 
 .purr {
-  color: #ff7eb0;
+  color: var(--cs-purr-color, #ff7eb0);
   font-style: italic;
   letter-spacing: 0.04em;
   text-shadow: 0 0 5px rgba(200, 80, 120, 0.4);
 }
 
 .croon {
-  color: #e07a8a;
+  color: var(--cs-croon-color, #e07a8a);
   font-style: italic;
   text-shadow: 0 0 5px rgba(150, 60, 70, 0.45);
 }

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -359,14 +359,14 @@ em {
 }
 
 .emote {
-  color: #55555f;
+  color: var(--cs-emote-color, #4a4a55);
   font-style: italic;
   padding-left: 0.6em;
-  border-left: 2px solid rgba(80, 80, 95, 0.25);
+  border-left: 2px solid rgba(80, 80, 95, 0.4);
 }
 
 .deadsay {
-  color: #5c00e6;
+  color: var(--cs-deadsay-color, #5c00e6);
 }
 
 .binarysay {
@@ -1091,11 +1091,7 @@ blockquote.nicegreen {
 
 .lewd {
   font-style: italic;
-  background: linear-gradient(90deg, #d6258f, #8b2fb0);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: #7a2d8f;
-  -webkit-text-fill-color: transparent;
+  color: var(--cs-lewd-color, #b0269c);
 }
 
 /* BLUEMOON ADD START - напитки для синтетиков */
@@ -1465,23 +1461,7 @@ blockquote.brass {
 .singing {
   font-family: "Trebuchet MS", cursive, sans-serif;
   font-style: italic;
-  letter-spacing: 0.6px;
-  background: linear-gradient(90deg, #2b6fb0, #6a3fb0, #b03d7a);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: #6a3fb0;
-  -webkit-text-fill-color: transparent;
-  animation: song-drift 6000ms ease-in-out infinite alternate;
-}
-
-@keyframes song-drift {
-  0% {
-    filter: hue-rotate(0deg);
-  }
-
-  100% {
-    filter: hue-rotate(20deg);
-  }
+  color: var(--cs-singing-color, #6a3fb0);
 }
 
 .his_grace {
@@ -1801,19 +1781,15 @@ li {
 /* Голоса видов и существ */
 .ember {
   color: #a85a23;
-  font-family: Georgia, "Times New Roman", serif;
   text-shadow: 0 0 2px rgba(120, 45, 10, 0.3);
 }
 
 .felinspeak {
   color: #c85bb0;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
 }
 
 .voxshriek {
   color: #3a7d6d;
-  font-family: "Consolas", "Courier New", monospace;
-  letter-spacing: -0.04em;
   font-weight: bold;
 }
 
@@ -1824,14 +1800,11 @@ li {
 
 .plasmavoice {
   color: #7d4fd6;
-  font-family: "Consolas", "Courier New", monospace;
   text-shadow: 0 0 2px rgba(150, 100, 255, 0.2);
 }
 
 .chitvoice {
   color: #6f7d22;
-  font-family: "Verdana", sans-serif;
-  letter-spacing: 0.02em;
 }
 
 .shadekinvoice {
@@ -1842,14 +1815,14 @@ li {
 
 .frostvoice {
   color: #4f9bb5;
-  font-size: 310%;
+  font-size: 185%;
   font-weight: bold;
   text-shadow: 0 0 4px rgba(120, 200, 230, 0.3);
 }
 
 .bloodmad {
   color: #c41010;
-  font-size: 310%;
+  font-size: 185%;
   font-weight: bold;
   font-style: italic;
   text-shadow: 0 0 3px rgba(120, 0, 0, 0.35);
@@ -1899,20 +1872,20 @@ li {
 .infernal_ascension {
   color: #e0461a;
   font-weight: bold;
-  font-size: 245%;
+  font-size: 185%;
   text-shadow: 0 0 8px rgba(255, 90, 0, 0.4);
-  animation: infernoflicker 220ms infinite alternate;
+  animation: infernoflicker 1400ms ease-in-out infinite alternate;
 }
 
 @keyframes infernoflicker {
   0% {
-    opacity: 0.82;
+    opacity: 0.92;
     text-shadow: 0 0 6px rgba(255, 80, 0, 0.4);
   }
 
   100% {
     opacity: 1;
-    text-shadow: 0 0 11px rgba(220, 110, 30, 0.6);
+    text-shadow: 0 0 10px rgba(220, 110, 30, 0.55);
   }
 }
 
@@ -1947,19 +1920,19 @@ li {
   color: #b5103a;
   font-style: italic;
   font-weight: bold;
-  text-shadow: 0 0 7px rgba(120, 0, 30, 0.45);
+  text-shadow: 0 0 6px rgba(120, 0, 30, 0.4);
   animation: mesmer-pulse 2600ms ease-in-out infinite alternate;
 }
 
 @keyframes mesmer-pulse {
   0% {
     color: #9c1030;
-    text-shadow: 0 0 4px rgba(90, 0, 20, 0.4);
+    text-shadow: 0 0 4px rgba(90, 0, 20, 0.35);
   }
 
   100% {
-    color: #ff385f;
-    text-shadow: 0 0 11px rgba(180, 20, 60, 0.6);
+    color: #d92b52;
+    text-shadow: 0 0 9px rgba(180, 20, 60, 0.5);
   }
 }
 
@@ -1994,28 +1967,21 @@ li {
   font-weight: bold;
   letter-spacing: 0.04em;
   color: #0aa0a0;
-  animation: ai_glitch 900ms steps(2) infinite;
+  text-shadow: 1px 0 rgba(209, 31, 60, 0.5), -1px 0 rgba(10, 160, 160, 0.5);
+  animation: ai_glitch 2400ms steps(2) infinite;
 }
 
 @keyframes ai_glitch {
   0% {
-    color: #0aa0a0;
-    text-shadow: 1px 0 #d11f3c, -1px 0 #0aa0a0;
+    text-shadow: 1px 0 rgba(209, 31, 60, 0.5), -1px 0 rgba(10, 160, 160, 0.5);
   }
 
-  45% {
-    color: #d11f3c;
-    text-shadow: -1px 0 #0aa0a0, 1px 0 #d11f3c;
-  }
-
-  55% {
-    color: #1593b8;
-    text-shadow: 1px 0 #d11f3c, -1px 0 #0aa0a0;
+  50% {
+    text-shadow: -1px 0 rgba(209, 31, 60, 0.5), 1px 0 rgba(10, 160, 160, 0.5);
   }
 
   100% {
-    color: #0aa0a0;
-    text-shadow: -1px 0 #d11f3c, 1px 0 #0aa0a0;
+    text-shadow: 1px 0 rgba(209, 31, 60, 0.5), -1px 0 rgba(10, 160, 160, 0.5);
   }
 }
 
@@ -2029,26 +1995,24 @@ li {
   color: #5c6163;
   font-family: Consolas, "Courier New", monospace;
   letter-spacing: 0.03em;
-  transform: skewX(-3deg);
-  display: inline-block;
-  animation: bcast_flicker 1600ms steps(3) infinite;
+  animation: bcast_flicker 2400ms steps(3) infinite;
 }
 
 @keyframes bcast_flicker {
   0% {
-    opacity: 0.85;
+    opacity: 0.95;
   }
 
   30% {
-    opacity: 0.55;
+    opacity: 0.75;
   }
 
   60% {
-    opacity: 0.92;
+    opacity: 1;
   }
 
   100% {
-    opacity: 0.7;
+    opacity: 0.85;
   }
 }
 
@@ -2060,10 +2024,9 @@ li {
 
 /* Коммуникационные режимы и состояния персонажа */
 .whisper {
-  color: #5a6478;
+  color: var(--cs-whisper-color, #5a6478);
   font-style: italic;
-  font-size: 92%;
-  opacity: 0.9;
+  opacity: 0.92;
   letter-spacing: 0.02em;
 }
 
@@ -2083,25 +2046,22 @@ li {
   }
 
   100% {
-    opacity: 0.7;
-    letter-spacing: 1.4px;
+    opacity: 0.78;
+    letter-spacing: 1.2px;
   }
 }
 
 .slurring {
   display: inline-block;
-  filter: blur(0.35px);
   letter-spacing: 0.4px;
   transform: skewX(-3deg);
-  opacity: 0.9;
 }
 
 .glitch {
   display: inline-block;
-  font-family: "Courier New", monospace;
   color: #0a6e9c;
-  text-shadow: -1px 0 rgba(200, 0, 70, 0.8), 1px 0 rgba(0, 150, 90, 0.8);
-  animation: glitch-jit 400ms steps(3) infinite;
+  text-shadow: -1px 0 rgba(200, 0, 70, 0.6), 1px 0 rgba(0, 150, 90, 0.6);
+  animation: glitch-jit 700ms steps(3) infinite;
 }
 
 @keyframes glitch-jit {
@@ -2123,21 +2083,20 @@ li {
 }
 
 .telepathy {
-  color: #2a8a9c;
+  color: var(--cs-telepathy-color, #2a8a9c);
   font-style: italic;
   text-shadow: 0 0 5px rgba(80, 180, 210, 0.25);
 }
 
 .telepathybold {
-  color: #2a8a9c;
+  color: var(--cs-telepathy-color, #2a8a9c);
   font-style: italic;
   font-weight: bold;
   text-shadow: 0 0 6px rgba(80, 180, 210, 0.3);
 }
 
 .signlang {
-  color: #8a6f2e;
-  font-family: "Trebuchet MS", Verdana, sans-serif;
+  color: var(--cs-signlang-color, #8a6f2e);
   font-style: italic;
 }
 
@@ -2148,7 +2107,7 @@ li {
 }
 
 .thought {
-  color: #6e5d9c;
+  color: var(--cs-thought-color, #6e5d9c);
   font-style: italic;
   opacity: 0.9;
 }
@@ -2160,7 +2119,7 @@ li {
 }
 
 .dream {
-  color: #5f5b8c;
+  color: var(--cs-dream-color, #5f5b8c);
   font-style: italic;
   letter-spacing: 0.08em;
   animation: dreamhaze 5000ms infinite alternate;
@@ -2168,7 +2127,7 @@ li {
 
 @keyframes dreamhaze {
   0% {
-    opacity: 0.7;
+    opacity: 0.75;
   }
 
   100% {
@@ -2184,14 +2143,14 @@ li {
 }
 
 .purr {
-  color: #c85b8a;
+  color: var(--cs-purr-color, #c85b8a);
   font-style: italic;
   letter-spacing: 0.04em;
   text-shadow: 0 0 5px rgba(200, 80, 120, 0.2);
 }
 
 .croon {
-  color: #b04d5d;
+  color: var(--cs-croon-color, #b04d5d);
   font-style: italic;
   text-shadow: 0 0 5px rgba(150, 60, 70, 0.25);
 }


### PR DESCRIPTION
# Описание

Разбор фидбека по #3366 плюс кастомизация стилей под каждого игрока.

Смягчил самое агрессивное: убрал градиенты у лювда и пения (именно они ломали подсветку слов - текст превращался в нечитаемую цветную плашку, а на переносе строки выглядел "50% одного цвета, 50% другого"), расовые голоса больше не сбрасывают кастомный шрифт игрока, шёпот больше не мельче основного текста, крики мегафауны ужаты с 310% до 185%, у пьяной речи убран блюр, быстрые мерцания (вознесение, малф-ИИ, помехи) замедлены и приглушены. Подсветка заодно защищена на уровне Chat.scss, чтобы никакой будущий стиль её снова не сломал

Вторая часть: в шестерёнке чата новая вкладка "Стили текста". Каждому из 11 частых стилей (эмоции, шёпот, пение, НСФВ, мурчание, воркование, мёртвые, телепатия, жесты, мысли, сны) можно задать свой цвет, начертание, размер (50-200%) и анимацию (пульс, свечение, мерцание, радуга), либо выключить оформление совсем - тогда это обычный текст. Есть общий тумблер анимаций особых стилей. Всё с живым превью и сохраняется вместе с остальными настройками панели

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Жалобы игроков после #3366: фильтр "цензурит" вместо подсветки, градиентный текст разноцветный в случайных местах, кастомный шрифт сбрасывается и текст мельче основного, лювд не дружит с хайлайтами. Кастомизация закрывает вопрос "мне не нравится стиль X" раз и навсегда - каждый настраивает под себя, а не ждёт правок на сервере

## Демонстрация изменений
<img width="704" height="860" alt="pr-chat-demo" src="https://github.com/user-attachments/assets/2418a6fa-9a96-4cd8-b783-291e908fc025" />
<img width="704" height="860" alt="pr-settings-tab" src="https://github.com/user-attachments/assets/309b082b-7a45-4132-9463-7b6be6c9a24e" />




## Changelog

:cl:
fix: подсветка слов снова читается на лювд-тексте и пении, вместо цветной плашки
tweak: стили чата стали спокойнее: без градиентов, гигантских шрифтов, блюра и резкого мерцания; расовые голоса больше не сбрасывают шрифт игрока
qol: новая вкладка "Стили текста" в настройках чата: цвет, начертание, размер и анимация для частых стилей сообщений, либо их полное отключение
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Добавлена новая вкладка «Стили текста» для настройки оформления сообщений.
  * Появились параметры для выбора цвета, шрифта, размера и анимации для разных типов сообщений.
  * Добавлен общий переключатель анимаций для специальных стилей.

* **Bug Fixes**
  * Улучшено отображение подсветки и текста сообщений, включая более стабильные цвета и поведение анимаций.
  * Настройки стилей теперь применяются корректно и сохраняются без лишних изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->