### PR TITLE
Хардделиты и джукбокс

### DIFF
--- a/code/datums/components/jukebox/jukebox_prefs.dm
+++ b/code/datums/components/jukebox/jukebox_prefs.dm
@@ -4,6 +4,66 @@
 #define PLAYLIST_MAX_NAME_LEN 35
 #define PLAYLIST_MAX_COUNT 40
 
+/// Strict validation for imported track arrays. Associative/hybrid lists are never track arrays.
+/proc/jukebox_track_list_is_valid(candidate, allow_empty = FALSE)
+	if(!islist(candidate))
+		return FALSE
+	var/list/tracks = candidate
+	if(is_assoc_list(tracks) || (!allow_empty && !length(tracks)))
+		return FALSE
+	for(var/song in tracks)
+		if(!istext(song) || !length(song))
+			return FALSE
+	return TRUE
+
+/// Strict validation for the object produced by exporting all playlists.
+/proc/jukebox_playlists_are_valid(candidate)
+	if(!islist(candidate))
+		return FALSE
+	var/list/imported_playlists = candidate
+	if(!length(imported_playlists) || !is_assoc_list(imported_playlists) || length(imported_playlists) > PLAYLIST_MAX_COUNT)
+		return FALSE
+	for(var/playlist_name in imported_playlists)
+		if(!istext(playlist_name) || !length(playlist_name) || length_char(playlist_name) > PLAYLIST_MAX_NAME_LEN)
+			return FALSE
+		if(strip_control_chars(playlist_name) != playlist_name)
+			return FALSE
+		if(!jukebox_track_list_is_valid(imported_playlists[playlist_name], allow_empty = TRUE))
+			return FALSE
+	return TRUE
+
+/// Recovers a persisted preference into a JSON-safe sequential array.
+/proc/sanitize_jukebox_track_list(candidate)
+	if(!islist(candidate))
+		return list()
+	var/list/tracks = candidate
+	if(is_assoc_list(tracks))
+		return list()
+	var/list/sanitized = list()
+	for(var/song in tracks)
+		if(istext(song) && length(song))
+			sanitized |= song
+	return sanitized
+
+/// Recovers persisted playlists, enforcing the same shape and limits as the import UI.
+/proc/sanitize_jukebox_playlists(candidate)
+	if(!islist(candidate))
+		return list()
+	var/list/imported_playlists = candidate
+	if(length(imported_playlists) && !is_assoc_list(imported_playlists))
+		return list()
+	var/list/sanitized = list()
+	for(var/playlist_name in imported_playlists)
+		if(length(sanitized) >= PLAYLIST_MAX_COUNT)
+			break
+		if(!istext(playlist_name))
+			continue
+		var/clean_name = copytext_char(strip_control_chars(playlist_name), 1, PLAYLIST_MAX_NAME_LEN + 1)
+		if(!length(clean_name) || (clean_name in sanitized))
+			continue
+		sanitized[clean_name] = sanitize_jukebox_track_list(imported_playlists[playlist_name])
+	return sanitized
+
 ////////////////////	ОБЩИЕ 	////////////////////
 /datum/preferences/proc/tracks_move(list/track_list, track, up = TRUE)
 	if(!LAZYLEN(track_list) || !track)
@@ -40,14 +100,8 @@
 
 	return moveElementToPos(track_list, from, to_index)
 
-/datum/preferences/proc/track_import_check(list/new_track_list)
-	if(!LAZYLEN(new_track_list))
-		return
-	for(var/song in new_track_list)
-		// Это пустая строка или не текст
-		if(!istext(song) || !song)
-			return
-	return TRUE
+/datum/preferences/proc/track_import_check(new_track_list, allow_empty = FALSE)
+	return jukebox_track_list_is_valid(new_track_list, allow_empty)
 
 //////////////////// ИЗБРАННОЕ ////////////////////
 /datum/preferences/proc/favorite_tracks_toggle(track)
@@ -76,11 +130,16 @@
 	if(!manage_mode)
 		return
 	if(manage_mode == "Импорт")
-		var/list/new_track_list = safe_json_decode(tgui_input_text(parent, "Вставьте экспортированный список", "Import", multiline = TRUE))
-		if(!LAZYLEN(new_track_list))
+		var/import_json = tgui_input_text(parent, "Вставьте экспортированный список", "Import", multiline = TRUE)
+		if(isnull(import_json))
 			return
+		var/decoded = safe_json_decode(import_json)
+		if(!islist(decoded))
+			to_chat(parent, span_warning("Список поврежден: ожидался JSON-массив названий треков."))
+			return
+		var/list/new_track_list = decoded
 		if(!track_import_check(new_track_list))
-			to_chat(parent, span_warning("Список поврежден, все элементы списка должны быть строками!"))
+			to_chat(parent, span_warning("Список поврежден: ожидался JSON-массив непустых названий треков."))
 			return
 		if(favorite_tracks.len)
 			var/mode = tgui_alert(parent, "Желаете заменить список или добавить треки в конец,", "Режим добавления", list("Добавить", "Заменить"))
@@ -130,7 +189,7 @@
 			return
 		playlists -= playlist_name
 	else
-		var/new_playlist_name = tgui_input_text(parent, "Введите имя нового плейлиста", "Изменение плейлиста [playlist_name]", multiline = FALSE)
+		var/new_playlist_name = tgui_input_text(parent, "Введите имя нового плейлиста", "Изменение плейлиста [playlist_name]", multiline = FALSE, max_length = PLAYLIST_MAX_NAME_LEN)
 		if(!new_playlist_name)
 			return
 		if(new_playlist_name in playlists)
@@ -181,33 +240,37 @@
 	if(!manage_mode)
 		return
 	if(manage_mode == "Импорт")
-		var/list/new_track_list = safe_json_decode(tgui_input_text(parent, "Вставьте экспортированный список", "Импорт", multiline = TRUE))
-		if(!LAZYLEN(new_track_list))
+		var/import_json = tgui_input_text(parent, "Вставьте экспортированный список", "Импорт", multiline = TRUE)
+		if(isnull(import_json))
 			return
-
-		// Проверяем, что бы все названия плейлистов или треки были строками
-		if(!track_import_check(new_track_list))
-			to_chat(parent, span_warning("Список поврежден, все элементы списка должны быть строками!"))
+		var/decoded = safe_json_decode(import_json)
+		if(!islist(decoded))
+			to_chat(parent, span_warning("Список поврежден: ожидался JSON-массив треков или объект плейлистов."))
+			return
+		var/list/new_track_list = decoded
+		if(!length(new_track_list))
 			return
 
 		//Если вставили все плейлисты
 		if(is_assoc_list(new_track_list))
-			// Проверяем каждый плейлист
-			for(var/playlist_name in new_track_list)
-				if(!track_import_check(new_track_list[playlist_name]))
-					to_chat(parent, span_warning("Список поврежден, все элементы списка должны быть строками!"))
-					return
+			if(!jukebox_playlists_are_valid(new_track_list))
+				to_chat(parent, span_warning("Список поврежден: проверьте названия плейлистов и массивы треков."))
+				return
+			var/list/imported_playlists = sanitize_jukebox_playlists(new_track_list)
 			if(playlists.len)
 				var/confirm = tgui_alert(parent, "Будут заменены ВСЕ плейлисты. Продолжить?", "Замена всех плейлистов", list("Нет", "Да"))
 				if(confirm != "Да")
 					return
-				playlists.Cut()
+			playlists.Cut()
 
-			// Через цикл, для избежания дубликатов в отдельных плейлистах
-			for(var/playlist_name in new_track_list)
-				playlists[playlist_name] = uniqueList(new_track_list[playlist_name])
+			for(var/playlist_name in imported_playlists)
+				playlists[playlist_name] = imported_playlists[playlist_name]
 			save_preferences()
 			return TRUE
+
+		if(!track_import_check(new_track_list))
+			to_chat(parent, span_warning("Список поврежден: ожидался JSON-массив непустых названий треков."))
+			return
 
 		var/current_playlist_name
 		var/list/track_list

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -134,6 +134,7 @@
 	QDEL_NULL(tgui_panel)
 	QDEL_LIST(antag_datums)
 	QDEL_NULL(skill_holder)
+	RemoveAllSpells()
 	set_assigned_heirloom(null)
 	set_current(null)
 	soulOwner = null
@@ -1802,8 +1803,16 @@ GLOBAL_LIST(objective_choices)
 	special_role = ROLE_REV_HEAD
 
 /datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S)
+	if(!S || S in spell_list)
+		return
 	spell_list += S
+	RegisterSignal(S, COMSIG_PARENT_QDELETING, PROC_REF(on_spell_qdeleting))
 	S.action.Grant(current)
+
+/datum/mind/proc/on_spell_qdeleting(obj/effect/proc_holder/spell/spell)
+	SIGNAL_HANDLER
+	UnregisterSignal(spell, COMSIG_PARENT_QDELETING)
+	spell_list -= spell
 
 /datum/mind/proc/owns_soul()
 	return soulOwner == src
@@ -1812,16 +1821,19 @@ GLOBAL_LIST(objective_choices)
 /datum/mind/proc/RemoveSpell(obj/effect/proc_holder/spell/spell)
 	if(!spell)
 		return
-	for(var/X in spell_list)
-		var/obj/effect/proc_holder/spell/S = X
+	for(var/obj/effect/proc_holder/spell/S in spell_list.Copy())
 		if(istype(S, spell))
 			spell_list -= S
+			UnregisterSignal(S, COMSIG_PARENT_QDELETING)
 			qdel(S)
 	current?.client << output(null, "statbrowser:check_spells")
 
 /datum/mind/proc/RemoveAllSpells()
-	for(var/obj/effect/proc_holder/S in spell_list)
-		RemoveSpell(S)
+	for(var/obj/effect/proc_holder/S in spell_list.Copy())
+		spell_list -= S
+		UnregisterSignal(S, COMSIG_PARENT_QDELETING)
+		qdel(S)
+	current?.client << output(null, "statbrowser:check_spells")
 
 /datum/mind/proc/transfer_martial_arts(mob/living/new_character)
 	if(!ishuman(new_character))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1803,7 +1803,7 @@ GLOBAL_LIST(objective_choices)
 	special_role = ROLE_REV_HEAD
 
 /datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S)
-	if(!S || S in spell_list)
+	if(!S || (S in spell_list))
 		return
 	spell_list += S
 	RegisterSignal(S, COMSIG_PARENT_QDELETING, PROC_REF(on_spell_qdeleting))

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -544,9 +544,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	if(!template)
 		return FALSE
 	testing("Ruin \"[template_name]\" placed at ([T.x], [T.y], [T.z])")
+	// Снимаемся с учёта ДО загрузки, а не после. template.load() спит (маплоадер
+	// уступает тик), и всё это время лендмарк оставался в GLOB.stationroom_landmarks:
+	// параллельный seedStation() (таймер тикера, +60с после раундстарта) подхватывал
+	// тот же лендмарк и грузил шаблон второй раз в ту же точку. Дубль накладывал
+	// вторую копию каждой атмос-машины на те же тайлы, у устройств один слот nodes
+	// на копию - вторая уходила в setPipenet с nodes.Find() == 0.
+	GLOB.stationroom_landmarks -= src
 	template.load(T, centered = FALSE)
 	template.loaded++
-	GLOB.stationroom_landmarks -= src
 	qdel(src)
 	return TRUE
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -549,7 +549,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	// параллельный seedStation() (таймер тикера, +60с после раундстарта) подхватывал
 	// тот же лендмарк и грузил шаблон второй раз в ту же точку. Дубль накладывал
 	// вторую копию каждой атмос-машины на те же тайлы, у устройств один слот nodes
-	// на копию - вторая уходила в setPipenet с nodes.Find() == 0.
+	// на копию - вторая передавала в setPipenet отсутствующий в nodes объект.
 	GLOB.stationroom_landmarks -= src
 	template.load(T, centered = FALSE)
 	template.loaded++

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -276,10 +276,10 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/obj/item/radio/radio
 
 INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
-/atom/movable/virtualspeaker/Initialize(mapload, atom/movable/M, radio)
+/atom/movable/virtualspeaker/Initialize(mapload, atom/movable/M, obj/item/radio/new_radio)
 	. = ..()
-	radio = radio
-	source = M
+	set_source(M)
+	set_radio(new_radio)
 	if (istype(M))
 		name = M.GetVoice()
 		verb_say = M.verb_say
@@ -311,9 +311,37 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 		job = "Unknown"
 
 /atom/movable/virtualspeaker/Destroy()
-	source = null
-	radio = null
+	set_source(null)
+	set_radio(null)
 	return ..()
+
+/atom/movable/virtualspeaker/proc/set_source(atom/movable/new_source)
+	if(source == new_source)
+		return
+	if(source)
+		UnregisterSignal(source, COMSIG_PARENT_QDELETING)
+	source = new_source
+	if(source)
+		RegisterSignal(source, COMSIG_PARENT_QDELETING, PROC_REF(on_source_qdeleting))
+
+/atom/movable/virtualspeaker/proc/on_source_qdeleting(atom/movable/deleted_source)
+	SIGNAL_HANDLER
+	if(source == deleted_source)
+		set_source(null)
+
+/atom/movable/virtualspeaker/proc/set_radio(obj/item/radio/new_radio)
+	if(radio == new_radio)
+		return
+	if(radio)
+		UnregisterSignal(radio, COMSIG_PARENT_QDELETING)
+	radio = new_radio
+	if(radio)
+		RegisterSignal(radio, COMSIG_PARENT_QDELETING, PROC_REF(on_radio_qdeleting))
+
+/atom/movable/virtualspeaker/proc/on_radio_qdeleting(obj/item/radio/deleted_radio)
+	SIGNAL_HANDLER
+	if(radio == deleted_radio)
+		set_radio(null)
 
 /atom/movable/virtualspeaker/GetJob()
 	return job

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -160,11 +160,21 @@
 
 /obj/machinery/atmospherics/components/pipeline_expansion(datum/pipeline/reference)
 	if(reference)
-		return list(nodes[parents.Find(reference)])
+		if(!parents?.len || !nodes?.len)
+			return list()
+		var/index = parents.Find(reference)
+		if(!index || index > nodes.len)
+			return list()
+		return list(nodes[index])
 	return ..()
 
 /obj/machinery/atmospherics/components/setPipenet(datum/pipeline/reference, obj/machinery/atmospherics/A)
-	parents[nodes.Find(A)] = reference
+	if(!parents?.len || !nodes?.len)
+		return
+	var/index = nodes.Find(A)
+	if(!index || index > parents.len)
+		return
+	parents[index] = reference
 
 /obj/machinery/atmospherics/components/returnPipenet(obj/machinery/atmospherics/A = nodes[1]) //returns parents[1] if called without argument
 	if(!parents?.len || !nodes?.len)
@@ -175,7 +185,12 @@
 	return parents[index]
 
 /obj/machinery/atmospherics/components/replacePipenet(datum/pipeline/Old, datum/pipeline/New)
-	parents[parents.Find(Old)] = New
+	if(!parents?.len)
+		return
+	var/index = parents.Find(Old)
+	if(!index)
+		return
+	parents[index] = New
 
 /obj/machinery/atmospherics/components/unsafe_pressure_release(var/mob/user, var/pressures)
 	..()

--- a/code/modules/cards/cards.dm
+++ b/code/modules/cards/cards.dm
@@ -20,6 +20,10 @@
 	playsound(src, 'sound/items/cardshuffle.ogg', 50, 1)
 	return BRUTELOSS
 
+/obj/item/toy/cards/Destroy()
+	parentdeck = null
+	return ..()
+
 /obj/item/toy/cards/proc/apply_card_vars(obj/item/toy/cards/sourceobj) // Applies variables for supporting multiple types of card deck
 	. = TRUE
 	if(!istype(sourceobj))

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -675,7 +675,7 @@
 
 /obj/item/clothing/glasses/ar_interface/dropped(mob/user)
 	. = ..()
-	neural_interface?.RemoveSource("AR glasses")
+	clear_neural_interface()
 	UnregisterSignal(user, COMSIG_MOB_EXAMINATE)
 
 /obj/item/clothing/glasses/ar_interface/attackby(obj/item/I, mob/living/user)
@@ -704,10 +704,14 @@
 	adresses = null
 	if(net)
 		QDEL_NULL(net)
-	if(neural_interface)
-		neural_interface.RemoveSource("AR glasses")
-		QDEL_NULL(neural_interface)
+	clear_neural_interface()
 	. = ..()
+
+/obj/item/clothing/glasses/ar_interface/proc/clear_neural_interface()
+	var/datum/component/neural_interface/old_interface = neural_interface
+	neural_interface = null
+	if(!QDELETED(old_interface))
+		old_interface.RemoveSource("AR glasses")
 
 /obj/item/clothing/glasses/ar_interface/proc/on_examine_target(datum/source, atom/target)
 	if(get_dist(get_turf(source), get_turf(target)) > 8)

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -37,11 +37,20 @@
 /obj/item/clothing/glasses/hud/dropped(mob/living/carbon/human/user)
 	..()
 	if(hud_type && istype(user) && hud_granted)
-		interface?.RemoveSource(interface_source)
-		interface = null
+		clear_neural_interface()
 		hud_granted = FALSE
 		var/datum/atom_hud/H = GLOB.huds[hud_type]
 		H.remove_hud_from(user)
+
+/obj/item/clothing/glasses/hud/Destroy()
+	clear_neural_interface()
+	return ..()
+
+/obj/item/clothing/glasses/hud/proc/clear_neural_interface()
+	var/datum/component/neural_interface/old_interface = interface
+	interface = null
+	if(!QDELETED(old_interface))
+		old_interface.RemoveSource(interface_source)
 
 /obj/item/clothing/glasses/hud/emp_act(severity)
 	. = ..()

--- a/code/modules/mob/living/living_active_parry.dm
+++ b/code/modules/mob/living/living_active_parry.dm
@@ -45,9 +45,10 @@
 		return FALSE
 	// Point of no return, make sure everything is set.
 	parrying = method
-	if(method == ITEM_PARRY)
-		active_parry_item = tool
+	set_active_parry_item(method == ITEM_PARRY ? tool : null)
 	if(!UseStaminaBuffer(data.parry_stamina_cost, TRUE))
+		parrying = NOT_PARRYING
+		set_active_parry_item(null)
 		return FALSE
 	parry_start_time = world.time
 	successful_parries = list()
@@ -141,6 +142,7 @@
   */
 /mob/living/proc/end_parry_sequence()
 	if(!parrying)
+		set_active_parry_item(null)
 		return
 	REMOVE_TRAIT(src, TRAIT_MOBILITY_NOUSE, ACTIVE_PARRY_TRAIT)
 	REMOVE_TRAIT(src, TRAIT_SPRINT_LOCKED, ACTIVE_PARRY_TRAIT)
@@ -166,6 +168,25 @@
 	parry_end_time_last = world.time + (successful? 0 : data.parry_failed_cooldown_duration)
 	successful_parries = null
 	successful_parry_counterattacks = null
+	set_active_parry_item(null)
+
+/mob/living/proc/set_active_parry_item(obj/item/new_item)
+	if(active_parry_item == new_item)
+		return
+	if(active_parry_item)
+		UnregisterSignal(active_parry_item, COMSIG_PARENT_QDELETING)
+	active_parry_item = new_item
+	if(active_parry_item)
+		RegisterSignal(active_parry_item, COMSIG_PARENT_QDELETING, PROC_REF(on_active_parry_item_qdeleting))
+
+/mob/living/proc/on_active_parry_item_qdeleting(obj/item/deleted_item)
+	SIGNAL_HANDLER
+	if(active_parry_item != deleted_item)
+		return
+	if(parrying == ITEM_PARRY)
+		end_parry_sequence()
+	else
+		set_active_parry_item(null)
 
 /**
   * Handles starting effects for parrying.

--- a/code/modules/mod/modules/modules_visor.dm
+++ b/code/modules/mod/modules/modules_visor.dm
@@ -42,7 +42,10 @@
 	if(hud_type)
 		var/datum/atom_hud/hud = GLOB.huds[hud_type]
 		hud.remove_hud_from(mod.wearer)
-		interface?.RemoveSource(interface_source)
+		var/datum/component/neural_interface/old_interface = interface
+		interface = null
+		if(!QDELETED(old_interface))
+			old_interface.RemoveSource(interface_source)
 	for(var/trait in visor_traits)
 		REMOVE_TRAIT(mod.wearer, trait, MOD_TRAIT)
 	mod.wearer.update_sight()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1865,6 +1865,7 @@
 
 /obj/machinery/power/apc/proc/mark_light_cache_dirty()
 	light_cache_dirty = TRUE
+	cached_area_lights = null
 
 /obj/machinery/power/apc/proc/get_cached_area_lights()
 	ensure_light_cache()

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -95,5 +95,19 @@
 	return ..()
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/proc/make_item()
-	item = new item_type
+	set_item(new item_type)
 	return item
+
+/obj/effect/proc_holder/spell/targeted/conjure_item/proc/set_item(obj/item/new_item)
+	if(item == new_item)
+		return
+	if(item)
+		UnregisterSignal(item, COMSIG_PARENT_QDELETING)
+	item = new_item
+	if(item)
+		RegisterSignal(item, COMSIG_PARENT_QDELETING, PROC_REF(on_item_qdeleting))
+
+/obj/effect/proc_holder/spell/targeted/conjure_item/proc/on_item_qdeleting(obj/item/deleted_item)
+	SIGNAL_HANDLER
+	if(item == deleted_item)
+		set_item(null)

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -30,7 +30,10 @@
 	if(active)
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]
 		H.remove_hud_from(owner)
-		interface?.RemoveSource(interface_source)
+		var/datum/component/neural_interface/old_interface = interface
+		interface = null
+		if(!QDELETED(old_interface))
+			old_interface.RemoveSource(interface_source)
 	else
 		var/datum/atom_hud/H = GLOB.huds[HUD_type]
 		H.add_hud_to(owner)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -185,6 +185,7 @@
 #include "human_mob_gc.dm"
 #include "observer_reenter_race.dm"
 #include "jukebox_import.dm"
+#include "stationroom_landmark.dm"
 #include "latex_lockable.dm"
 #include "parallax_position.dm"
 #include "perf_optimizations.dm"

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -184,6 +184,7 @@
 #include "memory_leak_limits.dm"
 #include "human_mob_gc.dm"
 #include "observer_reenter_race.dm"
+#include "jukebox_import.dm"
 #include "latex_lockable.dm"
 #include "parallax_position.dm"
 #include "perf_optimizations.dm"

--- a/code/modules/unit_tests/harddel_cleanup.dm
+++ b/code/modules/unit_tests/harddel_cleanup.dm
@@ -159,6 +159,84 @@
 	TEST_ASSERT_NULL(mind.assigned_heirloom, "Mind оставил ссылку на удалённую assigned_heirloom")
 	qdel(mind)
 
+/// APC обязан немедленно отпустить удаляемый светильник из долгоживущего кэша.
+/datum/unit_test/apc_light_cache_qdel_cleanup/Run()
+	var/obj/machinery/power/apc/apc = allocate(/obj/machinery/power/apc)
+	var/obj/machinery/light/light = allocate(/obj/machinery/light)
+	apc.cached_area_lights = list(light)
+	apc.light_cache_dirty = FALSE
+
+	apc.mark_light_cache_dirty()
+	TEST_ASSERT(apc.light_cache_dirty, "APC не пометил кэш светильников грязным")
+	TEST_ASSERT_NULL(apc.cached_area_lights, "APC сохранил ссылку на светильник после инвалидации кэша")
+
+/// Virtualspeaker переживает исходный объект несколько секунд и должен отпустить его по qdel.
+/datum/unit_test/virtualspeaker_source_qdel_cleanup/Run()
+	var/obj/item/source = allocate(/obj/item)
+	var/obj/item/radio/radio = allocate(/obj/item/radio)
+	var/atom/movable/virtualspeaker/speaker = new(null, source, radio)
+	TEST_ASSERT_EQUAL(speaker.GetSource(), source, "Virtualspeaker не сохранил источник")
+	TEST_ASSERT_EQUAL(speaker.GetRadio(), radio, "Virtualspeaker не сохранил радио")
+
+	qdel(source)
+	TEST_ASSERT_NULL(speaker.GetSource(), "Virtualspeaker оставил ссылку на удалённый источник")
+	qdel(radio)
+	TEST_ASSERT_NULL(speaker.GetRadio(), "Virtualspeaker оставил ссылку на удалённое радио")
+	qdel(speaker)
+
+/// Завершённое парирование не должно удерживать использованный предмет.
+/datum/unit_test/active_parry_item_qdel_cleanup/Run()
+	var/mob/living/user = allocate(/mob/living)
+	var/obj/item/item = allocate(/obj/item)
+	user.set_active_parry_item(item)
+	TEST_ASSERT_EQUAL(user.active_parry_item, item, "Тест не назначил предмет парирования")
+
+	qdel(item)
+	TEST_ASSERT_NULL(user.active_parry_item, "Моб оставил ссылку на удалённый предмет парирования")
+
+/// Колода задаёт parentdeck на себя и обязана разорвать этот цикл в Destroy().
+/datum/unit_test/card_deck_parent_qdel_cleanup/Run()
+	var/obj/item/toy/cards/deck/deck = allocate(/obj/item/toy/cards/deck)
+	TEST_ASSERT_EQUAL(deck.parentdeck, deck, "Тестовая колода не создала self-reference parentdeck")
+
+	qdel(deck)
+	TEST_ASSERT_NULL(deck.parentdeck, "Удалённая колода оставила self-reference parentdeck")
+
+/// RemoveSpell должен удалить все совпадения, а внешний qdel — инвалидировать spell_list.
+/datum/unit_test/mind_spell_list_qdel_cleanup/Run()
+	var/datum/mind/mind = new
+	var/obj/effect/proc_holder/spell/first = new
+	var/obj/effect/proc_holder/spell/second = new
+	mind.AddSpell(first)
+	mind.AddSpell(second)
+
+	mind.RemoveSpell(/obj/effect/proc_holder/spell)
+	TEST_ASSERT(!length(mind.spell_list), "RemoveSpell пропустил заклинание при изменении spell_list во время обхода")
+	TEST_ASSERT(QDELETED(first) && QDELETED(second), "RemoveSpell не удалил все совпавшие заклинания")
+
+	var/obj/effect/proc_holder/spell/external = new
+	mind.AddSpell(external)
+	qdel(external)
+	TEST_ASSERT(!(external in mind.spell_list), "Mind оставил внешне удалённое заклинание в spell_list")
+
+	var/obj/effect/proc_holder/spell/owned = new
+	mind.AddSpell(owned)
+	qdel(mind)
+	TEST_ASSERT(QDELETED(owned), "Удаление mind не удалило принадлежащее ему заклинание")
+	TEST_ASSERT(!length(mind.spell_list), "Удалённый mind сохранил spell_list")
+
+/// RemoveSource может синхронно удалить последний neural_interface: holder очищается до вызова.
+/datum/unit_test/hud_neural_interface_qdel_cleanup/Run()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	var/obj/item/clothing/glasses/hud/health/glasses = allocate(/obj/item/clothing/glasses/hud/health)
+	var/datum/component/neural_interface/interface = user.LoadComponent(/datum/component/neural_interface)
+	interface.AddSource(glasses.interface_source)
+	glasses.interface = interface
+
+	glasses.clear_neural_interface()
+	TEST_ASSERT_NULL(glasses.interface, "HUD-очки оставили ссылку на удалённый neural_interface")
+	TEST_ASSERT(QDELETED(interface), "Последний neural_interface не удалился после RemoveSource")
+
 /// Обезьяна должна удалять qdeleted предметы из blacklistItems.
 /datum/unit_test/monkey_blacklist_item_qdel_cleanup/Run()
 	var/mob/living/carbon/monkey/monkey = allocate(/mob/living/carbon/monkey)

--- a/code/modules/unit_tests/harddel_cleanup.dm
+++ b/code/modules/unit_tests/harddel_cleanup.dm
@@ -237,6 +237,122 @@
 	TEST_ASSERT_NULL(glasses.interface, "HUD-очки оставили ссылку на удалённый neural_interface")
 	TEST_ASSERT(QDELETED(interface), "Последний neural_interface не удалился после RemoveSource")
 
+/// Точные типы из harddel-лога должны пройти softcheck после освобождения исправленных ссылок.
+/datum/unit_test/harddel_cleanup_soft_gc
+	parent_type = /datum/unit_test/gc_rewrite_base
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/target_record(datum/target, label)
+	return list(
+		"ref" = REF(target),
+		"type_path" = target.type,
+		"label" = label,
+	)
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_mapped_light(type_path, label)
+	var/list/candidates = SSmachines.get_machines_by_type(type_path)
+	var/obj/machinery/light/target
+	var/obj/machinery/power/apc/target_apc
+	for(var/obj/machinery/light/candidate as anything in candidates)
+		var/obj/machinery/power/apc/candidate_apc = candidate.get_area_apc()
+		if(!candidate_apc)
+			continue
+		if(!(candidate in candidate_apc.get_cached_area_lights()))
+			continue
+		target = candidate
+		target_apc = candidate_apc
+		break
+	TEST_ASSERT_NOTNULL(target, "Не найден уже инициализированный [type_path] с APC-кэшем")
+	var/list/record = target_record(target, label)
+
+	qdel(target)
+	TEST_ASSERT_NULL(target_apc.cached_area_lights, "Удаление [type_path] не очистило кэш APC")
+	candidates.Cut()
+	target = null
+	target_apc = null
+	return record
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_virtualspeaker_source()
+	var/obj/item/warp_machine_beacon/source = new(run_loc_floor_bottom_left)
+	var/obj/item/radio/radio = allocate(/obj/item/radio)
+	var/atom/movable/virtualspeaker/speaker = allocate(/atom/movable/virtualspeaker, run_loc_floor_bottom_left, source, radio)
+	var/list/record = target_record(source, "virtualspeaker source: /obj/item/warp_machine_beacon")
+
+	qdel(source)
+	TEST_ASSERT_NULL(speaker.GetSource(), "Virtualspeaker оставил ссылку на удалённый warp beacon")
+	return record
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_active_parry_item()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	var/obj/item/chair/stool/bar/stool = new(run_loc_floor_bottom_left)
+	var/list/record = target_record(stool, "active_parry_item: /obj/item/chair/stool/bar")
+	user.set_active_parry_item(stool)
+
+	qdel(stool)
+	TEST_ASSERT_NULL(user.active_parry_item, "Моб оставил ссылку на удалённый bar stool")
+	return record
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_card_deck()
+	var/obj/item/toy/cards/deck/deck = new(run_loc_floor_bottom_left)
+	var/list/record = target_record(deck, "parentdeck: /obj/item/toy/cards/deck")
+	qdel(deck)
+	TEST_ASSERT_NULL(deck.parentdeck, "Удалённая колода оставила self-reference parentdeck")
+	return record
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_mind_spell()
+	var/datum/mind/mind = new
+	allocated += mind
+	var/obj/effect/proc_holder/spell/targeted/lewd_chems/spell = new
+	var/list/record = target_record(spell, "mind spell_list: /obj/effect/proc_holder/spell/targeted/lewd_chems")
+	mind.AddSpell(spell)
+
+	qdel(spell)
+	TEST_ASSERT(!(spell in mind.spell_list), "Mind оставил удалённый lewd_chems в spell_list")
+	return record
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_neural_interface()
+	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
+	var/obj/item/clothing/glasses/hud/health/glasses = allocate(/obj/item/clothing/glasses/hud/health)
+	var/datum/component/neural_interface/interface = user.LoadComponent(/datum/component/neural_interface)
+	interface.AddSource(glasses.interface_source)
+	glasses.interface = interface
+	var/list/record = target_record(interface, "HUD interface: /datum/component/neural_interface")
+
+	glasses.clear_neural_interface()
+	TEST_ASSERT_NULL(glasses.interface, "HUD-очки оставили ссылку на удалённый neural_interface")
+	TEST_ASSERT(QDELETED(interface), "Последний neural_interface не удалился после RemoveSource")
+	return record
+
+/datum/unit_test/harddel_cleanup_soft_gc/proc/assert_soft_collected(list/target)
+	var/type_path = target["type_path"]
+	var/label = target["label"]
+	var/datum/qdel_item/item = SSgarbage.GetOrCreateItem(type_path)
+	TEST_ASSERT(item.qdels > 0, "[label] не попал в qdel")
+	TEST_ASSERT_EQUAL(item.failures, 0, "[label] не прошёл softcheck")
+	TEST_ASSERT_EQUAL(item.warnfail_count, 0, "[label] дошёл до warnfail")
+	TEST_ASSERT_EQUAL(item.hard_deletes, 0, "[label] ушёл в hard delete")
+	TEST_ASSERT(!(target["ref"] in SSgarbage.queue_refs[GC_QUEUE_SOFTCHECK]), "[label] остался в очереди softcheck")
+
+/datum/unit_test/harddel_cleanup_soft_gc/Run()
+	configure_immediate_gc()
+	var/list/targets = list()
+	targets += list(qdel_mapped_light(/obj/machinery/light, "APC cached_area_lights: /obj/machinery/light"))
+	targets += list(qdel_mapped_light(/obj/machinery/light/small, "APC cached_area_lights: /obj/machinery/light/small"))
+	targets += list(qdel_virtualspeaker_source())
+	targets += list(qdel_active_parry_item())
+	targets += list(qdel_card_deck())
+	targets += list(qdel_mind_spell())
+	targets += list(qdel_neural_interface())
+
+	for(var/list/target in targets)
+		var/label = target["label"]
+		TEST_ASSERT(target["ref"] in SSgarbage.queue_refs[GC_QUEUE_SOFTCHECK], "[label] не был поставлен в очередь softcheck")
+	var/start_soft_passes = SSgarbage.pass_counts[GC_QUEUE_SOFTCHECK]
+	run_gc_fire_cycles(2, yield_for_gc = TRUE)
+	TEST_ASSERT(SSgarbage.pass_counts[GC_QUEUE_SOFTCHECK] >= start_soft_passes + length(targets), "SSgarbage не обработал все проверяемые softcheck-записи")
+
+	for(var/list/target in targets)
+		assert_soft_collected(target)
+
 /// Обезьяна должна удалять qdeleted предметы из blacklistItems.
 /datum/unit_test/monkey_blacklist_item_qdel_cleanup/Run()
 	var/mob/living/carbon/monkey/monkey = allocate(/mob/living/carbon/monkey)

--- a/code/modules/unit_tests/harddel_cleanup.dm
+++ b/code/modules/unit_tests/harddel_cleanup.dm
@@ -207,7 +207,13 @@
 	var/datum/mind/mind = new
 	var/obj/effect/proc_holder/spell/first = new
 	var/obj/effect/proc_holder/spell/second = new
+
+	// `in` связывает слабее `||`: без скобок проверка вырождается в `(!S || S) in spell_list`.
+	mind.AddSpell(null)
+	TEST_ASSERT(!length(mind.spell_list), "AddSpell записал null в spell_list")
 	mind.AddSpell(first)
+	mind.AddSpell(first)
+	TEST_ASSERT_EQUAL(length(mind.spell_list), 1, "AddSpell продублировал заклинание в spell_list")
 	mind.AddSpell(second)
 
 	mind.RemoveSpell(/obj/effect/proc_holder/spell)

--- a/code/modules/unit_tests/harddel_cleanup.dm
+++ b/code/modules/unit_tests/harddel_cleanup.dm
@@ -231,6 +231,15 @@
 	TEST_ASSERT(QDELETED(owned), "Удаление mind не удалило принадлежащее ему заклинание")
 	TEST_ASSERT(!length(mind.spell_list), "Удалённый mind сохранил spell_list")
 
+/// Внешний qdel призванного предмета должен очистить ссылку в живом заклинании.
+/datum/unit_test/conjure_item_qdel_cleanup/Run()
+	var/obj/effect/proc_holder/spell/targeted/conjure_item/summon_cumburger/spell = allocate(/obj/effect/proc_holder/spell/targeted/conjure_item/summon_cumburger)
+	var/obj/item/reagent_containers/food/snacks/burger/cumburger/item = spell.make_item()
+	TEST_ASSERT_EQUAL(spell.item, item, "Заклинание не сохранило созданный предмет")
+
+	qdel(item)
+	TEST_ASSERT_NULL(spell.item, "Заклинание оставило ссылку на удалённый cumburger")
+
 /// RemoveSource может синхронно удалить последний neural_interface: holder очищается до вызова.
 /datum/unit_test/hud_neural_interface_qdel_cleanup/Run()
 	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
@@ -315,6 +324,15 @@
 	TEST_ASSERT(!(spell in mind.spell_list), "Mind оставил удалённый lewd_chems в spell_list")
 	return record
 
+/datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_conjured_item()
+	var/obj/effect/proc_holder/spell/targeted/conjure_item/summon_cumburger/spell = allocate(/obj/effect/proc_holder/spell/targeted/conjure_item/summon_cumburger)
+	var/obj/item/reagent_containers/food/snacks/burger/cumburger/item = spell.make_item()
+	var/list/record = target_record(item, "conjure_item item: /obj/item/reagent_containers/food/snacks/burger/cumburger")
+
+	qdel(item)
+	TEST_ASSERT_NULL(spell.item, "Заклинание оставило удалённый cumburger в item")
+	return record
+
 /datum/unit_test/harddel_cleanup_soft_gc/proc/qdel_neural_interface()
 	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
 	var/obj/item/clothing/glasses/hud/health/glasses = allocate(/obj/item/clothing/glasses/hud/health)
@@ -347,6 +365,7 @@
 	targets += list(qdel_active_parry_item())
 	targets += list(qdel_card_deck())
 	targets += list(qdel_mind_spell())
+	targets += list(qdel_conjured_item())
 	targets += list(qdel_neural_interface())
 
 	for(var/list/target in targets)

--- a/code/modules/unit_tests/jukebox_import.dm
+++ b/code/modules/unit_tests/jukebox_import.dm
@@ -1,9 +1,19 @@
 /// Exported playlist objects must never be accepted where a sequential track array is expected.
+/datum/unit_test/jukebox_import_shape_validation/proc/legacy_track_import_check(list/new_track_list)
+	if(!LAZYLEN(new_track_list))
+		return FALSE
+	for(var/song in new_track_list)
+		if(!istext(song) || !song)
+			return FALSE
+	return TRUE
+
 /datum/unit_test/jukebox_import_shape_validation/Run()
-	var/list/exported_playlists = list(
-		"Imported playlist" = list("Valid Track")
-	)
+	var/exported_playlists_json = "{\"Imported playlist\":\[\"Valid Track\"\]}"
+	var/decoded = safe_json_decode(exported_playlists_json)
+	TEST_ASSERT(islist(decoded), "Экспорт плейлистов не декодировался в список")
+	var/list/exported_playlists = decoded
 	TEST_ASSERT(is_assoc_list(exported_playlists), "Тестовые плейлисты не являются ассоциативным списком")
+	TEST_ASSERT(legacy_track_import_check(exported_playlists), "Тестовый JSON больше не воспроизводит принятие объекта старой проверкой импорта")
 	TEST_ASSERT(!jukebox_track_list_is_valid(exported_playlists), "Объект плейлистов принят как массив избранных треков")
 	TEST_ASSERT(!length(sanitize_jukebox_track_list(exported_playlists)), "Восстановление избранного сохранило ассоциативный список")
 

--- a/code/modules/unit_tests/jukebox_import.dm
+++ b/code/modules/unit_tests/jukebox_import.dm
@@ -1,0 +1,23 @@
+/// Exported playlist objects must never be accepted where a sequential track array is expected.
+/datum/unit_test/jukebox_import_shape_validation/Run()
+	var/list/exported_playlists = list(
+		"Imported playlist" = list("Valid Track")
+	)
+	TEST_ASSERT(is_assoc_list(exported_playlists), "Тестовые плейлисты не являются ассоциативным списком")
+	TEST_ASSERT(!jukebox_track_list_is_valid(exported_playlists), "Объект плейлистов принят как массив избранных треков")
+	TEST_ASSERT(!length(sanitize_jukebox_track_list(exported_playlists)), "Восстановление избранного сохранило ассоциативный список")
+
+	var/list/valid_tracks = list("First Track", "Second Track")
+	TEST_ASSERT(jukebox_track_list_is_valid(valid_tracks), "Корректный массив треков отклонён")
+
+/// Persisted malformed nested values are recovered into JSON-safe arrays before opening TGUI.
+/datum/unit_test/jukebox_saved_preferences_recovery/Run()
+	var/list/saved_playlists = list(
+		"Valid" = list("First Track", "First Track", "Second Track"),
+		"Broken" = "not an array"
+	)
+	var/list/recovered = sanitize_jukebox_playlists(saved_playlists)
+	TEST_ASSERT_EQUAL(length(recovered["Valid"]), 2, "Восстановление не удалило дубликаты треков")
+	TEST_ASSERT(islist(recovered["Broken"]), "Повреждённый плейлист не преобразован в безопасный массив")
+	TEST_ASSERT(!length(recovered["Broken"]), "Повреждённый плейлист сохранил скалярное значение")
+	TEST_ASSERT(!jukebox_playlists_are_valid(saved_playlists), "Импорт принял плейлист со скалярным значением")

--- a/code/modules/unit_tests/nightshift.dm
+++ b/code/modules/unit_tests/nightshift.dm
@@ -175,6 +175,7 @@
 	test_apc.light_cache_dirty = FALSE
 	qdel(test_light, force = TRUE)
 	TEST_ASSERT(test_apc.light_cache_dirty, "Deleting a light in the APC area should dirty the APC light cache.")
+	TEST_ASSERT_NULL(test_apc.cached_area_lights, "Deleting a light should immediately release the APC's cached reference.")
 	qdel(test_apc, force = TRUE)
 	test_area.power_apc = original_area_apc
 

--- a/code/modules/unit_tests/perf_optimizations.dm
+++ b/code/modules/unit_tests/perf_optimizations.dm
@@ -304,6 +304,41 @@
 	TEST_ASSERT(comp.airs[1] in P.other_airs, "Component's gas_mixture must be merged into other_airs")
 
 
+/// Malformed or overlapping map loads can ask a component about a pipeline or
+/// connector it does not actually contain. The lookup must fail softly instead
+/// of using Find() == 0 as a list index and raising a runtime.
+/datum/unit_test/atmos_component_pipenet_lookup_guards/Run()
+	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/connected_pipe = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)
+	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/unknown_pipe = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)
+	var/obj/machinery/atmospherics/components/build_pipeline_test_component/component = allocate(/obj/machinery/atmospherics/components/build_pipeline_test_component)
+	var/datum/pipeline/connected_pipeline = new
+	var/datum/pipeline/unknown_pipeline = new
+	var/datum/pipeline/replacement_pipeline = new
+	allocated += connected_pipeline
+	allocated += unknown_pipeline
+	allocated += replacement_pipeline
+
+	component.nodes[1] = connected_pipe
+	component.setPipenet(connected_pipeline, connected_pipe)
+	TEST_ASSERT_EQUAL(component.returnPipenet(connected_pipe), connected_pipeline, "Valid connector must be assigned its pipeline")
+
+	var/runtimes_before = GLOB.total_runtimes
+	var/list/missing_expansion = component.pipeline_expansion(unknown_pipeline)
+	component.setPipenet(replacement_pipeline, unknown_pipe)
+	component.replacePipenet(unknown_pipeline, replacement_pipeline)
+	var/runtimes_added = GLOB.total_runtimes - runtimes_before
+
+	TEST_ASSERT_EQUAL(runtimes_added, 0, "Missing pipenet lookups must not raise runtimes (got [runtimes_added])")
+	TEST_ASSERT_EQUAL(length(missing_expansion), 0, "Unknown pipeline must have no expansion")
+	TEST_ASSERT_EQUAL(component.returnPipenet(connected_pipe), connected_pipeline, "Failed lookups must not change the valid pipeline")
+
+	var/list/known_expansion = component.pipeline_expansion(connected_pipeline)
+	TEST_ASSERT_EQUAL(length(known_expansion), 1, "Known pipeline must return one connected node")
+	TEST_ASSERT_EQUAL(known_expansion[1], connected_pipe, "Known pipeline must expand to its connected pipe")
+	component.replacePipenet(connected_pipeline, replacement_pipeline)
+	TEST_ASSERT_EQUAL(component.returnPipenet(connected_pipe), replacement_pipeline, "Valid pipeline replacement must still succeed")
+
+
 #define BUILD_PIPELINE_PERF_N 3000
 /// Synthetic chain of [BUILD_PIPELINE_PERF_N] pipes. The pre-fix
 /// build_pipeline does ~N²/2 list scans through `members` (one per discovered

--- a/code/modules/unit_tests/perf_optimizations.dm
+++ b/code/modules/unit_tests/perf_optimizations.dm
@@ -306,7 +306,7 @@
 
 /// Malformed or overlapping map loads can ask a component about a pipeline or
 /// connector it does not actually contain. The lookup must fail softly instead
-/// of using Find() == 0 as a list index and raising a runtime.
+/// of using a failed lookup result as a list index and raising a runtime.
 /datum/unit_test/atmos_component_pipenet_lookup_guards/Run()
 	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/connected_pipe = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)
 	var/obj/machinery/atmospherics/pipe/build_pipeline_test_node/unknown_pipe = allocate(/obj/machinery/atmospherics/pipe/build_pipeline_test_node)

--- a/code/modules/unit_tests/stationroom_landmark.dm
+++ b/code/modules/unit_tests/stationroom_landmark.dm
@@ -1,0 +1,37 @@
+/// Шаблон-пустышка: ничего не грузит, только фиксирует состояние лендмарка на момент вызова load().
+/datum/map_template/stationroom_reentrancy_probe
+	name = "Stationroom Reentrancy Probe"
+	var/obj/effect/landmark/stationroom/probe_landmark
+	var/landmark_registered_during_load = FALSE
+	var/load_calls = 0
+
+/datum/map_template/stationroom_reentrancy_probe/load(turf/T, centered = FALSE, orientation = SOUTH, annihilate = default_annihilate, force_cache = FALSE, rotate_placement_to_orientation = FALSE)
+	load_calls++
+	if(probe_landmark in GLOB.stationroom_landmarks)
+		landmark_registered_during_load = TRUE
+	return null
+
+/obj/effect/landmark/stationroom/reentrancy_probe
+	template_names = list("Stationroom Reentrancy Probe" = 1)
+
+/// Настоящий template.load() спит (маплоадер уступает тик). Пока лендмарк висит в
+/// GLOB.stationroom_landmarks, параллельный seedStation() (таймер тикера, +60с после
+/// раундстарта) подхватывает тот же лендмарк и грузит шаблон второй раз в ту же точку:
+/// каждая атмос-машина дублируется, у устройства один слот nodes на две копии трубы,
+/// и вторая копия уходит в setPipenet с nodes.Find() == 0 (сотни рантаймов).
+/datum/unit_test/stationroom_landmark_reentrancy/Run()
+	var/datum/map_template/stationroom_reentrancy_probe/template = new
+	SSmapping.station_room_templates[template.name] = template
+
+	var/obj/effect/landmark/stationroom/reentrancy_probe/landmark = allocate(/obj/effect/landmark/stationroom/reentrancy_probe)
+	template.probe_landmark = landmark
+	TEST_ASSERT(landmark in GLOB.stationroom_landmarks, "Лендмарк не зарегистрировался в GLOB.stationroom_landmarks")
+
+	landmark.load()
+
+	TEST_ASSERT_EQUAL(template.load_calls, 1, "Шаблон станционной комнаты загрузился не ровно один раз")
+	TEST_ASSERT(!template.landmark_registered_during_load, "Лендмарк остался в GLOB.stationroom_landmarks во время спящего template.load(): параллельный seedStation() загрузит тот же шаблон повторно в ту же точку")
+	TEST_ASSERT(!(landmark in GLOB.stationroom_landmarks), "Лендмарк не снялся с учёта после загрузки")
+
+	SSmapping.station_room_templates -= template.name
+	GLOB.chosen_station_templates -= template.name

--- a/code/modules/unit_tests/stationroom_landmark.dm
+++ b/code/modules/unit_tests/stationroom_landmark.dm
@@ -18,7 +18,7 @@
 /// GLOB.stationroom_landmarks, параллельный seedStation() (таймер тикера, +60с после
 /// раундстарта) подхватывает тот же лендмарк и грузит шаблон второй раз в ту же точку:
 /// каждая атмос-машина дублируется, у устройства один слот nodes на две копии трубы,
-/// и вторая копия уходит в setPipenet с nodes.Find() == 0 (сотни рантаймов).
+/// и вторая копия передаёт в setPipenet отсутствующий в nodes объект (сотни рантаймов).
 /datum/unit_test/stationroom_landmark_reentrancy/Run()
 	var/datum/map_template/stationroom_reentrancy_probe/template = new
 	SSmapping.station_room_templates[template.name] = template

--- a/modular_sand/code/modules/client/preferences_savefile.dm
+++ b/modular_sand/code/modules/client/preferences_savefile.dm
@@ -70,13 +70,11 @@
 	use_moaning_multiplier = sanitize_integer(use_moaning_multiplier, 0, 1, initial(use_moaning_multiplier))
 	moaning_multiplier = sanitize_integer(moaning_multiplier, 0, 100, initial(moaning_multiplier))
 	.["favorite_tracks"] >> favorite_tracks
-	favorite_tracks = SANITIZE_LIST(favorite_tracks)
+	favorite_tracks = sanitize_jukebox_track_list(favorite_tracks)
 	.["favorite_paintings_md5"] >> favorite_paintings_md5
 	favorite_paintings_md5 = SANITIZE_LIST(favorite_paintings_md5)
 	.["playlists"] >> playlists
-	// Strip control chars from playlist-name keys so a broken name can't make a
-	// playlist permanently unselectable/undeletable through the jukebox UI.
-	playlists = sanitize_assoc_keys(playlists)
+	playlists = sanitize_jukebox_playlists(playlists)
 	.["metadollar_minute_pool"] >> metadollar_minute_pool
 	metadollar_minute_pool = isnum(metadollar_minute_pool) ? clamp(round(metadollar_minute_pool), 0, 500) : 0
 	.["metadollar_pending_items"] >> metadollar_pending_items

--- a/tgui/packages/tgui/interfaces/Jukebox.js
+++ b/tgui/packages/tgui/interfaces/Jukebox.js
@@ -48,13 +48,23 @@ export const Jukebox = (props) => {
 
   const songsPerPage = 25;
 
-  const playlistNames = Object.keys(playlists || {});
+  const normalizeTracks = (tracks) => Array.isArray(tracks)
+    ? tracks.filter((track) => typeof track === 'string')
+    : [];
+  const songList = normalizeTracks(songs);
+  const favoriteTrackList = normalizeTracks(favorite_tracks);
+  const playlistMap = playlists
+    && typeof playlists === 'object'
+    && !Array.isArray(playlists)
+    ? playlists
+    : {};
+  const playlistNames = Object.keys(playlistMap);
   const isPlaylistMode = tab === 'playlist';
-  const playlistTracks = playlists[playlist] || [];
+  const playlistTracks = normalizeTracks(playlistMap[playlist]);
 
   const baseTracks = isPlaylistMode
     ? [...playlistTracks].reverse()
-    : (inFavoritesMode ? [...favorite_tracks].reverse() : songs);
+    : (inFavoritesMode ? [...favoriteTrackList].reverse() : songList);
 
   const baseIndexByTrack = {};
   for (let idx = 0; idx < baseTracks.length; idx++) {
@@ -70,7 +80,9 @@ export const Jukebox = (props) => {
   const startIndex = (safePage - 1) * songsPerPage;
   const currentSongs = filteredSongs.slice(startIndex, startIndex + songsPerPage);
 
-  const validQueuedTracks = Array.isArray(queued_tracks) ? queued_tracks : [];
+  const validQueuedTracks = Array.isArray(queued_tracks)
+    ? queued_tracks.filter((track) => track && typeof track.name === 'string')
+    : [];
 
   const truncate = (text, maxLength) => {
     return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
@@ -281,8 +293,8 @@ export const Jukebox = (props) => {
             icon="shuffle"
             tooltip="Добавить случайную песню в очередь"
             onClick={() => {
-              if (songs.length === 0) return;
-              const randomSongName = songs[Math.floor(Math.random() * songs.length)];
+              if (songList.length === 0) return;
+              const randomSongName = songList[Math.floor(Math.random() * songList.length)];
               act('add_to_queue', { track: randomSongName, up: false });
             }}
           />
@@ -310,8 +322,8 @@ export const Jukebox = (props) => {
               </Box>
             ) : (
               currentSongs.map((track, i) => {
-                const isAvailable = songs.includes(track);
-                const isFavorite = favorite_tracks.includes(track);
+                const isAvailable = songList.includes(track);
+                const isFavorite = favoriteTrackList.includes(track);
                 const inPlaylist = playlist && playlistTracks.includes(track);
                 const showIndexInput = isPlaylistMode || inFavoritesMode;
                 const onIndexChange = isPlaylistMode

--- a/tgui/packages/tgui/interfaces/Jukebox.test.tsx
+++ b/tgui/packages/tgui/interfaces/Jukebox.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Playlist exports are JSON objects, while favorites and individual playlists
+ * are JSON arrays. A playlist object imported as favorites used to reach this
+ * interface and crash on array operations such as includes() and spread.
+ */
+import { render } from '@testing-library/react';
+import { combineReducers, createStore, setGlobalStore } from 'common/redux';
+
+import { backendReducer, backendUpdate } from '../backend';
+import { debugReducer } from '../debug';
+import { Jukebox } from './Jukebox';
+
+const setupStore = (data = {}) => {
+  (global as any).Byond = { winset: () => {}, topic: () => {} };
+  const store = createStore(
+    combineReducers({ backend: backendReducer, debug: debugReducer }),
+  );
+  setGlobalStore(store);
+  store.dispatch(
+    backendUpdate({
+      config: { interface: 'Jukebox', title: 'Jukebox' },
+      data: {
+        active: false,
+        track_selected: null,
+        track_length: null,
+        volume: 50,
+        is_emagged: false,
+        cost_for_play: 1,
+        has_access: true,
+        repeat: false,
+        songs: ['Valid Track'],
+        queued_tracks: [],
+        favorite_tracks: {
+          'Imported playlist': ['Valid Track'],
+        },
+        playlists: {
+          Broken: 'not an array',
+          Valid: ['Valid Track'],
+        },
+        ...data,
+      },
+    }),
+  );
+};
+
+describe('Jukebox imported preferences', () => {
+  test('renders malformed imported collection shapes without crashing', () => {
+    setupStore();
+    const { container } = render(<Jukebox />);
+    expect(container.innerHTML).toContain('Valid Track');
+  });
+});

--- a/tgui/packages/tgui/interfaces/Jukebox.test.tsx
+++ b/tgui/packages/tgui/interfaces/Jukebox.test.tsx
@@ -10,6 +10,9 @@ import { backendReducer, backendUpdate } from '../backend';
 import { debugReducer } from '../debug';
 import { Jukebox } from './Jukebox';
 
+const exportedPlaylistsJson = '{"Imported playlist":["Valid Track"]}';
+const malformedFavoriteTracks = JSON.parse(exportedPlaylistsJson);
+
 const setupStore = (data = {}) => {
   (global as any).Byond = { winset: () => {}, topic: () => {} };
   const store = createStore(
@@ -30,9 +33,7 @@ const setupStore = (data = {}) => {
         repeat: false,
         songs: ['Valid Track'],
         queued_tracks: [],
-        favorite_tracks: {
-          'Imported playlist': ['Valid Track'],
-        },
+        favorite_tracks: malformedFavoriteTracks,
         playlists: {
           Broken: 'not an array',
           Valid: ['Valid Track'],
@@ -44,6 +45,13 @@ const setupStore = (data = {}) => {
 };
 
 describe('Jukebox imported preferences', () => {
+  test('reproduces the former array-operation crash from playlist JSON', () => {
+    expect(() => malformedFavoriteTracks.includes('Valid Track')).toThrow(
+      TypeError,
+    );
+    expect(() => [...malformedFavoriteTracks]).toThrow(TypeError);
+  });
+
   test('renders malformed imported collection shapes without crashing', () => {
     setupStore();
     const { container } = render(<Jukebox />);

--- a/tgui/packages/tgui/interfaces/Jukebox.test.tsx
+++ b/tgui/packages/tgui/interfaces/Jukebox.test.tsx
@@ -6,7 +6,11 @@
 import { render } from '@testing-library/react';
 import { combineReducers, createStore, setGlobalStore } from 'common/redux';
 
-import { backendReducer, backendUpdate } from '../backend';
+import {
+  backendReducer,
+  backendSetSharedState,
+  backendUpdate,
+} from '../backend';
 import { debugReducer } from '../debug';
 import { Jukebox } from './Jukebox';
 
@@ -42,6 +46,7 @@ const setupStore = (data = {}) => {
       },
     }),
   );
+  return store;
 };
 
 describe('Jukebox imported preferences', () => {
@@ -53,8 +58,11 @@ describe('Jukebox imported preferences', () => {
   });
 
   test('renders malformed imported collection shapes without crashing', () => {
-    setupStore();
+    const store = setupStore();
+    store.dispatch(
+      backendSetSharedState({ key: 'inFavoritesMode', nextState: true }),
+    );
     const { container } = render(<Jukebox />);
-    expect(container.innerHTML).toContain('Valid Track');
+    expect(container.innerHTML).toContain('Нет треков');
   });
 });


### PR DESCRIPTION
# Описание

Эта ветка закрывает сразу несколько проблем, найденных по harddel-логам и рантаймам. Джукбокс теперь нормально переживает импорт плейлистов и повреждённые сохранённые данные, а игровые объекты своевременно освобождают удалённые заклинания, предметы, HUD-интерфейсы и другие ссылки.

Заодно станционные руины больше не могут загрузиться дважды, а атмос-компоненты не сыпят рантаймами при отсутствующих pipenet-связях. На исправленные случаи добавлены регрессионные тесты

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: Исправлен импорт избранного и плейлистов в джукбоксе
fix: Устранена повторная загрузка станционных руин и связанные рантаймы атмосферы
fix: Исправлены несколько причин harddel и зависших ссылок у игровых объектов
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Улучшен импорт и восстановление избранных треков и плейлистов: некорректные данные безопасно проверяются, очищаются и нормализуются.
  * Джукбокс устойчивее отображает повреждённые или нестандартные списки треков.
* **Исправления**
  * Исправлена очистка удаляемых заклинаний, предметов, источников виртуального голоса, HUD-интерфейсов и других связанных объектов.
  * Предотвращена повторная загрузка одной и той же станционной комнаты.
  * Исправлена работа кэша освещения APC и обработка некорректных атмосферных соединений.
* **Тесты**
  * Добавлены проверки импорта джукбокса, очистки объектов и защиты от повторной загрузки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->