### PR TITLE
Возврат PRELOAD_RSC=1, отключение мёртвого внешнего rsc

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -55,7 +55,7 @@
 //#define USE_BYOND_TRACY
 
 #ifndef PRELOAD_RSC //set to:
-#define PRELOAD_RSC 0 // 0 to allow using external resources or on-demand behaviour;
+#define PRELOAD_RSC 1 // 0 to allow using external resources or on-demand behaviour;
 #endif // 1 to use the default behaviour;
 								// 2 for preloading absolutely everything;
 

--- a/config/entries/resources.txt
+++ b/config/entries/resources.txt
@@ -3,7 +3,12 @@
 # If you set this mutiple times, the server will rotate between the links.
 # To use this, the compile option PRELOAD_RSC must be set to 0 to keep byond from preloading resources
 
-EXTERNAL_RSC_URLS https://wiki.ss13-bluemoon.ru/images/5/5f/tgstationv2.zip
+# Disabled: this wiki URL no longer serves the .rsc zip (returns an HTML page), and byond's
+# rsc downloader can't fetch https anyway. With PRELOAD_RSC set to 1 byond preloads resources
+# from the game server, so this entry is not read. To re-enable external rsc offload: set
+# PRELOAD_RSC to 0 and point this at an http:// static host serving a valid .rsc zip that is
+# re-uploaded on every build.
+#EXTERNAL_RSC_URLS http://your-cdn.example/byond/tgstationv2.zip
 
 ########################
 # Browser Asset Config #


### PR DESCRIPTION
При заходе на сервер клиент бесконечно докачивал ресурсы и лагал по несколько минут. Копнул - внешний .rsc был прописан на вики-ссылку, которая давно не отдаёт архив (возвращает HTML-страницу), да ещё и по https, который byond для .rsc не умеет. В итоге с PRELOAD_RSC=0 клиент, ничего не преднагрузив, реактивно тянул всё с игрового сервера прямо во время игры

Вернул дефолт /tg/ - PRELOAD_RSC=1: byond преднагружает ресурсы фоном сразу после коннекта, а не дёргается на каждый новый спрайт в бою. Мёртвую ссылку заодно закомментировал с пояснением, чтобы при возврате в режим 0 не наступить на те же грабли

:cl:
server: вернул фоновую преднагрузку ресурсов byond вместо мёртвого внешнего .rsc
/:cl:
