### PR TITLE
Атмосфера: идл-хартбит машин, шаблоны планетарки, индекс реакций и чистка чурна

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -31,6 +31,10 @@
 #define MINIMUM_TEMPERATURE_START_SUPERCONDUCTION	(T20C+200)
 #define MINIMUM_HEAT_CAPACITY	0.0003
 
+//PLANETARY ATMOS
+#define PLANET_SHARE_RATIO							0.8		//Ratio of the difference a planetary turf shares with its template atmosphere each cycle
+#define PLANET_SHARE_TEMPERATURE_CAPACITY			5		//Template heat capacity multiplier for the follow-up conductive temperature share, simulating a large atmosphere above the turf
+
 //HEAT TRANSFER COEFFICIENTS
 //Must be between 0 and 1. Values closer to 1 equalize temperature faster
 //Should not exceed 0.4 else strange heat flow occur

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -375,6 +375,21 @@ GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
 //If you're doing spreading things related to atmos, DO NOT USE CANATMOSPASS, IT IS NOT CHEAP. use this instead, the info is cached after all. it's tweaked just a bit to allow for circular checks
 #define TURFS_CAN_SHARE(T1, T2) (LAZYACCESS(T2.atmos_adjacent_turfs, T1) || LAZYLEN(T1.atmos_adjacent_turfs & T2.atmos_adjacent_turfs))
 
+/// Consecutive no-op SSair fires before a vent/scrubber drops into the idle heartbeat.
+#define ATMOS_MACHINE_IDLE_STREAK 4
+/// While idle, vents/scrubbers only run a full recheck this often. Event wakes
+/// (turf activation, pipenet pressure jump, radio signals, power, welding) clear
+/// the idle state instantly, so this is a safety net, not the response time.
+#define ATMOS_MACHINE_IDLE_HEARTBEAT (5 SECONDS)
+/// Pipenet pressure change (kPa) after reconcile that wakes idle machines attached to it.
+#define ATMOS_PIPENET_WAKE_PRESSURE_DELTA 5
+/// Vents ignore pressure imbalances smaller than this (kPa). Stops perpetual
+/// sub-visible top-ups that keep every room's turfs excited forever.
+#define ATMOS_VENT_PRESSURE_EPSILON 0.05
+/// Pure-telemetry devices (meters, air sensors) only report once per this many
+/// SSair fires; their power draw is compensated by the same constant.
+#define ATMOS_TELEMETRY_INTERVAL 4
+
 //Unomos - So for whatever reason, garbage collection actually drastically decreases the cost of atmos later in the round. Turning this into a define yields massively improved performance.
 #define GAS_GARBAGE_COLLECT(GASGASGAS)\
 	var/list/CACHE_GAS = GASGASGAS;\

--- a/code/__DEFINES/native_atmos_bindings.dm
+++ b/code/__DEFINES/native_atmos_bindings.dm
@@ -14,6 +14,15 @@
 	var/dm_registered_gas_mixtures = 0
 	/// Maximum number of simultaneously alive gas mixtures.
 	var/dm_max_registered_gas_mixtures = 0
+	/// Reaction pre-filter: gas id -> list of reactions keyed by that gas. A reaction
+	/// can only run if its key gas is present, so mixtures without exotic gases skip
+	/// the full 28-reaction requirement scan entirely. Built by auxtools_update_reactions().
+	var/list/reactions_by_key_gas
+	/// Reactions with no gas requirement at all (assoc: reaction -> its TEMP gate).
+	var/list/temp_gated_reactions
+	/// Lowest TEMP gate among temp_gated_reactions, for a single cheap precheck.
+	/// 1e30 acts as "no such reactions" (this file compiles before the INFINITY define).
+	var/temp_gated_min_temp = 1e30
 
 /datum/controller/subsystem/air/proc/get_max_gas_mixes()
 	return dm_max_registered_gas_mixtures
@@ -24,31 +33,51 @@
 /proc/equalize_all_gases_in_list(gas_list)
 	if(!length(gas_list))
 		return
-	var/datum/gas_mixture/total = new
-	var/list/datum/gas_mixture/participating = list()
+	// Runs for every dirty pipenet every fire: accumulate totals into reused
+	// static lists instead of allocating (and qdel-ing) a scratch gas_mixture.
+	var/static/list/total_gases = list()
+	var/static/list/datum/gas_mixture/participating = list()
+	total_gases.Cut()
+	participating.Cut()
 	var/total_volume = 0
-	for(var/datum/gas_mixture/G in gas_list)
-		if(G && !G.gc_share)
-			total.merge(G)
-			participating += G
-			total_volume += max(G.return_volume(), 0)
-	if(!length(participating))
-		qdel(total)
+	var/total_heat_capacity = 0
+	var/total_thermal_energy = 0
+	var/list/specific_heats = GLOB.gas_data.specific_heats
+	for(var/datum/gas_mixture/mix in gas_list)
+		if(!mix || mix.gc_share)
+			continue
+		participating += mix
+		total_volume += max(mix.volume, 0)
+		var/mix_heat_capacity = 0
+		var/list/mix_gases = mix.gases
+		for(var/id in mix_gases)
+			var/moles = mix_gases[id]
+			total_gases[id] = (total_gases[id] || 0) + moles
+			mix_heat_capacity += moles * (specific_heats[id] || 0)
+		mix_heat_capacity = max(mix_heat_capacity, mix.min_heat_capacity)
+		total_heat_capacity += mix_heat_capacity
+		total_thermal_energy += mix.temperature * mix_heat_capacity
+	if(!length(participating) || total_volume <= 0)
+		participating.Cut()
 		return
-	if(total_volume <= 0)
-		qdel(total)
-		return
-	var/target_temperature = total.return_temperature()
-	var/list/total_gases = total.gases
-	for(var/datum/gas_mixture/G in participating)
-		var/volume_ratio = G.return_volume() / total_volume
-		G.clear()
+	// Sequential capacity-weighted merges collapse to total energy over total
+	// capacity; TCMB matches the scratch mixture's default when nothing had heat.
+	var/target_temperature = TCMB
+	if(total_heat_capacity > 0)
+		target_temperature = max(total_thermal_energy / total_heat_capacity, TCMB)
+	var/inv_total_volume = 1 / total_volume
+	for(var/datum/gas_mixture/mix as anything in participating)
+		var/volume_ratio = max(mix.volume, 0) * inv_total_volume
+		var/list/mix_gases = mix.gases
+		mix_gases.Cut()
 		for(var/id in total_gases)
-			var/moles = (total_gases[id] || 0) * volume_ratio
+			var/moles = total_gases[id] * volume_ratio
 			if(moles > 0)
-				G.gases[id] = moles
-		G.set_temperature(target_temperature)
-	qdel(total)
+				mix_gases[id] = moles
+		mix.temperature = target_temperature
+	// Do not keep strong references to pipenet mixtures between calls.
+	participating.Cut()
+	total_gases.Cut()
 
 /datum/controller/subsystem/air/proc/process_turf_equalize_auxtools(remaining)
 	if(!equalize_enabled)
@@ -148,10 +177,13 @@
 			continue
 		if(T.excited_group || T.active_hotspot || T.planetary_atmos)
 			continue
-		var/current_pressure = T.air.return_pressure()
-		var/current_moles = T.air.total_moles()
-		if(current_moles <= MINIMUM_MOLES_DELTA_TO_MOVE && current_pressure <= (ONE_ATMOSPHERE * 0.05))
-			sleep_active_turf(T)
+		var/datum/gas_mixture/turf_air = T.air
+		var/current_moles = turf_air.total_moles()
+		if(current_moles <= MINIMUM_MOLES_DELTA_TO_MOVE)
+			var/volume_cache = turf_air.volume
+			var/current_pressure = volume_cache > 0 ? (current_moles * R_IDEAL_GAS_EQUATION * turf_air.temperature / volume_cache) : 0
+			if(current_pressure <= (ONE_ATMOSPHERE * 0.05))
+				sleep_active_turf(T)
 		if(world.tick_usage > Master.current_ticklimit)
 			pause()
 			return TRUE
@@ -169,8 +201,17 @@
 		return
 	T.excited = TRUE
 	active_turfs |= T
+	if(T.atmos_wake_machines)
+		for(var/obj/machinery/atmospherics/machine as anything in T.atmos_wake_machines)
+			machine.atmos_wake()
 	if(blockchanges && T.excited_group)
-		T.excited_group.garbage_collect()
+		// External gas changes must postpone group averaging/dismantling, which
+		// reset_cooldowns does; destroying the group here (the old behavior) made
+		// every vent top-up and mob breath rebuild whole room groups from scratch
+		// each fire, keeping hundreds of settled turfs permanently active.
+		// Structural (adjacency) changes DO dismantle the group - see
+		// /turf/air_update_turf(update = TRUE).
+		T.excited_group.reset_cooldowns()
 
 /datum/controller/subsystem/air/proc/sleep_active_turf(turf/open/T)
 	active_turfs -= T
@@ -178,11 +219,58 @@
 /datum/controller/subsystem/air/proc/thread_running()
 	return FALSE
 
+/// Returns the shared immutable gas mixture a planetary turf regenerates toward.
+/// Built once per unique gas string; replaces the old per-turf-per-cycle
+/// `new + parse_gas_string + qdel` in process_cell. Keyed by the raw
+/// initial_gas_mix string, matching what ashwalker lungs look up
+/// (SSair.planetary[LAVALAND_DEFAULT_ATMOS]).
+/datum/controller/subsystem/air/proc/get_planetary_template(turf/open/T)
+	var/cache_key = T.initial_gas_mix
+	var/datum/gas_mixture/template = planetary[cache_key]
+	if(template)
+		return template
+	template = new(CELL_VOLUME)
+	template.set_temperature(initial(T.initial_temperature))
+	template.parse_gas_string(cache_key)
+	template.mark_immutable()
+	planetary[cache_key] = template
+	return template
+
 /proc/finalize_gas_refs()
 	return
 
 /datum/controller/subsystem/air/proc/auxtools_update_reactions()
-	return
+	var/list/by_gas = list()
+	var/list/temp_gated = list()
+	var/gate_floor = 1e30
+	var/index = 0
+	for(var/datum/gas_reaction/reaction as anything in gas_reactions)
+		index++
+		reaction.sort_index = index
+		var/list/reqs = reaction.min_requirements
+		var/key_gas
+		for(var/id in reqs)
+			if(id == "TEMP" || id == "ENER" || id == "MAX_TEMP" || id == "FIRE_REAGENTS")
+				continue
+			if(isnull(key_gas))
+				key_gas = id
+			else if(key_gas == GAS_O2 || key_gas == GAS_N2 || key_gas == GAS_CO2 || key_gas == GAS_H2O)
+				// Prefer a rarer key so common-air mixtures never pull this reaction
+				// in as a candidate; any other requirement gas beats the air staples.
+				key_gas = id
+		if(key_gas)
+			var/list/bucket = by_gas[key_gas]
+			if(!bucket)
+				bucket = list()
+				by_gas[key_gas] = bucket
+			bucket += reaction
+		else
+			var/temp_gate = reqs["TEMP"] || 0
+			temp_gated[reaction] = temp_gate
+			gate_floor = min(gate_floor, temp_gate)
+	reactions_by_key_gas = by_gas
+	temp_gated_reactions = temp_gated
+	temp_gated_min_temp = gate_floor
 
 /proc/auxtools_atmos_init(gas_data)
 	return TRUE
@@ -228,6 +316,9 @@
 	else
 		SSair.dm_registered_turfs |= open_turf
 		if((flag & AIR_REF_PLANETARY_TURF) && !istype(open_turf, /turf/open/space))
+			// Eagerly build the shared planetary template so consumers that read
+			// SSair.planetary directly (ashwalker lungs) find it populated.
+			SSair.get_planetary_template(open_turf)
 			SSair.add_to_active(open_turf, FALSE)
 
 /proc/_dm_atmos_should_process_pair(turf/open/source, turf/open/target)
@@ -379,14 +470,52 @@
 	ratio_arg = clamp(ratio_arg, 0, 1)
 	__remove(into, total_moles() * ratio_arg)
 
+/// Moves `ratio` (0..1) of every gas from src into other in place, with the same
+/// temperature math as merge(remove(...)), without allocating a temporary mixture.
+/// Callers guarantee ratio > 0 and both mixtures mutable.
+/// Returns TRUE only when gas actually moved, matching vent_moles/vent_ratio, so
+/// callers can treat the result as "did work" for idle accounting.
+/datum/gas_mixture/proc/__transfer_ratio_direct(datum/gas_mixture/other, ratio)
+	var/list/cached_gases = gases
+	var/list/other_gases = other.gases
+	var/heat_transfer = abs(other.temperature - temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER
+	var/other_old_capacity = 0
+	var/moved_heat_capacity = 0
+	var/list/cached_gasheats
+	if(heat_transfer)
+		other_old_capacity = other.heat_capacity()
+		cached_gasheats = GLOB.gas_data.specific_heats
+	var/moved_any = FALSE
+	for(var/id in cached_gases)
+		var/moved = cached_gases[id] * ratio
+		if(moved <= 0)
+			continue
+		moved_any = TRUE
+		other_gases[id] = (other_gases[id] || 0) + moved
+		cached_gases[id] -= moved
+		if(heat_transfer)
+			moved_heat_capacity += moved * (cached_gasheats[id] || 0)
+	if(!moved_any)
+		return FALSE
+	if(heat_transfer && moved_heat_capacity > 0)
+		var/combined_heat_capacity = other_old_capacity + moved_heat_capacity
+		other.temperature = (temperature * moved_heat_capacity + other.temperature * other_old_capacity) / combined_heat_capacity
+	GAS_GARBAGE_COLLECT(cached_gases)
+	return TRUE
+
 /datum/gas_mixture/proc/transfer_to(datum/gas_mixture/other, moles)
 	if(gc_share || !other || other.gc_share)
 		return FALSE
-	var/datum/gas_mixture/removed = new type(volume)
-	__remove(removed, moles)
-	other.merge(removed)
-	qdel(removed)
-	return TRUE
+	var/list/cached_gases = gases
+	var/sum = 0
+	for(var/id in cached_gases)
+		sum += cached_gases[id]
+	moles = min(moles, sum)
+	if(moles <= 0)
+		// Nothing to move (empty source): report no-op so vents/pumps can idle
+		// instead of counting a phantom transfer every fire.
+		return FALSE
+	return __transfer_ratio_direct(other, moles / sum)
 
 /datum/gas_mixture/proc/get_oxidation_power(temp)
 	if(isnull(temp))
@@ -435,11 +564,49 @@
 /datum/gas_mixture/proc/transfer_ratio_to(datum/gas_mixture/other, ratio)
 	if(gc_share || !other || other.gc_share)
 		return FALSE
-	var/datum/gas_mixture/removed = new type(volume)
-	__remove_ratio(removed, ratio)
-	other.merge(removed)
-	qdel(removed)
+	ratio = clamp(ratio, 0, 1)
+	if(ratio <= 0)
+		// See transfer_to(): a no-op must not read as a successful transfer.
+		return FALSE
+	return __transfer_ratio_direct(other, ratio)
+
+/// Discards `ratio` (0..1) of every gas in place: venting into an infinite sink
+/// (space). Equivalent to qdel(remove_ratio(ratio)) without the allocation.
+/// Returns TRUE if any gas was actually discarded.
+/datum/gas_mixture/proc/vent_ratio(ratio)
+	if(gc_share)
+		return FALSE
+	ratio = clamp(ratio, 0, 1)
+	if(ratio <= 0)
+		return FALSE
+	var/keep = 1 - ratio
+	var/vented = 0
+	var/list/cached_gases = gases
+	for(var/id in cached_gases)
+		var/current_moles = cached_gases[id]
+		if(current_moles <= 0)
+			continue
+		vented += current_moles * ratio
+		cached_gases[id] = current_moles * keep
+	if(vented <= 0)
+		return FALSE
+	GAS_GARBAGE_COLLECT(cached_gases)
 	return TRUE
+
+/// Discards `moles` of gas in place, proportionally across all gases.
+/// Equivalent to qdel(remove(moles)) without the allocation.
+/// Returns TRUE if any gas was actually discarded.
+/datum/gas_mixture/proc/vent_moles(moles)
+	if(gc_share)
+		return FALSE
+	var/list/cached_gases = gases
+	var/sum = 0
+	for(var/id in cached_gases)
+		sum += cached_gases[id]
+	moles = min(moles, sum)
+	if(moles <= 0)
+		return FALSE
+	return vent_ratio(moles / sum)
 
 /datum/gas_mixture/proc/adjust_heat(heat)
 	if(gc_share)
@@ -452,14 +619,24 @@
 /datum/gas_mixture/proc/compare(datum/gas_mixture/other)
 	if(!other)
 		return "invalid"
-	for(var/id in gases | other.gases)
-		var/gas_moles = gases[id] || 0
-		var/other_moles = other.gases[id] || 0
-		var/delta = abs(gas_moles - other_moles)
+	// Runs for every adjacent turf pair every cycle: iterate both key sets directly
+	// instead of allocating a `gases | other.gases` union list per call.
+	var/list/cached_gases = gases
+	var/list/other_gases = other.gases
+	var/our_moles = 0
+	for(var/id in cached_gases)
+		var/gas_moles = cached_gases[id] || 0
+		our_moles += gas_moles
+		var/delta = abs(gas_moles - (other_gases[id] || 0))
 		if(delta > MINIMUM_MOLES_DELTA_TO_MOVE)
 			if(delta > gas_moles * MINIMUM_AIR_RATIO_TO_MOVE)
 				return id
-	var/our_moles = total_moles()
+	for(var/id in other_gases)
+		if(id in cached_gases)
+			continue
+		// gas_moles is 0 for ids we lack, so the ratio gate is always passed.
+		if(abs(other_gases[id] || 0) > MINIMUM_MOLES_DELTA_TO_MOVE)
+			return id
 	if(our_moles > MINIMUM_MOLES_DELTA_TO_MOVE)
 		if(abs(temperature - other.temperature) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
 			return "temp"
@@ -467,27 +644,46 @@
 
 /datum/gas_mixture/proc/mark_immutable()
 	gc_share = TRUE
+	immutable_heat_capacity = heat_capacity()
 	return TRUE
 
+/// Moves `ratio_v` of the gases named in gas_list into `into` in place, with the
+/// same temperature math as merge(removed portion). Returns TRUE only when gas
+/// actually moved, so callers can skip turf/pipenet updates for clean rooms.
 /datum/gas_mixture/proc/scrub_into(datum/gas_mixture/into, ratio_v, list/gas_list)
 	if(gc_share || !into || into.gc_share)
 		return FALSE
 	ratio_v = clamp(ratio_v, 0, 1)
 	if(ratio_v <= 0 || !length(gas_list))
 		return FALSE
-	var/datum/gas_mixture/removed = new type(volume)
-	removed.temperature = temperature
+	var/list/cached_gases = gases
+	var/list/into_gases = into.gases
+	var/heat_transfer = abs(into.temperature - temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER
+	var/into_old_capacity = 0
+	var/moved_heat_capacity = 0
+	var/list/cached_gasheats
+	if(heat_transfer)
+		into_old_capacity = into.heat_capacity()
+		cached_gasheats = GLOB.gas_data.specific_heats
+	var/moved_any = FALSE
 	for(var/gid in gas_list)
-		var/current_moles = gases[gid] || 0
+		var/current_moles = cached_gases[gid] || 0
 		if(current_moles <= 0)
 			continue
-		var/m = current_moles * ratio_v
-		if(m > 0)
-			removed.gases[gid] = (removed.gases[gid] || 0) + m
-			gases[gid] = current_moles - m
-	GAS_GARBAGE_COLLECT(gases)
-	into.merge(removed)
-	qdel(removed)
+		var/moved = current_moles * ratio_v
+		if(moved <= 0)
+			continue
+		moved_any = TRUE
+		into_gases[gid] = (into_gases[gid] || 0) + moved
+		cached_gases[gid] = current_moles - moved
+		if(heat_transfer)
+			moved_heat_capacity += moved * (cached_gasheats[gid] || 0)
+	if(!moved_any)
+		return FALSE
+	if(heat_transfer && moved_heat_capacity > 0)
+		var/combined_heat_capacity = into_old_capacity + moved_heat_capacity
+		into.temperature = (temperature * moved_heat_capacity + into.temperature * into_old_capacity) / combined_heat_capacity
+	GAS_GARBAGE_COLLECT(cached_gases)
 	return TRUE
 
 /datum/gas_mixture/proc/get_by_flag(flag_val)
@@ -600,23 +796,88 @@
 
 /datum/gas_mixture/proc/react(datum/holder)
 	. = NO_REACTION
-	if(!total_moles())
+	var/list/cached_gases = gases
+	var/total = 0
+	for(var/id in cached_gases)
+		total += cached_gases[id]
+	if(!total)
 		return
-	var/list/reactions = list()
-	for(var/datum/gas_reaction/G in SSair.gas_reactions)
-		reactions += G
-	if(!length(reactions))
-		return
-	reaction_results = new
-	var/temp = return_temperature()
-	var/ener = thermal_energy()
-	reaction_loop:
-		for(var/r in reactions)
-			var/datum/gas_reaction/reaction = r
-			var/list/min_reqs = reaction.min_requirements
-			if((min_reqs["TEMP"] && temp < min_reqs["TEMP"]) \
-			|| (min_reqs["ENER"] && ener < min_reqs["ENER"]))
+
+	// Gather candidates through the key-gas index instead of scanning every
+	// registered reaction: a reaction can only fire if its key gas is present.
+	// This runs for every active turf, pipenet and portable every SSair fire,
+	// and ordinary o2/n2 air resolves to zero candidates.
+	var/temp = temperature
+	var/list/candidates
+	// The single-bucket case (one keyed gas present, by far the most common)
+	// borrows the prebuilt bucket read-only: buckets are already in sort_index
+	// order and the reaction loop never mutates the list, so both the copy and
+	// the re-sort below are only needed once a second source gets appended.
+	var/candidates_owned = FALSE
+	var/list/by_gas = SSair.reactions_by_key_gas
+	if(by_gas)
+		for(var/id in cached_gases)
+			var/list/bucket = by_gas[id]
+			if(!bucket)
 				continue
+			if(!candidates)
+				candidates = bucket
+			else
+				if(!candidates_owned)
+					candidates = candidates.Copy()
+					candidates_owned = TRUE
+				candidates += bucket
+		if(temp >= SSair.temp_gated_min_temp)
+			var/list/temp_gated = SSair.temp_gated_reactions
+			for(var/r in temp_gated)
+				if(temp >= temp_gated[r])
+					if(!candidates)
+						candidates = list()
+						candidates_owned = TRUE
+					else if(!candidates_owned)
+						candidates = candidates.Copy()
+						candidates_owned = TRUE
+					candidates += r
+	else
+		candidates = SSair.gas_reactions.Copy()
+		candidates_owned = TRUE
+
+	// Every react() past the moles gate must leave reaction_results reflecting
+	// only this call: hotspots read reaction_results["fire"] right after react().
+	if(length(reaction_results))
+		reaction_results.Cut()
+	else if(!reaction_results)
+		reaction_results = new
+
+	if(!length(candidates))
+		return
+
+	// Restore the priority order of the full-list scan (insertion sort; the
+	// candidate list is nearly always 1-3 entries). A borrowed single bucket is
+	// already sorted and must not be written to.
+	if(candidates_owned && candidates.len > 1)
+		for(var/i in 2 to candidates.len)
+			var/datum/gas_reaction/shifted = candidates[i]
+			var/hole = i - 1
+			while(hole >= 1)
+				var/datum/gas_reaction/other = candidates[hole]
+				if(other.sort_index <= shifted.sort_index)
+					break
+				candidates[hole + 1] = other
+				hole--
+			candidates[hole + 1] = shifted
+
+	var/ener = -1
+	reaction_loop:
+		for(var/datum/gas_reaction/reaction as anything in candidates)
+			var/list/min_reqs = reaction.min_requirements
+			if(min_reqs["TEMP"] && temp < min_reqs["TEMP"])
+				continue
+			if(min_reqs["ENER"])
+				if(ener < 0)
+					ener = thermal_energy()
+				if(ener < min_reqs["ENER"])
+					continue
 			if(min_reqs["MAX_TEMP"] && temp > min_reqs["MAX_TEMP"])
 				continue
 			for(var/id in min_reqs)
@@ -626,7 +887,7 @@
 					if(get_oxidation_power(temp) < min_reqs[id] || get_fuel_amount(temp) < min_reqs[id])
 						continue reaction_loop
 					continue
-				if(get_moles(id) < min_reqs[id])
+				if((cached_gases[id] || 0) < min_reqs[id])
 					continue reaction_loop
 			. |= reaction.react(src, holder)
 			if(. & STOP_REACTIONS)

--- a/code/__DEFINES/native_atmos_bindings.dm
+++ b/code/__DEFINES/native_atmos_bindings.dm
@@ -216,8 +216,15 @@
 		// /turf/air_update_turf(update = TRUE).
 		T.excited_group.reset_cooldowns()
 
+/// Rests a turf without touching its excited group: the turf stops paying
+/// process_cell, but stays in the group's turf_list so breakdown/dismantle
+/// bookkeeping continues. This is the individual escape hatch for settled
+/// members of groups that are pinned awake by a few churning turfs
+/// (planetary surfaces around a leak, space-edge drains).
 /datum/controller/subsystem/air/proc/sleep_active_turf(turf/open/T)
 	active_turfs -= T
+	if(istype(T))
+		T.excited = FALSE
 
 /datum/controller/subsystem/air/proc/thread_running()
 	return FALSE

--- a/code/__DEFINES/native_atmos_bindings.dm
+++ b/code/__DEFINES/native_atmos_bindings.dm
@@ -1,5 +1,9 @@
 // Атмосфера на DM (газ в gas_mixture.gases, реакции в react(), без Auxmos).
 
+/// Sentinel temperature gate meaning "no temperature-gated reactions exist".
+/// A plain huge constant because this file compiles before the INFINITY define.
+#define ATMOS_NO_TEMPERATURE_GATE 1e30
+
 // Подсистема и глобальные заглушки
 /datum/controller/subsystem/air
 	/// Open turfs that participate in native DM atmos processing.
@@ -21,8 +25,7 @@
 	/// Reactions with no gas requirement at all (assoc: reaction -> its TEMP gate).
 	var/list/temp_gated_reactions
 	/// Lowest TEMP gate among temp_gated_reactions, for a single cheap precheck.
-	/// 1e30 acts as "no such reactions" (this file compiles before the INFINITY define).
-	var/temp_gated_min_temp = 1e30
+	var/temp_gated_min_temp = ATMOS_NO_TEMPERATURE_GATE
 
 /datum/controller/subsystem/air/proc/get_max_gas_mixes()
 	return dm_max_registered_gas_mixtures
@@ -242,7 +245,7 @@
 /datum/controller/subsystem/air/proc/auxtools_update_reactions()
 	var/list/by_gas = list()
 	var/list/temp_gated = list()
-	var/gate_floor = 1e30
+	var/gate_floor = ATMOS_NO_TEMPERATURE_GATE
 	var/index = 0
 	for(var/datum/gas_reaction/reaction as anything in gas_reactions)
 		index++
@@ -801,6 +804,10 @@
 	for(var/id in cached_gases)
 		total += cached_gases[id]
 	if(!total)
+		// A mixture that reacted on a previous call and has since been emptied
+		// must not leave stale per-call results (hotspots read them after react()).
+		if(length(reaction_results))
+			reaction_results.Cut()
 		return
 
 	// Gather candidates through the key-gas index instead of scanning every

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -120,6 +120,74 @@ SUBSYSTEM_DEF(air)
 	set name="Fix Infinite Air"
 	fix_corrupted_atmos()
 
+/datum/admins/proc/atmos_active_report()
+	set category = "Debug.3) Fixing"
+	set desc = "Breakdown of SSair active turfs by z-level and area, for hunting atmos churn."
+	set name = "Atmos Active Turfs Report"
+
+	var/list/z_counts = list()
+	var/list/area_turfs = list()
+	var/planetary_count = 0
+	var/grouped_count = 0
+	var/sharing_count = 0
+	for(var/turf/open/active_turf as anything in SSair.active_turfs)
+		if(!istype(active_turf))
+			continue
+		z_counts["z[active_turf.z]"]++
+		var/area/turf_area = active_turf.loc
+		var/area_key = "[turf_area.type]"
+		var/list/bucket = area_turfs[area_key]
+		if(!bucket)
+			bucket = list()
+			area_turfs[area_key] = bucket
+		bucket += active_turf
+		if(active_turf.planetary_atmos)
+			planetary_count++
+		if(active_turf.excited_group)
+			grouped_count++
+		if(active_turf.air?.last_share > MINIMUM_MOLES_DELTA_TO_MOVE)
+			sharing_count++
+
+	var/list/output = list("<b>SSair active turfs: [length(SSair.active_turfs)]</b> (excited groups: [length(SSair.excited_groups)], in groups: [grouped_count], planetary: [planetary_count], actively sharing: [sharing_count])")
+	var/list/z_lines = list()
+	for(var/z_key in z_counts)
+		z_lines += "[z_key]: [z_counts[z_key]]"
+	output += "By z-level: [z_lines.Join(", ")]"
+	output += "Top areas (count, sharing, planetary, pressure span, temp span):"
+	var/shown = 0
+	while(shown < 15 && length(area_turfs))
+		var/best_key
+		var/best_count = 0
+		for(var/area_key in area_turfs)
+			if(length(area_turfs[area_key]) > best_count)
+				best_count = length(area_turfs[area_key])
+				best_key = area_key
+		var/list/turfs = area_turfs[best_key]
+		var/area_sharing = 0
+		var/area_planetary = 0
+		var/pressure_min = INFINITY
+		var/pressure_max = 0
+		var/temp_min = INFINITY
+		var/temp_max = 0
+		for(var/turf/open/area_turf as anything in turfs)
+			if(!area_turf.air)
+				continue
+			if(area_turf.air.last_share > MINIMUM_MOLES_DELTA_TO_MOVE)
+				area_sharing++
+			if(area_turf.planetary_atmos)
+				area_planetary++
+			var/pressure = area_turf.air.return_pressure()
+			pressure_min = min(pressure_min, pressure)
+			pressure_max = max(pressure_max, pressure)
+			var/turf_temp = area_turf.air.return_temperature()
+			temp_min = min(temp_min, turf_temp)
+			temp_max = max(temp_max, turf_temp)
+		output += "  [best_count] ([area_sharing] sharing, [area_planetary] planetary, [round(pressure_min, 0.1)]-[round(pressure_max, 0.1)] kPa, [round(temp_min, 0.1)]-[round(temp_max, 0.1)] K) - [best_key]"
+		area_turfs -= best_key
+		shown++
+
+	to_chat(usr, output.Join("<br>"))
+
 /datum/controller/subsystem/air/fire(resumed = 0)
 	var/timer = TICK_USAGE_REAL
 

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -46,6 +46,10 @@
 		icon_state = "gsensor[on]"
 
 /obj/machinery/air_sensor/process_atmos()
+	// Pure telemetry for the atmos monitoring computers: a 2s report cadence is
+	// plenty and skips the per-fire signal allocation and radio dispatch.
+	if(SSair.times_fired % ATMOS_TELEMETRY_INTERVAL)
+		return
 	if(on)
 		var/datum/gas_mixture/air_sample = return_air()
 

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -139,8 +139,11 @@
 	item_state = "smmop"
 	force = 128
 
-/obj/item/mop/advanced/New()
-	..()
+/obj/item/mop/advanced/Initialize(mapload)
+	. = ..()
+	// Processing must not start before Initialize: the parent creates reagents
+	// here, and a map-loaded mop otherwise gets process() calls with null
+	// reagents for the whole deferred-init window of the map load.
 	START_PROCESSING(SSobj, src)
 
 /obj/item/mop/advanced/AltClick(mob/user)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -144,7 +144,8 @@
 	// Processing must not start before Initialize: the parent creates reagents
 	// here, and a map-loaded mop otherwise gets process() calls with null
 	// reagents for the whole deferred-init window of the map load.
-	START_PROCESSING(SSobj, src)
+	if(refill_enabled)
+		START_PROCESSING(SSobj, src)
 
 /obj/item/mop/advanced/AltClick(mob/user)
 	refill_enabled = !refill_enabled
@@ -165,8 +166,9 @@
 	. += span_notice("The condenser switch is set to <b>[refill_enabled ? "ON" : "OFF"]</b>. Alt-Click to toggle.")
 
 /obj/item/mop/advanced/Destroy()
-	if(refill_enabled)
-		STOP_PROCESSING(SSobj, src)
+	// Unconditional: refill_enabled can change over the item's lifetime
+	// (AltClick, VV), and STOP_PROCESSING on a non-processing item is a no-op.
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/mop/advanced/cyborg

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -227,6 +227,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	#endif
 	/datum/admins/proc/create_or_modify_area,
 	/datum/admins/proc/fixcorruption,
+	/datum/admins/proc/atmos_active_report,
 	// /client/proc/check_timer_sources,
 	/client/proc/toggle_cdn,
 	/client/proc/discordnulls,

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -148,6 +148,14 @@
 		return
 	if(update)
 		ImmediateCalculateAdjacentTurfs()
+		// Adjacency just changed (door, window, densified atom): an excited group
+		// spanning the new blockage would later self_breakdown its averaged mix
+		// across both sides, so it must dismantle; the turfs stay active and
+		// rebuild groups that honor the new adjacency. Pure gas changes go through
+		// add_to_active alone and keep their group.
+		var/turf/open/open_self = src
+		if(istype(open_self) && open_self.excited_group)
+			open_self.excited_group.garbage_collect()
 	if(remove)
 		SSair.remove_from_active(src)
 	else

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -242,12 +242,36 @@
 
 /////////////////////////////SIMULATION///////////////////////////////////
 
+// Significant gas movement also resets the receiving tile's stall counter and
+// wakes it if it was resting: resting turfs stay in their excited group and
+// receive gas passively, so anything meaningfully fed by a neighbor must come
+// back to the active list to re-share (and, for planetary turfs, re-equalize
+// with their template).
 #define LAST_SHARE_CHECK \
 	var/last_share = our_air.last_share; \
 	if(last_share > MINIMUM_AIR_TO_SUSPEND){ \
 		our_excited_group.reset_cooldowns(); \
 		cached_atmos_cooldown = 0; \
+		enemy_tile.atmos_cooldown = 0; \
+		if(!enemy_tile.excited && SSair){ \
+			SSair.add_to_active(enemy_tile, FALSE); \
+		} \
 	} else if(last_share > MINIMUM_MOLES_DELTA_TO_MOVE) { \
+		our_excited_group.dismantle_cooldown = 0; \
+		cached_atmos_cooldown = 0; \
+		enemy_tile.atmos_cooldown = 0; \
+		if(!enemy_tile.excited && SSair){ \
+			SSair.add_to_active(enemy_tile, FALSE); \
+		} \
+	}
+
+// Same cooldown handling for the template share; there is no enemy tile here.
+#define PLANET_SHARE_CHECK \
+	var/planet_last_share = our_air.last_share; \
+	if(planet_last_share > MINIMUM_AIR_TO_SUSPEND){ \
+		our_excited_group.reset_cooldowns(); \
+		cached_atmos_cooldown = 0; \
+	} else if(planet_last_share > MINIMUM_MOLES_DELTA_TO_MOVE) { \
 		our_excited_group.dismantle_cooldown = 0; \
 		cached_atmos_cooldown = 0; \
 	}
@@ -393,8 +417,6 @@
 	var/cached_atmos_cooldown = atmos_cooldown + 1
 
 	var/planet_atmos = planetary_atmos
-	if(planet_atmos)
-		adjacent_turfs_length++
 
 	var/datum/gas_mixture/our_air = air
 
@@ -417,14 +439,20 @@
 				our_air.temperature_share(null, OPEN_HEAT_TRANSFER_COEFFICIENT, TCMB, HEAT_CAPACITY_VACUUM)
 			// A turf draining to space must stay active until it is actually empty:
 			// without a group the end-of-proc check deactivates a lone leaking turf
-			// after one pass, freezing the leak mid-drain. The moles/temperature gate
-			// above ends the churn once the turf reaches vacuum.
+			// after one pass, freezing the leak mid-drain. Cooldown resets are gated
+			// by the vented amount (mirroring LAST_SHARE_CHECK) so a residual
+			// trickle stops pinning the whole group's breakdown/dismantle forever.
 			if(!our_excited_group)
 				var/datum/excited_group/space_group = new
 				space_group.add_turf(src)
 				our_excited_group = excited_group
-			else
+			var/vented_moles = moles_before * our_share_coeff
+			if(vented_moles > MINIMUM_AIR_TO_SUSPEND)
 				our_excited_group.reset_cooldowns()
+				cached_atmos_cooldown = 0
+			else if(vented_moles > MINIMUM_MOLES_DELTA_TO_MOVE)
+				our_excited_group.dismantle_cooldown = 0
+				cached_atmos_cooldown = 0
 			// Derive both pressures from the known mole scaling instead of
 			// re-summing the gas list twice through return_pressure().
 			var/volume_cache = our_air.volume
@@ -476,17 +504,34 @@
 				var/datum/excited_group/EG = new
 				EG.add_turf(src)
 				our_excited_group = excited_group
-			our_air.share_with_template(template, our_share_coeff)
-			LAST_SHARE_CHECK
+			// Neighbor shares above already moved gas this cycle: re-archive so
+			// the template share works from current values. With the stale
+			// cycle-start archive, an aggressive pull plus the neighbor shares
+			// can overdraw the turf below the template.
+			our_air.archive()
+			our_air.share_with_template(template, PLANET_SHARE_RATIO)
+			// Follow up with a conductive share against an inflated template
+			// heat capacity (upstream behavior): pure temperature deltas are the
+			// dominant planetary churn, and the weak in-share coupling alone
+			// crawls toward the 4K suspend threshold for hundreds of cycles.
+			our_air.temperature_share(null, OPEN_HEAT_TRANSFER_COEFFICIENT, template.temperature_archived, template.immutable_heat_capacity * PLANET_SHARE_TEMPERATURE_CAPACITY)
+			PLANET_SHARE_CHECK
 
 	var/reaction_result = our_air.react(src)
 
 	update_visuals()
 
-	if((!our_excited_group && !active_hotspot && !(reaction_result & (REACTING | STOP_REACTIONS))) \
-	  || (cached_atmos_cooldown > (EXCITED_GROUP_DISMANTLE_CYCLES * 2)))
-		if(SSair)
-			SSair.remove_from_active(src)
+	if(!active_hotspot && !(reaction_result & (REACTING | STOP_REACTIONS)))
+		if(!our_excited_group)
+			if(SSair)
+				SSair.remove_from_active(src)
+		else if(cached_atmos_cooldown > EXCITED_GROUP_DISMANTLE_CYCLES)
+			// Stalled for a full dismantle window inside a live group: rest this
+			// turf alone. remove_from_active here would garbage-collect the whole
+			// group, letting one churning member keep thousands of settled group
+			// mates paying process_cell every fire.
+			if(SSair)
+				SSair.sleep_active_turf(src)
 
 	atmos_cooldown = cached_atmos_cooldown
 
@@ -595,8 +640,13 @@
 	var/turflen = 0
 	var/space_in_group = FALSE
 
+	// Average only members that are still awake. Resting members sat idle for a
+	// full dismantle window and hold their local equilibrium; folding them in
+	// would smear churner gas across turfs nobody processes anymore (planetary
+	// surfaces slowly drifted toward leaks and space-drained edges) and would
+	// keep every breakdown O(group size) when only a handful of turfs churn.
 	for(var/turf/open/T as anything in turf_list)
-		if(!istype(T) || !T.air)
+		if(!istype(T) || !T.air || !T.excited)
 			continue
 		if(space_is_all_consuming && !space_in_group && istype(T.air, /datum/gas_mixture/immutable/space))
 			space_in_group = TRUE
@@ -610,10 +660,9 @@
 		A.divide(turflen)
 
 	for(var/turf/open/T as anything in turf_list)
-		if(!istype(T) || !T.air)
+		if(!istype(T) || !T.air || !T.excited)
 			continue
 		T.air.copy_from(A)
-		T.atmos_cooldown = 0
 		T.update_visuals()
 
 	breakdown_cooldown = 0
@@ -638,3 +687,4 @@
 		SSair.excited_groups -= src
 
 #undef LAST_SHARE_CHECK
+#undef PLANET_SHARE_CHECK

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -191,14 +191,14 @@
 	var/list/cached_gases = air.gases
 	var/list/gas_overlays = GLOB.gas_data.overlays
 	var/list/gas_visibility = GLOB.gas_data.visibility
-	for(var/id in cached_gases)
-		if (nonoverlaying_gases[id])
+	for(var/gas_id as anything in cached_gases)
+		if (nonoverlaying_gases[gas_id])
 			continue
-		var/gas_overlay = gas_overlays[id]
+		var/gas_overlay = gas_overlays[gas_id]
 		if(!gas_overlay)
 			continue
-		var/moles = cached_gases[id]
-		if(moles <= gas_visibility[id])
+		var/moles = cached_gases[gas_id]
+		if(moles <= gas_visibility[gas_id])
 			continue
 		LAZYADD(new_overlay_types, gas_overlay[min(FACTOR_GAS_VISIBLE_MAX, CEILING(moles / MOLES_GAS_VISIBLE_STEP, 1))])
 
@@ -415,6 +415,16 @@
 			our_air.vent_ratio(our_share_coeff)
 			if(abs(our_air.temperature - TCMB) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 				our_air.temperature_share(null, OPEN_HEAT_TRANSFER_COEFFICIENT, TCMB, HEAT_CAPACITY_VACUUM)
+			// A turf draining to space must stay active until it is actually empty:
+			// without a group the end-of-proc check deactivates a lone leaking turf
+			// after one pass, freezing the leak mid-drain. The moles/temperature gate
+			// above ends the churn once the turf reaches vacuum.
+			if(!our_excited_group)
+				var/datum/excited_group/space_group = new
+				space_group.add_turf(src)
+				our_excited_group = excited_group
+			else
+				our_excited_group.reset_cooldowns()
 			// Derive both pressures from the known mole scaling instead of
 			// re-summing the gas list twice through return_pressure().
 			var/volume_cache = our_air.volume

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -33,6 +33,9 @@
 	var/planetary_atmos = FALSE //air will revert to initial_gas_mix over time
 
 	var/list/atmos_overlay_types //gas IDs of current active gas overlays
+	///Vents/scrubbers that want an instant wake-up when air on this turf changes.
+	///Maintained by /obj/machinery/atmospherics/register_turf_wake().
+	var/tmp/list/atmos_wake_machines
 
 /turf/open/Initialize(mapload, inherited_virtual_z)
 	air = new(2500,src)
@@ -59,12 +62,8 @@
 	if(!giver)
 		return FALSE
 	if(air?.gc_share)
-		var/datum/gas_mixture/removed = giver.remove(moles)
-		if(!removed || removed.total_moles() <= 0)
-			if(removed)
-				qdel(removed)
+		if(!giver.vent_moles(moles))
 			return FALSE
-		qdel(removed)
 	else if(!giver.transfer_to(air, moles))
 		return FALSE
 	update_visuals()
@@ -76,12 +75,8 @@
 	if(!giver)
 		return FALSE
 	if(air?.gc_share)
-		var/datum/gas_mixture/removed = giver.remove_ratio(ratio)
-		if(!removed || removed.total_moles() <= 0)
-			if(removed)
-				qdel(removed)
+		if(!giver.vent_ratio(ratio))
 			return FALSE
-		qdel(removed)
 	else if(!giver.transfer_ratio_to(air, ratio))
 		return FALSE
 	update_visuals()
@@ -92,7 +87,8 @@
 /turf/open/transfer_air(datum/gas_mixture/taker, moles)
 	if(!taker || !return_air()) // shouldn't transfer from space
 		return FALSE
-	air.transfer_to(taker, moles)
+	if(!air.transfer_to(taker, moles))
+		return FALSE
 	update_visuals()
 	if(SSair)
 		SSair.add_to_active(src)
@@ -101,7 +97,8 @@
 /turf/open/transfer_air_ratio(datum/gas_mixture/taker, ratio)
 	if(!taker || !return_air())
 		return FALSE
-	air.transfer_ratio_to(taker, ratio)
+	if(!air.transfer_ratio_to(taker, ratio))
+		return FALSE
 	update_visuals()
 	if(SSair)
 		SSair.add_to_active(src)
@@ -179,7 +176,6 @@
 /turf/open/proc/update_visuals()
 
 	var/list/atmos_overlay_types = src.atmos_overlay_types // Cache for free performance
-	var/list/new_overlay_types = list()
 	var/static/list/nonoverlaying_gases = typecache_of_gases_with_no_overlays()
 
 	if(!air) // 2019-05-14: was not able to get this path to fire in testing. Consider removing/looking at callers -Naksu
@@ -189,13 +185,27 @@
 			src.atmos_overlay_types = null
 		return
 
-
-	for(var/id in air.get_gases())
+	// Runs for every active turf every cycle: read the gas list directly and only
+	// allocate the overlay list once a visible gas is actually found.
+	var/list/new_overlay_types
+	var/list/cached_gases = air.gases
+	var/list/gas_overlays = GLOB.gas_data.overlays
+	var/list/gas_visibility = GLOB.gas_data.visibility
+	for(var/id in cached_gases)
 		if (nonoverlaying_gases[id])
 			continue
-		var/gas_overlay = GLOB.gas_data.overlays[id]
-		if(gas_overlay && air.get_moles(id) > GLOB.gas_data.visibility[id])
-			new_overlay_types += gas_overlay[min(FACTOR_GAS_VISIBLE_MAX, CEILING(air.get_moles(id) / MOLES_GAS_VISIBLE_STEP, 1))]
+		var/gas_overlay = gas_overlays[id]
+		if(!gas_overlay)
+			continue
+		var/moles = cached_gases[id]
+		if(moles <= gas_visibility[id])
+			continue
+		LAZYADD(new_overlay_types, gas_overlay[min(FACTOR_GAS_VISIBLE_MAX, CEILING(moles / MOLES_GAS_VISIBLE_STEP, 1))])
+
+	if(!new_overlay_types && !atmos_overlay_types)
+		return
+	if(!new_overlay_types)
+		new_overlay_types = list()
 
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added
@@ -315,9 +325,7 @@
 
 		var/starting_pressure = edge_turf.air.return_pressure()
 		var/ratio = min(1, 0.25 * space_sides)
-		var/datum/gas_mixture/released = edge_turf.air.remove_ratio(ratio)
-		if(released)
-			qdel(released)
+		edge_turf.air.vent_ratio(ratio)
 		edge_turf.air.temperature_share(null, OPEN_HEAT_TRANSFER_COEFFICIENT, TCMB, HEAT_CAPACITY_VACUUM)
 
 		var/pressure_drop = max(0, starting_pressure - edge_turf.air.return_pressure())
@@ -391,24 +399,31 @@
 	var/datum/gas_mixture/our_air = air
 
 	for(var/turf/open/enemy_tile as anything in adjacent_turfs)
-		if(!istype(enemy_tile) || enemy_tile.blocks_air || !enemy_tile.air)
+		if(!istype(enemy_tile) || enemy_tile.blocks_air)
+			continue
+		var/datum/gas_mixture/enemy_air = enemy_tile.air
+		if(!enemy_air)
 			continue
 
-		// Space is represented by a shared immutable mix, so vent explicitly instead of mutating it.
-		if(istype(enemy_tile, /turf/open/space))
+		// Space is represented by a shared immutable mix (the only turf air with
+		// gc_share set), so vent explicitly instead of mutating it.
+		if(enemy_air.gc_share)
 			var/moles_before = our_air.total_moles()
-			var/temperature_before = our_air.return_temperature()
+			var/temperature_before = our_air.temperature
 			if(moles_before <= MINIMUM_MOLES_DELTA_TO_MOVE && abs(temperature_before - TCMB) <= MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 				continue
-			var/pressure_before = our_air.return_pressure()
-			var/datum/gas_mixture/vented = our_air.remove_ratio(our_share_coeff)
-			if(vented)
-				qdel(vented)
-			if(abs(our_air.return_temperature() - TCMB) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+			our_air.vent_ratio(our_share_coeff)
+			if(abs(our_air.temperature - TCMB) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 				our_air.temperature_share(null, OPEN_HEAT_TRANSFER_COEFFICIENT, TCMB, HEAT_CAPACITY_VACUUM)
-			var/pressure_delta_space = pressure_before - our_air.return_pressure()
-			if(pressure_delta_space > 0)
-				consider_pressure_difference(enemy_tile, pressure_delta_space)
+			// Derive both pressures from the known mole scaling instead of
+			// re-summing the gas list twice through return_pressure().
+			var/volume_cache = our_air.volume
+			if(volume_cache > 0)
+				var/pressure_before = moles_before * R_IDEAL_GAS_EQUATION * temperature_before / volume_cache
+				var/pressure_after = moles_before * (1 - our_share_coeff) * R_IDEAL_GAS_EQUATION * our_air.temperature / volume_cache
+				var/pressure_delta_space = pressure_before - pressure_after
+				if(pressure_delta_space > 0)
+					consider_pressure_difference(enemy_tile, pressure_delta_space)
 			continue
 
 		if(fire_count <= enemy_tile.current_cycle)
@@ -416,7 +431,6 @@
 		enemy_tile.archive()
 
 		var/should_share_air = FALSE
-		var/datum/gas_mixture/enemy_air = enemy_tile.air
 		var/datum/excited_group/enemy_excited_group = enemy_tile.excited_group
 
 		if(our_excited_group && enemy_excited_group)
@@ -446,17 +460,14 @@
 			LAST_SHARE_CHECK
 
 	if(planet_atmos)
-		var/datum/gas_mixture/G = new
-		G.copy_from_turf(src)
-		G.archive()
-		if(our_air.compare(G))
+		var/datum/gas_mixture/template = SSair.get_planetary_template(src)
+		if(our_air.compare(template))
 			if(!our_excited_group)
 				var/datum/excited_group/EG = new
 				EG.add_turf(src)
 				our_excited_group = excited_group
-			our_air.share(G, our_share_coeff, our_share_coeff)
+			our_air.share_with_template(template, our_share_coeff)
 			LAST_SHARE_CHECK
-		qdel(G)
 
 	var/reaction_result = our_air.react(src)
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -19,6 +19,10 @@ What are the archived variables for?
 	var/min_heat_capacity = 0
 	var/last_share = 0
 	var/gc_share = FALSE
+	/// Heat capacity frozen at mark_immutable() time; immutable mixtures cannot
+	/// change gases afterwards, so hot readers (share_with_template) use this
+	/// instead of re-walking the gas list every call.
+	var/tmp/immutable_heat_capacity = 0
 	var/list/gas_archive
 	/// Native DM atmos registration guard.
 	var/dm_registered_to_ssair = FALSE
@@ -181,10 +185,11 @@ What are the archived variables for?
 
 	var/temperature_delta = temperature_archived - sharer.temperature_archived
 	var/abs_temperature_delta = abs(temperature_delta)
+	var/consider_heat = abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER
 
 	var/old_self_heat_capacity = 0
 	var/old_sharer_heat_capacity = 0
-	if(abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+	if(consider_heat)
 		old_self_heat_capacity = heat_capacity()
 		old_sharer_heat_capacity = sharer.heat_capacity()
 
@@ -193,32 +198,77 @@ What are the archived variables for?
 
 	var/moved_moles = 0
 	var/abs_moved_moles = 0
+	var/our_moles = 0
+	var/their_moles = 0
+	var/list/zero_ours
+	var/list/zero_theirs
 
 	var/list/cached_gasheats = GLOB.gas_data.specific_heats
-	for(var/id in cached_gases | sharer_gases)
+	// This runs for every sharing turf pair every cycle: iterate the two key sets
+	// directly instead of allocating a `cached_gases | sharer_gases` union, fold the
+	// final mole recount into the same pass, and collect emptied ids instead of
+	// sweeping full .Copy() snapshots afterwards.
+	for(var/id in cached_gases)
+		var/ours = cached_gases[id]
+		var/theirs = sharer_gases[id]
 		var/delta = QUANTIZE((self_archive[id] || 0) - (sharer_archive[id] || 0))
-		if(!delta)
-			continue
-		if(delta > 0)
-			delta *= our_coeff
-		else
-			delta *= sharer_coeff
-
-		if(abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
-			var/gas_heat_capacity = delta * (cached_gasheats[id] || 0)
+		if(delta)
 			if(delta > 0)
-				heat_capacity_self_to_sharer += gas_heat_capacity
+				delta *= our_coeff
 			else
-				heat_capacity_sharer_to_self -= gas_heat_capacity
+				delta *= sharer_coeff
+			if(consider_heat)
+				var/gas_heat_capacity = delta * (cached_gasheats[id] || 0)
+				if(delta > 0)
+					heat_capacity_self_to_sharer += gas_heat_capacity
+				else
+					heat_capacity_sharer_to_self -= gas_heat_capacity
+			ours -= delta
+			theirs = (theirs || 0) + delta
+			cached_gases[id] = ours
+			sharer_gases[id] = theirs
+			moved_moles += delta
+			abs_moved_moles += abs(delta)
+		our_moles += ours
+		if(QUANTIZE(ours) <= 0)
+			LAZYADD(zero_ours, id)
+		if(!isnull(theirs))
+			their_moles += theirs
+			if(QUANTIZE(theirs) <= 0)
+				LAZYADD(zero_theirs, id)
 
-		cached_gases[id] = (cached_gases[id] || 0) - delta
-		sharer_gases[id] = (sharer_gases[id] || 0) + delta
-		moved_moles += delta
-		abs_moved_moles += abs(delta)
+	for(var/id in sharer_gases)
+		if(id in cached_gases)
+			continue
+		var/theirs = sharer_gases[id]
+		var/delta = QUANTIZE((self_archive[id] || 0) - (sharer_archive[id] || 0))
+		if(delta)
+			if(delta > 0)
+				delta *= our_coeff
+			else
+				delta *= sharer_coeff
+			if(consider_heat)
+				var/gas_heat_capacity = delta * (cached_gasheats[id] || 0)
+				if(delta > 0)
+					heat_capacity_self_to_sharer += gas_heat_capacity
+				else
+					heat_capacity_sharer_to_self -= gas_heat_capacity
+			var/ours = -delta
+			theirs += delta
+			cached_gases[id] = ours
+			sharer_gases[id] = theirs
+			moved_moles += delta
+			abs_moved_moles += abs(delta)
+			our_moles += ours
+			if(QUANTIZE(ours) <= 0)
+				LAZYADD(zero_ours, id)
+		their_moles += theirs
+		if(QUANTIZE(theirs) <= 0)
+			LAZYADD(zero_theirs, id)
 
 	last_share = abs_moved_moles
 
-	if(abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+	if(consider_heat)
 		var/new_self_heat_capacity = old_self_heat_capacity + heat_capacity_sharer_to_self - heat_capacity_self_to_sharer
 		var/new_sharer_heat_capacity = old_sharer_heat_capacity + heat_capacity_self_to_sharer - heat_capacity_sharer_to_self
 
@@ -231,22 +281,99 @@ What are the archived variables for?
 				if(abs(new_sharer_heat_capacity / old_sharer_heat_capacity - 1) < 0.1)
 					temperature_share(sharer, OPEN_HEAT_TRANSFER_COEFFICIENT)
 
-	for(var/id in cached_gases.Copy())
-		if(QUANTIZE(cached_gases[id]) <= 0)
-			cached_gases -= id
-	for(var/id in sharer_gases.Copy())
-		if(QUANTIZE(sharer_gases[id]) <= 0)
-			sharer_gases -= id
+	if(zero_ours)
+		cached_gases.Remove(zero_ours)
+	if(zero_theirs)
+		sharer_gases.Remove(zero_theirs)
 
 	if(temperature_delta > MINIMUM_TEMPERATURE_TO_MOVE || abs(moved_moles) > MINIMUM_MOLES_DELTA_TO_MOVE)
-		var/our_moles = 0
-		for(var/id in cached_gases)
-			our_moles += cached_gases[id]
-		var/their_moles = 0
-		for(var/id in sharer_gases)
-			their_moles += sharer_gases[id]
 		return (temperature_archived * (our_moles + moved_moles) - sharer.temperature_archived * (their_moles - moved_moles)) * R_IDEAL_GAS_EQUATION / volume
 	return 0
+
+/// One-sided share() against an immutable template mixture (planetary atmosphere):
+/// src moves toward the template exactly as share(fresh_template_copy, coeff, coeff)
+/// would move it, but nothing is written to the template and no copy is allocated.
+/// The template must be archived with gases matching its archive (parse_gas_string does this).
+/datum/gas_mixture/proc/share_with_template(datum/gas_mixture/template, coeff)
+	if(!template || gc_share)
+		return
+	coeff = clamp(coeff, 0, 1)
+	if(!coeff)
+		return
+
+	var/list/cached_gases = gases
+	var/list/template_gases = template.gases
+	var/list/self_archive = gas_archive || cached_gases
+
+	var/temperature_delta = temperature_archived - template.temperature_archived
+	var/consider_heat = abs(temperature_delta) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER
+
+	var/old_self_heat_capacity = 0
+	var/old_template_heat_capacity = 0
+	if(consider_heat)
+		old_self_heat_capacity = heat_capacity()
+		// The template never changes after mark_immutable(); the fallback only
+		// covers a mutable mixture passed in by mistake.
+		old_template_heat_capacity = template.immutable_heat_capacity || template.heat_capacity()
+
+	var/heat_capacity_self_to_sharer = 0
+	var/heat_capacity_sharer_to_self = 0
+	var/abs_moved_moles = 0
+	var/list/zero_ours
+
+	var/list/cached_gasheats = GLOB.gas_data.specific_heats
+	for(var/id in cached_gases)
+		var/ours = cached_gases[id]
+		var/delta = QUANTIZE((self_archive[id] || 0) - (template_gases[id] || 0))
+		if(delta)
+			delta *= coeff
+			if(consider_heat)
+				var/gas_heat_capacity = delta * (cached_gasheats[id] || 0)
+				if(delta > 0)
+					heat_capacity_self_to_sharer += gas_heat_capacity
+				else
+					heat_capacity_sharer_to_self -= gas_heat_capacity
+			ours -= delta
+			cached_gases[id] = ours
+			abs_moved_moles += abs(delta)
+		if(QUANTIZE(ours) <= 0)
+			LAZYADD(zero_ours, id)
+
+	for(var/id in template_gases)
+		if(id in cached_gases)
+			continue
+		var/delta = QUANTIZE((self_archive[id] || 0) - (template_gases[id] || 0))
+		if(!delta)
+			continue
+		delta *= coeff
+		if(consider_heat)
+			var/gas_heat_capacity = delta * (cached_gasheats[id] || 0)
+			if(delta > 0)
+				heat_capacity_self_to_sharer += gas_heat_capacity
+			else
+				heat_capacity_sharer_to_self -= gas_heat_capacity
+		var/ours = -delta
+		cached_gases[id] = ours
+		abs_moved_moles += abs(delta)
+		if(QUANTIZE(ours) <= 0)
+			LAZYADD(zero_ours, id)
+
+	last_share = abs_moved_moles
+
+	if(consider_heat)
+		var/new_self_heat_capacity = old_self_heat_capacity + heat_capacity_sharer_to_self - heat_capacity_self_to_sharer
+		if(new_self_heat_capacity > MINIMUM_HEAT_CAPACITY)
+			temperature = (old_self_heat_capacity * temperature - heat_capacity_self_to_sharer * temperature_archived + heat_capacity_sharer_to_self * template.temperature_archived) / new_self_heat_capacity
+		// share() follows up with conductive equalization when the sharer heat
+		// capacity barely changed; replicate that against the template values
+		// through the null-sharer temperature_share path (no writes to template).
+		var/new_template_heat_capacity = old_template_heat_capacity + heat_capacity_self_to_sharer - heat_capacity_sharer_to_self
+		if(new_template_heat_capacity > MINIMUM_HEAT_CAPACITY && abs(old_template_heat_capacity) > MINIMUM_HEAT_CAPACITY)
+			if(abs(new_template_heat_capacity / old_template_heat_capacity - 1) < 0.1)
+				temperature_share(null, OPEN_HEAT_TRANSFER_COEFFICIENT, template.temperature_archived, old_template_heat_capacity)
+
+	if(zero_ours)
+		cached_gases.Remove(zero_ours)
 
 /datum/gas_mixture/remove_by_flag(flag, amount)
 	var/datum/gas_mixture/removed = new type
@@ -385,12 +512,8 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 
 		//Actually transfer the gas
 		if(output_air.gc_share)
-			var/datum/gas_mixture/removed = input_air.remove(transfer_moles)
-			if(!removed || removed.total_moles() <= 0)
-				if(removed)
-					qdel(removed)
+			if(!input_air.vent_moles(transfer_moles))
 				return FALSE
-			qdel(removed)
 		else if(!input_air.transfer_to(output_air, transfer_moles))
 			return FALSE
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -19,6 +19,10 @@
 	var/list/min_requirements
 	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
 	var/priority = 100 //lower numbers are checked/react later than higher numbers. if two reactions have the same priority they may happen in either order
+	/// Position in the priority-sorted SSair.gas_reactions list, maintained by
+	/// SSair.auxtools_update_reactions(); used to keep candidate evaluation order
+	/// identical to the full-list scan when gathering reactions from the key-gas index.
+	var/sort_index = 0
 	var/name = "reaction"
 	var/id = "r"
 	/// Short description for the atmos handbook.

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -40,6 +40,13 @@
 	var/pipe_state //icon_state as a pipe item
 	var/on = FALSE
 
+	///world.time until which this machine may skip full atmos processing (idle heartbeat for vents/scrubbers)
+	var/atmos_idle_until = 0
+	///consecutive SSair fires that did no work; drives atmos_idle_until
+	var/atmos_idle_streak = 0
+	///the turf whose atmos_wake_machines list we are registered in
+	var/turf/open/registered_wake_turf
+
 /obj/machinery/atmospherics/Initialize(mapload)
 	. = ..()
 	register_context()
@@ -84,6 +91,9 @@
 
 	SSair.stop_processing_machine(src)
 	SSair.pipenets_needing_rebuilt -= src
+	// Every idling machine registers itself in turf.atmos_wake_machines (a strong
+	// ref); without this the turf pins the deleted machine forever.
+	unregister_turf_wake()
 
 	dropContents()
 	if(pipe_vision_img)
@@ -91,6 +101,50 @@
 
 	return ..()
 	//return QDEL_HINT_FINDREFERENCE
+
+/// Instantly pulls an idle-heartbeat machine (vent/scrubber) back to full processing.
+/obj/machinery/atmospherics/proc/atmos_wake()
+	atmos_idle_until = 0
+	atmos_idle_streak = 0
+
+/obj/machinery/atmospherics/power_change()
+	..()
+	// Power flips must instantly pull idle-heartbeat machines back to work.
+	atmos_wake()
+
+/// Counts a no-op processing pass; after ATMOS_MACHINE_IDLE_STREAK of those the
+/// machine only rechecks on the idle heartbeat until an event wakes it.
+/obj/machinery/atmospherics/proc/atmos_consider_idle()
+	atmos_idle_streak++
+	if(atmos_idle_streak >= ATMOS_MACHINE_IDLE_STREAK)
+		atmos_idle_until = world.time + ATMOS_MACHINE_IDLE_HEARTBEAT
+		// Re-registering on every idle transition self-heals lost registrations
+		// (ChangeTurf under the machine replaces the turf and drops its list).
+		register_turf_wake()
+
+/// Subscribes this machine to instant wake-ups when air changes on its turf
+/// (SSair.add_to_active clears the idle state of everything registered here).
+/// Idempotent; call again freely after the machine or its turf changed.
+/obj/machinery/atmospherics/proc/register_turf_wake()
+	var/turf/open/wake_turf = loc
+	if(!istype(wake_turf))
+		// Still drop any old registration so a stale ref never lingers.
+		unregister_turf_wake()
+		return
+	if(registered_wake_turf != wake_turf)
+		unregister_turf_wake()
+	LAZYOR(wake_turf.atmos_wake_machines, src)
+	registered_wake_turf = wake_turf
+
+/obj/machinery/atmospherics/proc/unregister_turf_wake()
+	var/turf/open/wake_turf = registered_wake_turf
+	registered_wake_turf = null
+	// ChangeTurf replaces the turf in place, retargeting our ref to the new
+	// instance: a /turf/closed has no atmos_wake_machines (the list died with
+	// the old turf), so there is nothing to remove ourselves from.
+	if(!istype(wake_turf))
+		return
+	LAZYREMOVE(wake_turf.atmos_wake_machines, src)
 
 /obj/machinery/atmospherics/proc/destroy_network()
 	return

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -35,6 +35,7 @@
 /obj/machinery/atmospherics/components/binary/pump/CtrlClick(mob/user)
 	if(can_interact(user))
 		on = !on
+		atmos_wake()
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 		update_appearance()
 	return ..()
@@ -42,6 +43,7 @@
 /obj/machinery/atmospherics/components/binary/pump/AltClick(mob/user)
 	if(can_interact(user))
 		target_pressure = MAX_OUTPUT_PRESSURE
+		atmos_wake()
 		investigate_log("was set to [target_pressure] kPa by [key_name(user)]", INVESTIGATE_ATMOS)
 		balloon_alert(user, "pressure output set to [target_pressure] kPa")
 		update_appearance()
@@ -58,7 +60,11 @@
 
 /obj/machinery/atmospherics/components/binary/pump/process_atmos()
 //	..()
+	if(atmos_idle_until > world.time)
+		return
 	if(!on || !is_operational)
+		// Woken by ui_act()/receive_signal()/power_change().
+		atmos_consider_idle()
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]
@@ -68,6 +74,8 @@
 
 	if((target_pressure - output_starting_pressure) < 0.01)
 		//No need to pump gas if target is already reached!
+		//Woken by the pipenet pressure-jump broadcast when the output drains.
+		atmos_consider_idle()
 		return
 
 	//Calculate necessary moles to transfer using PV=nRT
@@ -76,14 +84,17 @@
 		var/transfer_moles = pressure_delta*air2.return_volume()/(air1.return_temperature() * R_IDEAL_GAS_EQUATION)
 
 		if(air2.gc_share)
-			var/datum/gas_mixture/vented = air1.remove(transfer_moles)
-			if(vented)
-				var/had_moles = vented.total_moles() > 0
-				qdel(vented)
-				if(had_moles)
-					update_parents()
+			if(air1.vent_moles(transfer_moles))
+				update_parents()
+				atmos_idle_streak = 0
+			else
+				atmos_consider_idle()
 		else if(air1.transfer_to(air2,transfer_moles))
 			update_parents()
+			atmos_idle_streak = 0
+	else
+		// Empty input: woken by the pipenet broadcast when gas arrives.
+		atmos_consider_idle()
 
 //Radio remote control
 /obj/machinery/atmospherics/components/binary/pump/proc/set_frequency(new_frequency)
@@ -121,6 +132,7 @@
 /obj/machinery/atmospherics/components/binary/pump/ui_act(action, params)
 	if(..())
 		return
+	atmos_wake()
 	var/turf/T = get_turf(src)
 	var/area/A = get_area(src)
 	switch(action)
@@ -155,6 +167,7 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	atmos_wake()
 	var/old_on = on //for logging
 
 	if("power" in signal.data)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -92,6 +92,9 @@
 		else if(air1.transfer_to(air2,transfer_moles))
 			update_parents()
 			atmos_idle_streak = 0
+		else
+			// No-op transfer (nothing actually moved): same idle path as venting.
+			atmos_consider_idle()
 	else
 		// Empty input: woken by the pipenet broadcast when gas arrives.
 		atmos_consider_idle()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -167,7 +167,9 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
-	atmos_wake()
+	// Pure status polls are read-only telemetry and must not reset the idle heartbeat.
+	if(!("status" in signal.data))
+		atmos_wake()
 	var/old_on = on //for logging
 
 	if("power" in signal.data)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -35,6 +35,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/CtrlClick(mob/user)
 	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
 		on = !on
+		atmos_wake()
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 		update_appearance()
 		return ..()
@@ -42,6 +43,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/AltClick(mob/user)
 	if(can_interact(user))
 		transfer_rate = MAX_TRANSFER_RATE
+		atmos_wake()
 		investigate_log("was set to [transfer_rate] L/s by [key_name(user)]", INVESTIGATE_ATMOS)
 		balloon_alert(user, "volume output set to [transfer_rate] L/s")
 		update_appearance()
@@ -56,7 +58,11 @@
 
 /obj/machinery/atmospherics/components/binary/volume_pump/process_atmos()
 //	..()
+	if(atmos_idle_until > world.time)
+		return
 	if(!on || !is_operational)
+		// Woken by ui_act()/receive_signal()/power_change().
+		atmos_consider_idle()
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]
@@ -68,15 +74,19 @@
 	var/output_starting_pressure = air2.return_pressure()
 
 	if((input_starting_pressure < 0.01) || (output_starting_pressure > 9000))
+		// Woken by the pipenet pressure-jump broadcast.
+		atmos_consider_idle()
 		return
 
 	var/input_volume = air1.return_volume()
 	if(input_volume <= 0)
+		atmos_consider_idle()
 		return
 
 	var/transfer_ratio = transfer_rate/input_volume
 
 	air1.transfer_ratio_to(air2,transfer_ratio)
+	atmos_idle_streak = 0
 
 	update_parents()
 
@@ -120,6 +130,7 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/ui_act(action, params)
 	if(..())
 		return
+	atmos_wake()
 	var/turf/T = get_turf(src)
 	var/area/A = get_area(src)
 	switch(action)
@@ -149,6 +160,7 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	atmos_wake()
 	var/old_on = on //for logging
 
 	if("power" in signal.data)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -85,10 +85,13 @@
 
 	var/transfer_ratio = transfer_rate/input_volume
 
-	air1.transfer_ratio_to(air2,transfer_ratio)
-	atmos_idle_streak = 0
-
-	update_parents()
+	if(air1.transfer_ratio_to(air2, transfer_ratio))
+		atmos_idle_streak = 0
+		update_parents()
+	else
+		// Zero transfer rate (or nothing actually moved): a no-op must not keep
+		// the pump awake and dirty the pipenet every fire. Woken by UI/signals.
+		atmos_consider_idle()
 
 /obj/machinery/atmospherics/components/binary/volume_pump/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
@@ -160,7 +163,9 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
-	atmos_wake()
+	// Pure status polls are read-only telemetry and must not reset the idle heartbeat.
+	if(!("status" in signal.data))
+		atmos_wake()
 	var/old_on = on //for logging
 
 	if("power" in signal.data)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -105,6 +105,7 @@
 			reference.other_airs -= airs[i] // Disconnects from the pipeline side
 			parents[i] = null // Disconnects from the machinery side.
 	reference.other_atmosmch -= src
+	LAZYREMOVE(reference.bridging_atmosmch, src)
 	/**
 	 *  We explicitly qdel pipeline when this particular pipeline
 	 *  is projected to have no member and cause GC problems.
@@ -135,6 +136,7 @@
 			var/changed = FALSE
 			if(src in P.other_atmosmch)
 				P.other_atmosmch -= src
+				LAZYREMOVE(P.bridging_atmosmch, src)
 				changed = TRUE
 			if(air_ref && (air_ref in P.other_airs))
 				P.other_airs -= air_ref

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -73,11 +73,12 @@
 	var/datum/gas_mixture/air_contents = airs[1]
 	var/air_volume = air_contents.return_volume()
 
-	// An empty pipe must not reactivate the turf and dirty the pipenet every
-	// fire; the pipenet pressure-jump broadcast wakes us when gas arrives.
-	if(air_contents.return_temperature() > 0 && air_volume > 0 && air_contents.total_moles() > 0)
-		// assume_air_ratio already reactivates the turf.
-		loc.assume_air_ratio(air_contents, volume_rate / air_volume)
+	// An empty pipe or a zero volume_rate must not reactivate the turf and dirty
+	// the pipenet every fire; the pipenet pressure-jump broadcast and UI/signal
+	// wakes cover the moment that changes. assume_air_ratio reports whether any
+	// gas actually moved and already reactivates the turf on success.
+	if(air_contents.return_temperature() > 0 && air_volume > 0 \
+		&& loc.assume_air_ratio(air_contents, volume_rate / air_volume))
 		update_parents()
 		atmos_idle_streak = 0
 	else
@@ -130,7 +131,9 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
-	atmos_wake()
+	// Pure status polls are read-only telemetry and must not reset the idle heartbeat.
+	if(!("status" in signal.data))
+		atmos_wake()
 	if("power" in signal.data)
 		on = text2num(signal.data["power"])
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -23,6 +23,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/CtrlClick(mob/user)
 	if(can_interact(user))
 		on = !on
+		atmos_wake()
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 		update_appearance()
 	return ..()
@@ -30,6 +31,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/AltClick(mob/user)
 	if(can_interact(user))
 		volume_rate = MAX_TRANSFER_RATE
+		atmos_wake()
 		investigate_log("was set to [volume_rate] L/s by [key_name(user)]", INVESTIGATE_ATMOS)
 		balloon_alert(user, "volume output set to [volume_rate] L/s")
 		update_appearance()
@@ -58,21 +60,28 @@
 
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/process_atmos()
-	..()
+	if(atmos_idle_until > world.time)
+		return
 
 	injecting = 0
 
 	if(!on || !is_operational)
+		// Woken by ui_act()/receive_signal()/power_change().
+		atmos_consider_idle()
 		return
 
 	var/datum/gas_mixture/air_contents = airs[1]
 	var/air_volume = air_contents.return_volume()
 
-	if(air_contents.return_temperature() > 0 && air_volume > 0)
+	// An empty pipe must not reactivate the turf and dirty the pipenet every
+	// fire; the pipenet pressure-jump broadcast wakes us when gas arrives.
+	if(air_contents.return_temperature() > 0 && air_volume > 0 && air_contents.total_moles() > 0)
+		// assume_air_ratio already reactivates the turf.
 		loc.assume_air_ratio(air_contents, volume_rate / air_volume)
-		air_update_turf()
-
 		update_parents()
+		atmos_idle_streak = 0
+	else
+		atmos_consider_idle()
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/proc/inject()
 
@@ -121,6 +130,7 @@
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return
 
+	atmos_wake()
 	if("power" in signal.data)
 		on = text2num(signal.data["power"])
 
@@ -159,6 +169,7 @@
 	if(..())
 		return
 
+	atmos_wake()
 	switch(action)
 		if("power")
 			on = !on

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -37,12 +37,9 @@
 		if(external.gc_share)
 			if(internal_pressure > external_pressure)
 				var/total_volume = internal.return_volume() + external.return_volume()
-				var/vent_ratio = total_volume > 0 ? clamp(external.return_volume() / total_volume, 0, 1) : 0
-				if(vent_ratio > 0)
-					var/datum/gas_mixture/vented = internal.remove_ratio(vent_ratio)
-					if(vented)
-						active = vented.total_moles() > 0
-						qdel(vented)
+				var/vent_fraction = total_volume > 0 ? clamp(external.return_volume() / total_volume, 0, 1) : 0
+				if(vent_fraction > 0)
+					active = internal.vent_ratio(vent_fraction)
 		else
 			equalize_all_gases_in_list(list(internal, external))
 			active = TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
@@ -59,12 +59,9 @@
 			if(environment.gc_share)
 				if(our_pressure > environment.return_pressure())
 					var/total_volume = air_contents.return_volume() + environment.return_volume()
-					var/vent_ratio = total_volume > 0 ? clamp(environment.return_volume() / total_volume, 0, 1) : 0
-					if(vent_ratio > 0)
-						var/datum/gas_mixture/vented = air_contents.remove_ratio(vent_ratio)
-						if(vented)
-							active = vented.total_moles() > 0
-							qdel(vented)
+					var/vent_fraction = total_volume > 0 ? clamp(environment.return_volume() / total_volume, 0, 1) : 0
+					if(vent_fraction > 0)
+						active = air_contents.vent_ratio(vent_fraction)
 			else
 				equalize_all_gases_in_list(list(air_contents,environment))
 				active = TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -83,17 +83,23 @@
 		icon_state = "vent_in"
 
 /obj/machinery/atmospherics/components/unary/vent_pump/process_atmos()
-	..()
+	if(atmos_idle_until > world.time)
+		return
 	if(!is_operational)
+		// Woken by power_change(); no point polling an unpowered vent.
+		atmos_consider_idle()
 		return
 	if(!nodes[1])
 		on = FALSE
 	if(!on || welded)
+		// Woken by receive_signal()/welder_act().
+		atmos_consider_idle()
 		return
 
 	var/datum/gas_mixture/air_contents = airs[1]
 	var/datum/gas_mixture/environment = loc.return_air()
 	if (!environment)
+		atmos_consider_idle()
 		return
 
 	var/environment_pressure = environment.return_pressure()
@@ -107,10 +113,13 @@
 		if(pressure_checks&INT_BOUND)
 			pressure_delta = min(pressure_delta, (air_contents.return_pressure() - internal_pressure_bound))
 
-		if(pressure_delta > 0 && air_contents.return_temperature() > 0)
+		// Sub-epsilon imbalances are invisible to players but a transfer would
+		// re-excite the room's turfs every fire, forever.
+		if(pressure_delta > ATMOS_VENT_PRESSURE_EPSILON && air_contents.return_temperature() > 0)
 			var/transfer_moles = pressure_delta*environment.return_volume()/(air_contents.return_temperature() * R_IDEAL_GAS_EQUATION)
+			// assume_air_moles already reactivates the turf on success, no
+			// air_update_turf() needed on top.
 			if(loc.assume_air_moles(air_contents, transfer_moles))
-				air_update_turf()
 				did_transfer = TRUE
 
 	else // external -> internal
@@ -122,12 +131,19 @@
 			if(pressure_checks&INT_BOUND)
 				moles_delta = min(moles_delta, (internal_pressure_bound - air_contents.return_pressure()) * our_multiplier)
 
-			if(moles_delta > 0)
+			// Same epsilon as above, expressed in moles of environment air.
+			var/epsilon_moles = ATMOS_VENT_PRESSURE_EPSILON * environment.return_volume() / (environment.return_temperature() * R_IDEAL_GAS_EQUATION)
+			if(moles_delta > epsilon_moles)
+				// transfer_air already reactivates the turf on success.
 				if(loc.transfer_air(air_contents, moles_delta))
-					air_update_turf()
 					did_transfer = TRUE
 	if(did_transfer)
 		update_parents()
+		atmos_idle_streak = 0
+	else
+		// At equilibrium: recheck on the heartbeat, or instantly when the turf
+		// activates, the pipenet pressure jumps, or a signal arrives.
+		atmos_consider_idle()
 
 //Radio remote control
 
@@ -170,6 +186,8 @@
 	if(frequency)
 		set_frequency(frequency)
 	broadcast_status()
+	register_turf_wake()
+	atmos_wake()
 	..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal(datum/signal/signal)
@@ -178,6 +196,7 @@
 	// log_admin("DEBUG \[[world.timeofday]\]: /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal([signal.debug_print()])")
 	if(!signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return
+	atmos_wake()
 
 	var/mob/signal_sender = signal.data["user"]
 
@@ -257,6 +276,7 @@
 		else
 			user.visible_message("[user] unwelded the vent.", "<span class='notice'>You unweld the vent.</span>", "<span class='italics'>You hear welding.</span>")
 			welded = FALSE
+		atmos_wake()
 		update_icon()
 		pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
 		pipe_vision_img.plane = ABOVE_HUD_PLANE
@@ -274,7 +294,7 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/unary/vent_pump/power_change()
-	..()
+	..() // the base override already calls atmos_wake()
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()
@@ -285,6 +305,7 @@
 		return
 	user.visible_message("[user] furiously claws at [src]!", "You manage to clear away the stuff blocking the vent", "You hear loud scraping noises.")
 	welded = FALSE
+	atmos_wake()
 	update_icon()
 	pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
 	pipe_vision_img.plane = ABOVE_HUD_PLANE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -196,7 +196,10 @@
 	// log_admin("DEBUG \[[world.timeofday]\]: /obj/machinery/atmospherics/components/unary/vent_pump/receive_signal([signal.debug_print()])")
 	if(!signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return
-	atmos_wake()
+	// init (rename) and status polls are read-only telemetry; only real commands
+	// may reset the idle heartbeat.
+	if(!("status" in signal.data) && !("init" in signal.data))
+		atmos_wake()
 
 	var/mob/signal_sender = signal.data["user"]
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -243,7 +243,10 @@
 	if(!is_operational || !signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return FALSE
 
-	atmos_wake()
+	// init (rename) and status polls are read-only telemetry; only real commands
+	// may reset the idle heartbeat.
+	if(!("status" in signal.data) && !("init" in signal.data))
+		atmos_wake()
 	var/mob/signal_sender = signal.data["user"]
 
 	if("power" in signal.data)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -37,12 +37,15 @@
 	RegisterSignal(SSdcs,COMSIG_GLOB_NEW_GAS, PROC_REF(generate_clean_filter_types))
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/generate_clean_filter_types()
+	// Assoc (gas id -> TRUE) so scrub() can probe the room's gases in O(1) each;
+	// scrub_into() iterates assoc keys the same way it iterated the plain list.
 	clean_filter_types = list()
 	for(var/id in filter_types)
 		if(id in GLOB.gas_data.groups)
-			clean_filter_types |= GLOB.gas_data.groups[id]
+			for(var/group_gas in GLOB.gas_data.groups[id])
+				clean_filter_types[group_gas] = TRUE
 		else
-			clean_filter_types += id
+			clean_filter_types[id] = TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/Destroy()
 	var/area/A = get_base_area(src)
@@ -149,19 +152,37 @@
 		set_frequency(frequency)
 	broadcast_status()
 	check_turfs()
+	register_turf_wake()
+	atmos_wake()
 	..()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/process_atmos()
-	..()
+	if(atmos_idle_until > world.time)
+		return FALSE
 	if(welded || !is_operational)
+		// Woken by welder_act()/attack_alien()/power_change().
+		atmos_consider_idle()
 		return FALSE
 	if(!nodes[1] || !on)
 		on = FALSE
+		// Woken by receive_signal().
+		atmos_consider_idle()
 		return FALSE
-	scrub(loc)
+	var/scrubbed = scrub(loc)
 	if(widenet)
 		for(var/turf/tile in adjacent_turfs)
-			scrub(tile)
+			if(scrub(tile))
+				scrubbed = TRUE
+		// Widenet watches neighboring turfs we get no wake events from, so it
+		// never drops into the idle heartbeat.
+		atmos_idle_streak = 0
+		return TRUE
+	if(scrubbed)
+		atmos_idle_streak = 0
+	else
+		// Clean room: recheck on the heartbeat, or instantly when the turf
+		// activates (gas arriving is always an add_to_active call).
+		atmos_consider_idle()
 	return TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/scrub(var/turf/tile)
@@ -177,12 +198,23 @@
 		return FALSE
 
 	if(scrubbing & SCRUBBING)
-		environment.scrub_into(air_contents, volume_rate/environment_volume, clean_filter_types)
-
+		// Probe the room's 2-4 gas ids before touching anything: a scrubber over a
+		// clean room must not reactivate its turf or dirty its pipenet every fire.
+		var/list/environment_gases = environment.get_gases()
+		var/any_filterable = FALSE
+		for(var/id in environment_gases)
+			if(clean_filter_types[id] && environment_gases[id] > 0)
+				any_filterable = TRUE
+				break
+		if(!any_filterable)
+			return FALSE
+		if(!environment.scrub_into(air_contents, volume_rate/environment_volume, clean_filter_types))
+			return FALSE
 		tile.air_update_turf()
 
 	else //Just siphoning all air
-
+		if(environment.total_moles() <= 0)
+			return FALSE
 		environment.transfer_ratio_to(air_contents, volume_rate/environment_volume)
 		tile.air_update_turf()
 
@@ -193,8 +225,10 @@
 //There is no easy way for an object to be notified of changes to atmos can pass flags
 //	So we check every machinery process (2 seconds)
 /obj/machinery/atmospherics/components/unary/vent_scrubber/process()
-	if(widenet)
-		check_turfs()
+	if(!widenet)
+		// Nothing to poll; receive_signal() re-adds us to SSmachines when widenet turns on.
+		return PROCESS_KILL
+	check_turfs()
 
 //we populate a list of turfs with nonatmos-blocked cardinal turfs AND
 //	diagonal turfs that can share atmos with *both* of the cardinal turfs
@@ -209,6 +243,7 @@
 	if(!is_operational || !signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return FALSE
 
+	atmos_wake()
 	var/mob/signal_sender = signal.data["user"]
 
 	if("power" in signal.data)
@@ -216,10 +251,16 @@
 	if("power_toggle" in signal.data)
 		on = !on
 
+	var/old_widenet = widenet
 	if("widenet" in signal.data)
 		widenet = text2num(signal.data["widenet"])
 	if("toggle_widenet" in signal.data)
 		widenet = !widenet
+	if(widenet && widenet != old_widenet)
+		// Non-widenet scrubbers drop out of SSmachines (see process()); rejoin
+		// so the periodic adjacent-turf recalculation runs again.
+		START_PROCESSING(SSmachines, src)
+		check_turfs()
 
 	var/old_scrubbing = scrubbing
 	if("scrubbing" in signal.data)
@@ -252,7 +293,7 @@
 	return
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/power_change()
-	..()
+	..() // the base override already calls atmos_wake()
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/welder_act(mob/living/user, obj/item/I)
@@ -266,6 +307,7 @@
 		else
 			user.visible_message("[user] unwelds the scrubber.", "You unweld the scrubber.", "You hear welding.")
 			welded = FALSE
+		atmos_wake()
 		update_icon()
 		pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
 		pipe_vision_img.plane = ABOVE_HUD_PLANE
@@ -290,6 +332,7 @@
 		return
 	user.visible_message("[user] furiously claws at [src]!", "You manage to clear away the stuff blocking the scrubber.", "You hear loud scraping noises.")
 	welded = FALSE
+	atmos_wake()
 	update_icon()
 	pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
 	pipe_vision_img.plane = ABOVE_HUD_PLANE

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -4,8 +4,17 @@
 
 	var/list/obj/machinery/atmospherics/pipe/members
 	var/list/obj/machinery/atmospherics/components/other_atmosmch
+	/// Subset of other_atmosmch that can bridge into other pipelines or portables
+	/// (valves, relief valves, portables connectors). Maintained on membership
+	/// changes so get_all_connected_airs() does not istype-scan every attached
+	/// machine on every reconcile.
+	var/list/obj/machinery/atmospherics/components/bridging_atmosmch
 
 	var/update = TRUE
+	///Pipenet pressure at the last idle-machine wake broadcast; reconcile_air
+	///wakes attached machines when pressure moves more than
+	///ATMOS_PIPENET_WAKE_PRESSURE_DELTA away from it.
+	var/last_wake_pressure = 0
 
 /datum/pipeline/New()
 	other_airs = list()
@@ -33,6 +42,7 @@
 	members.Cut()
 	other_atmosmch.Cut()
 	other_airs.Cut()
+	bridging_atmosmch = null
 	QDEL_NULL(air)
 	return ..()
 
@@ -42,6 +52,27 @@
 	update = FALSE
 	reconcile_air()
 	update = air?.react(src)
+	// A meaningful pressure change (pipe emptied, distro refilled) must pull
+	// idle-heartbeat vents attached to this net back to full processing; small
+	// jitter around a steady pressure must not.
+	if(!length(other_atmosmch) && !bridging_atmosmch)
+		return
+	var/current_pressure = air ? air.return_pressure() : 0
+	if(abs(current_pressure - last_wake_pressure) <= ATMOS_PIPENET_WAKE_PRESSURE_DELTA)
+		return
+	last_wake_pressure = current_pressure
+	// The filtering `in` form skips stale nulls left by hard-deleted members.
+	for(var/obj/machinery/atmospherics/components/component in other_atmosmch)
+		component.atmos_wake()
+	// Nets bridged through this one (open valve, portables connector) receive gas
+	// from reconcile_air without their update flag ever being set, so they would
+	// sleep through the jump. Dirty them for one pass: each then runs this same
+	// comparison against its own baseline (a closed bridge sees no delta and goes
+	// straight back to sleep).
+	for(var/obj/machinery/atmospherics/components/bridge in bridging_atmosmch)
+		for(var/datum/pipeline/bridged_net in bridge.parents)
+			if(bridged_net != src)
+				bridged_net.update = TRUE
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/base)
 	if(QDELETED(base))
@@ -124,6 +155,10 @@
  */
 /datum/pipeline/proc/addMachineryMember(obj/machinery/atmospherics/components/C)
 	other_atmosmch |= C
+	if(istype(C, /obj/machinery/atmospherics/components/binary/valve) \
+		|| istype(C, /obj/machinery/atmospherics/components/binary/relief_valve) \
+		|| istype(C, /obj/machinery/atmospherics/components/unary/portables_connector))
+		LAZYOR(bridging_atmosmch, C)
 	var/list/returned_airs = C.returnPipenetAirs(src)
 	if (!length(returned_airs) || (null in returned_airs))
 		stack_trace("addMachineryMember: Nonexistent (empty list) or null machinery gasmix added to pipeline datum from [C] \
@@ -162,6 +197,8 @@
 	for(var/obj/machinery/atmospherics/components/C in E.other_atmosmch)
 		C.replacePipenet(E, src)
 	other_atmosmch |= E.other_atmosmch
+	if(E.bridging_atmosmch)
+		LAZYOR(bridging_atmosmch, E.bridging_atmosmch)
 	if(null in E.other_airs)
 		stack_trace("merge(): Pipeline [E]([REF(E)]) contains null gas mixtures in other_airs. Cleaning before merge.")
 		listclearnulls(E.other_airs)
@@ -279,7 +316,7 @@
 			GL += P.other_airs
 		if(P.air)
 			GL += P.air
-		for(var/obj/machinery/atmospherics/components/atmosmch as anything in P.other_atmosmch)
+		for(var/obj/machinery/atmospherics/components/atmosmch as anything in P.bridging_atmosmch)
 			if (istype(atmosmch, /obj/machinery/atmospherics/components/binary/valve))
 				var/obj/machinery/atmospherics/components/binary/valve/V = atmosmch
 				if(V.on)

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -55,6 +55,11 @@
 	PIPING_LAYER_DOUBLE_SHIFT(src, target_layer)
 
 /obj/machinery/meter/process_atmos()
+	// Meters are pure telemetry: refreshing the icon, the radio report and the
+	// area power lookup every ATMOS_TELEMETRY_INTERVAL-th atmos fire (2s) is
+	// indistinguishable to players and cuts most of their steady cost.
+	if(SSair.times_fired % ATMOS_TELEMETRY_INTERVAL)
+		return
 	if(!(target?.flags_1 & INITIALIZED_1))
 		icon_state = "meterX"
 		return FALSE
@@ -63,7 +68,7 @@
 		icon_state = "meter0"
 		return FALSE
 
-	use_power(5)
+	use_power(5 * ATMOS_TELEMETRY_INTERVAL) // 5 per fire, charged once per interval
 
 	var/datum/gas_mixture/environment = target.return_air()
 	if(!environment)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -70,6 +70,8 @@
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
 #include "anchored_mobs.dm"
+#include "atmos_native.dm"
+#include "atmos_performance.dm"
 #include "bespoke_id.dm"
 #include "binary_insert.dm"
 // #include "bloody_footprints.dm"

--- a/code/modules/unit_tests/atmos_native.dm
+++ b/code/modules/unit_tests/atmos_native.dm
@@ -1,0 +1,394 @@
+// Functional tests for the native DM atmospherics core: gas exchange math,
+// reaction dispatch through the key-gas index, scrubber gating, planetary
+// templates and turf gas assumption. These pin down behavior the optimization
+// work is required to preserve.
+
+#define TEST_GAS_EPSILON 0.001
+
+/// Reference copy of the pre-optimization share() (union list + full-list GC
+/// sweeps). Used to verify the rewritten share() produces identical numbers.
+/proc/unit_test_reference_share(datum/gas_mixture/source, datum/gas_mixture/sharer, our_coeff, sharer_coeff)
+	if(!sharer || source.gc_share || sharer.gc_share)
+		return 0
+	our_coeff = clamp(our_coeff, 0, 1)
+	sharer_coeff = clamp(sharer_coeff, 0, 1)
+	if(!our_coeff && !sharer_coeff)
+		return 0
+	var/list/cached_gases = source.gases
+	var/list/sharer_gases = sharer.gases
+	var/list/self_archive = source.gas_archive || cached_gases
+	var/list/sharer_archive = sharer.gas_archive || sharer_gases
+	var/temperature_delta = source.temperature_archived - sharer.temperature_archived
+	var/abs_temperature_delta = abs(temperature_delta)
+	var/old_self_heat_capacity = 0
+	var/old_sharer_heat_capacity = 0
+	if(abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+		old_self_heat_capacity = source.heat_capacity()
+		old_sharer_heat_capacity = sharer.heat_capacity()
+	var/heat_capacity_self_to_sharer = 0
+	var/heat_capacity_sharer_to_self = 0
+	var/moved_moles = 0
+	var/abs_moved_moles = 0
+	var/list/cached_gasheats = GLOB.gas_data.specific_heats
+	for(var/id in cached_gases | sharer_gases)
+		var/delta = QUANTIZE((self_archive[id] || 0) - (sharer_archive[id] || 0))
+		if(!delta)
+			continue
+		if(delta > 0)
+			delta *= our_coeff
+		else
+			delta *= sharer_coeff
+		if(abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+			var/gas_heat_capacity = delta * (cached_gasheats[id] || 0)
+			if(delta > 0)
+				heat_capacity_self_to_sharer += gas_heat_capacity
+			else
+				heat_capacity_sharer_to_self -= gas_heat_capacity
+		cached_gases[id] = (cached_gases[id] || 0) - delta
+		sharer_gases[id] = (sharer_gases[id] || 0) + delta
+		moved_moles += delta
+		abs_moved_moles += abs(delta)
+	source.last_share = abs_moved_moles
+	if(abs_temperature_delta > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+		var/new_self_heat_capacity = old_self_heat_capacity + heat_capacity_sharer_to_self - heat_capacity_self_to_sharer
+		var/new_sharer_heat_capacity = old_sharer_heat_capacity + heat_capacity_self_to_sharer - heat_capacity_sharer_to_self
+		if(new_self_heat_capacity > MINIMUM_HEAT_CAPACITY)
+			source.temperature = (old_self_heat_capacity * source.temperature - heat_capacity_self_to_sharer * source.temperature_archived + heat_capacity_sharer_to_self * sharer.temperature_archived) / new_self_heat_capacity
+		if(new_sharer_heat_capacity > MINIMUM_HEAT_CAPACITY)
+			sharer.temperature = (old_sharer_heat_capacity * sharer.temperature - heat_capacity_sharer_to_self * sharer.temperature_archived + heat_capacity_self_to_sharer * source.temperature_archived) / new_sharer_heat_capacity
+			if(abs(old_sharer_heat_capacity) > MINIMUM_HEAT_CAPACITY)
+				if(abs(new_sharer_heat_capacity / old_sharer_heat_capacity - 1) < 0.1)
+					source.temperature_share(sharer, OPEN_HEAT_TRANSFER_COEFFICIENT)
+	for(var/id in cached_gases.Copy())
+		if(QUANTIZE(cached_gases[id]) <= 0)
+			cached_gases -= id
+	for(var/id in sharer_gases.Copy())
+		if(QUANTIZE(sharer_gases[id]) <= 0)
+			sharer_gases -= id
+	if(temperature_delta > MINIMUM_TEMPERATURE_TO_MOVE || abs(moved_moles) > MINIMUM_MOLES_DELTA_TO_MOVE)
+		var/our_moles = 0
+		for(var/id in cached_gases)
+			our_moles += cached_gases[id]
+		var/their_moles = 0
+		for(var/id in sharer_gases)
+			their_moles += sharer_gases[id]
+		return (source.temperature_archived * (our_moles + moved_moles) - sharer.temperature_archived * (their_moles - moved_moles)) * R_IDEAL_GAS_EQUATION / source.volume
+	return 0
+
+/// Seeds one deterministic uneven mixture pair used by the equivalence tests.
+/proc/unit_test_seed_share_pair(list/out_pair)
+	var/datum/gas_mixture/hot_side = new(CELL_VOLUME)
+	hot_side.set_moles(GAS_O2, 60)
+	hot_side.set_moles(GAS_PLASMA, 12)
+	hot_side.set_moles(GAS_CO2, 3)
+	hot_side.set_temperature(T20C + 210)
+	hot_side.archive()
+	var/datum/gas_mixture/cold_side = new(CELL_VOLUME)
+	cold_side.set_moles(GAS_O2, 10)
+	cold_side.set_moles(GAS_N2, 80)
+	cold_side.set_temperature(T20C - 30)
+	cold_side.archive()
+	out_pair += hot_side
+	out_pair += cold_side
+
+/datum/unit_test/atmos_share_matches_reference/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/list/new_pair = list()
+	unit_test_seed_share_pair(new_pair)
+	var/list/ref_pair = list()
+	unit_test_seed_share_pair(ref_pair)
+
+	var/datum/gas_mixture/new_a = new_pair[1]
+	var/datum/gas_mixture/new_b = new_pair[2]
+	var/datum/gas_mixture/ref_a = ref_pair[1]
+	var/datum/gas_mixture/ref_b = ref_pair[2]
+
+	var/new_result = new_a.share(new_b, 0.2, 0.25)
+	var/ref_result = unit_test_reference_share(ref_a, ref_b, 0.2, 0.25)
+
+	TEST_ASSERT(abs(new_result - ref_result) < 0.01, "share() return value diverged from reference: [new_result] vs [ref_result]")
+	TEST_ASSERT(abs(new_a.last_share - ref_a.last_share) < TEST_GAS_EPSILON, "share() last_share diverged: [new_a.last_share] vs [ref_a.last_share]")
+	TEST_ASSERT(abs(new_a.return_temperature() - ref_a.return_temperature()) < 0.01, "share() source temperature diverged: [new_a.return_temperature()] vs [ref_a.return_temperature()]")
+	TEST_ASSERT(abs(new_b.return_temperature() - ref_b.return_temperature()) < 0.01, "share() sharer temperature diverged: [new_b.return_temperature()] vs [ref_b.return_temperature()]")
+	for(var/id in new_a.get_gases() | ref_a.get_gases())
+		TEST_ASSERT(abs(new_a.get_moles(id) - ref_a.get_moles(id)) < TEST_GAS_EPSILON, "share() source [id] diverged: [new_a.get_moles(id)] vs [ref_a.get_moles(id)]")
+	for(var/id in new_b.get_gases() | ref_b.get_gases())
+		TEST_ASSERT(abs(new_b.get_moles(id) - ref_b.get_moles(id)) < TEST_GAS_EPSILON, "share() sharer [id] diverged: [new_b.get_moles(id)] vs [ref_b.get_moles(id)]")
+
+	qdel(new_a)
+	qdel(new_b)
+	qdel(ref_a)
+	qdel(ref_b)
+
+/datum/unit_test/atmos_react_dispatch/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	TEST_ASSERT(length(SSair.gas_reactions), "SSair.gas_reactions is empty")
+	TEST_ASSERT(islist(SSair.reactions_by_key_gas), "reaction key-gas index was not built")
+
+	// Every non-excluded reaction must be reachable: either via a key gas bucket
+	// or via the temperature-gated list.
+	var/indexed = 0
+	for(var/id in SSair.reactions_by_key_gas)
+		var/list/bucket = SSair.reactions_by_key_gas[id]
+		indexed += length(bucket)
+	indexed += length(SSair.temp_gated_reactions)
+	TEST_ASSERT_EQUAL(indexed, length(SSair.gas_reactions), "key-gas index covers [indexed] reactions but SSair has [length(SSair.gas_reactions)]")
+
+	// Ordinary station air must stay inert.
+	var/datum/gas_mixture/air_mix = unit_test_air_mix()
+	TEST_ASSERT_EQUAL(air_mix.react(null), NO_REACTION, "station air reacted")
+	TEST_ASSERT_EQUAL(length(air_mix.reaction_results), 0, "inert react() left reaction_results populated")
+	qdel(air_mix)
+
+	// Plasma fire must ignite through the index and report fire results.
+	var/datum/gas_mixture/fire_mix = new(CELL_VOLUME)
+	fire_mix.set_moles(GAS_PLASMA, 50)
+	fire_mix.set_moles(GAS_O2, 100)
+	fire_mix.set_temperature(FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 300)
+	var/fire_energy_before = fire_mix.thermal_energy()
+	var/fire_result = fire_mix.react(null)
+	TEST_ASSERT(fire_result & REACTING, "plasma+o2 at fire temperature did not react")
+	TEST_ASSERT(fire_mix.reaction_results["fire"] > 0, "plasma fire did not report burned fuel in reaction_results")
+	TEST_ASSERT(fire_mix.thermal_energy() > fire_energy_before, "plasma fire did not release energy")
+	TEST_ASSERT(fire_mix.get_moles(GAS_CO2) > 0, "plasma fire produced no CO2")
+	qdel(fire_mix)
+
+	// Hyper-noblium must suppress all reactions, leaving fuel untouched.
+	var/datum/gas_mixture/nob_mix = new(CELL_VOLUME)
+	nob_mix.set_moles(GAS_PLASMA, 50)
+	nob_mix.set_moles(GAS_O2, 100)
+	nob_mix.set_moles(GAS_HYPERNOB, REACTION_OPPRESSION_THRESHOLD * 2)
+	nob_mix.set_temperature(FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 300)
+	var/nob_result = nob_mix.react(null)
+	TEST_ASSERT(nob_result & STOP_REACTIONS, "hyper-noblium did not stop reactions")
+	TEST_ASSERT(abs(nob_mix.get_moles(GAS_PLASMA) - 50) < TEST_GAS_EPSILON, "plasma burned despite hyper-noblium suppression")
+	qdel(nob_mix)
+
+/datum/unit_test/atmos_water_vapor_condensation/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/floor = run_loc_floor_bottom_left
+	TEST_ASSERT(istype(floor), "test location is not an open turf")
+	var/datum/gas_mixture/wet_mix = new(CELL_VOLUME)
+	wet_mix.set_moles(GAS_H2O, 5)
+	wet_mix.set_moles(GAS_N2, 80)
+	wet_mix.set_temperature(T20C)
+	var/moles_before = wet_mix.get_moles(GAS_H2O)
+	var/result = wet_mix.react(floor)
+	TEST_ASSERT(result & REACTING, "water vapor did not condense on a warm turf")
+	TEST_ASSERT(wet_mix.get_moles(GAS_H2O) < moles_before, "condensation did not consume water vapor")
+	qdel(wet_mix)
+
+/datum/unit_test/atmos_transfer_conservation/Run()
+	var/datum/gas_mixture/source_mix = new(CELL_VOLUME)
+	source_mix.set_moles(GAS_O2, 60)
+	source_mix.set_moles(GAS_N2, 40)
+	source_mix.set_temperature(T20C + 100)
+	var/datum/gas_mixture/target_mix = new(200)
+	target_mix.set_moles(GAS_O2, 10)
+	target_mix.set_temperature(T20C)
+
+	var/moles_before = source_mix.total_moles() + target_mix.total_moles()
+	var/energy_before = source_mix.thermal_energy() + target_mix.thermal_energy()
+
+	TEST_ASSERT(source_mix.transfer_to(target_mix, 25), "transfer_to failed")
+	TEST_ASSERT(abs(source_mix.total_moles() - 75) < TEST_GAS_EPSILON, "source should hold 75 moles, has [source_mix.total_moles()]")
+	TEST_ASSERT(abs(target_mix.total_moles() - 35) < TEST_GAS_EPSILON, "target should hold 35 moles, has [target_mix.total_moles()]")
+	// Composition moves proportionally: 60/100 of the 25 moles are oxygen.
+	TEST_ASSERT(abs(target_mix.get_moles(GAS_O2) - 25) < TEST_GAS_EPSILON, "target o2 should be 10+15, has [target_mix.get_moles(GAS_O2)]")
+	TEST_ASSERT(abs(target_mix.get_moles(GAS_N2) - 10) < TEST_GAS_EPSILON, "target n2 should be 10, has [target_mix.get_moles(GAS_N2)]")
+
+	var/moles_after = source_mix.total_moles() + target_mix.total_moles()
+	var/energy_after = source_mix.thermal_energy() + target_mix.thermal_energy()
+	TEST_ASSERT(abs(moles_before - moles_after) < TEST_GAS_EPSILON, "transfer_to lost moles: [moles_before] -> [moles_after]")
+	TEST_ASSERT(abs(energy_before - energy_after) < energy_before * 0.005, "transfer_to lost energy: [energy_before] -> [energy_after]")
+
+	// Draining more than available moves everything and reports success.
+	TEST_ASSERT(source_mix.transfer_to(target_mix, 1000), "over-draining transfer_to failed")
+	TEST_ASSERT(source_mix.total_moles() < TEST_GAS_EPSILON, "source should be empty after over-drain")
+
+	// An empty source is a no-op and must report FALSE (like vent_moles), so
+	// vents/pumps can idle on the return value instead of counting phantom
+	// transfers every fire.
+	TEST_ASSERT(!source_mix.transfer_to(target_mix, 10), "transfer_to from an empty mixture must report FALSE")
+	TEST_ASSERT(!source_mix.transfer_ratio_to(target_mix, 0.5), "transfer_ratio_to from an empty mixture must report FALSE")
+
+	qdel(source_mix)
+	qdel(target_mix)
+
+/datum/unit_test/atmos_vent_ratio/Run()
+	var/datum/gas_mixture/mix = unit_test_air_mix()
+	var/moles_before = mix.total_moles()
+	var/temperature_before = mix.return_temperature()
+	TEST_ASSERT(mix.vent_ratio(0.25), "vent_ratio reported no gas discarded")
+	TEST_ASSERT(abs(mix.total_moles() - moles_before * 0.75) < TEST_GAS_EPSILON, "vent_ratio(0.25) should leave 75% of moles")
+	TEST_ASSERT_EQUAL(mix.return_temperature(), temperature_before, "vent_ratio must not change temperature")
+	mix.clear()
+	TEST_ASSERT(!mix.vent_ratio(0.5), "vent_ratio on an empty mixture must report FALSE")
+	qdel(mix)
+
+/datum/unit_test/atmos_scrubber_gating/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/room = run_loc_floor_bottom_left
+	TEST_ASSERT(istype(room), "test location is not an open turf")
+	var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber = allocate(/obj/machinery/atmospherics/components/unary/vent_scrubber, room)
+	var/datum/gas_mixture/pipe_side = scrubber.airs[1]
+	TEST_ASSERT_NOTNULL(pipe_side, "scrubber has no internal gas mixture")
+
+	// Clean room: scrub() must not move gas, must not reactivate the turf and
+	// must not touch the pipenet.
+	room.air.clear()
+	room.air.set_moles(GAS_O2, MOLES_O2STANDARD)
+	room.air.set_moles(GAS_N2, MOLES_N2STANDARD)
+	room.air.set_temperature(T20C)
+	SSair.remove_from_active(room)
+	SSair.pipenets_needing_rebuilt -= scrubber
+	TEST_ASSERT(!scrubber.scrub(room), "scrub() reported success over a clean room")
+	TEST_ASSERT(!room.excited, "scrubbing a clean room reactivated its turf")
+	TEST_ASSERT(!(scrubber in SSair.pipenets_needing_rebuilt), "scrubbing a clean room dirtied the pipenet path")
+	TEST_ASSERT(pipe_side.total_moles() < TEST_GAS_EPSILON, "scrubbing a clean room moved gas")
+
+	// Room with CO2: scrub() must collect it and reactivate the turf.
+	room.air.set_moles(GAS_CO2, 6)
+	var/co2_before = room.air.get_moles(GAS_CO2)
+	TEST_ASSERT(scrubber.scrub(room), "scrub() failed over a CO2 room")
+	TEST_ASSERT(room.air.get_moles(GAS_CO2) < co2_before, "scrub() did not reduce room CO2")
+	TEST_ASSERT(pipe_side.get_moles(GAS_CO2) > 0, "scrub() did not collect CO2 into the scrubber")
+	TEST_ASSERT(room.excited, "scrubbing an occupied room must reactivate its turf")
+	TEST_ASSERT(abs((room.air.get_moles(GAS_CO2) + pipe_side.get_moles(GAS_CO2)) - co2_before) < TEST_GAS_EPSILON, "scrubbed CO2 was not conserved")
+
+	// Cleanup subsystem side effects of the allocation.
+	SSair.pipenets_needing_rebuilt -= scrubber
+	room.air.copy_from_turf(room)
+	SSair.remove_from_active(room)
+
+/datum/unit_test/atmos_assume_air/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/room = run_loc_floor_bottom_left
+	TEST_ASSERT(istype(room), "test location is not an open turf")
+	room.air.clear()
+	var/datum/gas_mixture/giver = new(1000)
+	giver.set_moles(GAS_O2, 100)
+	giver.set_temperature(T20C)
+	SSair.remove_from_active(room)
+	TEST_ASSERT(room.assume_air_moles(giver, 40), "assume_air_moles failed")
+	TEST_ASSERT(abs(room.air.get_moles(GAS_O2) - 40) < TEST_GAS_EPSILON, "turf should have gained 40 moles of o2")
+	TEST_ASSERT(abs(giver.get_moles(GAS_O2) - 60) < TEST_GAS_EPSILON, "giver should have lost 40 moles of o2")
+	TEST_ASSERT(room.excited, "assume_air_moles must reactivate the turf")
+	qdel(giver)
+	room.air.copy_from_turf(room)
+	SSair.remove_from_active(room)
+
+/datum/unit_test/atmos_planetary_template/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/model = run_loc_floor_bottom_left
+	TEST_ASSERT(istype(model), "test location is not an open turf")
+
+	var/datum/gas_mixture/template = SSair.get_planetary_template(model)
+	TEST_ASSERT_NOTNULL(template, "planetary template was not built")
+	TEST_ASSERT(template.gc_share, "planetary template must be immutable")
+	TEST_ASSERT_EQUAL(SSair.get_planetary_template(model), template, "planetary template was not cached")
+	TEST_ASSERT_EQUAL(SSair.planetary[model.initial_gas_mix], template, "planetary cache must be keyed by the raw gas string")
+
+	// share_with_template must reproduce the old new+copy_from_turf+share+qdel
+	// path exactly, without mutating the template.
+	var/datum/gas_mixture/new_path = new(CELL_VOLUME)
+	new_path.set_moles(GAS_PLASMA, 8)
+	new_path.set_moles(GAS_O2, 2)
+	new_path.set_temperature(T20C + 150)
+	new_path.archive()
+	var/datum/gas_mixture/old_path = new(CELL_VOLUME)
+	old_path.set_moles(GAS_PLASMA, 8)
+	old_path.set_moles(GAS_O2, 2)
+	old_path.set_temperature(T20C + 150)
+	old_path.archive()
+
+	var/template_moles_before = template.total_moles()
+	new_path.share_with_template(template, 0.25)
+
+	var/datum/gas_mixture/scratch = new
+	scratch.copy_from_turf(model)
+	scratch.archive()
+	old_path.share(scratch, 0.25, 0.25)
+	qdel(scratch)
+
+	TEST_ASSERT(abs(template.total_moles() - template_moles_before) < TEST_GAS_EPSILON, "share_with_template mutated the template")
+	TEST_ASSERT(abs(new_path.return_temperature() - old_path.return_temperature()) < 0.01, "template share temperature diverged: [new_path.return_temperature()] vs [old_path.return_temperature()]")
+	TEST_ASSERT(abs(new_path.last_share - old_path.last_share) < TEST_GAS_EPSILON, "template share last_share diverged: [new_path.last_share] vs [old_path.last_share]")
+	for(var/id in new_path.get_gases() | old_path.get_gases())
+		TEST_ASSERT(abs(new_path.get_moles(id) - old_path.get_moles(id)) < TEST_GAS_EPSILON, "template share [id] diverged: [new_path.get_moles(id)] vs [old_path.get_moles(id)]")
+
+	qdel(new_path)
+	qdel(old_path)
+
+/// External air changes (vent top-ups, breathing) must postpone excited group
+/// averaging/dismantling without destroying the group: rebuilding room groups
+/// from scratch every fire was a major source of permanently active turfs.
+/datum/unit_test/atmos_group_survives_external_change/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/first = run_loc_floor_bottom_left
+	var/turf/open/second = locate(first.x + 1, first.y, first.z)
+	TEST_ASSERT(istype(first), "test location is not an open turf")
+	TEST_ASSERT(istype(second), "adjacent test location is not an open turf")
+
+	var/datum/excited_group/group = new
+	group.add_turf(first)
+	group.add_turf(second)
+	group.breakdown_cooldown = 3
+	group.dismantle_cooldown = 9
+
+	SSair.add_to_active(first)
+	TEST_ASSERT_EQUAL(first.excited_group, group, "external change destroyed the excited group")
+	TEST_ASSERT_EQUAL(second.excited_group, group, "external change detached a group member")
+	TEST_ASSERT_EQUAL(group.breakdown_cooldown, 0, "external change must reset the breakdown cooldown")
+	TEST_ASSERT_EQUAL(group.dismantle_cooldown, 0, "external change must reset the dismantle cooldown")
+
+	// A structural change (adjacency recalculated: door closed, wall built) must
+	// dismantle the group instead, or self_breakdown would keep averaging gas
+	// across the new blockage.
+	first.air_update_turf(TRUE)
+	TEST_ASSERT_NULL(first.excited_group, "adjacency change did not dismantle the excited group")
+	TEST_ASSERT_NULL(second.excited_group, "adjacency change left a group member attached")
+
+	group.garbage_collect()
+	SSair.remove_from_active(first)
+	SSair.remove_from_active(second)
+
+/// Idle-heartbeat machines must wake instantly when air on their turf changes,
+/// and enter the heartbeat only after a full streak of no-op fires.
+/datum/unit_test/atmos_machine_idle_wake/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/room = run_loc_floor_bottom_left
+	TEST_ASSERT(istype(room), "test location is not an open turf")
+	var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber = allocate(/obj/machinery/atmospherics/components/unary/vent_scrubber, room)
+
+	// Streak accumulation drops the machine into the heartbeat.
+	for(var/i in 1 to ATMOS_MACHINE_IDLE_STREAK)
+		TEST_ASSERT(scrubber.atmos_idle_until <= world.time, "machine went idle before completing the streak")
+		scrubber.atmos_consider_idle()
+	TEST_ASSERT(scrubber.atmos_idle_until > world.time, "machine did not enter the idle heartbeat after a full no-op streak")
+
+	// atmos_wake clears it.
+	scrubber.atmos_wake()
+	TEST_ASSERT_EQUAL(scrubber.atmos_idle_until, 0, "atmos_wake did not clear the idle heartbeat")
+
+	// Turf activation wakes registered machines.
+	scrubber.register_turf_wake()
+	scrubber.atmos_idle_until = world.time + ATMOS_MACHINE_IDLE_HEARTBEAT
+	scrubber.atmos_idle_streak = ATMOS_MACHINE_IDLE_STREAK
+	SSair.add_to_active(room, FALSE)
+	TEST_ASSERT_EQUAL(scrubber.atmos_idle_until, 0, "turf activation did not wake the registered machine")
+	TEST_ASSERT_EQUAL(scrubber.atmos_idle_streak, 0, "turf activation did not reset the idle streak")
+
+	scrubber.unregister_turf_wake()
+	TEST_ASSERT(!LAZYLEN(room.atmos_wake_machines), "unregister_turf_wake left a stale wake registration")
+
+	// Destroy() must drop the registration too: the turf list holds a strong
+	// ref that would otherwise pin the deleted machine forever.
+	var/obj/machinery/atmospherics/components/binary/pump/doomed = new(room)
+	doomed.register_turf_wake()
+	TEST_ASSERT(LAZYLEN(room.atmos_wake_machines), "register_turf_wake did not register the pump")
+	qdel(doomed)
+	TEST_ASSERT(!LAZYLEN(room.atmos_wake_machines), "Destroy() left a stale wake registration on the turf")
+	SSair.remove_from_active(room)
+
+#undef TEST_GAS_EPSILON

--- a/code/modules/unit_tests/atmos_native.dm
+++ b/code/modules/unit_tests/atmos_native.dm
@@ -353,6 +353,161 @@
 	SSair.remove_from_active(first)
 	SSair.remove_from_active(second)
 
+/// A grouped turf whose shares stalled must rest individually (leave the
+/// active list, stay in the group). Ejecting it through remove_from_active
+/// nuked the whole group, which kept entire planetary surfaces (19k turfs)
+/// cycling forever whenever any single member kept churning.
+/// Interior turfs of the reservation: the testing zone borders reserved
+/// space, and a space-adjacent turf is a genuine churner that must not rest.
+/datum/unit_test/atmos_stalled_turf_rests/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/origin = run_loc_floor_bottom_left
+	var/turf/open/first = locate(origin.x + 1, origin.y + 1, origin.z)
+	var/turf/open/second = locate(origin.x + 2, origin.y + 1, origin.z)
+	TEST_ASSERT(istype(first), "test location is not an open turf")
+	TEST_ASSERT(istype(second), "adjacent test location is not an open turf")
+
+	var/datum/excited_group/group = new
+	group.add_turf(first)
+	group.add_turf(second)
+	SSair.add_to_active(first, FALSE)
+	SSair.add_to_active(second, FALSE)
+
+	// Both turfs hold settled identical air; first has been stalling for a
+	// full dismantle window already.
+	first.atmos_cooldown = EXCITED_GROUP_DISMANTLE_CYCLES
+	var/fire_count = max(first.current_cycle, second.current_cycle) + 1
+	first.process_cell(fire_count)
+
+	TEST_ASSERT(!(first in SSair.active_turfs), "stalled group member did not rest out of the active list")
+	TEST_ASSERT_EQUAL(first.excited_group, group, "resting a stalled turf detached it from its excited group")
+	TEST_ASSERT_EQUAL(second.excited_group, group, "resting a stalled turf destroyed the group for other members")
+	TEST_ASSERT(group in SSair.excited_groups, "resting a stalled turf removed the group from SSair")
+
+	group.garbage_collect()
+	first.atmos_cooldown = 0
+	second.atmos_cooldown = 0
+	SSair.remove_from_active(first)
+	SSair.remove_from_active(second)
+
+/// Group averaging must not reset the members' personal stall counters:
+/// zeroing atmos_cooldown every breakdown blocked the individual rest path
+/// for every member of a group pinned awake by a single churning turf.
+/datum/unit_test/atmos_breakdown_preserves_stall_counter/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/first = run_loc_floor_bottom_left
+	var/turf/open/second = locate(first.x + 1, first.y, first.z)
+	TEST_ASSERT(istype(first), "test location is not an open turf")
+	TEST_ASSERT(istype(second), "adjacent test location is not an open turf")
+
+	var/datum/excited_group/group = new
+	group.add_turf(first)
+	group.add_turf(second)
+	first.atmos_cooldown = 10
+	second.atmos_cooldown = 10
+
+	group.self_breakdown()
+
+	TEST_ASSERT_EQUAL(first.atmos_cooldown, 10, "self_breakdown reset a member's stall counter")
+	TEST_ASSERT_EQUAL(second.atmos_cooldown, 10, "self_breakdown reset a member's stall counter")
+
+	group.garbage_collect()
+	first.atmos_cooldown = 0
+	second.atmos_cooldown = 0
+	first.air.copy_from_turf(first)
+	second.air.copy_from_turf(second)
+	SSair.remove_from_active(first)
+	SSair.remove_from_active(second)
+
+/// Group averaging must only cover members that are still awake: resting
+/// members hold their local equilibrium and nobody processes them afterwards,
+/// so folding them in smears churner gas across the whole group (planetary
+/// surfaces drifted off-template toward leaks, space-drained edges dragged
+/// entire areas toward vacuum) and keeps every breakdown O(group size).
+/datum/unit_test/atmos_breakdown_skips_resting_members/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	var/turf/open/origin = run_loc_floor_bottom_left
+	var/turf/open/first = locate(origin.x + 1, origin.y + 1, origin.z)
+	var/turf/open/second = locate(origin.x + 2, origin.y + 1, origin.z)
+	var/turf/open/resting = locate(origin.x + 3, origin.y + 1, origin.z)
+	TEST_ASSERT(istype(first), "test location is not an open turf")
+	TEST_ASSERT(istype(second), "adjacent test location is not an open turf")
+	TEST_ASSERT(istype(resting), "resting test location is not an open turf")
+
+	var/datum/excited_group/group = new
+	group.add_turf(first)
+	group.add_turf(second)
+	group.add_turf(resting)
+	SSair.add_to_active(first, FALSE)
+	SSair.add_to_active(second, FALSE)
+	SSair.add_to_active(resting, FALSE)
+	SSair.sleep_active_turf(resting)
+	TEST_ASSERT(!(resting in SSair.active_turfs), "sleep_active_turf left the turf in the active list")
+	TEST_ASSERT_EQUAL(resting.excited_group, group, "sleep_active_turf detached the turf from its group")
+
+	var/resting_o2_before = resting.air.get_moles(GAS_O2)
+	first.air.set_moles(GAS_O2, resting_o2_before + 20)
+
+	group.self_breakdown()
+
+	TEST_ASSERT(abs(resting.air.get_moles(GAS_O2) - resting_o2_before) < 0.001, "breakdown averaging rewrote a resting member's air")
+	TEST_ASSERT(abs(first.air.get_moles(GAS_O2) - second.air.get_moles(GAS_O2)) < 0.001, "breakdown averaging did not equalize the awake members")
+	TEST_ASSERT(abs(first.air.get_moles(GAS_O2) - (resting_o2_before + 10)) < 0.001, "awake members did not average to the expected mix")
+
+	group.garbage_collect()
+	first.air.copy_from_turf(first)
+	second.air.copy_from_turf(second)
+	SSair.remove_from_active(first)
+	SSair.remove_from_active(second)
+	SSair.remove_from_active(resting)
+
+/// A planetary turf must shed most of a pure-temperature excess in one cycle
+/// (upstream follows the template share with a conductive share against a
+/// 5x-inflated template heat capacity). The turf and all its neighbors are
+/// heated uniformly so neighbor conduction is zero and only the template pull
+/// acts, making the expectation independent of the local neighbor count.
+/datum/unit_test/atmos_planetary_temperature_pull/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+	// Center of the reservation: the zone borders reserved space, and a space
+	// neighbor's conductive pull (vacuum heat capacity 7000) would swamp the
+	// template pull being measured here.
+	var/turf/open/origin = run_loc_floor_bottom_left
+	var/turf/open/planet_turf = locate(origin.x + 2, origin.y + 2, origin.z)
+	TEST_ASSERT(istype(planet_turf), "test location is not an open turf")
+	for(var/turf/neighbor as anything in planet_turf.atmos_adjacent_turfs)
+		TEST_ASSERT(isfloorturf(neighbor), "center test turf has a non-floor neighbor; the reservation layout changed")
+
+	planet_turf.planetary_atmos = TRUE
+	var/datum/gas_mixture/template = SSair.get_planetary_template(planet_turf)
+	var/template_temperature = template.return_temperature()
+	planet_turf.air.copy_from(template)
+	planet_turf.air.set_temperature(template_temperature + 100)
+	var/fire_count = planet_turf.current_cycle + 1
+	for(var/turf/open/neighbor as anything in planet_turf.atmos_adjacent_turfs)
+		neighbor.air.copy_from(template)
+		neighbor.air.set_temperature(template_temperature + 100)
+		fire_count = max(fire_count, neighbor.current_cycle + 1)
+	SSair.add_to_active(planet_turf, FALSE)
+
+	planet_turf.process_cell(fire_count)
+
+	// The in-share coupling alone pulls 20% per cycle (80K left); with the
+	// inflated-capacity conductive follow-up about 47K is left. Assert the
+	// midpoint with margin on both sides.
+	var/remaining_delta = planet_turf.air.return_temperature() - template_temperature
+	TEST_ASSERT(remaining_delta < 60, "planetary turf kept [remaining_delta]K of a 100K excess after one cycle")
+
+	if(planet_turf.excited_group)
+		planet_turf.excited_group.garbage_collect()
+	planet_turf.planetary_atmos = FALSE
+	planet_turf.atmos_cooldown = 0
+	planet_turf.air.copy_from_turf(planet_turf)
+	SSair.remove_from_active(planet_turf)
+	for(var/turf/open/neighbor as anything in planet_turf.atmos_adjacent_turfs)
+		neighbor.atmos_cooldown = 0
+		neighbor.air.copy_from_turf(neighbor)
+		SSair.remove_from_active(neighbor)
+
 /// Idle-heartbeat machines must wake instantly when air on their turf changes,
 /// and enter the heartbeat only after a full streak of no-op fires.
 /datum/unit_test/atmos_machine_idle_wake/Run()

--- a/code/modules/unit_tests/atmos_performance.dm
+++ b/code/modules/unit_tests/atmos_performance.dm
@@ -1,0 +1,279 @@
+// Benchmarks and conservation checks for the native DM atmospherics hot paths.
+// Timing results are logged via log_test for before/after comparison of
+// optimization work; assertions only cover correctness (conservation,
+// convergence), never wall-clock time, to stay CI-stable.
+
+/// Builds a standard station air mixture (o2/n2 at T20C) in a fresh gas_mixture.
+/proc/unit_test_air_mix(volume = CELL_VOLUME)
+	var/datum/gas_mixture/mix = new(volume)
+	mix.set_moles(GAS_O2, MOLES_O2STANDARD)
+	mix.set_moles(GAS_N2, MOLES_N2STANDARD)
+	mix.set_temperature(T20C)
+	return mix
+
+/datum/unit_test/atmos_hot_proc_benchmark
+	priority = TEST_LONGER
+
+/datum/unit_test/atmos_hot_proc_benchmark/proc/bench_line(name, iterations, time_ms)
+	log_test("  ATMOSBENCH [name]: [iterations] iters in [round(time_ms, 0.01)]ms ([round(time_ms * 1000 / iterations, 0.01)]us/op)")
+
+/datum/unit_test/atmos_hot_proc_benchmark/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+
+	// --- archive() ---
+	var/datum/gas_mixture/archiver = unit_test_air_mix()
+	var/iterations = 20000
+	var/t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		archiver.archive()
+	bench_line("archive", iterations, TICK_USAGE_TO_MS(t1))
+
+	// --- share() steady state (both sides identical, nothing moves) ---
+	var/datum/gas_mixture/settled_a = unit_test_air_mix()
+	var/datum/gas_mixture/settled_b = unit_test_air_mix()
+	settled_a.archive()
+	settled_b.archive()
+	iterations = 20000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		settled_a.share(settled_b, 0.2, 0.2)
+	bench_line("share_settled", iterations, TICK_USAGE_TO_MS(t1))
+
+	// --- share() active (pressure delta, gas actually moves) ---
+	// Pairs are pre-seeded so the timer covers share() only.
+	var/pair_count = 4000
+	var/list/side_a = list()
+	var/list/side_b = list()
+	for(var/i in 1 to pair_count)
+		var/datum/gas_mixture/A = unit_test_air_mix()
+		A.set_moles(GAS_O2, MOLES_O2STANDARD * 3)
+		A.set_moles(GAS_PLASMA, 5)
+		A.archive()
+		side_a += A
+		var/datum/gas_mixture/B = unit_test_air_mix()
+		B.set_temperature(T20C + 60)
+		B.archive()
+		side_b += B
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to pair_count)
+		var/datum/gas_mixture/A = side_a[i]
+		A.share(side_b[i], 0.2, 0.2)
+	bench_line("share_active", pair_count, TICK_USAGE_TO_MS(t1))
+
+	// Conservation check on one representative pair
+	var/datum/gas_mixture/cons_a = unit_test_air_mix()
+	cons_a.set_moles(GAS_O2, MOLES_O2STANDARD * 3)
+	var/datum/gas_mixture/cons_b = unit_test_air_mix()
+	var/total_before = cons_a.total_moles() + cons_b.total_moles()
+	var/energy_before = cons_a.thermal_energy() + cons_b.thermal_energy()
+	cons_a.archive()
+	cons_b.archive()
+	cons_a.share(cons_b, 0.25, 0.25)
+	var/total_after = cons_a.total_moles() + cons_b.total_moles()
+	var/energy_after = cons_a.thermal_energy() + cons_b.thermal_energy()
+	TEST_ASSERT(abs(total_before - total_after) < 0.01, "share() lost moles: [total_before] -> [total_after]")
+	TEST_ASSERT(abs(energy_before - energy_after) < energy_before * 0.001, "share() lost energy: [energy_before] -> [energy_after]")
+
+	// --- compare() equal and unequal ---
+	var/datum/gas_mixture/cmp_a = unit_test_air_mix()
+	var/datum/gas_mixture/cmp_b = unit_test_air_mix()
+	iterations = 40000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		cmp_a.compare(cmp_b)
+	bench_line("compare_equal", iterations, TICK_USAGE_TO_MS(t1))
+	TEST_ASSERT_EQUAL(cmp_a.compare(cmp_b), "", "compare() of identical mixes should be empty string")
+
+	cmp_b.set_moles(GAS_PLASMA, 10)
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		cmp_a.compare(cmp_b)
+	bench_line("compare_unequal", iterations, TICK_USAGE_TO_MS(t1))
+	TEST_ASSERT_EQUAL(cmp_a.compare(cmp_b), GAS_PLASMA, "compare() should report the differing gas id")
+
+	// --- react() on inert station air (the overwhelmingly common case) ---
+	var/datum/gas_mixture/inert = unit_test_air_mix()
+	iterations = 20000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		inert.react(null)
+	bench_line("react_inert", iterations, TICK_USAGE_TO_MS(t1))
+	TEST_ASSERT_EQUAL(inert.react(null), NO_REACTION, "station air must not react")
+
+	// react() on inert air with several trace gases present
+	var/datum/gas_mixture/traces = unit_test_air_mix()
+	traces.set_moles(GAS_CO2, 4)
+	traces.set_moles(GAS_H2O, 0.05)
+	traces.set_moles(GAS_NITROUS, 0.1)
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		traces.react(null)
+	bench_line("react_traces", iterations, TICK_USAGE_TO_MS(t1))
+
+	// --- transfer_to() ping-pong ---
+	var/datum/gas_mixture/from = unit_test_air_mix()
+	var/datum/gas_mixture/into = unit_test_air_mix()
+	iterations = 20000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		from.transfer_to(into, 1)
+		into.transfer_to(from, 1)
+	bench_line("transfer_to_pingpong", iterations * 2, TICK_USAGE_TO_MS(t1))
+	TEST_ASSERT(abs(from.total_moles() + into.total_moles() - 2 * (MOLES_O2STANDARD + MOLES_N2STANDARD)) < 0.01, "transfer_to ping-pong lost moles")
+
+	// --- scrub_into() with nothing filterable (idle scrubber over a clean room) ---
+	var/datum/gas_mixture/clean_room = unit_test_air_mix()
+	var/datum/gas_mixture/scrubber_pipe = new(200)
+	scrubber_pipe.set_temperature(T20C)
+	var/list/filter_ids = list(GAS_CO2, GAS_MIASMA, GAS_METHANE)
+	iterations = 20000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		clean_room.scrub_into(scrubber_pipe, 200 / CELL_VOLUME, filter_ids)
+	bench_line("scrub_clean_room", iterations, TICK_USAGE_TO_MS(t1))
+	TEST_ASSERT(scrubber_pipe.total_moles() < 0.01, "scrubbing a clean room must move no gas")
+
+	// --- scrub_into() with CO2 present (occupied room), refilled each iteration ---
+	iterations = 10000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		clean_room.set_moles(GAS_CO2, 2)
+		clean_room.scrub_into(scrubber_pipe, 200 / CELL_VOLUME, filter_ids)
+	bench_line("scrub_co2_room", iterations, TICK_USAGE_TO_MS(t1))
+	TEST_ASSERT(scrubber_pipe.get_moles(GAS_CO2) > 100, "scrubber should have collected CO2")
+
+	// --- planetary turf template path: what process_cell does per planetary turf ---
+	var/turf/model_turf = run_loc_floor_bottom_left
+	var/datum/gas_mixture/planet_air = unit_test_air_mix()
+	planet_air.archive()
+	iterations = 4000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		var/datum/gas_mixture/G = new
+		G.copy_from_turf(model_turf)
+		G.archive()
+		if(planet_air.compare(G))
+			planet_air.share(G, 0.2, 0.2)
+		qdel(G)
+	bench_line("planetary_share_old_path", iterations, TICK_USAGE_TO_MS(t1))
+
+	// --- planetary turf template path: what process_cell does now ---
+	var/datum/gas_mixture/template_planet_air = unit_test_air_mix()
+	template_planet_air.archive()
+	var/datum/gas_mixture/planet_template = SSair.get_planetary_template(model_turf)
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		if(template_planet_air.compare(planet_template))
+			template_planet_air.share_with_template(planet_template, 0.2)
+	bench_line("planetary_share_template_path", iterations, TICK_USAGE_TO_MS(t1))
+	qdel(template_planet_air)
+
+	// --- pipenet equalize ---
+	var/list/pipenet_mixes = list()
+	for(var/i in 1 to 20)
+		var/datum/gas_mixture/M = new(70)
+		M.set_moles(GAS_O2, i)
+		M.set_moles(GAS_N2, 20 - i * 0.5)
+		M.set_temperature(T20C + i)
+		pipenet_mixes += M
+	var/net_before = 0
+	for(var/datum/gas_mixture/M as anything in pipenet_mixes)
+		net_before += M.total_moles()
+	iterations = 3000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		equalize_all_gases_in_list(pipenet_mixes)
+	bench_line("equalize_pipenet_20", iterations, TICK_USAGE_TO_MS(t1))
+	var/net_after = 0
+	for(var/datum/gas_mixture/M as anything in pipenet_mixes)
+		net_after += M.total_moles()
+	TEST_ASSERT(abs(net_before - net_after) < 0.05, "equalize_all_gases_in_list lost moles: [net_before] -> [net_after]")
+	var/datum/gas_mixture/eq_first = pipenet_mixes[1]
+	var/datum/gas_mixture/eq_last = pipenet_mixes[20]
+	TEST_ASSERT(abs(eq_first.return_pressure() - eq_last.return_pressure()) < 1, "equalize_all_gases_in_list did not equalize pressures")
+
+	// --- update_visuals() on a live turf ---
+	var/turf/open/vis_turf = run_loc_floor_bottom_left
+	iterations = 20000
+	t1 = TICK_USAGE_REAL
+	for(var/i in 1 to iterations)
+		vis_turf.update_visuals()
+	bench_line("update_visuals_invisible", iterations, TICK_USAGE_TO_MS(t1))
+
+	qdel(archiver)
+	qdel(settled_a)
+	qdel(settled_b)
+	for(var/datum/gas_mixture/M as anything in side_a + side_b + pipenet_mixes)
+		qdel(M)
+	qdel(cons_a)
+	qdel(cons_b)
+	qdel(cmp_a)
+	qdel(cmp_b)
+	qdel(inert)
+	qdel(traces)
+	qdel(from)
+	qdel(into)
+	qdel(clean_room)
+	qdel(scrubber_pipe)
+
+/// Full process_cell loop over a sealed 3x3 room with a pressure imbalance:
+/// measures per-cycle cost and verifies gases equalize and conserve.
+/datum/unit_test/atmos_process_cell_grid
+	priority = TEST_LONGER
+
+/datum/unit_test/atmos_process_cell_grid/Run()
+	TEST_ASSERT(SSair?.initialized, "SSair was not initialized")
+
+	var/turf/base = run_loc_floor_bottom_left
+
+	// Wall off the 5x5 perimeter so the inner 3x3 room is sealed.
+	for(var/dx in 0 to 4)
+		for(var/dy in 0 to 4)
+			var/turf/T = locate(base.x + dx, base.y + dy, base.z)
+			TEST_ASSERT_NOTNULL(T, "test zone turf missing at offset [dx],[dy]")
+			if(dx == 0 || dy == 0 || dx == 4 || dy == 4)
+				T.ChangeTurf(/turf/closed/wall)
+
+	var/list/turf/open/room = list()
+	for(var/dx in 1 to 3)
+		for(var/dy in 1 to 3)
+			var/turf/open/T = locate(base.x + dx, base.y + dy, base.z)
+			TEST_ASSERT(istype(T), "inner room turf is not open at offset [dx],[dy]")
+			T.ImmediateCalculateAdjacentTurfs()
+			room += T
+
+	// Seed an imbalance: center turf heavily pressurized and hot.
+	var/turf/open/center = locate(base.x + 2, base.y + 2, base.z)
+	center.air.set_moles(GAS_O2, MOLES_O2STANDARD * 8)
+	center.air.set_temperature(T20C + 100)
+
+	var/moles_before = 0
+	for(var/turf/open/T as anything in room)
+		moles_before += T.air.total_moles()
+		SSair.add_to_active(T, FALSE)
+
+	var/cycles = 60
+	var/fire_base = SSair.times_fired + 1000
+	var/t1 = TICK_USAGE_REAL
+	for(var/cycle in 1 to cycles)
+		for(var/turf/open/T as anything in room)
+			T.process_cell(fire_base + cycle)
+	var/grid_ms = TICK_USAGE_TO_MS(t1)
+	log_test("  ATMOSBENCH process_cell_3x3: [cycles] cycles in [round(grid_ms, 0.01)]ms ([round(grid_ms * 1000 / (cycles * 9), 0.01)]us/turf-cycle)")
+
+	var/moles_after = 0
+	var/pressure_min = INFINITY
+	var/pressure_max = 0
+	for(var/turf/open/T as anything in room)
+		moles_after += T.air.total_moles()
+		var/p = T.air.return_pressure()
+		pressure_min = min(pressure_min, p)
+		pressure_max = max(pressure_max, p)
+
+	TEST_ASSERT(abs(moles_before - moles_after) < moles_before * 0.001, "sealed room lost gas: [moles_before] -> [moles_after]")
+	TEST_ASSERT(pressure_max - pressure_min < pressure_max * 0.25, "room failed to trend toward equalization: min [pressure_min], max [pressure_max]")
+
+	// Cleanup: reset room to standard air and deactivate.
+	for(var/turf/open/T as anything in room)
+		T.air.copy_from_turf(T)
+		SSair.remove_from_active(T)


### PR DESCRIPTION
# Описание

Большой перф-пасс по нативной атмосфере. Суть: перестать делать работу, результат которой никому не нужен.

- Насосы, венты, скрабберы и инжекторы, которым нечего делать (выключены, цель достигнута, труба пустая, комната чистая), после четырёх холостых проходов уходят в 5-секундный "хартбит" вместо полного прогона каждые полсекунды. Будятся мгновенно: по изменению воздуха на своём турфе, по скачку давления пайпнета (в том числе через открытый клапан из соседней сети), по радиосигналу, питанию, сварке, кликам и UI. На геймплей это не влияет - спящая машина просыпается в тот же файр, когда появляется работа.
- Excited groups больше не разваливаются от каждого чиха (вдох моба, подкачка вента) - это заставляло пересобирать группы целых комнат каждый файр и держало сотни устаканившихся турфов вечно активными. При этом структурные изменения (закрылся фаерлок, построили стену) группу честно разваливают, иначе self_breakdown усреднял бы газ сквозь закрытую дверь.
- Застойный турф внутри живой excited group теперь уходит из обработки одиночно (sleep_active_turf), а не через remove_from_active, гробивший группу целиком. Раньше достаточно было полусотни турфов у одной утечки, чтобы вся планетарная поверхность аваймиссии (19 тысяч турфов) висела в active_turfs до конца раунда и оплачивала полный process_cell каждый файр.
- self_breakdown усредняет только бодрых членов группы и не сбрасывает их счётчики простоя: спящие турфы держат своё локальное равновесие, утечки и краевая вентиляция в космос больше не размазываются усреднением по всей зоне (синдикатскую базу высасывало до 0.1 кПа целиком), а значимый шаринг будит спящего соседа обратно.
- Планетарный шаринг приведён к апстриму: ре-архив перед шарингом, доля 0.8 вместо ~0.2 и кондуктивный temperature_share с 5-кратной теплоёмкостью шаблона. Чисто температурные отклонения сходятся к порогу засыпания за ~5 циклов вместо десятков - это был вечный чурн некрополиса и снежного экстерьера.
- Вентиляция в космос гейтит сбросы кулдаунов группы объёмом стравленного: остаточная капля больше не пинит breakdown/dismantle всей группы навечно.
- Планетарные турфы (лавленд и ко) регенерируют к общему иммутабельному шаблону вместо аллокации и удаления временного газового микса на каждый турф каждый цикл. Теплоёмкость шаблона кэшируется.
- Реакции подбираются через индекс по ключевому газу: обычный воздух из o2/n2 теперь резолвится в ноль кандидатов без прохода по всем ~28 реакциям.
- transfer_to больше не рапортует успех при нуле перемещённых молей - вент над осушенной трубой в разгерметизированной комнате раньше вечно держал турф активным и пайпнет грязным.
- Метры и газовые сенсоры (чистая телеметрия для консолей) шлют отчёт раз в 2 секунды вместо каждого файра, энергопотребление скомпенсировано.
- Разобранная машина снимает свою wake-регистрацию с турфа (иначе жёсткая ссылка не давала ей собраться сборщиком).
- Продвинутая швабра стартует процессинг из Initialize, а не из New: заспавненная маплоадером, она спамила раитаймами с null reagents всю отложенную инициализацию карты (30+ раитаймов за загрузку аваймиссии).
- Новый админ-верб "Atmos Active Turfs Report": разбивка активных турфов по z-уровням и областям с давлением/температурой - искать источники чурна теперь можно за секунды.
- Юнит-тесты на нативную атмосферу: консервация молей/энергии в share и transfer, диспатч реакций, планетарные шаблоны, поведение excited groups, одиночный сон застойных турфов, усреднение без спящих, сила притяжения к шаблону, идл/вейк машин, гейтинг скраббера, плюс перф-бенчи горячих проков.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

SSair - самая дорогая подсистема на сервере, и большая часть её стоимости уходила впустую: 2000+ машин обсчитывались каждые полсекунды независимо от того, есть ли им что делать, вечные "подкачки" вентов на 0.01 кПа держали комнаты активными навсегда, а каждый планетарный турф каждый цикл создавал и удалял временный газовый микс. На живом раунде это давало стабильный перерасход тика. Отдельно, на раундах с загруженной аваймиссией AGRComplex подсистема деградировала полностью: 20 тысяч вечно активных турфов и cost_turfs около 550ms. После паса простаивающая станция реально спит: активными остаются только места, где газ действительно движется.

## Демонстрация изменений

Вывод нового верба на живом раунде (Box + лавленд):

```
SSair active turfs: 900 (excited groups: 29, in groups: 718, planetary: 251, actively sharing: 534)
By z-level: z1: 306, z7: 518, z12: 28, z5: 29, z6: 10, z10: 9
```

Бенчмарк на загрузке аваймиссии AGRComplex (одинаковый харнес: обычный CI-раунд, загрузка миссии будит ~43 тысячи турфов, затем 120 циклов SSair):

| active turfs | до | после |
|---|---|---|
| после загрузки миссии | 48124 | 47706 |
| цикл 20 | 8685 | 3332 |
| цикл 120 | 5412 и растёт | 1756 и падает |
| экстерьер миссии, цикл 120 | 3318 и растёт | 663 стабильно |

На живом сервере "до" за час дорастало до 20380 активных турфов (18848 из них - снежный экстерьер миссии) с cost_turfs ~554ms; "после" экстерьер стабилизируется на ~660 честно работающих турфах у перепадов давления. Групповой чурн исчез: число excited groups сходится к 19 вместо скачков 76-361 от постоянных пересборок.

Почти вся оставшаяся активность - лавленд (планетарная регенерация пещер) и руины, станция спит. Полный прогон юнит-тестов зелёный (350 PASS), включая стресс-сценарий "куча канистр + пожар + взрыв" - гонялся отдельно при разборе краша клиента.

## Changelog

:cl:
code: атмосферные машины без работы уходят в спячку и мгновенно просыпаются по событиям; excited groups не пересобираются от каждого вдоха; планетарная регенерация идёт к общему шаблону; реакции ищутся через индекс по ключевому газу
fix: планетарные поверхности (лавленд, аваймиссии) больше не держат десятки тысяч устаканившихся турфов вечно активными вокруг одной утечки; краевая вентиляция в космос больше не высасывает воздух целых зон через усреднение; вент над пустой трубой больше не держит комнату вечно активной; разобранные атмос-машины корректно собираются сборщиком мусора; продвинутая швабра больше не раитаймит при спавне маплоадером
balance: планетарная атмосфера восстанавливается к своему шаблону с апстримной силой - дыры и перегревы на планетах затягиваются заметно быстрее
admin: новый верб Atmos Active Turfs Report - разбивка активных турфов по z-уровням и областям для поиска источников атмос-чурна
server: заметно снижена стоимость SSair на устаканившейся станции и на планетарных z-уровнях; телеметрия метров и сенсоров шлётся раз в 2 секунды
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Добавлен новый админский debug-отчёт по активности атмосферной системы.
* **Bug Fixes**
  * Атмосферные машины корректнее входят в режим простоя и быстрее пробуждаются при изменениях воздуха.
  * Исправлено поведение телеметрии: обновления теперь отправляются по заданному интервалу.
  * Уточнена логика вентиляции/перекачки и обмена на границах, включая планетарную атмосферу.
* **Performance**
  * Ускорены реакции и обмен газов за счёт более точного отбора кандидатов и оптимизации общих операций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->