### PR TITLE
Починка ПКМ по генам в консоли ДНК и ховер-превью аплинков/биогенератора

### DIFF
--- a/tgui/packages/tgui/interfaces/Biogenerator.js
+++ b/tgui/packages/tgui/interfaces/Biogenerator.js
@@ -180,8 +180,8 @@ const ItemList = (props) => {
           fluid
           content={item.cost * item.amount + ' ' + "BIO"}
           disabled={item.disabled}
-          onmouseover={() => setHoveredItem(item)}
-          onmouseout={() => setHoveredItem({})}
+          onMouseOver={() => setHoveredItem(item)}
+          onMouseOut={() => setHoveredItem({})}
           onClick={() => act('create', {
             id: item.id,
             amount: item.amount,

--- a/tgui/packages/tgui/interfaces/DnaConsole.js
+++ b/tgui/packages/tgui/interfaces/DnaConsole.js
@@ -906,7 +906,7 @@ const GeneCycler = (props) => {
         const nextGene = GENES[(index + 1) % length];
         onChange(e, nextGene);
       }}
-      oncontextmenu={e => {
+      onContextMenu={e => {
         e.preventDefault();
         if (!onChange) {
           return;

--- a/tgui/packages/tgui/interfaces/Uplink.js
+++ b/tgui/packages/tgui/interfaces/Uplink.js
@@ -163,8 +163,8 @@ const ItemList = (props) => {
                 disabled={item.disabled}
                 tooltip={item.desc}
                 tooltipPosition="left"
-                onmouseover={() => setHoveredItem(item)}
-                onmouseout={() => setHoveredItem({})}
+                onMouseOver={() => setHoveredItem(item)}
+                onMouseOut={() => setHoveredItem({})}
                 onClick={() => act('buy', {
                   name: item.name,
                 })} />
@@ -183,8 +183,8 @@ const ItemList = (props) => {
         <Button
           content={item.cost + ' ' + currencySymbol}
           disabled={item.disabled}
-          onmouseover={() => setHoveredItem(item)}
-          onmouseout={() => setHoveredItem({})}
+          onMouseOver={() => setHoveredItem(item)}
+          onMouseOut={() => setHoveredItem({})}
           onClick={() => act('buy', {
             name: item.name,
           })} />

--- a/tgui/packages/tgui/interfaces/UplinkInteQ.js
+++ b/tgui/packages/tgui/interfaces/UplinkInteQ.js
@@ -162,8 +162,8 @@ const ItemList = (props) => {
                 disabled={item.disabled}
                 tooltip={item.desc}
                 tooltipPosition="left"
-                onmouseover={() => setHoveredItem(item)}
-                onmouseout={() => setHoveredItem({})}
+                onMouseOver={() => setHoveredItem(item)}
+                onMouseOut={() => setHoveredItem({})}
                 onClick={() => act('buy', {
                   name: item.name,
                 })} />
@@ -182,8 +182,8 @@ const ItemList = (props) => {
         <Button
           content={item.cost + ' ' + currencySymbol}
           disabled={item.disabled}
-          onmouseover={() => setHoveredItem(item)}
-          onmouseout={() => setHoveredItem({})}
+          onMouseOver={() => setHoveredItem(item)}
+          onMouseOut={() => setHoveredItem({})}
           onClick={() => act('buy', {
             name: item.name,
           })} />


### PR DESCRIPTION
# Описание

React 19 молча игнорирует lowercase-пропсы событий, которые Inferno вешал как нативные DOM-слушатели. Переименованы в camelCase: `oncontextmenu` -> `onContextMenu` в консоли ДНК (ПКМ-прокрутка генов в обратном порядке снова работает), `onmouseover`/`onmouseout` -> `onMouseOver`/`onMouseOut` в аплинке, аплинке InteQ и биогенераторе (ховер-превью предметов)

## Changelog

:cl:
fix: ПКМ по генам в консоли ДНК снова прокручивает их в обратном порядке
fix: починено ховер-превью предметов в аплинках и биогенераторе
/:cl:
