### PR TITLE
fix: корректное управление компонентом и сигналами waddling

### DIFF
--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -6,9 +6,13 @@
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(Waddle))
 
+/datum/component/waddling/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
+
 /datum/component/waddling/proc/Waddle()
 	var/mob/living/L = parent
-	if(L.incapacitated() || L.lying)
+	if(!L || L.incapacitated() || L.lying)
 		return
 	var/prev_pixel_z = L.pixel_z
 	var/matrix/otransform = matrix(L.transform) //make a copy of the current transform

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -131,8 +131,9 @@
 
 /obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
 	. = ..()
+	REMOVE_TRAIT(user, TRAIT_WADDLING, CLOTHING_TRAIT)
 	if(!HAS_TRAIT(user, TRAIT_WADDLING))
-		var/datum/component/waddling = GetComponent(/datum/component/waddling)
+		var/datum/component/waddling = user.GetComponent(/datum/component/waddling)
 		waddling?.RemoveComponent()
 	if(user.mind && HAS_TRAIT(user.mind, TRAIT_CLOWN_MENTALITY))
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "noshoes", /datum/mood_event/noshoes)


### PR DESCRIPTION
# Описание

- [✅] Изменения были проверены на локальном сервере
- [✅] Этот пулл-реквест готов к тест-мерджу.


## Причина изменений

Клоунские башмаки не снимали waddle трейт и персонаж после всегда подпрыгивал, даже если соответствующего квирка нет.

## Changelog

- clown shoes: При надевании обуви добавлялся TRAIT_WADDLING как CLOTHING_TRAIT, но при снятии логика не работала.
Для квирка TRAIT_WADDLING как ROUNDSTART_TRAIT это было не так важно, но если у персонажа квирка нет то CLOTHING_TRAIT оставался и его было никак не снять.

- Добавила REMOVE_TRAIT что всегда снимает трейт как безусловное действие.
RemoveComponent теперь вызывается через user.GetComponent(), так как компонент загружен на моба (user), а не на обувь (src) и удалять нужно оттуда же.

- waddling component: добавила UnregisterFromParent по аналогии с другими компонентами для очистки сигналов при удалении, а null-guard в Waddle() предотвращает краш после снятия компонента.

:cl:
fix: корректное управление компонентом и сигналами waddling
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Исправлено снятие эффекта «ковыляния» при снятии клоунской обуви.
  * Компонент движения теперь корректно отключается при отписке от родителя.
  * Предотвращены ошибки анимации для неподходящих объектов и обездвиженных персонажей.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->