### PR TITLE
haunted tarot fix

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -123,7 +123,6 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/reagent_containers/pill/labebium = 15,
 	/obj/item/organ/tongue/bone/chatter = 1,
 	//SPLURT EDIT END
-	/obj/item/toy/cards/deck/tarot/haunted = 1, // есть на оффах = легит
 	"" = 3
 	))
 

--- a/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
+++ b/modular_bluemoon/code/game/objects/structures/kirbyplants_holiday_loot.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_INIT(plant_loot_common, list(
 	/obj/item/restraints/legcuffs/bola/energy = WEIGHT_SECRET,
 	/obj/item/sign/flag/rus = WEIGHT_SECRET, // пасхалко
 	/obj/item/toy/figure/inteq = WEIGHT_SECRET,
+	/obj/item/toy/cards/deck/tarot/haunted = WEIGHT_SECRET,
 	// WEIGHT_UNCOMMON
 	/obj/item/trash/syndi_cakes = WEIGHT_UNCOMMON,
 	/obj/item/trash/can = WEIGHT_UNCOMMON,


### PR DESCRIPTION
# Описание
- Карты таро, позволяющие читать гост чат теперь не будут спавниться в техах, вместо этого они могут быть с маленьким шансам спрятаны в кустах

## Причина изменений
https://discord.com/channels/875735187449847830/1052875182672449617/1532712184252076132

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Карты таро, позволяющие читать гост чат теперь не будут спавниться в техах, вместо этого они могут быть с маленьким шансам спрятаны в кустах
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Карта Таро с привидением удалена из добычи при обслуживании.
  * Предмет добавлен в обычный праздничный пул добычи с редкой вероятностью появления.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->