### PR TITLE
Bugfix Industrial Suit Storage Unit sprite

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -642,7 +642,7 @@
 		wires.interact(user)
 		return
 	if(!state_open)
-		if(default_deconstruction_screwdriver(user, "[base_icon_state]", "classic", I))
+		if(default_deconstruction_screwdriver(user, "[base_icon_state]", "[base_icon_state]", I))
 			return
 	if(default_pry_open(I))
 		dump_contents()


### PR DESCRIPTION
# Описание
Фикс бага при котором Industrial Suit Storage Unit меняет текстурку при откручивании и обратном прикручивание крышки панели обслуживания меня спрайт на классического сьют стореджа.
## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Industrial Suit Storage Unit не меняет текстурку при откручивании крышки панели обслуживания на классический
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Исправлено отображение закрытого состояния установки хранения костюмов при вскрытии отвёрткой для разборки.
  * Теперь используется корректное базовое состояние иконки, благодаря чему внешний вид разных вариантов установки отображается правильно.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->