### PR TITLE
Atom Load Time Statistic Logging

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -3,6 +3,8 @@
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
 
+//#define ATOM_STATISTICS_LOGGING //Collect atoms load time statisctics from Atoms Subsystem to "atom_loading_stats.log"
+
 // Comment this out if you are debugging problems that might be obscured by custom error handling in world/Error
 #ifdef DEBUG
 #define USE_CUSTOM_ERROR_HANDLER

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -19,13 +19,13 @@ SUBSYSTEM_DEF(atoms)
 
 	initialized = INITIALIZATION_INSSATOMS
 
-	// --- ATOM LOADING TIMER & GROUPING ---
+	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 	var/atoms_count = 0
 	var/total_duration
 	var/atom_types = list()
 	var/type_counts = list()
 	var/type_times = list()
-	// --- END ATOM LOADING TIMER & GROUPING ---
+	#endif								// --- END ATOM STATISTICS LOGGING ---
 
 /datum/controller/subsystem/atoms/Initialize(timeofday)
 	GLOB.fire_overlay.appearance_flags = RESET_COLOR
@@ -34,6 +34,11 @@ SUBSYSTEM_DEF(atoms)
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
 	initialized = INITIALIZATION_INNEW_REGULAR
+
+	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
+	Savelog(short = FALSE)
+	#endif								// --- END ATOM STATISTICS LOGGING ---
+
 	return ..()
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms)
@@ -46,6 +51,7 @@ SUBSYSTEM_DEF(atoms)
 	var/count
 	var/list/mapload_arg = list(TRUE)
 
+	#ifdef ATOM_STATISTICS_LOGGING			// --- ATOM STATISTICS LOGGING ---
 	var/list/logged_atoms = list()
 	var/list/logged_times = list()
 
@@ -55,6 +61,7 @@ SUBSYSTEM_DEF(atoms)
 	var/total_start_time
 
 	total_start_time = world.timeofday
+	#endif									// --- END ATOM STATISTICS LOGGING ---
 
 	if(atoms)
 		count = atoms.len
@@ -65,27 +72,36 @@ SUBSYSTEM_DEF(atoms)
 			if(isnull(A))
 				continue
 			if(!(A.flags_1 & INITIALIZED_1))
+				#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 				start_time = world.timeofday
 				InitAtom(A, mapload_arg)
 				end_time = world.timeofday
 				LAZYADD(logged_atoms,A)
 				LAZYADD(logged_times, end_time - start_time)
+				#else								// --- END ATOM STATISTICS LOGGING ---
+				InitAtom(A, mapload_arg)
+				#endif
 				CHECK_TICK
 	else
 		count = 0
 		for(var/atom/A in world)
 			if(!(A.flags_1 & INITIALIZED_1))
+				#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 				start_time = world.timeofday
 				InitAtom(A, mapload_arg)
 				end_time = world.timeofday
 				LAZYADD(logged_atoms,A)
 				LAZYADD(logged_times, end_time - start_time)
+				#else								// --- END ATOM STATISTICS LOGGING ---
+				InitAtom(A, mapload_arg)
+				#endif
 				++count
 				CHECK_TICK
 
 	testing("Initialized [count] atoms")
 	pass(count)
 
+	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 	// --- ATOM LOADING TIMER & GROUPING ---
 	total_end_time = world.timeofday
 	total_duration = total_duration + (total_end_time - total_start_time)
@@ -103,6 +119,7 @@ SUBSYSTEM_DEF(atoms)
 			atom_types[the_type] = TRUE
 			type_counts[the_type] = 1
 			type_times[the_type] = logged_times[I]
+	#endif								// --- END ATOM STATISTICS LOGGING ---
 
 	initialized = old_initialized
 
@@ -213,6 +230,7 @@ SUBSYSTEM_DEF(atoms)
 		if(fails & BAD_INIT_SLEPT)
 			. += "- Slept during Initialize()\n"
 
+#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 /datum/controller/subsystem/atoms/proc/atom_load_log(short = FALSE)
 	var/log = ""
 	log += "=== ATOM LOADING STATISTICS ===\n"
@@ -239,6 +257,7 @@ SUBSYSTEM_DEF(atoms)
 			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
 
 	return log
+#endif								// --- END ATOM STATISTICS LOGGING ---
 
 /// Prepares an atom to be deleted once the atoms SS is initialized.
 /datum/controller/subsystem/atoms/proc/prepare_deletion(atom/target)
@@ -255,7 +274,9 @@ SUBSYSTEM_DEF(atoms)
 	var/initlog = InitLog()
 	if(initlog)
 		text2file(initlog, "[GLOB.log_directory]/initialize.log")
-	// --- ATOM LOADING STATISTICS LOGGING ---
+
+	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 	var/atom_log = atom_load_log(short)
 	if(atom_log)
 		text2file(atom_log, "[GLOB.log_directory]/atom_loading_stats.log")
+	#endif								// --- END ATOM STATISTICS LOGGING ---

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -19,6 +19,14 @@ SUBSYSTEM_DEF(atoms)
 
 	initialized = INITIALIZATION_INSSATOMS
 
+	// --- ATOM LOADING TIMER & GROUPING ---
+	var/atoms_count = 0
+	var/total_duration
+	var/atom_types = list()
+	var/type_counts = list()
+	var/type_times = list()
+	// --- END ATOM LOADING TIMER & GROUPING ---
+
 /datum/controller/subsystem/atoms/Initialize(timeofday)
 	GLOB.fire_overlay.appearance_flags = RESET_COLOR
 	setupGenetics() //to set the mutations' sequence
@@ -38,6 +46,16 @@ SUBSYSTEM_DEF(atoms)
 	var/count
 	var/list/mapload_arg = list(TRUE)
 
+	var/list/logged_atoms = list()
+	var/list/logged_times = list()
+
+	var/start_time
+	var/end_time
+	var/total_end_time
+	var/total_start_time
+
+	total_start_time = world.timeofday
+
 	if(atoms)
 		count = atoms.len
 		for(var/I in 1 to count)
@@ -47,18 +65,44 @@ SUBSYSTEM_DEF(atoms)
 			if(isnull(A))
 				continue
 			if(!(A.flags_1 & INITIALIZED_1))
+				start_time = world.timeofday
 				InitAtom(A, mapload_arg)
+				end_time = world.timeofday
+				LAZYADD(logged_atoms,A)
+				LAZYADD(logged_times, end_time - start_time)
 				CHECK_TICK
 	else
 		count = 0
 		for(var/atom/A in world)
 			if(!(A.flags_1 & INITIALIZED_1))
+				start_time = world.timeofday
 				InitAtom(A, mapload_arg)
+				end_time = world.timeofday
+				LAZYADD(logged_atoms,A)
+				LAZYADD(logged_times, end_time - start_time)
 				++count
 				CHECK_TICK
 
 	testing("Initialized [count] atoms")
 	pass(count)
+
+	// --- ATOM LOADING TIMER & GROUPING ---
+	total_end_time = world.timeofday
+	total_duration = total_duration + (total_end_time - total_start_time)
+
+	atoms_count = atoms_count + logged_atoms.len
+
+	for(var/I in 1 to logged_atoms.len)
+		var/atom/A = logged_atoms[I]
+		if(isnull(A)) continue
+		var/the_type = A.type
+		if(the_type in atom_types)
+			type_counts[the_type] += 1
+			type_times[the_type] += logged_times[I]
+		else
+			atom_types[the_type] = TRUE
+			type_counts[the_type] = 1
+			type_times[the_type] = logged_times[I]
 
 	initialized = old_initialized
 
@@ -169,6 +213,33 @@ SUBSYSTEM_DEF(atoms)
 		if(fails & BAD_INIT_SLEPT)
 			. += "- Slept during Initialize()\n"
 
+/datum/controller/subsystem/atoms/proc/atom_load_log(short = FALSE)
+	var/log = ""
+	log += "=== ATOM LOADING STATISTICS ===\n"
+	log += "Total atoms initialized: [atoms_count]\n"
+	log += "Total duration: [total_duration / 10] seconds\n"
+
+	if(short) //список из тысяч типов атомов, избавляемся от лишней проверки в цикле для скорости
+		for(var/path in atom_types)
+			var/num = type_counts[path]
+			var/duration = type_times[path]
+			if(duration == 0) continue
+			log += "  [path]:\n"
+			log += "    Count: [num]\n"
+			log += "    Duration: [duration / 10] seconds\n"
+			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
+
+	else
+		for(var/path in atom_types)
+			var/num = type_counts[path]
+			var/duration = type_times[path]
+			log += "  [path]:\n"
+			log += "    Count: [num]\n"
+			log += "    Duration: [duration / 10] seconds\n"
+			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
+
+	return log
+
 /// Prepares an atom to be deleted once the atoms SS is initialized.
 /datum/controller/subsystem/atoms/proc/prepare_deletion(atom/target)
 	if (initialized == INITIALIZATION_INNEW_REGULAR)
@@ -178,6 +249,13 @@ SUBSYSTEM_DEF(atoms)
 		queued_deletions += WEAKREF(target)
 
 /datum/controller/subsystem/atoms/Shutdown()
+	Savelog()
+
+/datum/controller/subsystem/atoms/proc/Savelog(short = FALSE)
 	var/initlog = InitLog()
 	if(initlog)
 		text2file(initlog, "[GLOB.log_directory]/initialize.log")
+	// --- ATOM LOADING STATISTICS LOGGING ---
+	var/atom_log = atom_load_log(short)
+	if(atom_log)
+		text2file(atom_log, "[GLOB.log_directory]/atom_loading_stats.log")

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(atoms)
 
 	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 	var/atoms_count = 0
-	var/total_duration
+	var/total_duration = 0
 	var/atom_types = list()
 	var/type_counts = list()
 	var/type_times = list()
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(atoms)
 	initialized = INITIALIZATION_INNEW_REGULAR
 
 	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
-	Savelog(short = FALSE)
+	Savelog()
 	#endif								// --- END ATOM STATISTICS LOGGING ---
 
 	return ..()
@@ -56,8 +56,6 @@ SUBSYSTEM_DEF(atoms)
 	var/list/logged_times = list()
 
 	var/start_time
-	var/end_time
-	var/total_end_time
 	var/total_start_time
 
 	total_start_time = world.timeofday
@@ -73,11 +71,10 @@ SUBSYSTEM_DEF(atoms)
 				continue
 			if(!(A.flags_1 & INITIALIZED_1))
 				#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
-				start_time = world.timeofday
+				start_time = TICK_USAGE
 				InitAtom(A, mapload_arg)
-				end_time = world.timeofday
-				LAZYADD(logged_atoms,A)
-				LAZYADD(logged_times, end_time - start_time)
+				LAZYADD(logged_atoms,A.type)
+				LAZYADD(logged_times, TICK_USAGE_TO_MS(start_time))
 				#else								// --- END ATOM STATISTICS LOGGING ---
 				InitAtom(A, mapload_arg)
 				#endif
@@ -87,11 +84,10 @@ SUBSYSTEM_DEF(atoms)
 		for(var/atom/A in world)
 			if(!(A.flags_1 & INITIALIZED_1))
 				#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
-				start_time = world.timeofday
+				start_time = TICK_USAGE
 				InitAtom(A, mapload_arg)
-				end_time = world.timeofday
-				LAZYADD(logged_atoms,A)
-				LAZYADD(logged_times, end_time - start_time)
+				LAZYADD(logged_atoms,A.type)
+				LAZYADD(logged_times, TICK_USAGE_TO_MS(start_time))
 				#else								// --- END ATOM STATISTICS LOGGING ---
 				InitAtom(A, mapload_arg)
 				#endif
@@ -103,15 +99,13 @@ SUBSYSTEM_DEF(atoms)
 
 	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
 	// --- ATOM LOADING TIMER & GROUPING ---
-	total_end_time = world.timeofday
-	total_duration = total_duration + (total_end_time - total_start_time)
+	total_duration += (world.timeofday - total_start_time) / 10
 
 	atoms_count = atoms_count + logged_atoms.len
 
 	for(var/I in 1 to logged_atoms.len)
-		var/atom/A = logged_atoms[I]
-		if(isnull(A)) continue
-		var/the_type = A.type
+		var/the_type = logged_atoms[I]
+		if(isnull(the_type)) continue
 		if(the_type in atom_types)
 			type_counts[the_type] += 1
 			type_times[the_type] += logged_times[I]
@@ -232,34 +226,17 @@ SUBSYSTEM_DEF(atoms)
 			. += "- Slept during Initialize()\n"
 
 #ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
-/datum/controller/subsystem/atoms/proc/atom_load_log(short = FALSE)
-	var/log = ""
-	log += "=== ATOM LOADING STATISTICS ===\n"
-	log += "Total atoms initialized: [atoms_count]\n"
-	log += "Total duration: [total_duration / 10] seconds\n"
+/datum/controller/subsystem/atoms/proc/atom_load_log()
+	var/msg = list()
+	msg += "=== ATOM LOADING STATISTICS ===\nTotal atoms initialized: [atoms_count]\nTotal duration: [total_duration] seconds\n"
 
-	if(short) //список из тысяч типов атомов, избавляемся от лишней проверки в цикле для скорости
-		for(var/path in atom_types)
-			var/num = type_counts[path]
-			var/duration = type_times[path]
-			if(duration == 0) continue
-			log += "  [path]:\n"
-			log += "    Count: [num]\n"
-			log += "    Duration: [duration / 10] seconds\n"
-			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
-			CHECK_TICK
+	for(var/path in atom_types)
+		var/num = type_counts[path]
+		var/duration = type_times[path]
+		msg += "[path]:\n  Count: [num]\n  Duration: [duration] ms\n  Avg per atom: [duration / num] ms\n"
+		CHECK_TICK
 
-	else
-		for(var/path in atom_types)
-			var/num = type_counts[path]
-			var/duration = type_times[path]
-			log += "  [path]:\n"
-			log += "    Count: [num]\n"
-			log += "    Duration: [duration / 10] seconds\n"
-			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
-			CHECK_TICK
-
-	return log
+	return jointext(msg, "\n")
 #endif								// --- END ATOM STATISTICS LOGGING ---
 
 /// Prepares an atom to be deleted once the atoms SS is initialized.
@@ -273,13 +250,15 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/Shutdown()
 	Savelog()
 
-/datum/controller/subsystem/atoms/proc/Savelog(short = FALSE)
+/datum/controller/subsystem/atoms/proc/Savelog()
 	var/initlog = InitLog()
 	if(initlog)
+		fdel("[GLOB.log_directory]/initialize.log")
 		text2file(initlog, "[GLOB.log_directory]/initialize.log")
 
 	#ifdef ATOM_STATISTICS_LOGGING		// --- ATOM STATISTICS LOGGING ---
-	var/atom_log = atom_load_log(short)
+	var/atom_log = atom_load_log()
 	if(atom_log)
+		fdel("[GLOB.log_directory]/atom_loading_stats.log")
 		text2file(atom_log, "[GLOB.log_directory]/atom_loading_stats.log")
 	#endif								// --- END ATOM STATISTICS LOGGING ---

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -119,6 +119,7 @@ SUBSYSTEM_DEF(atoms)
 			atom_types[the_type] = TRUE
 			type_counts[the_type] = 1
 			type_times[the_type] = logged_times[I]
+		CHECK_TICK
 	#endif								// --- END ATOM STATISTICS LOGGING ---
 
 	initialized = old_initialized
@@ -246,6 +247,7 @@ SUBSYSTEM_DEF(atoms)
 			log += "    Count: [num]\n"
 			log += "    Duration: [duration / 10] seconds\n"
 			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
+			CHECK_TICK
 
 	else
 		for(var/path in atom_types)
@@ -255,6 +257,7 @@ SUBSYSTEM_DEF(atoms)
 			log += "    Count: [num]\n"
 			log += "    Duration: [duration / 10] seconds\n"
 			log += "    Avg per atom: [(duration / num) / 10] seconds\n"
+			CHECK_TICK
 
 	return log
 #endif								// --- END ATOM STATISTICS LOGGING ---


### PR DESCRIPTION
# Описание
Добавлено логирование времени загрузки атомов.

## Причина изменений
Теперь можно отследить какие атомы загружаются слишком долго. Не очень точно, но провисания на тяжелых объектах заметны.

## Демонстрация изменений
<img width="372" height="147" alt="Снимок экрана 2026-07-21 213735" src="https://github.com/user-attachments/assets/7e8cb42e-20d4-4e77-a636-047f877287a5" />
<img width="550" height="345" alt="Снимок экрана 2026-07-21 214254" src="https://github.com/user-attachments/assets/51e2ea5f-4223-4138-be53-bceb54bf350a" />
<img width="525" height="163" alt="Снимок экрана 2026-07-21 214259" src="https://github.com/user-attachments/assets/8e5b7df2-81ff-461a-9801-fa1f23bcb64a" />


## Changelog
:cl:
code: Add define ATOM_STATISTICS_LOGGING
code: Add Atom Statistics Logging to Atoms Subsystem
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен опциональный сбор статистики загрузки атомов.
  * При включении формируется `atom_loading_stats.log` со сводкой: общее время, количество и разбивка по типам, включая среднюю длительность инициализации.
  * Сохранено ведение стандартного журнала инициализации; запись логов теперь выполняется централизованно.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->