### PR TITLE
Исправление подтверждённых harddel-утечек

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -200,10 +200,31 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	mymob = null
 
 	QDEL_NULL(screentip_text)
-	last_screentip_atom = null
-	last_screentip_held = null
+	set_screentip_cache(null, null)
 
 	return ..()
+
+/// Updates the strong screentip cache references and makes them self-clearing on qdel.
+/datum/hud/proc/set_screentip_cache(atom/new_atom, obj/item/new_held_item)
+	if(last_screentip_atom == new_atom && last_screentip_held == new_held_item)
+		return
+	if(last_screentip_atom)
+		UnregisterSignal(last_screentip_atom, COMSIG_PARENT_QDELETING)
+	if(last_screentip_held && last_screentip_held != last_screentip_atom)
+		UnregisterSignal(last_screentip_held, COMSIG_PARENT_QDELETING)
+
+	last_screentip_atom = new_atom
+	last_screentip_held = new_held_item
+
+	if(last_screentip_atom)
+		RegisterSignal(last_screentip_atom, COMSIG_PARENT_QDELETING, PROC_REF(on_screentip_cache_target_qdeleting))
+	if(last_screentip_held && last_screentip_held != last_screentip_atom)
+		RegisterSignal(last_screentip_held, COMSIG_PARENT_QDELETING, PROC_REF(on_screentip_cache_target_qdeleting))
+
+/datum/hud/proc/on_screentip_cache_target_qdeleting(datum/source)
+	SIGNAL_HANDLER
+	if(source == last_screentip_atom || source == last_screentip_held)
+		set_screentip_cache(null, null)
 
 /mob/proc/create_mob_hud()
 	if(!client || hud_used)

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -14,6 +14,6 @@
 
 /atom/movable/screen/screentip/proc/update_view(datum/source)
 	SIGNAL_HANDLER
-	if(!hud || !hud.mymob.client.view_size) //Might not have been initialized by now
+	if(!hud?.mymob?.client?.view_size) //Might not have been initialized by now
 		return
 	maptext_width = view_to_pixels(hud.mymob.client.view_size.getView())[1]

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -880,7 +880,7 @@ SUBSYSTEM_DEF(job)
 		if(i[LOADOUT_IS_HEIRLOOM] && !QDELETED(I) && heirloomer)
 			I.item_flags |= FAMILY_HEIRLOOM
 			if(M.mind)
-				M.mind.assigned_heirloom = I
+				M.mind.set_assigned_heirloom(I)
 			if(!i[LOADOUT_CUSTOM_NAME])
 				var/list/family_name = splittext(M.real_name, " ")
 				if(length(family_name))
@@ -1012,7 +1012,7 @@ SUBSYSTEM_DEF(job)
 		if(i[LOADOUT_IS_HEIRLOOM] && !QDELETED(I) && heirloomer)
 			I.item_flags |= FAMILY_HEIRLOOM
 			if(M.mind)
-				M.mind.assigned_heirloom = I
+				M.mind.set_assigned_heirloom(I)
 			if(!i[LOADOUT_CUSTOM_NAME])
 				var/list/family_name = splittext(M.real_name, " ")
 				if(length(family_name))

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -51,6 +51,7 @@ handles linking back and forth.
 		// specify explicitly in case the other component is deleted first
 		var/atom/P = parent
 		mat_container.retrieve_all(P.drop_location())
+	QDEL_NULL(after_insert)
 	return ..()
 
 /datum/component/remote_materials/proc/_MakeLocal()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -80,7 +80,7 @@
 	///has this mind ever been an AI
 	var/has_ever_been_ai = FALSE
 
-	var/assigned_heirloom = null // BLUEMOON EDIT - лодаутные реликвии. Дерьмовейшее решение, но по-другому не знаю, как сделать, чтобы спавнящиеся под ногами лодаутные предметы мог обрабатывать квирк
+	var/obj/item/assigned_heirloom = null // BLUEMOON EDIT - лодаутные реликвии. Дерьмовейшее решение, но по-другому не знаю, как сделать, чтобы спавнящиеся под ногами лодаутные предметы мог обрабатывать квирк
 	var/force_escaped = FALSE  // Set by Into The Sunset command of the shuttle manipulator
 	var/list/learned_recipes //List of learned recipe TYPES.
 
@@ -134,9 +134,24 @@
 	QDEL_NULL(tgui_panel)
 	QDEL_LIST(antag_datums)
 	QDEL_NULL(skill_holder)
+	set_assigned_heirloom(null)
 	set_current(null)
 	soulOwner = null
 	return ..()
+
+/datum/mind/proc/set_assigned_heirloom(obj/item/new_heirloom)
+	if(assigned_heirloom == new_heirloom)
+		return
+	if(assigned_heirloom)
+		UnregisterSignal(assigned_heirloom, COMSIG_PARENT_QDELETING)
+	assigned_heirloom = new_heirloom
+	if(assigned_heirloom)
+		RegisterSignal(assigned_heirloom, COMSIG_PARENT_QDELETING, PROC_REF(on_assigned_heirloom_qdeleting))
+
+/datum/mind/proc/on_assigned_heirloom_qdeleting(obj/item/source)
+	SIGNAL_HANDLER
+	if(source == assigned_heirloom)
+		set_assigned_heirloom(null)
 
 /datum/mind/proc/set_current(mob/new_current)
 	if(new_current && QDELETED(new_current))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1597,8 +1597,7 @@
 	var/screentips_enabled = user.client.prefs.screentip_pref
 	if(screentips_enabled == SCREENTIP_PREFERENCE_DISABLED || (flags_1 & NO_SCREENTIPS_1))
 		active_hud.screentip_text.maptext = ""
-		active_hud.last_screentip_atom = null
-		active_hud.last_screentip_held = null
+		active_hud.set_screentip_cache(null, null)
 		return
 
 	// Dedup repeat hovers — same atom with same held item produces an identical
@@ -1607,8 +1606,7 @@
 	var/obj/item/held_item = user.get_active_held_item()
 	if(active_hud.last_screentip_atom == src && active_hud.last_screentip_held == held_item)
 		return
-	active_hud.last_screentip_atom = src
-	active_hud.last_screentip_held = held_item
+	active_hud.set_screentip_cache(src, held_item)
 
 	active_hud.screentip_text.maptext_y = 10 // 10px lines us up with the action buttons top left corner
 	var/lmb_rmb_line = ""

--- a/code/modules/admin/spawn_panel/spawn_panel.dm
+++ b/code/modules/admin/spawn_panel/spawn_panel.dm
@@ -11,22 +11,36 @@
 	var/precise_mode = PRECISE_MODE_OFF
 	var/mob/owner = null
 
-/datum/spawnpanel/New()
-	. = (..())
-	owner = usr
+/datum/spawnpanel/New(mob/new_owner)
+	. = ..()
+	set_owner(new_owner || usr)
 	offset = list("X" = 0, "Y" = 0, "Z" = 0)
 
 /datum/spawnpanel/Destroy()
-	if(precise_mode != PRECISE_MODE_OFF && owner?.client)
-		owner.client.click_intercept = null
-		owner.client.mouse_up_icon = null
-		owner.client.mouse_down_icon = null
-		owner.client.mouse_override_icon = null
-		owner.update_mouse_pointer()
-	owner = null
+	set_owner(null)
 	. = ..()
 
+/datum/spawnpanel/proc/set_owner(mob/new_owner)
+	if(owner == new_owner)
+		return
+	if(owner)
+		if(precise_mode != PRECISE_MODE_OFF)
+			if(owner.client)
+				toggle_precise_mode(PRECISE_MODE_OFF, owner)
+			else
+				precise_mode = PRECISE_MODE_OFF
+		UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
+	owner = new_owner
+	if(owner)
+		RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(on_owner_qdeleting))
+
+/datum/spawnpanel/proc/on_owner_qdeleting(mob/source)
+	SIGNAL_HANDLER
+	if(source == owner)
+		set_owner(null)
+
 /datum/spawnpanel/ui_interact(mob/user, datum/tgui/ui)
+	set_owner(user)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "SpawnPanel")

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -6,6 +6,8 @@
 	var/in_progress = FALSE
 
 /obj/effect/proc_holder/slab/Destroy()
+	if(slab?.slab_ability == src)
+		slab.slab_ability = null
 	slab = null
 	return ..()
 

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -6,7 +6,7 @@
 	var/in_progress = FALSE
 
 /obj/effect/proc_holder/slab/Destroy()
-	if(slab?.slab_ability == src)
+	if(!QDELETED(slab) && slab.slab_ability == src)
 		slab.slab_ability = null
 	slab = null
 	return ..()

--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -52,6 +52,20 @@
 	..()
 	trigger_spooky_trap()
 
+/obj/structure/closet/proc/set_trapped_mob(mob/new_trapped_mob)
+	if(trapped_mob == new_trapped_mob)
+		return
+	if(trapped_mob)
+		UnregisterSignal(trapped_mob, COMSIG_PARENT_QDELETING)
+	trapped_mob = new_trapped_mob
+	if(trapped_mob)
+		RegisterSignal(trapped_mob, COMSIG_PARENT_QDELETING, PROC_REF(on_trapped_mob_qdeleting))
+
+/obj/structure/closet/proc/on_trapped_mob_qdeleting(mob/source)
+	SIGNAL_HANDLER
+	if(source == trapped_mob)
+		set_trapped_mob(null)
+
 /obj/structure/closet/proc/set_spooky_trap()
 	if(prob(5))
 		trapped = INSANE_CLOWN
@@ -73,7 +87,7 @@
 		H.makeSkeleton()
 		H.health = 1e5
 		insert(H)
-		trapped_mob = H
+		set_trapped_mob(H)
 		trapped = SPOOKY_SKELETON
 		return
 
@@ -85,7 +99,9 @@
 		visible_message("<span class='userdanger'><font size='5'>БУУ!</font></span>")
 		playsound(loc, 'sound/spookoween/girlscream.ogg', 500, 1)
 		trapped = 0
-		QDEL_IN(trapped_mob, 90)
+		var/mob/doomed_mob = trapped_mob
+		set_trapped_mob(null)
+		QDEL_IN(doomed_mob, 90)
 
 	else if(trapped == HOWLING_GHOST)
 		visible_message("<span class='userdanger'><font size='5'>[pick("OooOOooooOOOoOoOOooooOOOOO", "БуУууУуУУУУ", "БУУ!", "УуУУуУ	уУ")]</font></span>")

--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -37,6 +37,7 @@
 #define INSANE_CLOWN	4
 #define HOWLING_GHOST	5
 #define EVILL_HUNTER    6
+#define SPOOKY_SKELETON_DELETE_DELAY (9 SECONDS)
 
 //Spookoween variables
 /obj/structure/closet
@@ -101,7 +102,7 @@
 		trapped = 0
 		var/mob/doomed_mob = trapped_mob
 		set_trapped_mob(null)
-		QDEL_IN(doomed_mob, 90)
+		QDEL_IN(doomed_mob, SPOOKY_SKELETON_DELETE_DELAY)
 
 	else if(trapped == HOWLING_GHOST)
 		visible_message("<span class='userdanger'><font size='5'>[pick("OooOOooooOOOoOoOOooooOOOOO", "БуУууУуУУУУ", "БУУ!", "УуУУуУ	уУ")]</font></span>")

--- a/code/modules/mob/living/carbon/monkey/combat.dm
+++ b/code/modules/mob/living/carbon/monkey/combat.dm
@@ -49,6 +49,18 @@
 		pickupTarget = null
 		pickupTimer = 0
 
+/mob/living/carbon/monkey/proc/blacklist_item(obj/item/item)
+	if(!item)
+		return
+	if(!blacklistItems[item])
+		RegisterSignal(item, COMSIG_PARENT_QDELETING, PROC_REF(on_blacklisted_item_qdeleting))
+	blacklistItems[item]++
+
+/mob/living/carbon/monkey/proc/on_blacklisted_item_qdeleting(obj/item/item)
+	SIGNAL_HANDLER
+	UnregisterSignal(item, COMSIG_PARENT_QDELETING)
+	blacklistItems -= item
+
 /mob/living/carbon/monkey/proc/on_enemy_qdeleting(mob/living/enemy)
 	SIGNAL_HANDLER
 
@@ -106,7 +118,9 @@
 		return TRUE
 
 	if(I.anchored || !put_in_hands(I))
-		blacklistItems[I] ++
+		if(pickupTarget == I)
+			set_pickup_target(null)
+		blacklist_item(I)
 		return FALSE
 
 	if(I.force >= best_force)
@@ -157,8 +171,9 @@
 		else if(!isobj(loc) || istype(loc, /obj/item/clothing/head/mob_holder))
 			pickupTimer++
 			if(pickupTimer >= 4)
-				blacklistItems[pickupTarget] ++
+				var/obj/item/timed_out_item = pickupTarget
 				set_pickup_target(null)
+				blacklist_item(timed_out_item)
 			else
 				INVOKE_ASYNC(src, PROC_REF(walk2derpless), pickupTarget.loc)
 				if(Adjacent(pickupTarget) || Adjacent(pickupTarget.loc)) // next to target

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -15,7 +15,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/backwards		// hopefully self-explanatory
 	var/movedir			// the actual direction to move stuff in
 
-	var/list/affecting	// the list of all items that will be moved this ptick
 	var/id = ""			// the control ID	- must match controller ID
 	var/verted = 1		// Inverts the direction the conveyor belt moves.
 	speed_process = TRUE
@@ -132,7 +131,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(!operating)
 		return PROCESS_KILL
 	use_power(6)
-	affecting = loc.contents - src		// moved items will be all in loc
+	var/list/affecting = loc.contents - src		// moved items will be all in loc
 	addtimer(CALLBACK(src, PROC_REF(convey), affecting), 1)
 
 /obj/machinery/conveyor/proc/convey(list/affecting)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -91,8 +91,7 @@
 				C.put_in_hands(make_item(), TRUE)
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/Destroy()
-	if(item)
-		qdel(item)
+	QDEL_NULL(item)
 	return ..()
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/proc/make_item()

--- a/code/modules/unit_tests/harddel_cleanup.dm
+++ b/code/modules/unit_tests/harddel_cleanup.dm
@@ -84,3 +84,104 @@
 
 /datum/unit_test/radial_menu_caller_callback_ownership/proc/radial_check_stub()
 	return TRUE
+
+/// remote_materials владеет after_insert и не должен оставлять удалённый callback в своём поле.
+/datum/unit_test/remote_materials_callback_cleanup/Run()
+	var/obj/effect/parent = allocate(/obj/effect)
+	var/datum/callback/after_insert = CALLBACK(src, PROC_REF(after_insert_stub))
+	var/datum/component/remote_materials/component = parent.AddComponent(/datum/component/remote_materials, "unit_test", FALSE, FALSE, FALSE, after_insert)
+	TEST_ASSERT_NOTNULL(component, "Не удалось создать remote_materials")
+
+	qdel(component)
+	TEST_ASSERT(QDELETED(after_insert), "Удаление remote_materials не удалило принадлежащий ему callback")
+	TEST_ASSERT_NULL(component.after_insert, "remote_materials оставил ссылку на удалённый callback")
+
+/datum/unit_test/remote_materials_callback_cleanup/proc/after_insert_stub()
+	return
+
+/// Conjure spell владеет последним созданным предметом и обязан обнулить ссылку после qdel.
+/datum/unit_test/conjure_item_destroy_clears_item/Run()
+	var/obj/effect/proc_holder/spell/targeted/conjure_item/summon_pie/spell = new
+	var/obj/item/item = spell.make_item()
+	TEST_ASSERT_NOTNULL(item, "Summon pie не создал предмет")
+
+	qdel(spell)
+	TEST_ASSERT(QDELETED(item), "Удаление conjure spell не удалило созданный предмет")
+	TEST_ASSERT_NULL(spell.item, "Conjure spell оставил ссылку на удалённый предмет")
+
+/// Удалившаяся slab ability должна разорвать обратную ссылку живого slab.
+/datum/unit_test/clockwork_slab_ability_backref_cleanup/Run()
+	var/obj/item/clockwork/slab/slab = allocate(/obj/item/clockwork/slab)
+	var/obj/effect/proc_holder/slab/volt/ability = new(slab)
+	slab.slab_ability = ability
+	ability.slab = slab
+
+	qdel(ability)
+	TEST_ASSERT_NULL(slab.slab_ability, "Clockwork slab оставил ссылку на удалённую ability")
+
+/// Однотиковый список конвейера не должен сохраняться в var машины после process().
+/datum/unit_test/conveyor_process_does_not_cache_affecting/Run()
+	var/source = read_source_file("code/modules/recycling/conveyor2.dm")
+	TEST_ASSERT_NOTNULL(source, "Не удалось прочитать conveyor2.dm")
+	TEST_ASSERT(!findtext(source, "\tvar/list/affecting\t// the list of all items that will be moved this ptick"), "Конвейер хранит однотиковый affecting как долгоживущий var")
+	TEST_ASSERT(findtext(source, "\tvar/list/affecting = loc.contents - src"), "process() не использует локальный affecting")
+
+/// Кэш screentip обязан инвалидироваться, если закэшированный атом удалён.
+/datum/unit_test/hud_screentip_cache_qdel_cleanup/Run()
+	var/mob/owner = allocate(/mob)
+	var/datum/hud/hud = new(owner)
+	var/atom/movable/screen/fullscreen/dimmer/target = allocate(/atom/movable/screen/fullscreen/dimmer)
+	hud.set_screentip_cache(target, null)
+	TEST_ASSERT_EQUAL(hud.last_screentip_atom, target, "Тест не заполнил screentip-кэш")
+
+	qdel(target)
+	TEST_ASSERT_NULL(hud.last_screentip_atom, "HUD оставил ссылку на удалённый screentip target")
+	qdel(hud)
+
+/// Cached spawnpanel живёт дольше тела админа и должен отпустить удаляемого owner.
+/datum/unit_test/spawnpanel_owner_qdel_cleanup/Run()
+	var/mob/owner = allocate(/mob)
+	var/datum/spawnpanel/panel = new(owner)
+	TEST_ASSERT_EQUAL(panel.owner, owner, "Spawnpanel проигнорировал переданного owner")
+
+	qdel(owner)
+	TEST_ASSERT_NULL(panel.owner, "Spawnpanel оставил ссылку на удалённого owner")
+	qdel(panel)
+
+/// Mind живёт дольше loadout-реликвии и должен очистить assigned_heirloom по её qdel.
+/datum/unit_test/mind_assigned_heirloom_qdel_cleanup/Run()
+	var/datum/mind/mind = new
+	var/obj/item/clothing/wrists/clockwork_watch/red/heirloom = allocate(/obj/item/clothing/wrists/clockwork_watch/red)
+	mind.set_assigned_heirloom(heirloom)
+	TEST_ASSERT_EQUAL(mind.assigned_heirloom, heirloom, "Тест не назначил реликвию")
+
+	qdel(heirloom)
+	TEST_ASSERT_NULL(mind.assigned_heirloom, "Mind оставил ссылку на удалённую assigned_heirloom")
+	qdel(mind)
+
+/// Обезьяна должна удалять qdeleted предметы из blacklistItems.
+/datum/unit_test/monkey_blacklist_item_qdel_cleanup/Run()
+	var/mob/living/carbon/monkey/monkey = allocate(/mob/living/carbon/monkey)
+	var/obj/item/item = allocate(/obj/item)
+	item.setAnchored(TRUE)
+	monkey.set_pickup_target(item)
+	TEST_ASSERT(!monkey.equip_item(item), "Обезьяна неожиданно подобрала anchored предмет")
+	TEST_ASSERT_NULL(monkey.pickupTarget, "Blacklist-путь не очистил pickupTarget")
+	TEST_ASSERT(item in monkey.blacklistItems, "Тестовый предмет не попал в blacklistItems")
+
+	qdel(item)
+	TEST_ASSERT(!(item in monkey.blacklistItems), "Обезьяна оставила удалённый предмет в blacklistItems")
+
+/// Halloween closet не должен удерживать моба после удаления или постановки delayed qdel.
+/datum/unit_test/spooky_closet_trapped_mob_cleanup/Run()
+	var/obj/structure/closet/closet = allocate(/obj/structure/closet)
+	var/mob/first_mob = allocate(/mob)
+	closet.set_trapped_mob(first_mob)
+	qdel(first_mob)
+	TEST_ASSERT_NULL(closet.trapped_mob, "Шкаф оставил ссылку на удалённого trapped_mob")
+
+	var/mob/second_mob = allocate(/mob)
+	closet.set_trapped_mob(second_mob)
+	closet.trapped = SPOOKY_SKELETON
+	closet.trigger_spooky_trap()
+	TEST_ASSERT_NULL(closet.trapped_mob, "Шкаф удерживает trapped_mob во время delayed qdel")


### PR DESCRIPTION
# Описание

Исправлены подтверждённые держатели ссылок из harddel-логов. Добавлены регрессионные тесты для девяти сценариев

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

Устраняет утечки ссылок, мешавшие корректному удалению объектов и датумов

## Changelog

:cl:
fix: Исправлен ряд утечек ссылок при удалении объектов
code: Добавлены регрессионные тесты для harddel-ошибок
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшена стабильность подсказок при наведении и удалении отображаемых объектов.
  * Исправлено автоматическое обновление семейных реликвий при удалении связанных предметов.
  * Админ-панель спавна корректно освобождает владельца и отключает точный режим при закрытии или удалении персонажа.
  * Исправлена очистка временных объектов, способностей и материалов после их удаления.
  * Замки Хэллоуина больше не сохраняют удалённых пленников.
  * Обезьяны корректнее обрабатывают запрещённые для подбора предметы.

* **Тесты**
  * Добавлены проверки корректной очистки ссылок и временных данных во всех затронутых сценариях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->