### PR TITLE
Фикс с гениталиями Пеплоходов

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -77,20 +77,6 @@
 	C.dna.features["mcolor2"] = C.dna.features["mcolor"] //for no funne rainbows
 	C.dna.features["mcolor3"] = C.dna.features["mcolor"]
 
-	if(C.gender == MALE)
-		C.dna.features["has_cock"] = TRUE
-		C.dna.features["has_balls"] = TRUE
-		C.dna.features["cock_color"] = "[C.dna.features["cock_color"]]"
-		C.dna.features["cock_shape"] = "[C.dna.features["cock_shape"]]"
-		C.dna.features["cock_diameter_ratio"] = "[C.dna.features["cock_diameter_ratio"]]"
-		C.dna.features["testicles_color"] = "[C.dna.features["balls_color"]]"
-		C.dna.features["balls_shape"] = "[C.dna.features["balls_shape"]]"
 
-	else
-		C.dna.features["has_vag"] = TRUE
-		C.dna.features["has_womb"] = TRUE
-		C.dna.features["vag_color"] = C.dna.features["mcolor"]
-		C.dna.features["vag_shape"] = "Cloaca"
-	C.give_genitals(1)
 	C.update_body()
 	return ..()

--- a/modular_splurt/code/modules/mob/living/carbon/human/species_types/ashwalker.dm
+++ b/modular_splurt/code/modules/mob/living/carbon/human/species_types/ashwalker.dm
@@ -9,14 +9,6 @@
 	id = SPECIES_ASHWALKER_WEST
 	burnmod = 0.95
 	brutemod = 0.95
-	// Western ash walkers are the female subtype and retain normal item dexterity.
-	inherent_traits = list()
-
-/datum/species/lizard/ashwalker/western/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
-	C.gender = FEMALE
-	if(C.dna?.features)
-		C.dna.features["body_model"] = FEMALE
-	return ..()
 
 /// Selectable in character prefs (generate_selectable_species); station jobs blocked via qualifies_for_rank.
 /datum/species/lizard/ashwalker/eastern/check_roundstart_eligible()


### PR DESCRIPTION
# Описание

По просьбе ЭшМейнеров, пофиксил гениталии. Теперь они не принудительные.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/98526fe6-fad2-4a20-a806-cd0079602933" />

(Если что всё работает, карта грузит)

:cl:
add: Фикс с гениталиями пеплоходцев
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Исправления**
  * Убран принудительный женский пол и женская модель тела для западных пеплоходцев при получении вида.
  * Прекращена автоматическая настройка половых признаков при смене на пеплоходцев.
  * Западные пеплоходцы больше не переопределяют наследуемые врождённые признаки.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->