### PR TITLE
Пофиксил прыжок горилок и таймстоп+болы+капканы

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -562,6 +562,9 @@ GLOBAL_LIST_EMPTY(species_datums)
 
 #define IS_IN_STASIS(mob) (mob.has_status_effect(/datum/status_effect/grouped/stasis))
 
+#define IS_BOLA_ENSNARED(mob) (mob.has_status_effect(/datum/status_effect/bola_snared))
+#define IS_BEARTRAP_ENSNARED(mob) (mob.has_status_effect(/datum/status_effect/beartrap_ensnared))
+
 /proc/set_criminal_status(mob/living/user, datum/data/record/target_records , criminal_status, comment, user_rank, list/authcard_access = list(), user_name)
 	var/status = criminal_status
 	var/old_status = target_records.fields["criminal"] // BLUEMOON ADD - логгирование

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -1088,6 +1088,11 @@ so as to remain in compliance with the most up-to-date laws."
 	L.MarkResistTime()
 	return L.resist_restraints()
 
+/atom/movable/screen/alert/restrained/legcuffed/beartrap/Click()
+	. = ..()
+	var/mob/living/L = usr
+	L.remove_status_effect(/datum/status_effect/beartrap_ensnared)
+
 /atom/movable/screen/alert/buckled/Click()
 	. = ..()
 	if(!.)

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -83,33 +83,42 @@
 		return
 
 	if(HAS_TRAIT(user, TRAIT_HULK))
-		to_chat(user, "<span class='warning'>You're too angry to remember how to tackle!</span>")
+		to_chat(user, "<span class='warning'>Вы слишком злые, чтобы вспомнить, как выполнять захват!</span>")
+		return
+
+	if(IS_BOLA_ENSNARED(user))
+		to_chat(user, "<span class='warning'>Вы не можете хватать, если ваши ноги связаны!</span>")
+		return
+
+	if(IS_BEARTRAP_ENSNARED(user))
+		to_chat(user, "<span class='warning'>Вы не можете хватать, на вашей ноге капкан!</span>")
 		return
 
 	if(user.restrained())
-		to_chat(user, "<span class='warning'>You need free use of your hands to tackle!</span>")
+		to_chat(user, "<span class='warning'>Вам нужны свободные руки, чтобы выполнить захват!</span>")
 		return
 
 	if(!(user.mobility_flags & MOBILITY_STAND))
-		to_chat(user, "<span class='warning'>You must be standing to tackle!</span>")
+		to_chat(user, "<span class='warning'>Вы должны стоять, чтобы выполнить захват!</span>")
 		return
 
-	if(user.tackling)
-		to_chat(user, "<span class='warning'>You're not ready to tackle!</span>")
+	if(user.tackling || user.IsStun())
+		to_chat(user, "<span class='warning'>Вы ещё не готовы к захвату!</span>")
 		return
 
-	if(!user.mob_has_gravity() ||!user.loc.has_gravity() || isspaceturf(user.loc))
-		to_chat(user, "<span class='warning'>You can't find your footing without gravity!</span>")
+	if(!user.mob_has_gravity() || !user.loc.has_gravity() || isspaceturf(user.loc))
+		to_chat(user, "<span class='warning'>Вы не можете как следует устоять на ногах без гравитации!</span>")
 		return
 
 	if(user.has_status_effect(STATUS_EFFECT_TASED)) // can't tackle if you just got tased
-		to_chat(user, "<span class='warning'>You can't tackle while tased!</span>")
+		to_chat(user, "<span class='warning'>Вы не можете выполнять захват, пока вас шокируют!</span>")
 		return
+
 
 	var/left_paralysis = HAS_TRAIT(user, TRAIT_PARALYSIS_L_ARM)
 	var/right_paralysis = HAS_TRAIT(user, TRAIT_PARALYSIS_R_ARM)
 	if(left_paralysis && right_paralysis)
-		to_chat(user, "<span class='warning'>You can't tackle without the use of your arms!</span>")
+		to_chat(user, "<span class='warning'>Вы не можете выполнить захват без использования рук!</span>")
 
 	user.face_atom(A)
 

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -273,6 +273,13 @@
 /obj/item/restraints/legcuffs/proc/on_removed()
 	return
 
+/datum/status_effect/beartrap_ensnared
+	id = "bola_snared"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = null
+	var/was_teleported = FALSE // для проверки на факт телепортации
+	var/obj/item/restraints/legcuffs/beartrap/beartrap
+
 /obj/item/restraints/legcuffs/beartrap
 	name = "bear trap"
 	throw_speed = 1
@@ -332,6 +339,7 @@
 				L.visible_message("<span class='danger'>[L] активирует \the [src].</span>", \
 						"<span class='userdanger'>Вы активируете \the [src]!</span>")
 				L.apply_damage(trap_damage, BRUTE, def_zone)
+				L.apply_status_effect(/datum/status_effect/beartrap_ensnared)
 	..()
 
 /obj/item/restraints/legcuffs/beartrap/energy


### PR DESCRIPTION
# Описание
багрепорт https://discord.com/channels/875735187449847830/1530643151436513498
можно было прыгать горилками даже со связанными ногами, будучи в таймстопе и т.д.

## Причина изменений
это баг

## Changelog

:cl:
fix: больше нельзя прыгать в таймстопе, со связанными ногами и на капкане
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлено отслеживание состояния захвата медвежьим капканом.
  * При срабатывании капкана персонаж получает соответствующее ограничение.
  * Добавлена возможность снять ограничение через уведомление о капкане.

* **Исправления**
  * Персонажи, обездвиженные болой или медвежьим капканом, теперь корректно не могут выполнять захваты.
  * Обновлены и уточнены уведомления при невозможности выполнить захват из-за текущих состояний персонажа.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->