### PR TITLE
Изменение трейтов для Воксов, снятие ограничений.

### DIFF
--- a/modular_splurt/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/modular_splurt/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -9,14 +9,6 @@
 
 	mutantlungs = /obj/item/organ/lungs/vox
 
-	species_traits = list(MUTCOLORS,
-		EYECOLOR,
-		NO_UNDERWEAR,
-		HAIR,
-		FACEHAIR,
-		MARKINGS
-		)
-
 	exotic_blood_color = "#9066BD"
 	//flesh_color = "#808D11"
 


### PR DESCRIPTION
# Описание

По просьбе некоторых игроков убираю ограничение по изменению и редакции Воксов, для их же блага.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Снятие ограничений по внешности для Воксов
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Для вида Vox больше не применяется отдельный набор ограничений внешности и расовых особенностей.
  * Остальные характеристики и поведение вида Vox не изменились.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->