### PR TITLE
Изменение карточек пермитов + просьба Смайли

### DIFF
--- a/code/game/objects/items/cards_sticker.dm
+++ b/code/game/objects/items/cards_sticker.dm
@@ -174,17 +174,6 @@
 /obj/item/card_sticker/agony/loadout
 	auto_equip = TRUE
 
-/obj/item/card_sticker/muck
-	name = "Muck sticker"
-	desc = "Sticker for employees with dirty thoughts and such more..."
-	icon_state = "muck_id"
-	prefix = "Mucker"
-	special_assignment = "muck"
-	permit = /obj/item/clothing/accessory/permit/special/deviant/muck
-
-/obj/item/card_sticker/muck/loadout
-	auto_equip = TRUE
-
 /obj/item/card_sticker/vampire
 	name = "Bloodfledge sticker"
 	desc = "An sticker made to easily recognize bloodsucker fledglings without requiring medical scans."

--- a/modular_bluemoon/code/game/objects/items/deviant_permits.dm
+++ b/modular_bluemoon/code/game/objects/items/deviant_permits.dm
@@ -14,7 +14,7 @@
 	notes = "Носитель имеет право на проведение безвредных для станции ритуалов и аггитирование без страха преследования со стороны службы безопасности."
 
 /obj/item/clothing/accessory/permit/deviant/lust
-	icon_state = "lust_plus"
+	icon_state = "lust_permit"
 	name = "Horny activity permit"
 	desc = "Вещественное одобрение на проведение извращённой~ деятельности"
 	permitted_weapons = "N/A"

--- a/modular_bluemoon/code/game/objects/items/deviant_permits.dm
+++ b/modular_bluemoon/code/game/objects/items/deviant_permits.dm
@@ -14,11 +14,11 @@
 	notes = "Носитель имеет право на проведение безвредных для станции ритуалов и аггитирование без страха преследования со стороны службы безопасности."
 
 /obj/item/clothing/accessory/permit/deviant/lust
-	icon_state = "lust_permit"
+	icon_state = "lust_plus"
 	name = "Horny activity permit"
 	desc = "Вещественное одобрение на проведение извращённой~ деятельности"
-	permitted_weapons = "Holy dildo, BDSM whip, Riding crop "
-	notes = "Носитель имеет право обустраивать бордели и оргии, иметь при себе и использовать афродизиаки, ходить голым, а также имеет права на публичное совокупление без страха преследования со стороны службы безопасности."
+	permitted_weapons = "N/A"
+	notes = "Носитель имеет право на обустройство свободных отсеков станции под бордели и стриптиз клубы."
 
 /obj/item/clothing/accessory/permit/deviant/agony
 	icon_state = "agony_permit"
@@ -26,13 +26,6 @@
 	desc = "Вещественное одобрение на проведение жестокой деструктивной деятельности"
 	permitted_weapons = "Bloody Nullrods(Armblade, Darkblade, Red Claymore, Pithfork, Tentacle) Satan Bible"
 	notes = "Носитель имеет право на поклонение любому божеству (Нар`си, Сатана в т.ч.). Также проводить активность на проведения аггитирования, молитв, проведение безвредных для станции ритуалов и т.п. без страха преследования со стороны службы безопасности. Вооружения разрешено использовать только в качестве самообороны и не более."
-
-/obj/item/clothing/accessory/permit/deviant/muck
-	icon_state = "muck_permit"
-	name = "Muck activity permit"
-	desc = "Вещественное одобрение на проведение мерзкой в общем понимании деятельности"
-	permitted_weapons = "N/A"
-	notes = "Носитель имеет право на раскидывание мусора, быть грязным, вонючим и противным без страха преследования со стороны службы безопасности."
 
 ///
 
@@ -43,13 +36,6 @@
 	desc = "Вещественное одобрение ЦК на проведение оккультной деятельности"
 	permitted_weapons = "Вооружение культа"
 	notes = "Носитель имеет право на проведение безвредных для станции ритуалов и аггитирование без страха преследования со стороны службы безопасности."
-
-/obj/item/clothing/accessory/permit/special/deviant/lust
-	icon_state = "lust_plus"
-	name = "Horny activity permit"
-	desc = "Вещественное одобрение ЦК на проведение извращённой~ деятельности"
-	permitted_weapons = "Holy dildo, BDSM whip, Riding crop "
-	notes = "Носитель имеет право обустраивать бордели и оргии, иметь при себе и использовать афродизиаки, ходить голым, а также имеет права на публичное совокупление без страха преследования со стороны службы безопасности."
 
 /obj/item/clothing/accessory/permit/special/deviant/lust/changeling
 	name = "Horny Activity Permit"
@@ -77,12 +63,6 @@
 	permitted_weapons = "Bloody Nullrods(Armblade, Darkblade, Red Claymore, Pithfork, Tentacle) Satan Bible"
 	notes = "Носитель имеет право на поклонение любому божеству (Нар`си, Сатана в т.ч.). Также проводить активность на проведения аггитирования, молитв, проведение безвредных для станции ритуалов и т.п. без страха преследования со стороны службы безопасности. Вооружения разрешено использовать только в качестве самообороны и не более."
 
-/obj/item/clothing/accessory/permit/special/deviant/muck
-	icon_state = "muck_plus"
-	name = "Muck activity permit"
-	desc = "Вещественное одобрение ЦК на проведение мерзкой в общем понимании деятельности"
-	permitted_weapons = "N/A"
-	notes = "Носитель имеет право на раскидывание мусора, быть грязным, вонючим и противным без страха преследования со стороны службы безопасности."
 
 /obj/item/clothing/accessory/permit/special/lessnightmareish
 	icon = 'modular_bluemoon/icons/obj/permits.dmi'

--- a/modular_bluemoon/code/game/objects/items/storage/boxes.dm
+++ b/modular_bluemoon/code/game/objects/items/storage/boxes.dm
@@ -58,6 +58,7 @@
 	new	/obj/item/clothing/accessory/permit/deviant/lust(src)
 	new	/obj/item/clothing/accessory/permit/deviant/agony(src)
 	new	/obj/item/clothing/accessory/permit/deviant/agony(src)
+	new	/obj/item/clothing/accessory/permit/deviant/lust(src)
 
 /obj/item/storage/box/service_permits
 	name = "box of service permits"
@@ -65,6 +66,7 @@
 	illustration = "id"
 
 /obj/item/storage/box/service_permits/PopulateContents()
+	new	/obj/item/clothing/accessory/permit/special/bartender(src)
 	new	/obj/item/clothing/accessory/permit/special/bartender(src)
 	new	/obj/item/clothing/accessory/permit/special/bartender(src)
 	new	/obj/item/clothing/accessory/permit/special/bartender(src)

--- a/modular_bluemoon/code/game/objects/items/storage/boxes.dm
+++ b/modular_bluemoon/code/game/objects/items/storage/boxes.dm
@@ -25,14 +25,6 @@
 	new /obj/item/card_sticker/agony(src)
 	new /obj/item/clothing/accessory/permit/special/deviant/agony(src)
 
-/obj/item/storage/box/deviant_kit/muck
-	name = "Muck activity kit"
-	desc = "Жрать гавно."
-	illustration = "id"
-
-/obj/item/storage/box/deviant_kit/muck/PopulateContents()
-	new /obj/item/card_sticker/muck(src)
-	new /obj/item/clothing/accessory/permit/special/deviant/muck(src)
 
 /obj/item/storage/box/raven_box
 	name = "dark red box"
@@ -66,7 +58,6 @@
 	new	/obj/item/clothing/accessory/permit/deviant/lust(src)
 	new	/obj/item/clothing/accessory/permit/deviant/agony(src)
 	new	/obj/item/clothing/accessory/permit/deviant/agony(src)
-	new	/obj/item/clothing/accessory/permit/deviant/muck(src)
 
 /obj/item/storage/box/service_permits
 	name = "box of service permits"
@@ -74,7 +65,6 @@
 	illustration = "id"
 
 /obj/item/storage/box/service_permits/PopulateContents()
-	new	/obj/item/clothing/accessory/permit/special/bartender(src)
 	new	/obj/item/clothing/accessory/permit/special/bartender(src)
 	new	/obj/item/clothing/accessory/permit/special/bartender(src)
 	new	/obj/item/clothing/accessory/permit/special/bartender(src)

--- a/modular_bluemoon/code/modules/vending/wardrobes.dm
+++ b/modular_bluemoon/code/modules/vending/wardrobes.dm
@@ -482,9 +482,6 @@
 		/obj/item/book/granter/crafting_recipe/coldcooking = 2,
 		/obj/item/clothing/gloves/color/white = 3,
 	)
-	contraband = list(
-		/obj/item/card_sticker/muck = 2,
-	)
 	refill_canister = /obj/item/vending_refill/wardrobe/chef_wardrobe
 	payment_department = ACCOUNT_SRV
 

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -63,10 +63,6 @@
 
 ////////////////////////////////////////////////////////////////////////
 
-/datum/gear/donator/muck_kit
-	name = "Muck activity kit"
-	path = /obj/item/storage/box/deviant_kit/muck
-	cost = 1
 
 /datum/gear/donator/backpack/penetrator
 	name = "The Penetrator"


### PR DESCRIPTION
# Описание

<!-- Поменяй этот комментарий на краткое описание изменений, которые ты внёс -->
<!-- Если изменения косметические и ты уверен в их работоспособности, можно не проверять на локальном сервере. -->
<!-- Создавать предложку или багрепорт тоже необязательно. Если же они были, вставь ссылку на них. -->
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Многие трактуют пермиты, как будто есть запрет на эксгибиционизм, поэтому поменяли прикол. Убрали трактовку и по просьбе Смайли убрал пермит на грязнулю.


## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения**
  * Обновлено разрешение **Lust**: изменены значок, список допустимого оружия и текст заметок.
* **Удаления**
  * Убраны предметы и лут, связанные с **Muck**: стикер, девиант-разрешения и комплект из коробок.
  * Набор **Muck activity kit** больше не доступен в донаторском лоадауте.
  * Убран “Muck” из ассортимента вендомата для поваров.
  * Удалена базовая специальная версия разрешения **Lust** для special/deviant, при этом дочерние варианты (например, для changeling) сохранены.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->