### PR TITLE
Возможный фикс фриза таймера лобби

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -699,8 +699,12 @@ SUBSYSTEM_DEF(vote)
 			C.player_details.player_actions += V
 			V.Grant(C.mob)
 			generated_actions += V
-			if(forced)
-				SSvote.ui_interact(C.mob) // Мяяяу
+			if(forced && C.mob)
+				// Только асинхронно: открытие tgui делает winexists/browse_queue_flush - блокирующие
+				// round-trip'ы к клиенту. Синхронный вызов из fire() тикера (роундстарт-воут) усыплял
+				// SSticker навсегда, если клиент завис или дисконнектится - таймер лобби замирал
+				// до рестарта МК.
+				INVOKE_ASYNC(src, PROC_REF(ui_interact), C.mob) // Мяяяу
 		return TRUE
 	return FALSE
 
@@ -819,7 +823,9 @@ SUBSYSTEM_DEF(vote)
 	return src
 
 /datum/controller/subsystem/vote/ui_interact(mob/user, datum/tgui/ui)
-	voting |= user?.client
+	if(!user?.client)
+		return
+	voting |= user.client
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Vote")


### PR DESCRIPTION
# Описание

Фикс вечного фриза таймера в лобби, который лечился только рестартом МК.

Оказалось, роундстарт-воут за режим форс-открывал tgui-окно каждому клиенту синхронно прямо из fire() тикера, а открытие tgui-окна внутри делает winexists() - блокирующий запрос к клиенту. Если в этот момент у кого-то в лобби клиент завис или отваливается - ответ не приходит никогда, fire() не возвращается, и МК больше не зовёт тикер: отсчёт стоит намертво. Рестарт МК помогал, потому что сбрасывает state сабсистем.

Теперь окно каждому открывается асинхронно - зависший клиент вредит только себе. Заодно ушли и мелкие подвисания таймера на открытии воута (раньше тикер по очереди ждал ответа от всего лобби). Тот же цикл используют мапвоут после краша и прайм-тайм ранофф, так что они тоже покрыты.

- [ ] Изменения были проверены на локальном сервере (зависшего клиента локально не воспроизвести, нужен прод)
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: таймер начала раунда больше не замирает намертво из-за зависшего клиента в лобби
/:cl:
