### PR TITLE
subtler target fix & vore minor updt

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -935,16 +935,6 @@
 		};\
 	} while(FALSE)
 
-///Returns the src and all recursive contents as a list.
-/atom/proc/get_all_contents(ignore_flag_1)
-	. = list(src)
-	var/i = 0
-	while(i < length(.))
-		var/atom/checked_atom = .[++i]
-		if(checked_atom.flags_1 & ignore_flag_1)
-			continue
-		. += checked_atom.contents
-
 /** Прок ищет объект и его дочерние объекты среди указанного листа.
  * typepath – аргумент атома, обычно записывается как [x.path]
  * list/type_list – указанный глобально или локально лист, по которому будет произведён поиск

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -695,19 +695,6 @@
 		return
 	winset(C, "mainwindow", "flash=5")
 
-//Recursively checks if an item is inside a given type, even through layers of storage. Returns the atom if it finds it.
-/proc/recursive_loc_check(atom/movable/target, type)
-	var/atom/A = target
-	if(istype(A, type))
-		return A
-
-	while(!istype(A.loc, type))
-		if(!A.loc)
-			return
-		A = A.loc
-
-	return A.loc
-
 ///Send a message in common radio when a player arrives
 /proc/announce_arrival(mob/living/carbon/human/character, rank)
 	if(!SSticker.IsRoundInProgress() || QDELETED(character))

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -463,11 +463,18 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/y = min(world.maxy, max(1, A.y + dy))
 	return locate(x,y,A.z)
 
+/atom/proc/contains(var/atom/A)
+	if(!A)
+		return FALSE
+	for(var/atom/location = A.loc, location, location = location.loc)
+		if(location == src)
+			return TRUE
+
 /*
 	Gets all contents of contents and returns them all in a list.
 */
 
-/atom/proc/GetAllContents(var/T)
+/atom/proc/GetAllContents(T)
 	if(!length(contents))
 		if(!T || istype(src, T))
 			return list(src)
@@ -508,7 +515,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 			processing += A.contents
 			lim = processing.len
 			. += A
-
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
@@ -1030,13 +1036,6 @@ B --><-- A
 			CHECK_TICK
 
 	return L
-
-/atom/proc/contains(var/atom/A)
-	if(!A)
-		return FALSE
-	for(var/atom/location = A.loc, location, location = location.loc)
-		if(location == src)
-			return TRUE
 
 /proc/flick_overlay_static(O, atom/A, duration)
 	set waitfor = 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -516,16 +516,14 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 /// Возвращает список всех объектов указанного типа в цепочке loc
 /atom/proc/get_all_recursive_loc(T)
-	var/list/founds = list()
+	. = list()
 	var/atom/A = src.loc
 
 	while(A)
 		if(istype(A, T))
-			founds += A
+			. += A
 
 		A = A.loc
-
-	return founds
 
 //Recursively checks if an item is inside a given type, even through layers of storage. Returns the atom if it finds it.
 /proc/recursive_loc_check(atom/movable/target, type)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -470,10 +470,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if(location == src)
 			return TRUE
 
-/*
-	Gets all contents of contents and returns them all in a list.
-*/
 
+/// Gets all contents of contents and returns them all in a list.
 /atom/proc/GetAllContents(T)
 	if(!length(contents))
 		if(!T || istype(src, T))
@@ -515,6 +513,32 @@ Turf and target are separate in case you want to teleport some distance from a t
 			processing += A.contents
 			lim = processing.len
 			. += A
+
+/// Возвращает список всех объектов указанного типа в цепочке loc
+/atom/proc/get_all_recursive_loc(T)
+	var/list/founds = list()
+	var/atom/A = src.loc
+
+	while(A)
+		if(istype(A, T))
+			founds += A
+
+		A = A.loc
+
+	return founds
+
+//Recursively checks if an item is inside a given type, even through layers of storage. Returns the atom if it finds it.
+/proc/recursive_loc_check(atom/movable/target, type)
+	var/atom/A = target
+	if(istype(A, type))
+		return A
+
+	while(!istype(A.loc, type))
+		if(!A.loc)
+			return
+		A = A.loc
+
+	return A.loc
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -308,7 +308,7 @@
 		// Логи
 		user.log_message("[message] (SUBTLER-TARGET to [target.name])", LOG_SUBTLER)
 	else
-		to_chat(user, span_alert("[target_name] удалился слишком далеко и не увидел твои действия."))
+		to_chat(user, span_alert("[target_name] удали[target.ru_sya()] слишком далеко и не увидел[target.ru_a()] твои действия."))
 		// Логи
 		user.log_message("[message] (SUBTLER-TARGET to [target.name] (unheard))", LOG_SUBTLER)
 	to_chat(user, message)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -268,13 +268,13 @@
 			for(var/mob/living/listed as anything in possible_target)
 				possible_target[listed] = new /mutable_appearance(listed)
 
-			if(!possible_target || !possible_target.len)
+			if(!LAZYLEN(possible_target))
 				to_chat(user, span_warning("No target around."))
 				return FALSE
 
 			target = possible_target.len == 1 ? possible_target[1] : show_radial_menu(user, user, possible_target, radius = 40)
 
-		if(!target)
+		if(QDELETED(target))
 			return FALSE
 
 	var/target_name = target.get_visible_name()
@@ -303,7 +303,7 @@
 	message = "<span class='emote'><b>[user]</b> <i>[user.say_emphasis(message)]</i></span>"
 
 	// Отправка сообщений
-	if(target in view(work_distance, user))
+	if(!QDELETED(target) && get_dist(user, target) <= work_distance)
 		to_chat(target, "[span_nicegreen("Ты замечаешь, как")] [message]")
 		// Логи
 		user.log_message("[message] (SUBTLER-TARGET to [target.name])", LOG_SUBTLER)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -252,10 +252,18 @@
 		for(var/mob/living/L in oview(work_distance, user))
 			LAZYADD(possible_target, L)
 
+		if(isliving(user.loc))
+			LAZYADD(possible_target, user.loc)
+		else if(isliving(user.loc?.loc))
+			LAZYADD(possible_target, user.loc.loc)
+		else if(istype(user.loc, /obj/belly))
+			var/obj/belly/belly = user.loc
+			LAZYADD(possible_target, belly.owner || (isliving(belly.loc) && belly.loc))
+
 		if(possible_target.len > 13) // Много целей, TGUI с поиском
 			target = tgui_input_list(user, "Выберете персонажа, который увидит ваши действия", "Выбор персонажа", possible_target)
 		else // Радиальное меню
-			for(var/mob/living/listed in possible_target)
+			for(var/mob/living/listed as anything in possible_target)
 				possible_target[listed] = new /mutable_appearance(listed)
 
 			if(!possible_target || !possible_target.len)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -250,17 +250,17 @@
 	else
 		var/list/possible_target = list()
 		for(var/mob/living/L in oview(work_distance, user))
-			LAZYADD(possible_target, L)
+			possible_target += L
 
 		if(isliving(user.loc))
-			LAZYOR(possible_target, user.loc)
+			possible_target |= user.loc
 		if(isliving(user.loc?.loc))
-			LAZYOR(possible_target, user.loc.loc)
+			possible_target |= user.loc.loc
 		if(istype(user.loc, /obj/belly))
 			var/obj/belly/belly = user.loc
 			var/mob/living/L = belly.owner || belly.loc
 			if(istype(L))
-				LAZYOR(possible_target, L)
+				possible_target |= L
 
 		if(possible_target.len > 13) // Много целей, TGUI с поиском
 			target = tgui_input_list(user, "Выберете персонажа, который увидит ваши действия", "Выбор персонажа", possible_target)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -252,15 +252,10 @@
 		for(var/mob/living/L in oview(work_distance, user))
 			possible_target += L
 
-		if(isliving(user.loc))
-			possible_target |= user.loc
-		if(isliving(user.loc?.loc))
-			possible_target |= user.loc.loc
-		if(istype(user.loc, /obj/belly))
-			var/obj/belly/belly = user.loc
-			var/mob/living/L = belly.owner || belly.loc
-			if(istype(L))
-				possible_target |= L
+		// Все мобы в loc цепочке
+		possible_target |= user.get_all_recursive_loc(/mob/living)
+		// Все мобы внутри нас
+		possible_target |= user.GetAllContents(/mob/living)
 
 		if(possible_target.len > 13) // Много целей, TGUI с поиском
 			target = tgui_input_list(user, "Выберете персонажа, который увидит ваши действия", "Выбор персонажа", possible_target)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -258,7 +258,9 @@
 			LAZYADD(possible_target, user.loc.loc)
 		if(istype(user.loc, /obj/belly))
 			var/obj/belly/belly = user.loc
-			LAZYOR(possible_target, belly.owner || (isliving(belly.loc) && belly.loc))
+			var/mob/living/L = belly.owner || belly.loc
+			if(istype(L))
+				LAZYOR(possible_target, L)
 
 		if(possible_target.len > 13) // Много целей, TGUI с поиском
 			target = tgui_input_list(user, "Выберете персонажа, который увидит ваши действия", "Выбор персонажа", possible_target)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -90,7 +90,7 @@
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 	else if(!params)
-		var/subtle_emote = "" 
+		var/subtle_emote = ""
 		if(user.client?.prefs.tgui_input_verbs)
 			subtle_emote = tgui_input_text(user, "Введите сообщение, которое увидят персонажи в упор к вам. Призраки его не увидят.", "Введите скрытое сообщение", null, MAX_MESSAGE_LEN, TRUE, TRUE)
 		else
@@ -254,11 +254,11 @@
 
 		if(isliving(user.loc))
 			LAZYADD(possible_target, user.loc)
-		else if(isliving(user.loc?.loc))
+		if(isliving(user.loc?.loc))
 			LAZYADD(possible_target, user.loc.loc)
-		else if(istype(user.loc, /obj/belly))
+		if(istype(user.loc, /obj/belly))
 			var/obj/belly/belly = user.loc
-			LAZYADD(possible_target, belly.owner || (isliving(belly.loc) && belly.loc))
+			LAZYOR(possible_target, belly.owner || (isliving(belly.loc) && belly.loc))
 
 		if(possible_target.len > 13) // Много целей, TGUI с поиском
 			target = tgui_input_list(user, "Выберете персонажа, который увидит ваши действия", "Выбор персонажа", possible_target)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -253,9 +253,9 @@
 			LAZYADD(possible_target, L)
 
 		if(isliving(user.loc))
-			LAZYADD(possible_target, user.loc)
+			LAZYOR(possible_target, user.loc)
 		if(isliving(user.loc?.loc))
-			LAZYADD(possible_target, user.loc.loc)
+			LAZYOR(possible_target, user.loc.loc)
 		if(istype(user.loc, /obj/belly))
 			var/obj/belly/belly = user.loc
 			var/mob/living/L = belly.owner || belly.loc

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -41,7 +41,7 @@
 	var/vore_capacity = 1					// simple animal nom capacity
 	var/is_wet = TRUE						// Is this belly inside slimy parts?
 	var/wet_loop = TRUE						// Does this belly have a slimy internal loop?
-	var/can_victim_see = FALSE				// Should the victim be blinded?
+	var/can_victim_see = FALSE				// Can victim see from inside
 
 	//I don't think we've ever altered these lists. making them static until someone actually overrides them somewhere.
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_NOISY,DM_ABSORB,DM_UNABSORB)	// Possible digest modes
@@ -716,6 +716,7 @@
 	dupe.vore_capacity = vore_capacity
 	dupe.is_wet = is_wet
 	dupe.wet_loop = wet_loop
+	dupe.can_victim_see = can_victim_see
 
 	//// Object-holding variables
 	//struggle_messages_outside - strings

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -175,7 +175,7 @@
 	var/mob/living/L //for chat messages and blindness
 	if(isliving(thing))
 		L = thing
-		set_bling(L)
+		set_blinding(L)
 	if(OldLoc in contents)
 		return //Someone dropping something (or being stripdigested)
 
@@ -206,12 +206,12 @@
 /obj/belly/Exited(atom/movable/AM, atom/newloc)
 	. = ..()
 	if(isliving(AM))
-		set_bling(AM, TRUE)
+		set_blinding(AM, TRUE)
 
 /obj/belly/get_remote_view_fullscreens(mob/user)
 	user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/scaled/impaired, 1)
 
-/obj/belly/proc/set_bling(mob/living/target, clear)
+/obj/belly/proc/set_blinding(mob/living/target, clear)
 	if(!istype(target))
 		return
 	if(isnull(clear))

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -41,6 +41,7 @@
 	var/vore_capacity = 1					// simple animal nom capacity
 	var/is_wet = TRUE						// Is this belly inside slimy parts?
 	var/wet_loop = TRUE						// Does this belly have a slimy internal loop?
+	var/can_victim_see = FALSE				// Should the victim be blinded?
 
 	//I don't think we've ever altered these lists. making them static until someone actually overrides them somewhere.
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_NOISY,DM_ABSORB,DM_UNABSORB)	// Possible digest modes
@@ -142,7 +143,8 @@
 		"examine_messages",
 		"emote_lists",
 		"is_wet",
-		"wet_loop"
+		"wet_loop",
+		"can_victim_see",
 		)
 
 		//ommitted list
@@ -173,7 +175,7 @@
 	var/mob/living/L //for chat messages and blindness
 	if(isliving(thing))
 		L = thing
-		L.become_blind("belly_[REF(src)]")
+		set_bling(L)
 	if(OldLoc in contents)
 		return //Someone dropping something (or being stripdigested)
 
@@ -204,8 +206,17 @@
 /obj/belly/Exited(atom/movable/AM, atom/newloc)
 	. = ..()
 	if(isliving(AM))
-		var/mob/living/L = AM
-		L.cure_blind("belly_[REF(src)]")
+		set_bling(AM, TRUE)
+
+/obj/belly/proc/set_bling(mob/living/target, clear)
+	if(!istype(target))
+		return
+	if(isnull(clear))
+		clear = can_victim_see
+	if(clear)
+		target.cure_blind("belly_[REF(src)]")
+	else
+		target.become_blind("belly_[REF(src)]")
 
 // Release all contents of this belly into the owning mob's location.
 // If that location is another mob, contents are transferred into whichever of its bellies the owning mob is in.

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -208,6 +208,9 @@
 	if(isliving(AM))
 		set_bling(AM, TRUE)
 
+/obj/belly/get_remote_view_fullscreens(mob/user)
+	user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/scaled/impaired, 1)
+
 /obj/belly/proc/set_bling(mob/living/target, clear)
 	if(!istype(target))
 		return

--- a/code/modules/vore/eating/vorepanel.dm
+++ b/code/modules/vore/eating/vorepanel.dm
@@ -526,7 +526,7 @@
 			var/obj/belly/belly = host.vore_selected
 			belly.can_victim_see = !belly.can_victim_see
 			for(var/mob/living/L in belly.contents)
-				belly.set_bling(L)
+				belly.set_blinding(L)
 			. = TRUE
 		if("b_mode")
 			var/list/menu_list = host.vore_selected.digest_modes.Copy()

--- a/code/modules/vore/eating/vorepanel.dm
+++ b/code/modules/vore/eating/vorepanel.dm
@@ -141,6 +141,7 @@
 			"belly_name" = selected.name,
 			"is_wet" = selected.is_wet,
 			"wet_loop" = selected.wet_loop,
+			"can_victim_see" = selected.can_victim_see,
 			"mode" = selected.digest_mode,
 			"verb" = selected.vore_verb,
 			"desc" = selected.desc,
@@ -520,6 +521,12 @@
 			. = TRUE
 		if("b_wetloop")
 			host.vore_selected.wet_loop = !host.vore_selected.wet_loop
+			. = TRUE
+		if("b_can_victim_see")
+			var/obj/belly/belly = host.vore_selected
+			belly.can_victim_see = !belly.can_victim_see
+			for(var/mob/living/L in belly.contents)
+				belly.set_bling(L)
 			. = TRUE
 		if("b_mode")
 			var/list/menu_list = host.vore_selected.digest_modes.Copy()

--- a/modular_bluemoon/code/modules/antagonists/bloodsucker/bloodsucker_rework/code/clans/clan_nosferatu.dm
+++ b/modular_bluemoon/code/modules/antagonists/bloodsucker/bloodsucker_rework/code/clans/clan_nosferatu.dm
@@ -46,7 +46,7 @@
 
 /datum/objective/nosferatu_clan_objective/check_completion()
 	for(var/datum/mind/bloodsucker_minds as anything in get_antag_minds(/datum/antagonist/bloodsucker))
-		var/obj/item/book/kindred/the_book = locate() in bloodsucker_minds.current.get_all_contents()
+		var/obj/item/book/kindred/the_book = locate() in bloodsucker_minds.current.GetAllContents()
 		if(the_book)
 			return TRUE
 	return FALSE

--- a/modular_bluemoon/code/modules/vehicles/spacepods/spacepod.dm
+++ b/modular_bluemoon/code/modules/vehicles/spacepods/spacepod.dm
@@ -243,7 +243,7 @@
 /obj/spacepod/proc/on_mouse_moved(mob/user, object, location, control, params)
 	SIGNAL_HANDLER
 	var/list/modifiers = params2list(params)
-	if(object == src || (object && (object in user.get_all_contents())) || user != pilot)
+	if(object == src || (object && (object in user.GetAllContents())) || user != pilot)
 		return
 	if(weapon && modifiers["ctrl"])
 		INVOKE_ASYNC(src, PROC_REF(async_fire_weapons_at), object)

--- a/tgui/packages/tgui/interfaces/VorePanel.js
+++ b/tgui/packages/tgui/interfaces/VorePanel.js
@@ -144,6 +144,7 @@ const VoreSelectedBelly = (props) => {
     belly_name,
     is_wet,
     wet_loop,
+    can_victim_see,
     mode,
     verb,
     desc,
@@ -258,6 +259,13 @@ const VoreSelectedBelly = (props) => {
                   icon={wet_loop ? "toggle-on" : "toggle-off"}
                   selected={wet_loop}
                   content={wet_loop ? "Yes" : "No"} />
+              </LabeledList.Item>
+              <LabeledList.Item label="Victim can see from inside">
+                <Button
+                  onClick={() => act("set_attribute", { attribute: "b_can_victim_see" })}
+                  icon={can_victim_see ? "toggle-on" : "toggle-off"}
+                  selected={can_victim_see}
+                  content={can_victim_see ? "Yes" : "No"} />
               </LabeledList.Item>
             </LabeledList>
           </Flex.Item>


### PR DESCRIPTION
# Описание
- Пофикшена доступность таргентного субтайтлера при vore
- В настройки "животов" добавлена опция, позволяющая не ослеплять жертв при попадании внутрь
P.S. Я протестил
## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: В настройки "животов" добавлена опция, позволяющая не ослеплять жертв при попадании внутрь
fix: Пофикшена доступность таргентного субтайтлера при vore
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * В панели выбранного «брюха» добавлен переключатель *Victim can see from inside* (управляет тем, может ли жертва видеть изнутри).
* **Улучшения**
  * Для удалённого просмотра из «брюха» добавлены fullscreen-оверлеи remote-view.
* **Исправления**
  * Уточнён выбор целей для скрытых эмоций с учётом связанных локаций/контейнеров, улучшены проверки удалённости цели и дистанции при отправке сообщений.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->