### PR TITLE
no Random Heart Attack

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,3 +1,4 @@
+/* Никто не хочет умирать из-за рандома
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
@@ -28,3 +29,4 @@
 		var/datum/disease/D = new /datum/disease/heart_failure()
 		winner.ForceContractDisease(D, FALSE, TRUE)
 		announce_to_ghosts(winner)
+*/


### PR DESCRIPTION
# Описание
Выключил ивент случайной остановки сердца.

## Причина изменений
Никто не хочет умирать, просто из-за рандома свыше.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
del: Выключен ивент случайной остановки сердца
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Событие «Случайный сердечный приступ» отключено и больше не запускается во время раунда.
  * Убраны связанные уведомления и автоматическое создание заболевания сердечной недостаточности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->