### PR TITLE
Пробую пофиксить спавн семей

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -272,7 +272,7 @@
 	required_round_type = list(ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
 	weight = 16 //BLUEMOON CHANGES
 	cost = 10 //BLUEMOON CHANGES - низкая цена, т.к. надо в соло поднять семью
-	requirements = list(101,101,101,50,30,20,10,10,10,10)
+	requirements = list(30,20,20,20,20,20,20,20,20,20)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/families)
 	/// A reference to the handler that is used to run pre_execute(), execute(), etc..

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -555,7 +555,7 @@
 	weight = 32
 	cost = 10
 	required_round_type = list(ROUNDTYPE_DYNAMIC_LIGHT) // BLUEMOON ADD
-	requirements = list(101,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
+	requirements = list(10,10,10,10,10,10,10,10,10,10) //BLUEMOON CHANGES
 	flags = HIGH_IMPACT_RULESET
 	antag_cap = list("denominator" = 5, "offset" = 1) //BLUEMOON ADDITION
 	/// A reference to the handler that is used to run pre_execute(), execute(), etc..


### PR DESCRIPTION
# Описание

Командный антагонист "Семьи" не спавнился в лайт динамик. Пробую это пофиксить

## Changelog
:cl:
fix: Теперь семьи должны спавниться в Лайт
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Снижены пороги допуска для режима «families» на старте раунда и в середине раунда.
  * Событие стало появляться при более мягких условиях, что делает его доступнее и вероятнее в обычной игре.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->