### PR TITLE
Gc_fix + Preview fix 

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1142,12 +1142,44 @@ GLOBAL_LIST_EMPTY(humanoid_icon_cache)
 		else if (outfit_override)
 			body.equipOutfit(outfit_override,visualsOnly = TRUE)
 
+		// Синхронизация превью моба, без этого именно эти части почему-то ломает. Костыль.
+		body.update_body(update_genitals = TRUE)
+		body.update_hair()
+		body.update_mutations_overlay()
 
-		var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
+		var/icon/out_icon
+		var/list/good_partials = list()
+		var/list/good_dirs = list()
+		var/max_w = 0
+		var/max_h = 0
 		for(var/D in showDirs)
 			var/icon/partial = getFlatIcon(body, defdir = D, no_anim = no_anim)
 			if(istype(partial, /icon) && partial.Width() && partial.Height())
-				out_icon.Insert(partial, dir = D)
+				good_partials += partial
+				good_dirs += D
+				var/pw = partial.Width()
+				var/ph = partial.Height()
+				if(pw > max_w)
+					max_w = pw
+				if(ph > max_h)
+					max_h = ph
+
+		if(length(good_dirs))
+			// Чиню за собой партиклы моба, на некоторых персах с специфическими данными превью ломалось.
+			out_icon = new /icon()
+			for(var/i = 1 to length(good_dirs))
+				var/D = good_dirs[i]
+				var/icon/slot = good_partials[i]
+				if(slot.Width() != max_w || slot.Height() != max_h)
+					var/icon/padded = new /icon(slot)
+					padded.Crop(1, 1, max_w, max_h)
+					slot = padded
+				try
+					out_icon.Insert(slot, dir = D, frame = 1, delay = 0)
+				catch(var/exception/e)
+					stack_trace("get_flat_human_icon: Insert failed for dir=[D] ([e])")
+		if(!out_icon || !out_icon.Width())
+			out_icon = icon('icons/effects/effects.dmi', "nothing")
 
 		GLOB.humanoid_icon_cache[icon_id] = out_icon
 		if(length(GLOB.humanoid_icon_cache) > HUMANOID_ICON_CACHE_MAX)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -1165,7 +1165,6 @@ so as to remain in compliance with the most up-to-date laws."
 		deltimer(timeout_id)
 		timeout_id = null
 	detach_from_owner(TRUE)
-	animate(src)
 	transform = null
 	severity = 0
 	if(clickable_glow)

--- a/code/datums/soullink.dm
+++ b/code/datums/soullink.dm
@@ -5,13 +5,14 @@
 	var/list/sharedSoullinks //soullinks we are a/the sharer of
 
 /mob/living/Destroy()
-	for(var/s in ownedSoullinks)
-		var/datum/soullink/S = s
+	for(var/datum/soullink/S in ownedSoullinks)
 		S.ownerDies(FALSE)
-		qdel(s) //If the owner is destroy()'d, the soullink is destroy()'d
+		if(!QDELETED(S))
+			qdel(S) //If the owner is destroy()'d, the soullink is destroy()'d
 	ownedSoullinks = null
-	for(var/s in sharedSoullinks)
-		var/datum/soullink/S = s
+	for(var/datum/soullink/S in sharedSoullinks)
+		if(QDELETED(S))
+			continue
 		S.sharerDies(FALSE)
 		S.removeSoulsharer(src) //If a sharer is destroy()'d, they are simply removed
 	sharedSoullinks = null

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -319,6 +319,7 @@
 
 	GLOB.lighting_deferred_atoms -= src
 	QDEL_NULL(light)
+	QDEL_NULL(proximity_monitor)
 
 	return ..()
 

--- a/code/modules/mapping/space_management/space_reservation.dm
+++ b/code/modules/mapping/space_management/space_reservation.dm
@@ -81,6 +81,19 @@
 	LAZYADD(SSmapping.turf_reservations, src)
 
 /datum/turf_reservation/Destroy()
-	Release()
+	SSmapping.used_turfs -= reserved_turfs
+	for(var/i in reserved_turfs)
+		var/turf/T = i
+		LAZYINITLIST(SSmapping.unused_turfs["[T.z]"])
+		SSmapping.unused_turfs["[T.z]"] += T
+		T.flags_1 |= UNUSED_RESERVATION_TURF_1
+		GLOB.areas_by_type[world.area].contents += T
+	reserved_turfs.Cut()
 	LAZYREMOVE(SSmapping.turf_reservations, src)
 	return ..()
+
+/datum/turf_reservation/transit/Destroy()
+	for(var/turf/open/space/transit/T in reserved_turfs)
+		for(var/atom/movable/AM in T)
+			dump_in_space(AM)
+	. = ..()

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -12,7 +12,5 @@
 				UNSETEMPTY(target.observers)
 			observetarget = null
 	..()
-	if(!QDELING(src))
-		spawn(0)
-			if(src && !key)	//we've transferred to another mob. This ghost should be deleted.
-				qdel(src)
+	if(!QDELING(src) && !key)
+		qdel(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -18,6 +18,7 @@
 	//This must be done first, so the mob ghosts correctly before DNA etc is nulled
 	. =  ..()
 
+	QDEL_NULL(small_sprite)
 	QDEL_LIST(internal_organs)
 	QDEL_LIST(stomach_contents)
 	QDEL_LAZYLIST(all_wounds)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -94,6 +94,14 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 				SSquirks.AssignQuirks(human_target, human_target.client, TRUE, TRUE, null, FALSE, human_target)
 			human_target.copy_clothing_prefs(copycat)
 
+			// Синхронизируем ДНА к мобам не на Z-левеле. Т.е. для тех, кто не на уровне map. Чиним превью в тгуи.
+			copycat.hair_style = human_target.hair_style
+			copycat.facial_hair_style = human_target.facial_hair_style
+			copycat.grad_style = human_target.grad_style
+			copycat.grad_color = human_target.grad_color
+			copycat.left_eye_color = human_target.left_eye_color
+			copycat.right_eye_color = human_target.right_eye_color
+
 		copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
 	else
 		//even if target isn't a carbon, if they have a client we can make the

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -48,6 +48,7 @@
 /mob/living/carbon/human/Destroy()
 	QDEL_NULL(profile)
 	QDEL_NULL(physiology)
+	QDEL_NULL(mob_panel)
 	QDEL_NULL_LIST(vore_organs) // CITADEL EDIT belly stuff
 	GLOB.human_list -= src
 	GLOB.suit_sensors_list -= src

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -64,6 +64,7 @@ GLOBAL_LIST_INIT(strippable_monkey_items, create_strippable_list(list(
 
 /mob/living/carbon/monkey/Destroy()
 	walk(src, 0)
+	stop_pulling()
 	// Clean up references other monkeys hold to us (prevents GC failures)
 	for(var/mob/living/carbon/monkey/M in GLOB.carbon_list)
 		if(M == src)

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -30,6 +30,27 @@
 	release_vore_contents(include_absorbed = TRUE, silent = TRUE)
 	prey_excludes.Cut()
 	QDEL_NULL_LIST(vore_organs)
+
+	GLOB.simple_animals[AIStatus] -= src
+	if (LAZYLEN(SSnpcpool.currentrun))
+		SSnpcpool.currentrun -= src
+
+	if(nest)
+		nest.spawned_mobs -= src
+		nest = null
+
+	var/turf/T = get_turf(src)
+	if (AIStatus == AI_Z_OFF && islist(SSidlenpcpool.idle_mobs_by_zlevel))
+		if (T)
+			var/list/idle_z_list = SSidlenpcpool.idle_mobs_by_zlevel[T.z]
+			if(islist(idle_z_list))
+				idle_z_list -= src
+		else
+			for (var/i in 1 to SSidlenpcpool.idle_mobs_by_zlevel.len)
+				var/list/idle_z_list = SSidlenpcpool.idle_mobs_by_zlevel[i]
+				if(islist(idle_z_list))
+					idle_z_list -= src
+
 	. = ..()
 
 // Update fullness based on size & quantity of belly contents

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -112,18 +112,14 @@
 /mob/living/simple_animal/slime/Destroy()
 	deltimer(atkcool_timer_id)
 	AIproc = 0
-	for(var/friend in Friends)
-		UnregisterSignal(friend, COMSIG_PARENT_QDELETING)
-	for (var/A in actions)
-		var/datum/action/AC = A
-		AC.Remove(src)
 	Target = null
 	Leader = null
-	AIproc = 0
 	for(var/friend in Friends)
 		UnregisterSignal(friend, COMSIG_PARENT_QDELETING)
-	Friends.Cut()
-	speech_buffer.Cut()
+	Friends = null
+	speech_buffer = null
+	for(var/datum/action/innate/slime/A in actions)
+		A.Remove(src)
 	return ..()
 
 /mob/living/simple_animal/slime/proc/initialize_mutations()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -56,6 +56,7 @@
 		hud_list = null
 	QDEL_LIST(client_colours)
 	clear_typing_indicator()
+	QDEL_NULL(mob_panel)
 	ghostize()
 	if(mind?.current == src) //Let's just be safe yeah? This will occasionally be cleared, but not always. Can't do it with ghostize without changing behavior
 		mind.set_current(null)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -367,6 +367,7 @@
 		on = FALSE
 	mark_apc_light_cache_dirty(A)
 	nightshift_update_queued = FALSE
+	GLOB.nightshift_light_queue -= src
 	QDEL_NULL(cell)
 	return ..()
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -116,6 +116,7 @@
 /obj/shapeshift_holder/Destroy()
 	if(!restoring)
 		restore()
+	slink = null
 	stored = null
 	shape = null
 	. = ..()
@@ -170,6 +171,10 @@
 
 /datum/soullink/shapeshift
 	var/obj/shapeshift_holder/source
+
+/datum/soullink/shapeshift/Destroy()
+	source = null
+	return ..()
 
 /datum/soullink/shapeshift/ownerDies(gibbed, mob/living/owner)
 	if(source)

--- a/modular_bluemoon/code/modules/lobby/lobby_new_player.dm
+++ b/modular_bluemoon/code/modules/lobby/lobby_new_player.dm
@@ -16,6 +16,7 @@
 	// on_player_ready_change must run before ..() - otherwise we invoke SStitle_bm during/after
 	// destruction when we're invalid, causing "illegal operation" crash in GC (REF/Queue chain).
 	GLOB.new_player_list -= src
+	GLOB.player_list -= src
 	var/was_ready = ready
 	if(was_ready && SStitle_bm)
 		SStitle_bm.on_player_ready_change(-1)

--- a/modular_splurt/code/game/atoms_movable.dm
+++ b/modular_splurt/code/game/atoms_movable.dm
@@ -2,10 +2,6 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_BARK, PROC_REF(handle_special_bark)) //There must be a better way to do this
 
-/atom/movable/Destroy()
-	UnregisterSignal(src, COMSIG_MOVABLE_BARK)
-	. = ..()
-
 /atom/movable/proc/handle_special_bark(atom/movable/source, list/hearers, distance, volume, pitch)
 	SIGNAL_HANDLER
 

--- a/modular_splurt/code/modules/arousal/genitals.dm
+++ b/modular_splurt/code/modules/arousal/genitals.dm
@@ -7,6 +7,14 @@
 	var/list/writtentext = ""
 	var/list/obj/item/equipment = list()
 
+/obj/item/organ/genital/Destroy()
+	QDEL_NULL(climax_fluids)
+	QDEL_LIST(equipment)
+	if(linked_organ?.linked_organ == src)
+		linked_organ.linked_organ = null
+	linked_organ = null
+	return ..()
+
 /obj/item/organ/genital/modify_size(modifier, min, max)
 	. = ..()
 	if(owner) //Add extra space depending on the owner's size

--- a/modular_splurt/code/modules/mob/living/living.dm
+++ b/modular_splurt/code/modules/mob/living/living.dm
@@ -1,10 +1,6 @@
 /mob/living
 	var/datum/action/sizecode_smallsprite/small_sprite
 
-/mob/living/Destroy()
-	QDEL_NULL(small_sprite)
-	return ..()
-
 /// Gender Change
 // Intended only for silicons/robots (incl. pAI) and simple_animal code so far. This proc was made to somewhat ease up duplicated verb code.
 // There's probably better way to do this but I am terrible at it --Nopeman

--- a/modular_splurt/code/modules/mob/mob.dm
+++ b/modular_splurt/code/modules/mob/mob.dm
@@ -6,10 +6,6 @@
 	. = ..()
 	create_player_panel()
 
-/mob/Destroy()
-	QDEL_NULL(mob_panel)
-	. = ..()
-
 /mob/verb/tilt_left()
 	set hidden = TRUE
 	if(!canface() || is_tilted < -45)


### PR DESCRIPTION
# Описание

Доделываю работу, еще при миграции у нас была проблема с привью мобов находящихся на неопределенном или не находящихся на map уровне, вставлены небольшие костыли. GC ошибок будет меньше, в основном решены проблемы с клиентскими мобами, гениталиями и по мелочи разные штуки. ТМ на 3 дня.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшено отображение превью мобов: синхронизируются визуальные атрибуты перед генерацией и корректно собираются многонаправленные плоские иконки с подгонкой размеров и безопасным fallback при ошибках.
  * Исправлены визуальные артефакты и порядок очистки интерфейсов/эффектов при удалении (алерты, HUD-панели), а также повышена стабильность удаления и отвязки сущностей при выходе наблюдателя, уничтожении света, турф-резерваций, соуллинков и связанных перевоплощений.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->