### PR TITLE
Emote gender smallfix

### DIFF
--- a/modular_bluemoon/code/modules/mob/emotes.dm
+++ b/modular_bluemoon/code/modules/mob/emotes.dm
@@ -83,6 +83,13 @@
 	sound = 'sound/voice/human/bear_fight.ogg'
 	emote_cooldown = 10 SECONDS
 
+/datum/emote/sound/human/suka1/replace_pronoun(mob/user, message)
+	if(user.gender == "female")
+		message = "выглядит очень злой."
+	else
+		message = message
+	. = ..()
+
 /datum/emote/sound/human/suka2
 	name = "Агрессивное Сука!"
 	key = "suka2"
@@ -91,6 +98,13 @@
 	message_mime = null
 	sound = 'sound/voice/bear_fight2.ogg'
 	emote_cooldown = 10 SECONDS
+
+/datum/emote/sound/human/suka2/replace_pronoun(mob/user, message)
+	if(user.gender == "female")
+		message = "выглядит <b>очень</b> злой."
+	else
+		message = message
+	. = ..()
 
 /datum/emote/sound/human/jacket1
 	name = "Какое время?"

--- a/modular_bluemoon/code/modules/mob/emotes.dm
+++ b/modular_bluemoon/code/modules/mob/emotes.dm
@@ -84,7 +84,7 @@
 	emote_cooldown = 10 SECONDS
 
 /datum/emote/sound/human/suka1/replace_pronoun(mob/user, message)
-	if(user.gender == "female")
+	if(user.gender == FEMALE || (user.gender == PLURAL && isfeminine(user)))
 		message = "выглядит очень злой."
 	else
 		message = message
@@ -100,7 +100,7 @@
 	emote_cooldown = 10 SECONDS
 
 /datum/emote/sound/human/suka2/replace_pronoun(mob/user, message)
-	if(user.gender == "female")
+	if(user.gender == FEMALE || (user.gender == PLURAL && isfeminine(user)))
 		message = "выглядит <b>очень</b> злой."
 	else
 		message = message


### PR DESCRIPTION
# Описание
Добавил подбор гендера у эмоута, где нейтраль подобрать сложно

## Причина изменений
Тёлки злились как мужики

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Эмоуты *suka и *suka2 учитывают гендер эмоутящего.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Улучшено согласование формулировок в некоторых звуковых эмоциях человека.
  * Теперь при женском роде корректно подставляется женская форма текста (в одном случае сохраняется оформление разметкой).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->