### PR TITLE
Джетпак на пояс

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -148,6 +148,7 @@
 	volume = 50
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 
 /obj/item/tank/jetpack/oxygen/captain
 	name = "\improper Captain's jetpack"
@@ -248,6 +249,9 @@
 
 /mob/living/carbon/get_jetpack()
 	var/obj/item/I = back
+	var/obj/item/B = belt
+	if(istype(B, /obj/item/tank/jetpack/oxygen/harness))
+		return B
 	if(istype(I, /obj/item/tank/jetpack))
 		return I
 	else if(istype(I, /obj/item/mod/control))

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -18,6 +18,7 @@
 
 //inventory slots
 	var/obj/item/back = null
+	var/obj/item/belt = null
 	var/obj/item/clothing/mask/wear_mask = null
 	var/obj/item/clothing/neck/wear_neck = null
 	var/obj/item/tank/internal = null

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -53,7 +53,6 @@
 	//Equipment slots
 	var/obj/item/wear_suit = null
 	var/obj/item/w_uniform = null
-	var/obj/item/belt = null
 	var/obj/item/wear_id = null
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null

--- a/modular_splurt/code/modules/antagonists/wendigo/mob/defines_init.dm
+++ b/modular_splurt/code/modules/antagonists/wendigo/mob/defines_init.dm
@@ -24,7 +24,6 @@
 	//Equipment slots
 	var/obj/item/wear_suit = null
 	var/obj/item/w_uniform = null
-	var/obj/item/belt = null
 	var/obj/item/wear_id = null
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null


### PR DESCRIPTION
# Описание

Теперь  jet harness можно поместить на пояс и использовать по назначению. Это редкий предмет, который можно найти лишь глубоко в космосе, или у антагонистов, поэтому такая удобность оправдана

## Причина изменений

улучшения геймплея
## Демонстрация изменений


https://github.com/user-attachments/assets/51c5669c-c252-43cc-8220-48134580b053


## Changelog

:cl:
balance: теперь jet harness можно носить на поясе
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Реактивный жгут теперь можно размещать в слотах пояса и спины.
  * Игра корректно распознаёт реактивный жгут, установленный в слот пояса.
* **Исправления**
  * Улучшена обработка поясного слота для персонажей и особых игровых существ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->