### PR TITLE
Второе предупреждение при совмещении БС сумок

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -5,9 +5,16 @@
 	var/list/obj/item/storage/backpack/holding/matching = typecache_filter_list(W.GetAllContents(), typecacheof(/obj/item/storage/backpack/holding))
 	matching -= A
 	if(istype(W, /obj/item/storage/backpack/holding) || matching.len)
-		var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", "Abort", "Proceed")
-		if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)))
+		var/safety = alert(user, "Это действие будет иметь крайне серьёзные последствия для станции и её экипажа. Убедитесь, что вы знаете, что делаете.", "Засунуть это в [A.name]?", "Не делать это", "Сделать это")
+		if(safety != "Сделать это" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)))
 			return
+
+		var/final_safety = alert(user, "ПОСЛЕДНЕЕ ПРЕДУПРЕЖДЕНИЕ!\n\nСоздание сингулярности приведёт к уничтожению станции и гибели всего экипажа.\nВы уверены, что хотите сделать это? ЭТО НЕЛЬЗЯ ОТМЕНИТЬ!", "ФИНАЛЬНОЕ ПОДТВЕРЖДЕНИЕ", "НЕТ, НЕ ДЕЛАТЬ!", "ДА, УНИЧТОЖИТЬ ВСЁ!")
+
+		if(final_safety == "НЕТ, НЕ ДЕЛАТЬ!" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)))
+			to_chat(user, span_notice("Вы вовремя остановились. Катастрофа предотвращена."))
+			return
+
 		var/turf/loccheck = get_turf(A)
 		if(is_reebe(loccheck.z))
 			user.visible_message("<span class='warning'>An unseen force knocks [user] to the ground!</span>", "<span class='big_brass'>\"I think not!\"</span>")


### PR DESCRIPTION
# Описание

<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Дабы у людей с лагами не случался ужас ужасающий, на всякий случай

## Changelog

Добавил второе предупреждение


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлено взаимодействие «Массировать яйца» с визуальными и звуковыми эффектами, а также соответствующими игровыми эффектами.
  * Добавлена дополнительная защита при подтверждении опасного действия с сумкой хранения: теперь требуется пройти два этапа подтверждения.

* **Исправления**
  * Улучшена обработка отмены действия и недоступности игрока или объектов во время подтверждения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->