### PR TITLE
Фикс рантайма в Re-enter Corpse: призрак уничтожается во время переноса ключа

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -128,7 +128,7 @@
 	choice.transfer_ckey(pai)
 	card.setPersonality(pai)
 	for(var/datum/paiCandidate/candidate in SSpai.candidates)
-		if(candidate.key == choice.key)
+		if(candidate.key == pai.key) // после transfer_ckey() ключ уже на pAI, а призрак мог быть уничтожен
 			SSpai.candidates.Remove(candidate)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Make pAI") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -403,7 +403,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	//Two variables to properly announce later on.
 	var/admin = key_name_admin(src)
-	var/player_key = G_found.key
+	var/player_key = new_character.key // после transfer_ckey() ключ уже на новом персонаже, а призрак мог быть уничтожен
 
 	//Now for special roles and equipment.
 	var/datum/antagonist/traitor/traitordatum = new_character.mind.has_antag_datum(/datum/antagonist/traitor)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -465,10 +465,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
 	client.view_size.setDefault(getScreenSize(client.prefs.widescreenpref))//Let's reset so people can't become allseeing gods
-	transfer_ckey(mind.current, FALSE)
-	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
-	mind.current.client.init_verbs()
-	qdel(src) // Remove observer from dead_mob_list and all HUDs - prevents GC failures
+	return do_reenter_corpse()
+
+/// Ядро возврата в тело. Вербы проверяют входные условия, здесь только сам перенос.
+/mob/dead/observer/proc/do_reenter_corpse()
+	// После transfer_ckey() Logout() призрака ставит spawn(0) qdel(src), который успевает
+	// сработать до возврата сюда: Destroy() зануляет mind. Поэтому тело кешируем заранее,
+	// tgui переносим до переноса ключа (как в tg), а src после переноса не трогаем.
+	var/mob/living/body = mind.current
+	SStgui.on_transfer(src, body) // Transfer NanoUIs.
+	transfer_ckey(body, FALSE)
+	body.client?.init_verbs()
+	qdel(src) // Remove observer from dead_mob_list and all HUDs - prevents GC failures; no-op, если Logout уже удалил призрака
 	return TRUE
 
 /mob/dead/observer/verb/stay_dead()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -170,6 +170,7 @@
 #include "hallucination_stationmessage.dm"
 #include "memory_leak_limits.dm"
 #include "human_mob_gc.dm"
+#include "observer_reenter_race.dm"
 #include "latex_lockable.dm"
 #include "parallax_position.dm"
 #include "perf_optimizations.dm"

--- a/code/modules/unit_tests/observer_reenter_race.dm
+++ b/code/modules/unit_tests/observer_reenter_race.dm
@@ -1,0 +1,62 @@
+/**
+ * Регрессионные тесты на гонку в do_reenter_corpse() (observer.dm).
+ *
+ * В проде transfer_ckey() -> new_mob.key = key -> Logout() призрака ставит
+ * spawn(0) qdel(src), который успевает выполниться до возврата из transfer_ckey().
+ * Destroy() обсервера зануляет mind, поэтому любое чтение src.mind после
+ * переноса ключа даёт рант "Cannot read null.current" (десятки за раунд у
+ * визитёров Гост-Кафе). Тесты симулируют это уничтожение синхронно через
+ * COMSIG_MOB_PRE_PLAYER_CHANGE, который transfer_ckey() шлёт телу.
+ */
+
+/// Гонка: призрак уничтожается во время переноса ключа - перенос обязан завершиться без рантов
+/datum/unit_test/reenter_corpse_ghost_qdel_race
+
+/datum/unit_test/reenter_corpse_ghost_qdel_race/proc/kill_ghost_mid_transfer(datum/source, mob/new_mob, mob/old_mob)
+	SIGNAL_HANDLER
+	// В проде к моменту спавна qdel ключ уже уехал с призрака - повторяем это,
+	// иначе qdel моба с ключом уйдёт в ghostize() и наплодит новых обсерверов
+	old_mob.key = null
+	qdel(old_mob)
+
+/datum/unit_test/reenter_corpse_ghost_qdel_race/Run()
+	var/mob/living/carbon/human/body = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
+	var/datum/mind/test_mind = new()
+	test_mind.transfer_to(body)
+
+	var/mob/dead/observer/ghost = new(run_loc_floor_bottom_left)
+	allocated += ghost
+	ghost.mind = test_mind
+	ghost.can_reenter_corpse = TRUE
+	ghost.key = "unit_test_reenter"
+
+	RegisterSignal(body, COMSIG_MOB_PRE_PLAYER_CHANGE, PROC_REF(kill_ghost_mid_transfer))
+	var/result = ghost.do_reenter_corpse()
+	UnregisterSignal(body, COMSIG_MOB_PRE_PLAYER_CHANGE)
+
+	TEST_ASSERT(QDELETED(ghost), "Симуляция гонки не сработала: призрак должен быть уничтожен внутри transfer_ckey()")
+	TEST_ASSERT_EQUAL(result, TRUE, "do_reenter_corpse() оборвался рантом после уничтожения призрака во время переноса ключа")
+
+	body.key = null // иначе qdel тела в teardown уйдёт в ghostize()
+
+/// Обычный путь без гонки: ключ доезжает до тела, призрак удаляется, рантов нет
+/datum/unit_test/reenter_corpse_clean_path
+
+/datum/unit_test/reenter_corpse_clean_path/Run()
+	var/mob/living/carbon/human/body = allocate(/mob/living/carbon/human, run_loc_floor_bottom_left)
+	var/datum/mind/test_mind = new()
+	test_mind.transfer_to(body)
+
+	var/mob/dead/observer/ghost = new(run_loc_floor_bottom_left)
+	allocated += ghost
+	ghost.mind = test_mind
+	ghost.can_reenter_corpse = TRUE
+	ghost.key = "unit_test_reenter"
+
+	var/result = ghost.do_reenter_corpse()
+
+	TEST_ASSERT_EQUAL(result, TRUE, "do_reenter_corpse() оборвался рантом на пути без клиента (deref client без ?.)")
+	TEST_ASSERT_EQUAL(body.key, "unit_test_reenter", "Ключ призрака не доехал до тела")
+	TEST_ASSERT(QDELETED(ghost), "Призрак не был удалён после возврата в тело")
+
+	body.key = null // иначе qdel тела в teardown уйдёт в ghostize()

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -92,8 +92,9 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 				ghosts = shuffle(ghosts)//Shake those ghosts up!
 				for(var/mob/dead/observer/C2 in ghosts)
 					if(C2.key && C2)
+						var/ghost_key = C2.key // после transfer_ckey() ключ уже на клоне, а призрак мог быть уничтожен
 						C2.transfer_ckey(SM, FALSE)
-						message_admins("Ghost candidate found! [C2] key [C2.key] is becoming a clone of [M] key: [M.key] (They agreed to respect the character they're becoming, and agreed to not ERP without express permission from the original.)")
+						message_admins("Ghost candidate found! [C2] key [ghost_key] is becoming a clone of [M] key: [M.key] (They agreed to respect the character they're becoming, and agreed to not ERP without express permission from the original.)")
 						log_reagent("FERMICHEM: [M] ckey: [M.key] is creating a clone, controlled by [C2]")
 						break
 					else


### PR DESCRIPTION
# Описание

Чинит рант `Cannot read null.current` (observer.dm:469), который спамил в логи десятки раз за раунд при каждом возврате призрака в тело (чаще всего у визитёров Гост-Кафе, они постоянно скачут туда-сюда).

Суть бага: `transfer_ckey()` переносит ключ игрока в тело, в этот момент `Logout()` призрака ставит отложенный `qdel(src)`, и тот успевает сработать раньше, чем верб дочитает свои последние строки. А `Destroy()` обсервера с миграции на 516 зануляет `mind` - следующее же обращение к `mind.current` и падало. Из-за оборванного верба игрок попадал в тело, но без переноса открытых tgui-окон и без обновления вербов в статпанели.

Что сделано:
- ядро верба вынесено в `do_reenter_corpse()`: тело кешируется заранее, tgui переносится до переноса ключа (как у tg), поля призрака после переноса не читаются;
- гонка воспроизведена и закрыта юнит-тестами (`observer_reenter_race.dm`): на старом коде тест падает ровно с продовым рантом, на новом проходит;
- прошерстил все остальные ~70 вызовов `transfer_ckey` в репо - других краш-опасных мест нет, но заодно починил три места, где после переноса в лог/сравнение уходил уже снятый с призрака ключ (анонс респавна, снятие pAI-кандидата, админ-лог клона в SDGF).

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: возврат призрака в тело больше не обрывается рантом - открытые окна и вербы статпанели теперь корректно переезжают вместе с игроком
code: ядро Re-enter Corpse вынесено в do_reenter_corpse() и покрыто регрессионными тестами
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшена стабильность возврата из наблюдателя в тело: действие теперь корректно завершается даже при одновременном удалении персонажа.
  * Исправлено отображение ключа в админских сообщениях при возрождении и создании клона — данные стали точнее.
  * Снижена вероятность ошибок при выборе кандидата для особых форм возрождения.

* **Tests**
  * Добавлены регрессионные проверки для сценариев возврата в тело и гонки при переносе ключа.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->