### PR TITLE
починил магазины АА12

### DIFF
--- a/modular_bluemoon/Ren/Code/staff/bundles_and_outfits.dm
+++ b/modular_bluemoon/Ren/Code/staff/bundles_and_outfits.dm
@@ -106,7 +106,8 @@
 	new /obj/item/storage/box/survival/security/radio(src)
 	new /obj/item/gun/ballistic/automatic/shotgun/aa12(src)
 	for(var/i in 1 to 3)
-		new /obj/item/ammo_box/magazine/aa12/small(src)
+		new /obj/item/ammo_box/magazine/aa12(src)
+	new /obj/item/ammo_box/magazine/aa12/drum(src)
 	new /obj/item/storage/belt/utility/syndicate(src)
 	new /obj/item/clothing/gloves/tackler/combat/insulated(src)
 

--- a/modular_bluemoon/Ren/Code/staff/uplink.dm
+++ b/modular_bluemoon/Ren/Code/staff/uplink.dm
@@ -246,8 +246,8 @@
 			new /obj/item/clothing/suit/space/hardsuit/syndi/inteq(src) // 8 tc
 			new /obj/item/gun/ballistic/automatic/shotgun/aa12(src) // 8 tc
 			new /obj/item/implanter/explosive(src) // 2 tc
-			new /obj/item/ammo_box/magazine/aa12/small(src) // 2 tc
-			new /obj/item/ammo_box/magazine/aa12/small(src) // 2 tc
+			new /obj/item/ammo_box/magazine/aa12(src) // 2 tc
+			new /obj/item/ammo_box/magazine/aa12(src) // 2 tc
 			new /obj/item/grenade/plastic/c4 (src) // 1 tc
 			new /obj/item/grenade/plastic/c4 (src) // 1 tc
 			new /obj/item/card/emag(src) // 6 tc

--- a/modular_bluemoon/Ren/Code/weapons.dm
+++ b/modular_bluemoon/Ren/Code/weapons.dm
@@ -146,7 +146,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	recoil = 2
-	mag_type = /obj/item/ammo_box/magazine/aa12/small
+	mag_type = /obj/item/ammo_box/magazine/aa12
 	fire_sound = 'sound/weapons/gunshotshotgunshot.ogg'
 	automatic_burst_overlay = FALSE
 	can_suppress = FALSE

--- a/modular_bluemoon/Ren/Code/weapons.dm
+++ b/modular_bluemoon/Ren/Code/weapons.dm
@@ -109,7 +109,7 @@
 	burst_shot_delay = 2
 
 /// AA12
-/obj/item/ammo_box/magazine/aa12/small
+/obj/item/ammo_box/magazine/aa12
 	name = "AA12 magazine (12g buckshot)"
 	desc = "Здоровый коробчатый магазин для патрон 12 калибра"
 	icon_state = "mag-aa-small"
@@ -117,11 +117,11 @@
 	w_class = WEIGHT_CLASS_SMALL
 	max_ammo = 8
 
-/obj/item/ammo_box/magazine/aa12/small/update_icon()
+/obj/item/ammo_box/magazine/aa12/update_icon()
 	..()
 	icon_state = "mag-aa-small-[ammo_count() ? "1" : "0"]"
 
-/obj/item/ammo_box/magazine/aa12
+/obj/item/ammo_box/magazine/aa12/drum
 	name = "AA12 drum magazine (12g buckshot)"
 	desc = "Здоровый барабанный магазин для патрон 12 калибра"
 	icon_state = "mag-aa"
@@ -131,7 +131,7 @@
 	caliber = "shotgun"
 	max_ammo = 20
 
-/obj/item/ammo_box/magazine/aa12/update_icon()
+/obj/item/ammo_box/magazine/aa12/drum/update_icon()
 	..()
 	icon_state = "mag-aa-[ammo_count() ? "1" : "0"]"
 


### PR DESCRIPTION
Из за изменений двух годичной давности АА12 не мог пользоваться своими же магазинами. Сделал маленький магазин АА12 обычным, что бы в него обратно вставлялись барабаны

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшено отображение магазинов AA12: индикатор состояния теперь корректно обновляется в зависимости от количества патронов.
  * Исправлено отображение барабанного магазина AA12, чтобы иконка точнее отражала фактическое состояние.
* **Content Updates**
  * Обновлены наборы и комплекты, выдающие боеприпасы для AA12: теперь используется актуальный тип магазина (включая барабанную версию) вместо старого варианта.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->