### PR TITLE
Spontaneous Brain Trauma no extended

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -5,10 +5,13 @@
 	min_players = 10
 	category = EVENT_CATEGORY_HEALTH
 	severity = DIRECTOR_SEVERITY_MINOR
+	required_round_type = list(ROUNDTYPE_DYNAMIC_TEAMBASED, ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM)
 
 /datum/round_event_control/brain_trauma/can_fire(datum/director_signals/signals)
-	if(!..()) return FALSE
-	return director_has_living_role(list("Medical Doctor","Chief Medical Officer","Paramedic","AI","Chemist","Virologist","Captain","Head of Personnel","Roboticist"))
+	. = ..()
+	if(!.)
+		return
+	return director_has_living_role(list("Medical Doctor","Chief Medical Officer","Paramedic","Chemist","Virologist"))
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -5,7 +5,7 @@
 	min_players = 10
 	category = EVENT_CATEGORY_HEALTH
 	severity = DIRECTOR_SEVERITY_MINOR
-	required_round_type = list(ROUNDTYPE_DYNAMIC_TEAMBASED, ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM)
+	required_round_type = list(ROUNDTYPE_DYNAMIC_TEAMBASED, ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT)
 
 /datum/round_event_control/brain_trauma/can_fire(datum/director_signals/signals)
 	. = ..()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -15,7 +15,9 @@
 	var/max_severity = 3
 
 /datum/round_event_control/disease_outbreak/can_fire(datum/director_signals/signals)
-	if(!..()) return FALSE
+	. = ..()
+	if(!.)
+		return
 	return director_has_living_role(list("Medical Doctor","Chief Medical Officer","Paramedic","AI","Chemist","Virologist","Captain","Head of Personnel", "Geneticist"))
 
 /datum/round_event/disease_outbreak/announce(fake)

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -8,7 +8,9 @@
 	severity = DIRECTOR_SEVERITY_MINOR
 
 /datum/round_event_control/heart_attack/can_fire(datum/director_signals/signals)
-	if(!..()) return FALSE
+	. = ..()
+	if(!.)
+		return
 	return director_has_living_role(list("Medical Doctor","Chief Medical Officer","Paramedic","Chemist"))
 
 /datum/round_event/heart_attack/start()


### PR DESCRIPTION
# Описание
- Убрал рандомную травму мозга в эксту

## Причина изменений
Вообще странный ивент, но в эксту он вообще не в тему

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
del: Убран рандомный ивент травмы мозга в эксту
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Скорректированы условия запуска событий «Мозговая травма», «Вспышка заболевания» и «Сердечный приступ».
  * «Мозговая травма» теперь запускается только в подходящих типах раундов и при наличии живых медицинских или лабораторных специалистов.
  * Проверки доступности событий выполняются последовательнее, чтобы неподходящие события не запускались при несоблюдении базовых условий.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->