### PR TITLE
Фикс критбага, позволяющего стрелять, будучи мёртвым

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -234,6 +234,8 @@
 	if(get_dist(shooter, target) <= 0)
 		target = get_step(shooter, shooter.dir) //Shoot in the direction faced if the mouse is on the same tile as we are.
 		target_loc = target
+	if(shooter.incapacitated())
+		return FALSE
 	else if(!in_view_range(shooter, target))
 		stop_autofiring() //Elvis has left the building.
 		return FALSE


### PR DESCRIPTION
# Описание
Я заметил, что имея антидроп имплант, можно стрелять в полноавтоматическом режиме даже будучи мёртвым. Это оказалось связанно с компонентом fullauto. Я увидел этот багоюз, нашел причину и пофиксил.

## Причина изменений

баг, влияющий на геймплей

## Changelog

:cl:
fix: пофиксил багоюз стрельбы в крите/после смерти
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Автоматическая стрельба теперь прекращается, если стрелок временно недееспособен.
  * Предотвращено продолжение очереди выстрелов в таком состоянии.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->