### PR TITLE
Убрал барабаны у БЩ и ГСБ раундстарт

### DIFF
--- a/modular_splurt/code/game/objects/items/storage/secure.dm
+++ b/modular_splurt/code/game/objects/items/storage/secure.dm
@@ -5,14 +5,14 @@
 
 /obj/item/storage/secure/briefcase/hos/hos_e45_pack/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/pistol/enforcerred(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum/lethal(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum/lethal(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum/taser(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum/taser(src)
-	new /obj/item/ammo_box/magazine/e45/e45_drum/taser(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended/lethal(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended/lethal(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended/taser(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended/taser(src)
+	new /obj/item/ammo_box/magazine/e45/e45_extended/taser(src)
 
 // Sec Officer Boxes
 


### PR DESCRIPTION
# Описание

Барабаны это мидгейм вещи, которые не должны быть доступны раундстарт. Их выдаётся настолько много, что просто расходятся по рукам, ломая баланс. 

## Причина изменений

**Запрос хоста.**

## Changelog


:cl:
balance: Барабаны в кейсе для ГСБ и БЩ изменены на увеличенные магазины
/:cl:
