### PR TITLE
Чиним утечки GC у шейпшифтов (зверь/мышь/армси еретика)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -168,7 +168,7 @@
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	if(isanimal(shape)) //BLUEMOON ADD шейпы не двигаются и не пытаются кого-то убить если выйти
 		var/mob/living/simple_animal/s_a = shape
-		s_a.AIStatus = AI_OFF
+		s_a.toggle_ai(AI_OFF) // прямое присвоение AIStatus стрэндит моба в GLOB.simple_animals[AI_ON]
 		s_a.wander = FALSE //BLUEMOON ADD END
 	H = new(shape,src,human_caster)
 	if(istype(H, /mob/living/simple_animal))

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -161,7 +161,7 @@
 			current.icon_state = "armsy_mid"
 			current.icon_living = "armsy_mid"
 			current.front = src
-			current.AIStatus = AI_OFF
+			current.toggle_ai(AI_OFF)
 			back = current
 		else if(i < len)
 			current = new type(drop_location(),FALSE)
@@ -169,12 +169,12 @@
 			prev.icon_state = "armsy_mid"
 			prev.icon_living = "armsy_mid"
 			prev.front = next
-			prev.AIStatus = AI_OFF
+			prev.toggle_ai(AI_OFF)
 		else
 			prev.icon_state = "armsy_end"
 			prev.icon_living = "armsy_end"
 			prev.front = next
-			prev.AIStatus = AI_OFF
+			prev.toggle_ai(AI_OFF)
 		next = prev
 
 //we are literally a vessel of otherworldly destruction, we bring our own gravity unto this plane
@@ -241,7 +241,7 @@
 				prev.icon_state = "armsy_end"
 				prev.icon_living = "armsy_end"
 				prev.front = src
-				prev.AIStatus = AI_OFF
+				prev.toggle_ai(AI_OFF)
 				current_stacks = 0
 
 	adjustBruteLoss(-maxHealth * 0.5, FALSE)
@@ -317,7 +317,7 @@
 				prev.icon_state = "armsy_end"
 				prev.icon_living = "armsy_end"
 				prev.front = src
-				prev.AIStatus = AI_OFF
+				prev.toggle_ai(AI_OFF)
 				current_stacks = 0
 				var/matrix/matrix_transformation = matrix()
 				matrix_transformation.Scale(1.4,1.4)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -151,13 +151,13 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/StartAction(deci = 0)
 	stop_automated_movement = TRUE
-	AIStatus = AI_OFF
+	toggle_ai(AI_OFF)
 	addtimer(CALLBACK(src, PROC_REF(EndAction)), deci)
 
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/EndAction()
 	stop_automated_movement = FALSE
-	AIStatus = AI_ON
+	toggle_ai(AI_ON)
 
 
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -58,7 +58,7 @@
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	if(isanimal(shape)) //BLUEMOON ADD шейпы не двигаются и не пытаются кого-то убить если выйти
 		var/mob/living/simple_animal/s_a = shape
-		s_a.AIStatus = AI_OFF
+		s_a.toggle_ai(AI_OFF) // прямое присвоение AIStatus стрэндит моба в GLOB.simple_animals[AI_ON]
 		s_a.wander = FALSE //BLUEMOON ADD END
 	H = new(shape,src,caster)
 
@@ -118,11 +118,13 @@
 		restore()
 	stored = null
 	shape = null
+	slink = null // qdel'ится в restore(); без обнуления держит цикл holder <-> soullink и оба хардделятся
+	source = null
 	. = ..()
 
 /obj/shapeshift_holder/Moved()
 	. = ..()
-	if(!restoring || QDELETED(src))
+	if(!restoring && !QDELETED(src))
 		restore()
 
 /obj/shapeshift_holder/handle_atom_del(atom/A)
@@ -170,6 +172,10 @@
 
 /datum/soullink/shapeshift
 	var/obj/shapeshift_holder/source
+
+/datum/soullink/shapeshift/Destroy()
+	source = null
+	return ..()
 
 /datum/soullink/shapeshift/ownerDies(gibbed, mob/living/owner)
 	if(source)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -174,6 +174,7 @@
 #include "image_leak_audit.dm"
 #include "rtt_window.dm"
 #include "screen_gc.dm"
+#include "shapeshift_gc.dm"
 #include "space_drift.dm"
 #include "statpanel_listedturf.dm"
 #include "ssmobs_optimization.dm"

--- a/code/modules/unit_tests/shapeshift_gc.dm
+++ b/code/modules/unit_tests/shapeshift_gc.dm
@@ -1,0 +1,101 @@
+/// Test: full shapeshift/restore cycle leaves no GC failures behind.
+/// Regression coverage for the round-log leak trio: shape mob stranded in
+/// GLOB.simple_animals[AI_ON] (direct AIStatus write bypassing toggle_ai),
+/// plus the shapeshift_holder <-> soullink reference cycle.
+/datum/unit_test/gc_shapeshift_cycle_cleanup
+	parent_type = /datum/unit_test/gc_rewrite_base
+
+/datum/unit_test/gc_shapeshift_cycle_cleanup/Run()
+	configure_immediate_gc()
+
+	var/mob/living/carbon/human/caster = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
+	var/obj/effect/proc_holder/spell/targeted/shapeshift/spell = allocate(/obj/effect/proc_holder/spell/targeted/shapeshift)
+	spell.shapeshift_type = /mob/living/simple_animal/mouse
+
+	spell.Shapeshift(caster)
+
+	var/obj/shapeshift_holder/holder = caster.loc
+	TEST_ASSERT(istype(holder), "Shapeshift() did not move the caster into a shapeshift holder")
+	var/mob/living/simple_animal/shape = holder.shape
+	TEST_ASSERT_NOTNULL(shape, "Shapeshift holder has no shape mob")
+	var/datum/soullink/shapeshift/slink = holder.slink
+	TEST_ASSERT_NOTNULL(slink, "Shapeshift holder has no soullink")
+
+	// The BLUEMOON AI shutdown must migrate the mob between the AI bookkeeping
+	// lists; a direct AIStatus write leaves it stranded in the AI_ON list and
+	// Destroy() then removes it from the wrong one, leaking the mob forever.
+	TEST_ASSERT(!(shape in GLOB.simple_animals[AI_ON]), "Shape mob is still tracked in GLOB.simple_animals[AI_ON] after AI shutdown")
+	TEST_ASSERT(shape in GLOB.simple_animals[AI_OFF], "Shape mob is not tracked in GLOB.simple_animals[AI_OFF] after AI shutdown")
+
+	spell.Restore(shape)
+
+	TEST_ASSERT(QDELETED(holder), "Shapeshift holder was not qdeleted by restore()")
+	TEST_ASSERT(QDELETED(shape), "Shape mob was not qdeleted by restore()")
+	TEST_ASSERT(QDELETED(slink), "Shapeshift soullink was not qdeleted by restore()")
+	TEST_ASSERT(isturf(caster.loc), "Caster was not returned to a turf by restore()")
+	TEST_ASSERT(!caster.mob_transforming, "Caster is still flagged as mob_transforming after restore()")
+
+	// Both sides of the holder <-> soullink cycle must be broken, otherwise
+	// they keep each other's refcount above zero and both hard-delete.
+	TEST_ASSERT_NULL(holder.slink, "Holder Destroy() did not clear its soullink reference")
+	TEST_ASSERT_NULL(slink.source, "Soullink Destroy() did not clear its holder reference")
+
+	TEST_ASSERT(!(shape in GLOB.simple_animals[AI_ON]), "Deleted shape mob is still tracked in GLOB.simple_animals[AI_ON]")
+	TEST_ASSERT(!(shape in GLOB.simple_animals[AI_OFF]), "Deleted shape mob is still tracked in GLOB.simple_animals[AI_OFF]")
+
+	holder = null
+	shape = null
+	slink = null
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
+	run_gc_fire_cycles(1, yield_for_gc = TRUE)
+
+	assert_no_gc_failures(/obj/shapeshift_holder, "Shapeshift holder")
+	assert_no_gc_failures(/datum/soullink/shapeshift, "Shapeshift soullink")
+	// No GC-counter assert on the shape mob itself: at zero-timeout mobs are
+	// nondeterministically grazed by transient holders unrelated to shapeshift
+	// (a full-world reference scan finds no datum-side holders). The mob leak
+	// this test guards against is the GLOB.simple_animals stranding asserted
+	// explicitly above.
+
+/// Test: the Beast Spirit quirk transform (the exact trio from round logs:
+/// beastspirit + shapeshift_holder + soullink/shapeshift) collects cleanly.
+/datum/unit_test/gc_beastspirit_cycle_cleanup
+	parent_type = /datum/unit_test/gc_rewrite_base
+
+/datum/unit_test/gc_beastspirit_cycle_cleanup/Run()
+	configure_immediate_gc()
+
+	var/mob/living/carbon/human/caster = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
+	var/obj/effect/proc_holder/spell/targeted/shapeshift/beast/spell = allocate(/obj/effect/proc_holder/spell/targeted/shapeshift/beast)
+
+	spell.Shapeshift(caster) // sleeps 3 seconds for the transform animation
+
+	var/obj/shapeshift_holder/holder = caster.loc
+	TEST_ASSERT(istype(holder), "Beast Shapeshift() did not move the caster into a shapeshift holder")
+	var/mob/living/simple_animal/hostile/beastspirit/shape = holder.shape
+	TEST_ASSERT(istype(shape), "Beast shapeshift holder is not holding a beastspirit shape")
+	var/datum/soullink/shapeshift/slink = holder.slink
+	TEST_ASSERT_NOTNULL(slink, "Beast shapeshift holder has no soullink")
+
+	TEST_ASSERT(!(shape in GLOB.simple_animals[AI_ON]), "Beastspirit is still tracked in GLOB.simple_animals[AI_ON] after AI shutdown")
+
+	spell.Restore(shape)
+
+	TEST_ASSERT(QDELETED(holder), "Beast shapeshift holder was not qdeleted by restore()")
+	TEST_ASSERT(QDELETED(shape), "Beastspirit was not qdeleted by restore()")
+	TEST_ASSERT(QDELETED(slink), "Beast shapeshift soullink was not qdeleted by restore()")
+	TEST_ASSERT_NULL(holder.slink, "Beast holder Destroy() did not clear its soullink reference")
+	TEST_ASSERT_NULL(slink.source, "Beast soullink Destroy() did not clear its holder reference")
+	TEST_ASSERT(!(shape in GLOB.simple_animals[AI_ON]), "Deleted beastspirit is still tracked in GLOB.simple_animals[AI_ON]")
+	TEST_ASSERT(!(shape in GLOB.simple_animals[AI_OFF]), "Deleted beastspirit is still tracked in GLOB.simple_animals[AI_OFF]")
+
+	holder = null
+	shape = null
+	slink = null
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
+	run_gc_fire_cycles(1, yield_for_gc = TRUE)
+
+	assert_no_gc_failures(/obj/shapeshift_holder, "Beast shapeshift holder")
+	assert_no_gc_failures(/datum/soullink/shapeshift, "Beast shapeshift soullink")
+	// No GC-counter assert on the beastspirit itself; see the note in
+	// gc_shapeshift_cycle_cleanup.

--- a/modular_bluemoon/code/datums/traits/good/beast_spirit.dm
+++ b/modular_bluemoon/code/datums/traits/good/beast_spirit.dm
@@ -238,7 +238,7 @@
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	H = new(shape, src, action_owner)
 	var/mob/living/simple_animal/hostile/beastspirit/BEAST = shape
-	BEAST.AIStatus = AI_OFF //BLUEMOON ADD шейпы не двигаются и не пытаются кого-то убить если выйти
+	BEAST.toggle_ai(AI_OFF) //BLUEMOON ADD шейпы не двигаются и не пытаются кого-то убить если выйти; прямое присвоение AIStatus стрэндит моба в GLOB.simple_animals[AI_ON]
 	BEAST.wander = FALSE //BLUEMOON ADD END
 	BEAST.name = action_owner.name
 	BEAST.beast_type = beast_type


### PR DESCRIPTION
# Описание

В логах GC каждый раунд спамила тройка "beastspirit + shapeshift_holder + soullink/shapeshift" - каждое превращение зверя (и любой другой шейпшифт) навсегда утекало три объекта.

Причин было две:
- прямое `AIStatus = AI_OFF` в обход `toggle_ai()` стрэндило моба-шейпа в `GLOB.simple_animals[AI_ON]` навсегда (Destroy удаляет из списка по текущему статусу, а моб лежал в другом). Та же мина лежала у армси еретика и AI-свармеров - поправил и их;
- `shapeshift_holder` и его соуллинк держали ссылки друг на друга и после qdel не отпускали - оба стабильно доживали до харддела.

Бонусом починил перепутанное условие в `shapeshift_holder/Moved()`, из-за которого `restore()` дёргался повторно на уже почищенном холдере и кидал рантайм при каждом удалении.

На всё это написаны GC юнит-тесты (общий спелл + квирк "Звериный Дух"): без фиксов падают ровно на корне бага, с фиксами зелёные.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: превращения (Звериный Дух, мышь вампира, шейпшифты) больше не утекают в память при каждом использовании
code: добавлены GC юнит-тесты на цикл шейпшифта
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшена очистка и восстановление после шейпшифта: снижены риски зависаний, утечек и некорректного восстановления формы.
  * Исправлено отключение/включение ИИ у временных форм и связанных существ через единый механизм.
  * Обновлена логика обработки некоторых состояний, чтобы формы корректно завершали работу и удалялись.

* **Tests**
  * Добавлены unit-тесты, проверяющие полный цикл шейпшифта и очистку объектов после удаления.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->