### PR TITLE
Random Heart Attack no extended

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,4 +1,3 @@
-/* Никто не хочет умирать из-за рандома
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
@@ -6,18 +5,19 @@
 	max_occurrences = 5
 	min_players = 35 // To avoid shafting lowpop
 	category = EVENT_CATEGORY_HEALTH
-	severity = DIRECTOR_SEVERITY_MINOR
+	severity = DIRECTOR_SEVERITY_MODERATE
+	required_round_type = list(ROUNDTYPE_DYNAMIC_TEAMBASED, ROUNDTYPE_DYNAMIC_HARD, ROUNDTYPE_DYNAMIC_MEDIUM, ROUNDTYPE_DYNAMIC_LIGHT)
 
 /datum/round_event_control/heart_attack/can_fire(datum/director_signals/signals)
 	. = ..()
 	if(!.)
 		return
-	return director_has_living_role(list("Medical Doctor","Chief Medical Officer","Paramedic","Chemist"))
+	return director_has_living_role(list("Medical Doctor","Chief Medical Officer","Paramedic"))
 
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest() || HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
+		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest() || HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS) || !is_station_level(H.z))
 			continue
 		if(H.satiety <= -60) //Multiple junk food items recently
 			heart_attack_contestants[H] = 3
@@ -29,4 +29,3 @@
 		var/datum/disease/D = new /datum/disease/heart_failure()
 		winner.ForceContractDisease(D, FALSE, TRUE)
 		announce_to_ghosts(winner)
-*/

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,3 +1,4 @@
+/* Никто не хочет умирать из-за рандома
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
@@ -28,3 +29,4 @@
 		var/datum/disease/D = new /datum/disease/heart_failure()
 		winner.ForceContractDisease(D, FALSE, TRUE)
 		announce_to_ghosts(winner)
+*/


### PR DESCRIPTION
# Описание
- Random Heart Attack убран с эксты
- Добавлена проверка на сектор станции
- Понижен шанс выпадения

## Причина изменений
Рандомная смерть все еще плохо...

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Random Heart Attack убран с эксты, побавлена проверка на сектор станции, понижен шанс выпадения
/:cl:
