### PR TITLE
чиню фейл CL-проверки

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -78,7 +78,7 @@
 	var/obj/item/piece = part
 	REMOVE_TRAIT(piece, TRAIT_NODROP, MOD_TRAIT)
 	if(wearer)
-		wearer.doUnEquip(piece, force, null, FALSE)
+		wearer.transferItemToLoc(piece, piece.drop_location(), TRUE)
 	if(piece == helmet)
 		helmet.show_overslot()
 	if(piece == chestplate)


### PR DESCRIPTION
# Описание
меняю неверный прок на верный, теперь CL не будет фейлиться


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * При скрытии развернутой детали предмет теперь корректно возвращается в подходящее место рядом с владельцем, что улучшает поведение при снятии/скрытии элементов экипировки.
  * Сохранено корректное удаление ограничения на сброс предмета во время процедуры.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->