### PR TITLE
MetaFix_again

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31321,6 +31321,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "csQ" = (
@@ -60890,6 +60893,7 @@
 	pixel_y = -24;
 	req_access_txt = "47"
 	},
+/obj/item/toy/plush/mothplushie,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "jMq" = (


### PR DESCRIPTION
# Описание

Добавлен кабель под АПЦ на посту СБ в РНД.
- [✔] Изменения были проверены на локальном сервере
- [✔] Этот пулл-реквест готов к тест-мерджу.
- [❌] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

АПЦ не заряжался
https://discord.com/channels/875735187449847830/1532522614323675257

## Демонстрация изменений

<img width="259" height="395" alt="image" src="https://github.com/user-attachments/assets/873e690e-9f80-4f27-90db-5cb02b247733" />


## Changelog

:cl:
map: добавлен кабель для АПЦ на посту СБ в РНД на Мете.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * На карте MetaStation добавлены жёлтый кабель и плюшевая игрушка-мотылёк.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->