### PR TITLE
Fix/spawn panel eager assets

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -15,6 +15,14 @@
 #define MOLES_N2STANDARD		(MOLES_CELLSTANDARD*N2STANDARD)	// N2 standard value (79%)
 #define CELL_VOLUME				2500	//liters in a cell
 #define BREATH_VOLUME			0.5		//liters in a normal breath
+
+//Ключи разобранной строки газа, см. SSair.get_parsed_gas_string()
+#define GAS_STRING_TEMP			"temp"
+#define GAS_STRING_MOLES		"moles"
+///Потолок кэша разобранных строк. Карта укладывается в пару десятков ключей и
+///разбирается на старте, а atmos_spawn_air() лепит строки на лету ("o2=[N];...") -
+///их кэшировать бессмысленно, поэтому после потолка просто перестаём запоминать.
+#define GAS_STRING_CACHE_LIMIT	512
 #define BREATH_PERCENTAGE		(BREATH_VOLUME/CELL_VOLUME)					//Amount of air to take a from a tile
 
 //EXCITED GROUPS

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -83,6 +83,9 @@ SUBSYSTEM_DEF(air)
 	var/list/gas_reactions = list()
 	var/list/atmos_gen
 	var/list/planetary = list()
+	/// Разобранные строки газа: сырая строка -> list(температура, list(газ -> моли)).
+	/// См. [/datum/controller/subsystem/air/proc/get_parsed_gas_string].
+	var/list/parsed_gas_strings = list()
 	//Special functions lists
 	var/list/turf/open/high_pressure_delta = list()
 
@@ -638,9 +641,46 @@ SUBSYSTEM_DEF(air)
 
 /datum/controller/subsystem/air/proc/generate_atmos()
 	atmos_gen = list()
+	// Строки генераторов теперь другие, разобранные значения протухли.
+	parsed_gas_strings = list()
 	for(var/T in subtypesof(/datum/atmosphere))
 		var/datum/atmosphere/atmostype = T
 		atmos_gen[initial(atmostype.id)] = new atmostype
+
+/**
+ * Разбор строки газа с кэшем по самой строке.
+ *
+ * Карта раздаёт всего пару десятков уникальных initial_gas_mix, а
+ * parse_gas_string зовётся один раз на каждый открытый турф - это сотни тысяч
+ * прогонов params2list/text2num за старт мира на одних и тех же строках.
+ * Строки генераторов (atmos_gen) фиксируются один раз за раунд в
+ * /datum/atmosphere/New, так что соответствие "строка -> смесь" стабильно.
+ *
+ * Возвращает list(GAS_STRING_TEMP = температура или null, GAS_STRING_MOLES = list(газ -> моли)).
+ * Список общий на всех вызывающих - менять его нельзя, только читать.
+ */
+/datum/controller/subsystem/air/proc/get_parsed_gas_string(gas_string)
+	if(!gas_string)
+		gas_string = "" // пустая смесь, заодно не индексируем список по null
+	var/list/cached = parsed_gas_strings[gas_string]
+	if(cached)
+		return cached
+
+	var/list/gas = params2list(preprocess_gas_string(gas_string))
+	var/temperature = null
+	if(gas["TEMP"])
+		temperature = text2num(gas["TEMP"])
+		gas -= "TEMP"
+		if(!isnum(temperature) || temperature < TCMB)
+			temperature = TCMB
+	var/list/moles = list()
+	for(var/id in gas)
+		moles[id] = text2num(gas[id])
+
+	cached = list(GAS_STRING_TEMP = temperature, GAS_STRING_MOLES = moles)
+	if(length(parsed_gas_strings) < GAS_STRING_CACHE_LIMIT)
+		parsed_gas_strings[gas_string] = cached
+	return cached
 
 /datum/controller/subsystem/air/proc/preprocess_gas_string(gas_string)
 	if(!atmos_gen)

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(assets)
 /datum/controller/subsystem/assets/Initialize(timeofday)
 	for(var/type in typesof(/datum/asset))
 		var/datum/asset/A = type
-		if (type != initial(A._abstract) && initial(A.load_on_startup))
+		if (type != initial(A._abstract))
 			get_asset_datum(type)
 
 	transport.Initialize(cache)

--- a/code/modules/admin/spawn_panel/assets.dm
+++ b/code/modules/admin/spawn_panel/assets.dm
@@ -2,139 +2,90 @@ GLOBAL_LIST_EMPTY(spawnpanel_icon_map) // "[typepath]" → spritesheet imgid str
 
 /datum/asset/spritesheet/spawnpanel
 	name = "spawnpanel"
-	load_on_startup = FALSE
 
 /datum/asset/spritesheet/spawnpanel/ModifyInserted(icon/pre_asset)
 	if(pre_asset.Width() != 32 || pre_asset.Height() != 32)
 		pre_asset.Scale(32, 32)
 	return pre_asset
 
-/datum/asset/spritesheet/spawnpanel/proc/resolve_icon_state(icon_file, icon_state)
-	var/list/states = icon_states(icon_file)
-	if(!length(states))
-		return null
-	if(!isnull(icon_state) && (icon_state in states))
-		return icon_state
-	if("" in states)
-		return ""
-	return states[1]
-
+/**
+ * Строит спрайтшит превьюшек для панели спавна: по одному спрайту на уникальную
+ * пару "файл иконки + стейт", и карту "тип -> id спрайта" для JSON-ассета.
+ *
+ * Прок обходит все подтипы /obj, /turf и /mob (это десятки тысяч типов), поэтому
+ * все справочники здесь - ассоциативные списки с прямым индексированием.
+ * Оператор `in` по списку это линейный поиск, и на словаре дедупа, который
+ * дорастает до ~12000 записей, он один стоил около 5 секунд старта сервера.
+ */
 /datum/asset/spritesheet/spawnpanel/register()
-	var/list/icon_dedup = list()
-	var/list/states_cache = list()
+	var/list/icon_dedup = list() // "файл|стейт" -> id спрайта в шите
+	var/list/states_cache = list() // файл иконки -> icon_states() этого файла
 	var/counter = 0
 
-	for(var/atom_type in typesof(/obj))
-		if(atom_type == /obj)
-			continue
-		var/ifile = initial(atom_type:icon)
-		if(!ifile)
-			continue
-		if(!(ifile in states_cache))
-			states_cache[ifile] = icon_states(ifile)
-		var/list/fstates = states_cache[ifile]
-		if(!length(fstates))
-			continue
-		var/istate = initial(atom_type:icon_state)
-		if(isnull(istate) || !(istate in fstates))
-			istate = ("" in fstates) ? "" : fstates[1]
-		var/cache_key = "[ifile]|[istate]"
-		if(!(cache_key in icon_dedup))
-			var/icon/I = icon(ifile, istate, SOUTH, 1)
-			if(!I || !length(icon_states(I)))
+	for(var/root_type in list(/obj, /turf, /mob))
+		for(var/atom_type in typesof(root_type))
+			if(atom_type == root_type)
 				continue
-			var/imgid = "sp[counter]"
-			counter++
-			Insert(imgid, I)
-			icon_dedup[cache_key] = imgid
-		GLOB.spawnpanel_icon_map["[atom_type]"] = icon_dedup[cache_key]
-
-	for(var/turf_type in typesof(/turf))
-		if(turf_type == /turf)
-			continue
-		var/ifile2 = initial(turf_type:icon)
-		if(!ifile2)
-			continue
-		if(!(ifile2 in states_cache))
-			states_cache[ifile2] = icon_states(ifile2)
-		var/list/fstates2 = states_cache[ifile2]
-		if(!length(fstates2))
-			continue
-		var/istate2 = initial(turf_type:icon_state)
-		if(isnull(istate2) || !(istate2 in fstates2))
-			istate2 = ("" in fstates2) ? "" : fstates2[1]
-		var/cache_key2 = "[ifile2]|[istate2]"
-		if(!(cache_key2 in icon_dedup))
-			var/icon/I2 = icon(ifile2, istate2, SOUTH, 1)
-			if(!I2 || !length(icon_states(I2)))
+			var/atom/reference = atom_type
+			var/icon_file = initial(reference.icon)
+			if(!icon_file)
 				continue
-			var/imgid2 = "sp[counter]"
-			counter++
-			Insert(imgid2, I2)
-			icon_dedup[cache_key2] = imgid2
-		GLOB.spawnpanel_icon_map["[turf_type]"] = icon_dedup[cache_key2]
-
-	for(var/mob_type in typesof(/mob))
-		if(mob_type == /mob)
-			continue
-		var/ifile3 = initial(mob_type:icon)
-		if(!ifile3)
-			continue
-		if(!(ifile3 in states_cache))
-			states_cache[ifile3] = icon_states(ifile3)
-		var/list/fstates3 = states_cache[ifile3]
-		if(!length(fstates3))
-			continue
-		var/istate3 = initial(mob_type:icon_state)
-		if(isnull(istate3) || !(istate3 in fstates3))
-			istate3 = ("" in fstates3) ? "" : fstates3[1]
-		var/cache_key3 = "[ifile3]|[istate3]"
-		if(!(cache_key3 in icon_dedup))
-			var/icon/I3 = icon(ifile3, istate3, SOUTH, 1)
-			if(!I3 || !length(icon_states(I3)))
+			var/list/file_states = states_cache[icon_file]
+			if(isnull(file_states))
+				// Пустой список, а не null: иначе битый файл будет перечитываться
+				// на каждом типе, который на него ссылается.
+				file_states = icon_states(icon_file) || list()
+				states_cache[icon_file] = file_states
+			if(!length(file_states))
 				continue
-			var/imgid3 = "sp[counter]"
-			counter++
-			Insert(imgid3, I3)
-			icon_dedup[cache_key3] = imgid3
-		GLOB.spawnpanel_icon_map["[mob_type]"] = icon_dedup[cache_key3]
+			var/icon_state = initial(reference.icon_state)
+			if(isnull(icon_state) || !(icon_state in file_states))
+				icon_state = ("" in file_states) ? "" : file_states[1]
+			var/cache_key = "[icon_file]|[icon_state]"
+			var/imgid = icon_dedup[cache_key]
+			if(!imgid)
+				imgid = "sp[counter]"
+				// Insert сам вырезает нужный стейт и отсеивает битые иконки,
+				// так что отдельный icon()/icon_states() тут не нужен.
+				if(!Insert(imgid, icon_file, icon_state))
+					continue
+				counter++
+				icon_dedup[cache_key] = imgid
+			GLOB.spawnpanel_icon_map["[atom_type]"] = imgid
 
 	return ..()
 
 /datum/asset/json/spawnpanel
 	name = "spawnpanel_atom_data"
-	load_on_startup = FALSE
 
 /datum/asset/json/spawnpanel/generate()
+	// Порядок сборки ассетов в SSassets - это порядок typesof(), то есть порядок
+	// объявления типов. Сейчас спрайтшит объявлен выше и поднимается первым, но
+	// JSON без него бессмысленен: он читает spawnpanel_icon_map. Держим
+	// зависимость явной, чтобы перестановка объявлений не обнулила превьюшки.
+	// get_asset_datum идемпотентен.
+	get_asset_datum(/datum/asset/spritesheet/spawnpanel)
+
 	var/list/data = list()
 	var/list/atoms = list()
+	var/list/category_by_root = list(
+		/obj = "Objects",
+		/turf = "Turfs",
+		/mob = "Mobs",
+	)
 
-	for(var/obj_type in typesof(/obj))
-		if(obj_type == /obj)
-			continue
-		atoms["[obj_type]"] = list(
-			"name" = "[initial(obj_type:name)]",
-			"type" = "Objects",
-			"iconid" = GLOB.spawnpanel_icon_map["[obj_type]"]
-		)
-
-	for(var/turf_type in typesof(/turf))
-		if(turf_type == /turf)
-			continue
-		atoms["[turf_type]"] = list(
-			"name" = "[initial(turf_type:name)]",
-			"type" = "Turfs",
-			"iconid" = GLOB.spawnpanel_icon_map["[turf_type]"]
-		)
-
-	for(var/mob_type in typesof(/mob))
-		if(mob_type == /mob)
-			continue
-		atoms["[mob_type]"] = list(
-			"name" = "[initial(mob_type:name)]",
-			"type" = "Mobs",
-			"iconid" = GLOB.spawnpanel_icon_map["[mob_type]"]
-		)
+	for(var/root_type in category_by_root)
+		var/category = category_by_root[root_type]
+		for(var/atom_type in typesof(root_type))
+			if(atom_type == root_type)
+				continue
+			var/atom/reference = atom_type
+			var/type_key = "[atom_type]"
+			atoms[type_key] = list(
+				"name" = "[initial(reference.name)]",
+				"type" = category,
+				"iconid" = GLOB.spawnpanel_icon_map[type_key]
+			)
 
 	data["atoms"] = atoms
 	return data

--- a/code/modules/admin/spawn_panel/spawn_panel.dm
+++ b/code/modules/admin/spawn_panel/spawn_panel.dm
@@ -55,13 +55,9 @@
 	return GLOB.admin_state
 
 /datum/spawnpanel/ui_assets(mob/user)
-	// The spritesheet populates spawnpanel_icon_map consumed by the JSON asset,
-	// so materialize them explicitly in that order on the first panel open.
-	var/datum/asset/spritesheet/spawnpanel/icons = get_asset_datum(/datum/asset/spritesheet/spawnpanel)
-	var/datum/asset/json/spawnpanel/atom_data = get_asset_datum(/datum/asset/json/spawnpanel)
 	return list(
-		icons,
-		atom_data,
+		get_asset_datum(/datum/asset/spritesheet/spawnpanel),
+		get_asset_datum(/datum/asset/json/spawnpanel),
 	)
 
 /datum/spawnpanel/ui_data(mob/user)

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -5,9 +5,6 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /datum/asset
 	var/_abstract = /datum/asset
-	/// Instantiate and register this asset during SSassets.Initialize. Heavy,
-	/// rarely used UI assets may opt out and be created by get_asset_datum().
-	var/load_on_startup = TRUE
 	var/cached_url_mappings
 
 /datum/asset/New()
@@ -271,10 +268,12 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 	return out.Join("\n")
 
+/// Возвращает TRUE, если спрайт реально попал в шит. Вызывающий может передать
+/// сюда сам файл иконки со стейтом и не резать icon() у себя заранее.
 /datum/asset/spritesheet/proc/Insert(sprite_name, icon/I, icon_state="", dir=SOUTH, frame=1, moving=FALSE)
 	I = icon(I, icon_state=icon_state, dir=dir, frame=frame, moving=moving)
 	if (!I || !length(icon_states(I)))  // that direction or state doesn't exist
-		return
+		return FALSE
 	//any sprite modifications we want to do (aka, coloring a greyscaled asset)
 	I = ModifyInserted(I)
 	var/size_id = "[I.Width()]x[I.Height()]"
@@ -292,6 +291,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	else
 		sizes[size_id] = size = list(1, I, null)
 		sprites[sprite_name] = list(size_id, 0)
+	return TRUE
 
 /**
  * A simple proc handing the Icon for you to modify before it gets turned into an asset.

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -548,17 +548,16 @@ What are the archived variables for?
 /datum/gas_mixture/parse_gas_string(gas_string)
 	if(gc_share)
 		return FALSE
-	gas_string = SSair.preprocess_gas_string(gas_string)
-	var/list/gas = params2list(gas_string)
-	if(gas["TEMP"])
-		var/temp = text2num(gas["TEMP"])
-		gas -= "TEMP"
-		if(!isnum(temp) || temp < 2.7)
-			temp = 2.7
-		set_temperature(temp)
+	// Разбор строки кэшируется в SSair: строк на карте пара десятков, а вызовов
+	// сотни тысяч. Списки из кэша только читаем.
+	var/list/parsed = SSair.get_parsed_gas_string(gas_string)
+	var/temperature = parsed[GAS_STRING_TEMP]
+	if(!isnull(temperature))
+		set_temperature(temperature)
 	clear()
-	for(var/id in gas)
-		set_moles(id, text2num(gas[id]))
+	var/list/moles = parsed[GAS_STRING_MOLES]
+	for(var/id in moles)
+		set_moles(id, moles[id])
 	archive()
 	return TRUE
 

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -67,10 +67,17 @@
 							locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ]))
 	var/list/border = block(locate(max(bounds[MAP_MINX]-1, 1),			max(bounds[MAP_MINY]-1, 1),			 bounds[MAP_MINZ]),
 							locate(min(bounds[MAP_MAXX]+1, world.maxx),	min(bounds[MAP_MAXY]+1, world.maxy), bounds[MAP_MAXZ])) - turfs
+	// Дедуп зон через ассоциативный список: `areas |= B.loc` это линейный поиск
+	// по списку зон на каждый турф шаблона, и на полноразмерном z-уровне он
+	// съедает секунды загрузки.
+	var/list/seen_areas = list()
 	for(var/L in turfs)
 		var/turf/B = L
 		atoms += B
-		areas |= B.loc
+		var/area/turf_area = B.loc
+		if(turf_area && !seen_areas[turf_area])
+			seen_areas[turf_area] = TRUE
+			areas += turf_area
 		for(var/A in B)
 			atoms += A
 			if(istype(A, /obj/structure/cable))

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -6,7 +6,9 @@
 		if (z > z_list.len)
 			stack_trace("Unmanaged z-level [z]! maxz = [world.maxz], z_list.len = [z_list.len]")
 			return list()
-		var/datum/space_level/S = get_level(z)
+		// Индексируем z_list напрямую: границы уже проверены выше, а прок
+		// зовётся сотнями тысяч раз за инициализацию.
+		var/datum/space_level/S = z_list[z]
 		return S.traits[trait]
 	else
 		var/list/default = DEFAULT_MAP_TRAITS
@@ -61,23 +63,46 @@
 				. -= S.z_value
 				break
 
-/// Attempt to get the turf below the provided one according to Z traits
+/**
+ * Мультиз-связки читает каждый /turf/Initialize и /turf/Destroy, то есть больше
+ * миллиона раз за старт мира. Поэтому трейт тут берётся прямым индексом в
+ * z_list, а не через level_trait() + get_level(): это те же данные, но без двух
+ * вызовов проков на каждый турф. Нештатный z и ещё не поднятый z_list уходят на
+ * общий путь level_trait() со всеми его проверками и stack_trace.
+ *
+ * Attempt to get the turf below the provided one according to Z traits
+ */
 /datum/controller/subsystem/mapping/proc/get_turf_below(turf/T)
 	if (!T)
 		return
-	var/offset = level_trait(T.z, ZTRAIT_DOWN)
+	var/turf_z = T.z
+	var/list/levels = z_list
+	var/offset
+	if(levels && turf_z >= 1 && turf_z <= levels.len)
+		var/datum/space_level/level = levels[turf_z]
+		offset = level.traits[ZTRAIT_DOWN]
+	else
+		offset = level_trait(turf_z, ZTRAIT_DOWN)
 	if (!isnum(offset) || !offset)
 		return
-	return locate(T.x, T.y, T.z + offset)
+	return locate(T.x, T.y, turf_z + offset)
 
-/// Attempt to get the turf above the provided one according to Z traits
+/// Attempt to get the turf above the provided one according to Z traits.
+/// Быстрый путь такой же, как в [/datum/controller/subsystem/mapping/proc/get_turf_below].
 /datum/controller/subsystem/mapping/proc/get_turf_above(turf/T)
 	if (!T)
 		return
-	var/offset = level_trait(T.z, ZTRAIT_UP)
+	var/turf_z = T.z
+	var/list/levels = z_list
+	var/offset
+	if(levels && turf_z >= 1 && turf_z <= levels.len)
+		var/datum/space_level/level = levels[turf_z]
+		offset = level.traits[ZTRAIT_UP]
+	else
+		offset = level_trait(turf_z, ZTRAIT_UP)
 	if (!isnum(offset) || !offset)
 		return
-	return locate(T.x, T.y, T.z + offset)
+	return locate(T.x, T.y, turf_z + offset)
 
 /// Prefer not to use this one too often
 /datum/controller/subsystem/mapping/proc/get_station_center()

--- a/code/modules/unit_tests/startup_bootstrap.dm
+++ b/code/modules/unit_tests/startup_bootstrap.dm
@@ -12,5 +12,19 @@
 	// PostSetup is real work and can exceed 30 seconds on a full CI map. This
 	// ceiling still catches the old five-minute unattended vote path.
 	TEST_ASSERT(world.time - SSticker.round_start_time <= 90 SECONDS, "unit tests waited more than 90 seconds after roundstart")
-	TEST_ASSERT(isnull(GLOB.asset_datums[/datum/asset/spritesheet/spawnpanel]), "Spawn Panel spritesheet was built eagerly during startup")
-	TEST_ASSERT(isnull(GLOB.asset_datums[/datum/asset/json/spawnpanel]), "Spawn Panel JSON was built eagerly during startup")
+	// Панель спавна должна быть готова к первому клику админа, а не собираться
+	// на 3-5 секунд прямо в раунде. Ассеты обязаны существовать после SSassets.
+	TEST_ASSERT_NOTNULL(GLOB.asset_datums[/datum/asset/spritesheet/spawnpanel], "Spawn Panel spritesheet was not built during startup")
+	TEST_ASSERT_NOTNULL(GLOB.asset_datums[/datum/asset/json/spawnpanel], "Spawn Panel JSON was not built during startup")
+	// А порядок сборки ассетов обязан оставаться таким, чтобы карта иконок была
+	// заполнена до генерации JSON - иначе в панели пропадут все превьюшки.
+	TEST_ASSERT(length(GLOB.spawnpanel_icon_map) > 0, "Spawn Panel icon map is empty after startup")
+	var/datum/asset/json/spawnpanel/atom_data = GLOB.asset_datums[/datum/asset/json/spawnpanel]
+	var/list/generated = atom_data.generate()
+	var/list/generated_atoms = generated["atoms"]
+	var/with_sprite = 0
+	for(var/type_key in generated_atoms)
+		var/list/entry = generated_atoms[type_key]
+		if(entry["iconid"])
+			with_sprite++
+	TEST_ASSERT(with_sprite > 1000, "Spawn Panel JSON has only [with_sprite] entries with a sprite id out of [length(generated_atoms)]")

--- a/tgui/packages/tgui/interfaces/SpawnPanel/CreateObject.tsx
+++ b/tgui/packages/tgui/interfaces/SpawnPanel/CreateObject.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { useBackend } from '../../backend';
 import { Box, Button, Icon, Input, Stack } from '../../components';
-import { LOCATIONS_NEEDING_CLICK, MAX_ATOM_DISPLAY, PRECISE_MODE_OFF, PRECISE_MODE_TARGET, TAB_TYPE_COLORS, TAB_TYPE_LETTERS, TAB_TYPES } from './constants';
+import { LOCATIONS_NEEDING_CLICK, MAX_ATOM_DISPLAY, PRECISE_MODE_OFF, PRECISE_MODE_TARGET, TAB_TYPE_COLORS, TAB_TYPE_LABELS, TAB_TYPE_LETTERS, TAB_TYPES } from './constants';
 import { AtomData, SpawnPanelData } from './types';
 
 type CreateObjectProps = {
@@ -95,7 +95,7 @@ export const CreateObject = (props: CreateObjectProps) => {
                       >
                         {TAB_TYPE_LETTERS[tab]}
                       </Box>
-                      {tab}
+                      {TAB_TYPE_LABELS[tab] ?? tab}
                     </Box>
                   </Stack.Item>
                 );

--- a/tgui/packages/tgui/interfaces/SpawnPanel/constants.ts
+++ b/tgui/packages/tgui/interfaces/SpawnPanel/constants.ts
@@ -24,7 +24,15 @@ export const SPAWN_LOCATION_ICONS: Record<string, string> = {
   'В сумке выбранного существа': 'backpack',
 };
 
+// Значения приходят из spawnpanel_atom_data.json и используются как ключи
+// фильтрации, поэтому на экран идут через отдельные подписи.
 export const TAB_TYPES = ['Objects', 'Turfs', 'Mobs'] as const;
+
+export const TAB_TYPE_LABELS: Record<string, string> = {
+  Objects: 'Объекты',
+  Turfs: 'Турфы',
+  Mobs: 'Мобы',
+};
 
 export const TAB_TYPE_COLORS: Record<string, string> = {
   Objects: '#4a9fd4',


### PR DESCRIPTION
## Что и зачем

После #3519 ассеты панели спавна собирались лениво, при первом открытии. Экономия старта переехала в раунд: админ жмёт кнопку, мир встаёт на 3-5 секунд, панель не открывается с первого раза. Панель открывают почти каждый раунд, так что размен невыгодный - возвращаю сборку на инициализацию, а чтобы это не стоило серверу тех же секунд, чиню саму сборку и ещё три места, где старт тратил время впустую.

## Что сделано

**Панель спавна снова eager**

- Убран механизм `load_on_startup`: `SSassets.Initialize` снова поднимает все неабстрактные ассеты.
- `register()` переписан: дедуп иконок и кэш стейтов - ассоциативные списки с прямым индексом вместо оператора `in` (линейный поиск по словарю на ~12000 записей, опрашиваемый на каждом из ~25000 типов). Спрайт больше не режется дважды: `Insert()` сам вырезает стейт и сообщает, получилось ли.
- `json/spawnpanel/generate()` теперь явно поднимает спрайтшит: он читает `spawnpanel_icon_map`, и зависимость держалась только на порядке объявления типов в файле.
- Тест `startup_bootstrap` развёрнут: требует, чтобы ассеты существовали после инициализации и чтобы в JSON были непустые id спрайтов.

**Безвредные ускорения старта** (поведение не меняется)

- `get_turf_above()`/`get_turf_below()` читают трейт z-уровня прямым индексом в `z_list` вместо `level_trait()` + `get_level()`. Их зовёт каждый `/turf/Initialize` и `/turf/Destroy` - ~2.8 млн вызовов за старт. Нештатный z и ещё не поднятый `z_list` идут прежним путём.
- `initTemplateBounds()` дедуплицирует зоны шаблона ассоциативным списком вместо `areas |= B.loc`.
- `parse_gas_string()` берёт разобранную строку из кэша `SSair`: на карте пара десятков уникальных `initial_gas_mix`, а прок зовётся на каждый открытый турф (~214000 раз). Строки генераторов фиксируются один раз за раунд, динамические строки `atmos_spawn_air()` упираются в потолок кэша.

## Замеры

Box Station, `AUTO_PROFILE`, одна машина, мастер против ветки:

| Прок | master | ветка |
|---|---|---|
| `level_trait` (self / вызовов) | 2.73с / 2 994 388 | 0.16с / 207 313 |
| `get_level` (self / вызовов) | 1.28с / 2 994 389 | 0.00с / 1 |
| `get_turf_above` + `get_turf_below` (total) | 5.81с | 2.11с |
| `parse_gas_string` (total) | 2.52с | 1.78с |
| `spawnpanel/register` (self) | 7.36с (до #3519) | 2.04с |

По подсистемам: `Assets` 4.6с -> 13.3с (вернулась панель), `Mapping` -0.8с, `Atmospherics` -0.4с, `Shuttle` -0.7с. Чистая разница старта - около +4 секунд, и взамен нет 3-5-секундного стопа мира в раунде. `Atoms` разошёлся на +2.6с, но это разброс набора руин между прогонами

## Changelog

:cl:
fix: Панель спавна снова готова к моменту старта раунда - она больше не собирается на 3-5 секунд при первом открытии.
code_imp: Ускорена инициализация мира: мультиз-связки турфов, дедуп зон при загрузке шаблонов и разбор строк газа больше не делают лишнюю работу.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
  - Улучшена панель спавна: превью объектов, турфов и мобов формируются стабильнее, а данные для отображения загружаются автоматически.
  - Добавлена более эффективная обработка строк газовых смесей с повторным использованием разобранных данных.

- **Исправления**
  - Устранено дублирование областей при загрузке карт.
  - Повышена надежность определения соседних уровней карты и обработки атмосферных параметров.

- **Тесты**
  - Расширены проверки запуска и корректности данных панели спавна, включая наличие превью.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->