### PR TITLE
хотфикс жесткой ошибки в МОДах

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -78,7 +78,7 @@
 	var/obj/item/piece = part
 	REMOVE_TRAIT(piece, TRAIT_NODROP, MOD_TRAIT)
 	if(wearer)
-		wearer.transferItemToLoc(piece, piece.drop_location(), TRUE)
+		wearer.transferItemToLoc(piece, null, TRUE)
 	if(piece == helmet)
 		helmet.show_overslot()
 	if(piece == chestplate)


### PR DESCRIPTION
# Описание

Чтобы допустить такую глупую ошибку нужно кодить в 2 часа ночи после 12 часовой смены, как я.

## Причина изменений

части мода дропались на пол, не давая снять часть со спины, полностью ломая взаимодействие

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * При снятии части костюма предмет теперь возвращается в более ожидаемое место, вместо использования предыдущего места сброса.
  * Поведение втягивания/снятия экипировки стало стабильнее и предсказуемее для игрока.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->