### PR TITLE
Pizza Time Event rework

### DIFF
--- a/code/modules/events/misc/pizza_time.dm
+++ b/code/modules/events/misc/pizza_time.dm
@@ -4,17 +4,28 @@
 	weight = 5
 	max_occurrences = 1
 	category = EVENT_CATEGORY_HOLIDAY
-	description = "Мгновенная доставка пицца подом абсолютно всем сотрудникам."
+	description = "Доставка пиццы подом абсолютно всем сотрудникам с включёнными координатными датчиками."
 
 /datum/round_event/pizza_time/announce(fake)
-	priority_announce("Ваше начальство довольно вами и выделяет для вас подарочный обед за свой счёт. Слава ПАКТу!", "Центральное Командование")
+	priority_announce("Ваше начальство довольно вами и выделяет для вас подарочный обед за свой счёт через... Пять секунд! Для получения координатные датчики униформы должны быть включены. Слава ПАКТу!", "Центральное Командование")
 	sound_to_playing_players('sound/misc/pizza_time.ogg', volume = 25)
 
 /datum/round_event/pizza_time/start()
 	var/pizzatype_list = subtypesof(/obj/item/pizzabox)
 	pizzatype_list -= /obj/item/pizzabox/margherita/robo // No murder pizza
 	pizzatype_list -= /obj/item/pizzabox/bomb // No robo pizza
-	for(var/mob/living/carbon/human/person in GLOB.human_list)
+	addtimer(CALLBACK(src, PROC_REF(deliver_pizzas), pizzatype_list), 5 SECONDS)
+
+/datum/round_event/pizza_time/proc/deliver_pizzas(list/pizzatype_list)
+	for(var/target_mob in GLOB.joined_player_list)
+		var/mob/living/carbon/human/person = get_mob_by_ckey(target_mob)
+		var/turf/target_turf = get_turf(person)
+		if(!target_turf || !is_station_level(target_turf.z))
+			continue // НЕТ ТУРФА - НЕТ ПИЦЦЫ, НЕТ РАНТАЙМА
+		var/obj/item/clothing/under/uniforms = person.w_uniform
+		if(!uniforms || uniforms.sensor_mode != SENSOR_COORDS)
+			to_chat(person, span_red("Мои датчики! Я остался без пиццы..."))
+			continue // Униформа будет сортировать скрытных космонавтиков и трупы в морге
 		// Yes, this delivers to dead bodies. It's REALLY FUNNY.
 		var/obj/structure/closet/supplypod/centcompod/pod = new()
 		var/pizzatype = pick(pizzatype_list)
@@ -43,7 +54,7 @@
 	if(!ispath(delivery_type, /atom/movable))
 		message_admins("Present Time: неверный тип доставки, событие прервано.")
 		return
-	for(var/mob/living/carbon/human/person in GLOB.human_list)
+	for(var/mob/living/carbon/human/person in GLOB.joined_player_list)
 		var/obj/structure/closet/supplypod/centcompod/pod = new()
 		new delivery_type(pod)
 		pod.explosionSize = list(0,0,0,0)

--- a/code/modules/events/misc/pizza_time.dm
+++ b/code/modules/events/misc/pizza_time.dm
@@ -56,7 +56,7 @@
 		message_admins("Present Time: неверный тип доставки, событие прервано.")
 		return
 	for(var/mob/living/carbon/human/person in GLOB.human_list)
-		if(!person.mind || !(person.mind.key in GLOB.joined_player_list))
+		if(!person.mind || !((ckey(person.mind.key)) in GLOB.joined_player_list))
 			continue
 		var/turf/target_turf = get_turf(person)
 		if(!target_turf || !is_station_level(target_turf.z))

--- a/code/modules/events/misc/pizza_time.dm
+++ b/code/modules/events/misc/pizza_time.dm
@@ -17,8 +17,9 @@
 	addtimer(CALLBACK(src, PROC_REF(deliver_pizzas), pizzatype_list), 5 SECONDS)
 
 /datum/round_event/pizza_time/proc/deliver_pizzas(list/pizzatype_list)
-	for(var/target_mob in GLOB.joined_player_list)
-		var/mob/living/carbon/human/person = get_mob_by_ckey(target_mob)
+	for(var/mob/living/carbon/human/person in GLOB.human_list)
+		if(!person.mind || !(ckey(person.mind.key) in GLOB.joined_player_list)) // Нужно для отделения трупа НПС от игрока + поиск станционного экипажа вместо всех мобов мира
+			continue
 		var/turf/target_turf = get_turf(person)
 		if(!target_turf || !is_station_level(target_turf.z))
 			continue // НЕТ ТУРФА - НЕТ ПИЦЦЫ, НЕТ РАНТАЙМА
@@ -32,7 +33,7 @@
 		new pizzatype(pod)
 		pod.explosionSize = list(0,0,0,0)
 		to_chat(person, span_nicegreen("Время пиццы! Вот бы только чем запить..."))
-		new /obj/effect/pod_landingzone(get_turf(person), pod)
+		new /obj/effect/pod_landingzone(target_turf, pod)
 
 /datum/round_event_control/pizza_time_admin
 	name = "Present Time"
@@ -54,12 +55,17 @@
 	if(!ispath(delivery_type, /atom/movable))
 		message_admins("Present Time: неверный тип доставки, событие прервано.")
 		return
-	for(var/mob/living/carbon/human/person in GLOB.joined_player_list)
+	for(var/mob/living/carbon/human/person in GLOB.human_list)
+		if(!person.mind || !(person.mind.key in GLOB.joined_player_list))
+			continue
+		var/turf/target_turf = get_turf(person)
+		if(!target_turf || !is_station_level(target_turf.z))
+			continue
 		var/obj/structure/closet/supplypod/centcompod/pod = new()
 		new delivery_type(pod)
 		pod.explosionSize = list(0,0,0,0)
 		to_chat(person, span_nicegreen("К вам падает посылка!"))
-		new /obj/effect/pod_landingzone(get_turf(person), pod)
+		new /obj/effect/pod_landingzone(target_turf, pod)
 
 /datum/event_admin_setup/pizza_time_delivery_path
 	var/resolved


### PR DESCRIPTION
# Описание
- Добавлен таймер 5 секунд перед исполнением кода дроппода пиццы.
- Дроппод пиццы ищет экипаж вместо всех карбонов/хуманов в мире и отправляется только если на цели есть униформа и её датчики включены в третий режим.
- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений
Устранение нагрузки на игру в процессе ивента элиминацией дроппода на КАЖДОГО карбона мира, живого и мёртвого. Этим же устраняется проблема:
- Вынужденного раскрытия спрятавшегося стелс-антага, вместо ошибки если он держал датчики в третьем режиме.
- Бомбардировки игроков, занимавшися Е/РП наедине.
- Награждения ролей, которые никак не относятся к ЦК и довольству начальства: гостролей, антаг-гостролей и гкафе тел.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Pizza Time ивент теперь ищет станционный экипаж вместо всех human мира раунда и проверяет наличие униформы + датчиков в третьем режиме, чтобы пицца-под достиг цели.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Доставка пиццы теперь начинается через 5 секунд после объявления события.
  * Пицца доставляется только живым игрокам на станции, у которых включены координатные датчики.
  * При отключённых датчиках игроку приходит уведомление о невозможности доставки.

* **Изменения**
  * Текст объявления обновлён с предупреждением о задержке и требованиях к датчикам.
  * Административная раздача пиццы теперь направляет отправления только подходящим игрокам и размещает их в соответствующей зоне приземления.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->