### PR TITLE
[HOTFIX] Устранение БоХ-матрёшек внутри сумок

### DIFF
--- a/modular_bluemoon/phenyamomota/code/modules/holdingfashion_port/code/backpack.dm
+++ b/modular_bluemoon/phenyamomota/code/modules/holdingfashion_port/code/backpack.dm
@@ -8,6 +8,9 @@
 /obj/item/BoH_inert/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
 	if(I.type == /obj/item/assembly/signaler/anomaly/bluespace && !(user.a_intent == INTENT_HARM))
+		if(item_flags & IN_STORAGE)
+			to_chat(user, span_danger("Я не смогу вставить ядро, пока [src.name] лежит внутри чего-то!"))
+			return
 		if(INTERACTING_WITH(user, src))
 			return
 		to_chat(user, span_notice("Вы начинаете вставлять [I] в [src]."))


### PR DESCRIPTION
# Описание
- Инертным сумкам хранения добавлена проверка на наличие в `storage`, чтобы исключить матрёшкование БоХ внутри других сумок.

## Причина изменений
- Играющие ебанько считают своим жизненным долгом тестировать пределы правила 5-2 без багрепортинга подобных вещей. Пришлось лицезреть лично и фиксить.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Пофикшен крафт BoH и разновидности кликом ядра по инертной версии внутри других хранилищ типа сумок.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Добавлено предупреждение и блокировка попытки вставить ядро блюспейс-аномалии во внутреннее содержимое другого объекта.
  * Предотвращено некорректное использование инертного рюкзака в хранилище.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->