### PR TITLE
fix wide small frame offset

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -545,9 +545,14 @@
 	MA.pixel_x = current_canvas.framed_offset_x
 	MA.pixel_y = current_canvas.framed_offset_y
 	. += MA
-	if(istype(current_canvas, /obj/item/canvas/thirtysix_twentyfour) || istype(current_canvas, /obj/item/canvas/fortyfive_twentyseven))
+	if(istype(current_canvas, /obj/item/canvas/fortyfive_twentyseven))
 		var/mutable_appearance/frame = mutable_appearance('icons/obj/art/artstuff_64x64.dmi', "[current_canvas.icon_state]frame_simple")
 		frame.pixel_x = current_canvas.framed_offset_x - 9
+		frame.pixel_y = current_canvas.framed_offset_y - 4
+		. += frame
+	else if (istype(current_canvas, /obj/item/canvas/thirtysix_twentyfour))
+		var/mutable_appearance/frame = mutable_appearance('icons/obj/art/artstuff_64x64.dmi', "[current_canvas.icon_state]frame_simple")
+		frame.pixel_x = current_canvas.framed_offset_x - 14
 		frame.pixel_y = current_canvas.framed_offset_y - 4
 		. += frame
 	else


### PR DESCRIPTION
# Описание

Фикс офсета рамки для малых-широких холстов

## Причина изменений

рамка для малых-широких холстов оказывается обладает другим смещением

## Changelog

:cl:
fix: canvas frame offset
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшено отображение рамки у картин на холсте: для разных размеров полотна теперь применяется корректное смещение.
  * Это помогает избежать неточного позиционирования рамки у отдельных вариантов изображений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->