### PR TITLE
Кнопочки актуализации, лодаута.

### DIFF
--- a/code/modules/admin/player_panel2.dm
+++ b/code/modules/admin/player_panel2.dm
@@ -754,6 +754,14 @@ GLOBAL_LIST_INIT(pp_implants, init_pp_implants())
 			log_admin("[key_name(admin)] applied loadout to [key_name(targetMob)].")
 			message_admins("<span class='notice'>[key_name_admin(admin)] applied loadout to [key_name_admin(targetMob)].</span>")
 
+		if ("update_appearance")
+			if(!ishuman(targetMob) || !targetMob.client?.prefs)
+				return
+			targetMob.client.prefs.copy_to(targetMob, icon_updates = TRUE, roundstart_checks = FALSE)
+			targetMob.regenerate_icons()
+			log_admin("[key_name(admin)] актуализировал внешность [key_name(targetMob)].")
+			message_admins("<span class='notice'>[key_name_admin(admin)] актуализировал внешность [key_name_admin(targetMob)].</span>")
+
 		if ("set_organ")
 			if(!iscarbon(targetMob))
 				return

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -134,6 +134,7 @@
 	if(!cached_outfits)
 		cached_outfits = list()
 		cached_outfits += list(outfit_entry("General", /datum/outfit, "Naked", priority=TRUE))
+		cached_outfits += list(outfit_entry("General", /datum/outfit/admin_loadout, "Loadout", priority=TRUE))
 		cached_outfits += make_outfit_entries("General", subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman))
 		cached_outfits += make_outfit_entries("Jobs", typesof(/datum/outfit/job))
 		cached_outfits += make_outfit_entries("Plasmamen Outfits", typesof(/datum/outfit/plasmaman))
@@ -141,6 +142,10 @@
 	data["outfits"] = cached_outfits
 	return data
 
+
+/// Кукла в первью показывается голой, не баг и не фича, просто вид всегда будет изменчив. Человек появляется сразу с квирками.
+/datum/outfit/admin_loadout
+	name = "Loadout"
 
 /datum/select_equipment/proc/resolve_outfit(text)
 
@@ -221,7 +226,13 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Select Equipment") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	for(var/obj/item/item in human_target.get_equipped_items(delete_pocket))
 		qdel(item)
-	if(dresscode != "Naked")
+	if(istype(dresscode, /datum/outfit/admin_loadout))
+		if(human_target.client?.prefs)
+			human_target.client.prefs.copy_to(human_target, icon_updates = TRUE, roundstart_checks = FALSE)
+		SSjob.equip_loadout(null, human_target, bypass_prereqs = TRUE)
+		if(human_target.client)
+			SSquirks.AssignQuirks(human_target, human_target.client, TRUE, TRUE, null, FALSE)
+	else if(dresscode != "Naked")
 		human_target.equipOutfit(dresscode)
 
 	human_target.regenerate_icons()

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -135,7 +135,7 @@
 		cached_outfits = list()
 		cached_outfits += list(outfit_entry("General", /datum/outfit, "Naked", priority=TRUE))
 		cached_outfits += list(outfit_entry("General", /datum/outfit/admin_loadout, "Loadout", priority=TRUE))
-		cached_outfits += make_outfit_entries("General", subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman))
+		cached_outfits += make_outfit_entries("General", subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman) - typesof(/datum/outfit/admin_loadout))
 		cached_outfits += make_outfit_entries("Jobs", typesof(/datum/outfit/job))
 		cached_outfits += make_outfit_entries("Plasmamen Outfits", typesof(/datum/outfit/plasmaman))
 

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -94,15 +94,21 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 				SSquirks.AssignQuirks(human_target, human_target.client, TRUE, TRUE, null, FALSE, human_target)
 			human_target.copy_clothing_prefs(copycat)
 
-			// Синхронизируем ДНА к мобам не на Z-левеле. Т.е. для тех, кто не на уровне map. Чиним превью в тгуи.
-			copycat.hair_style = human_target.hair_style
-			copycat.facial_hair_style = human_target.facial_hair_style
-			copycat.grad_style = human_target.grad_style
-			copycat.grad_color = human_target.grad_color
-			copycat.left_eye_color = human_target.left_eye_color
-			copycat.right_eye_color = human_target.right_eye_color
-
-		copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
+			if(human_target.client?.prefs)
+				// Прописываю правильно для подключенных киентов.
+				human_target.client.prefs.copy_to(copycat, icon_updates = TRUE, roundstart_checks = FALSE)
+			else
+				// Синхронизируем ДНА к мобам не на Z-левеле. Т.е. для тех, кто не на уровне map. Чиним превью в тгуи.
+				// На всякий случай оставлю else как заглушку, по идее она должна отрабатываться когда моб без клиента, либо он отключен.
+				copycat.hair_style = human_target.hair_style
+				copycat.facial_hair_style = human_target.facial_hair_style
+				copycat.grad_style = human_target.grad_style
+				copycat.grad_color = human_target.grad_color
+				copycat.left_eye_color = human_target.left_eye_color
+				copycat.right_eye_color = human_target.right_eye_color
+				copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
+		else
+			copycat.updateappearance(icon_update=TRUE, mutcolor_update=TRUE, mutations_overlay_update=TRUE)
 	else
 		//even if target isn't a carbon, if they have a client we can make the
 		//dummy look like what their human would look like based on their prefs

--- a/tgui/packages/tgui/interfaces/PlayerPanel2.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel2.js
@@ -262,6 +262,14 @@ const PhysicalActions = (props) => {
             tooltip={!has_loadout ? "Player has no loadout data" : "Apply player's loadout"}
             onClick={() => act("apply_loadout")}
           />
+          <Button
+            width="100%"
+            icon="user-cog"
+            content="Appearance"
+            disabled={!mob_type.includes("/mob/living/carbon/human")}
+            tooltip="Apply saved character appearance"
+            onClick={() => act("update_appearance")}
+          />
         </Flex>
       </Section>
 
@@ -539,7 +547,7 @@ const QuirkCategory = (props) => {
               checked={active_quirks && active_quirks.includes(quirk.name)}
               content={quirk.name}
               tooltip={quirk.desc}
-              color={color}
+              color={active_quirks?.includes(quirk.name) ? color : null}
               disabled={!mob_type.includes("/mob/living/carbon/human")}
               onClick={() => act("toggle_quirk_direct", { quirk_name: quirk.name })}
             />


### PR DESCRIPTION
# Описание

В Select Equipment новая кнопочко Loadout, спавнит куклу с активным слотом лодаута + выдает квирки сразу при спавне. В PP вкладка Mob кнопочка актуализации внешности персонажа. Дорабатываю Select Equipment после своего факапа с мордами еблеволков.

## Changelog

:cl:
admin: Появление с лодаутом.
admin: Кнопка актуализации персонажа.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Добавлена кнопка **Appearance** в быстрые действия для применения сохранённого внешнего вида персонажа.
  * В админ-экипировке появилась опция **Loadout** для загрузки персонального набора внешности и особенностей.
* **Изменения**
  * Сохранённые настройки внешности теперь корректнее переносятся при обновлении внешнего вида и при создании копий персонажей.
* **Исправления**
  * В панели управления квирками цвет отображается только для активных квирков.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->