### PR TITLE
Пофиксил сплёвывание крови мёртвыми тушками

### DIFF
--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -189,7 +189,7 @@
 		if(NOBLOOD in human_victim.dna?.species.species_traits)
 			return
 
-	if(limb.body_zone == BODY_ZONE_CHEST && victim.blood_volume && prob(internal_bleeding_chance + wounding_dmg))
+	if(victim.stat != DEAD && limb.body_zone == BODY_ZONE_CHEST && victim.blood_volume && prob(internal_bleeding_chance + wounding_dmg))
 		var/blood_bled = rand(1, wounding_dmg * (severity == WOUND_SEVERITY_CRITICAL ? 2 : 1.5)) // 12 brute toolbox can cause up to 18/24 bleeding with a severe/critical chest wound
 		switch(blood_bled)
 			if(1 to 6)


### PR DESCRIPTION
# Описание
У нас есть механика сплёвывания крови при получении урона, если есть перелом груди.
Из-за этой механики, тела, что находились внутри демона резни, сплёвывали кровь прямо под демона, позволяя проявиться в комнате, даже если всю кровь отмыли.

Я исправил это и теперь туши не плюются кровью, если мертвы.

## Причина изменений

Это баг, который нарушает концепцию антагониста

## Changelog


:cl:
fix: мёртвые туши больше не плюются кровью
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Предотвращено возникновение новых внутренних кровотечений у уже погибших персонажей.
  * Поведение кровотечения у живых персонажей осталось без изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->