### PR TITLE
Увеличил сообщение о появлении синги для администрации

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -243,7 +243,7 @@
 	last_warning = world.time
 	var/count = locate(/obj/machinery/field/containment) in urange(30, src, 1)
 	if(!count)
-		message_admins("A singulo has been created without containment fields active at [ADMIN_VERBOSEJMP(T)].")
+		message_admins(span_big_warning("A singulo has been created without containment fields active at [ADMIN_VERBOSEJMP(T)]."))
 	investigate_log("was created at [AREACOORD(T)]. [count?"":"<font color='red'>No containment fields were active</font>"]", INVESTIGATE_SINGULO)
 
 /obj/singularity/proc/dissipate()


### PR DESCRIPTION
# Описание
Сообщение было слишком маленьким и при появлении синги где-то в далёком космосе, администраторы могли просто не заметить её создание.
## Причина изменений

удобство

<img width="857" height="279" alt="{F57E2A5D-C23D-481E-AE77-7E3F6405A7D4}" src="https://github.com/user-attachments/assets/3b883b4d-a08a-496a-a701-afdab8201482" />

## Changelog
:cl:

admin: Сообщение в чате о сингулярности теперь визуально больше
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения для администраторов**
  * Уведомления о создании сингулярности без активных полей сдерживания стали более заметными.
  * В предупреждение добавлены координаты и описание места создания сингулярности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->