### PR TITLE
Syndicate_stamp_add

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/space_syndicate_base.dmm
@@ -11209,6 +11209,7 @@
 	pixel_y = 3
 	},
 /obj/structure/table/wood/fancy/blackred,
+/obj/item/stamp/syndicate,
 /turf/open/floor/wood/wood_diagonal,
 /area/ruin/space/has_grav/bluemoon/deepspacetwo/bridge/cl)
 "RT" = (


### PR DESCRIPTION
# Описание

Преставителю Триглава Синдиката мобильного оперативного пункта DeepSpace-2 добавлена печать Синдиката
- [✔] Изменения были проверены на локальном сервере
- [✔] Этот пулл-реквест готов к тест-мерджу.
- [❌] Изменения были портированы с другого сервера

## Причина изменений

Командир БЧ связи(Представитель Триглава) будучи бюрократом ДСов не имел свою печать для штамповки документов.

## Демонстрация изменений

<img width="353" height="295" alt="image" src="https://github.com/user-attachments/assets/b7b58143-172c-4c24-a5a8-e3319a817a55" />

## Changelog



:cl:
map: добавлена печать синдиката представителю триглава DS2
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * На базе космического синдиката добавлен штамп синдиката для использования в игровых взаимодействиях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->