### PR TITLE
Убрал межфракционные транзакции ТК

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -80,6 +80,9 @@ GLOBAL_LIST_EMPTY(uplinks)
 	lockable |= U.lockable
 	active |= U.active
 	uplink_flag |= U.uplink_flag
+	if((is_syndicate && istype(U.telecrystals, /obj/item/stack/telecrystal/inteq)) || (!is_syndicate && !istype(U.telecrystals, /obj/item/stack/telecrystal/inteq)))
+		user.balloon_alert(user, "Аплинк не принимает валюту враждебной организации!")
+		return
 	telecrystals += U.telecrystals
 	if(purchase_log && U.purchase_log)
 		purchase_log.MergeWithAndDel(U.purchase_log)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -81,7 +81,6 @@ GLOBAL_LIST_EMPTY(uplinks)
 	active |= U.active
 	uplink_flag |= U.uplink_flag
 	if((is_syndicate && istype(U.telecrystals, /obj/item/stack/telecrystal/inteq)) || (!is_syndicate && !istype(U.telecrystals, /obj/item/stack/telecrystal/inteq)))
-		user.balloon_alert(user, "Аплинк не принимает валюту враждебной организации!")
 		return
 	telecrystals += U.telecrystals
 	if(purchase_log && U.purchase_log)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -31,9 +31,11 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/traitor_contract_rerolls = 0
 	///Instructions on how to access the uplink based on location
 	var/unlock_text
+	var/is_syndicate = FALSE
 	var/list/previous_attempts
 
-/datum/component/uplink/Initialize(_owner, _lockable = TRUE, _enabled = FALSE, uplink_flag = UPLINK_TRAITORS, starting_tc = TELECRYSTALS_DEFAULT)
+/datum/component/uplink/Initialize(_owner, _lockable = TRUE, _enabled = FALSE, uplink_flag = UPLINK_TRAITORS, starting_tc = TELECRYSTALS_DEFAULT, syndicate = FALSE)
+	is_syndicate = syndicate
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -138,6 +140,9 @@ GLOBAL_LIST_EMPTY(uplinks)
 	return TRUE
 
 /datum/component/uplink/proc/LoadTC(mob/user, obj/item/stack/telecrystal/TC, silent = FALSE)
+	if((is_syndicate && istype(TC, /obj/item/stack/telecrystal/inteq)) || (!is_syndicate && !istype(TC, /obj/item/stack/telecrystal/inteq)))
+		user.balloon_alert(user, "Аплинк не принимает валюту враждебной организации!")
+		return
 	if(!silent)
 		to_chat(user, span_notice("You slot [TC] into [parent] and charge its internal uplink."))
 	var/amt = TC.amount

--- a/code/modules/jobs/job_types/command/blueshield.dm
+++ b/code/modules/jobs/job_types/command/blueshield.dm
@@ -88,7 +88,6 @@
 	suit = /obj/item/clothing/suit/armor/vest/blueshield
 	shoes = /obj/item/clothing/shoes/jackboots/tall_default
 	suit_store = /obj/item/kitchen/knife/combat
-	l_pocket = /obj/item/sensor_device_command
 	backpack_contents = list(/obj/item/storage/firstaid/regular, /obj/item/storage/box/death_alert, /obj/item/storage/box/blue_shield_hs, /obj/item/storage/box/sec_kit,  /obj/item/choice_beacon/hosgun, /obj/item/choice_beacon/bsbaton, /obj/item/syndicate_uplink/station)
 	backpack = /obj/item/storage/backpack/duffelbag/syndie
 	satchel = /obj/item/storage/backpack/duffelbag/syndie

--- a/modular_bluemoon/krashly/code/uplink/uplink.dm
+++ b/modular_bluemoon/krashly/code/uplink/uplink.dm
@@ -55,9 +55,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/uplink_flag = UPLINK_SYNDICATE
 
-/obj/item/syndicate_uplink/Initialize(mapload, owner, tc_amount = 10)
+/obj/item/syndicate_uplink/Initialize(mapload, owner, tc_amount = 10, syndicate = TRUE)
 	. = ..()
-	AddComponent(/datum/component/uplink/syndicate, owner, FALSE, TRUE, uplink_flag, tc_amount)
+	AddComponent(/datum/component/uplink/syndicate, owner, FALSE, TRUE, uplink_flag, tc_amount, syndicate)
 
 /obj/item/syndicate_uplink/AltClick(mob/user)
 	. = ..()
@@ -76,11 +76,11 @@
 			некоторые дополнительные, разрешенные ПАКТом элементы снабжения."
 	uplink_flag = UPLINK_SYNDICATE_PACT_CREW
 
-/obj/item/syndicate_uplink/station/Initialize(mapload, owner, tc_amount = 10)
+/obj/item/syndicate_uplink/station/Initialize(mapload, owner, tc_amount = 10, syndicate = TRUE)
 	. = ..()
 	var/datum/component/old_component = GetComponent(/datum/component/uplink/syndicate)
 	old_component.Destroy()//я не смог решить иначе. Оно ТК суммирует :(
-	AddComponent(/datum/component/uplink/syndicate/pact, owner, FALSE, TRUE, uplink_flag, tc_amount)
+	AddComponent(/datum/component/uplink/syndicate/pact, owner, FALSE, TRUE, uplink_flag, tc_amount, syndicate)
 
 /datum/component/uplink/syndicate/pact
 	name = "Pact Uplink"
@@ -106,9 +106,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/uplink_flag = UPLINK_SYNDICATE
 
-/obj/item/syndicate_uplink_high/Initialize(mapload, owner, tc_amount = 20)
+/obj/item/syndicate_uplink_high/Initialize(mapload, owner, tc_amount = 10, syndicate = TRUE)
 	. = ..()
-	AddComponent(/datum/component/uplink/syndicate, owner, FALSE, TRUE, uplink_flag, tc_amount)
+	AddComponent(/datum/component/uplink/syndicate, owner, FALSE, TRUE, uplink_flag, tc_amount, syndicate)
 
 /obj/item/syndicate_uplink_high/AltClick(mob/user)
 	. = ..()


### PR DESCRIPTION
# Описание

Больше нельзя брать телекристалл и вставлять его в аплинк Интекью.
и наоборт
ТелеКРЕДИТ в аплинк Синдиката тоже больше нельзя

А ещё нашел небольшую ошибку в лодауте Синди БЩ, теперь у него нет дублирования монитора здоровья глав.

## Причина изменений

балансная правка

## Демонстрация изменений

<img width="618" height="839" alt="{FF6F7648-4998-4E12-AAB4-3F462F6C4332}" src="https://github.com/user-attachments/assets/a7c9e7d2-33e0-475c-a0fd-686b73a95fdc" />

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: убраны межфракционные транзакции телекристаллов
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Обновлены синдикатские варианты снаряжения и аплинков: они теперь корректнее выдают нужный стартовый набор и поддержку разных конфигураций.

* **Исправления**
  * Улучшена проверка загрузки телекристаллов: если тип валюты не подходит для текущего аплинка, загрузка теперь прекращается и показывается понятное уведомление.
  * Исправлены настройки отдельных аплинков, чтобы они корректно работали с синдикатной конфигурацией и стартовыми очками.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->