### PR TITLE
ТелеКРЕДИТЫ набору контрактора

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -87,7 +87,7 @@
 			return TRUE
 		if("PRG_redeem_TC")
 			if (hard_drive.traitor_data.contractor_hub.contract_TC_to_redeem)
-				var/obj/item/stack/telecrystal/crystals = new /obj/item/stack/telecrystal(get_turf(user),
+				var/obj/item/stack/telecrystal/crystals = new /obj/item/stack/telecrystal/inteq(get_turf(user),
 															hard_drive.traitor_data.contractor_hub.contract_TC_to_redeem)
 				if(ishuman(user))
 					var/mob/living/carbon/human/H = user


### PR DESCRIPTION
# Описание

Я убрал возможность пихать синдикатскую валюту в аплинк Интекью, а набор контрактора давал в качестве награды валюту синдиката. Исправляю.
## Причина изменений

багфикс


## Changelog

:cl:
fix: Набор контрактора теперь корректно даёт ТК
/:cl:
