### PR TITLE
SolFedupdate2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/BlueMoon/sol_ship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/BlueMoon/sol_ship.dmm
@@ -1010,12 +1010,14 @@
 /area/ruin/space/has_grav/bluemoon/solfed_ship/permabrig)
 "ge" = (
 /obj/effect/turf_decal/tile/dark_blue/half,
-/obj/machinery/vending/medical,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/vending/medical/syndicate_access/cybersun{
+	req_access = null
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/medbay)
@@ -1516,10 +1518,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/bar)
 "iS" = (
-/obj/machinery/atmospherics/pipe/manifold/orange{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/atmos)
 "iU" = (
@@ -2765,6 +2767,9 @@
 	dir = 1
 	},
 /obj/item/storage/box/firingpins,
+/obj/item/documents/syndicate/blue{
+	desc = "\"Совершенно Секретно\". Документы, содержащие сведения о секретной оперативной информации СолнечнойФедерации. Эти документы заверяются голубой сургучной печатью."
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/vault)
 "pw" = (
@@ -3132,8 +3137,6 @@
 /area/ruin/space/has_grav/bluemoon/solfed_ship/atmos)
 "rM" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/structure/closet,
-/obj/item/inducer/sci/combat,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
@@ -3141,8 +3144,6 @@
 /obj/machinery/airalarm/inteq{
 	pixel_y = 24
 	},
-/obj/item/clothing/under/inteq/baseball,
-/obj/item/clothing/under/inteq/baseball,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/outpost)
 "rQ" = (
@@ -3211,8 +3212,6 @@
 	},
 /obj/item/clothing/suit/space/hardsuit/ert/alert/sol/adv,
 /obj/item/gun/ballistic/automatic/pistol/deagle,
-/obj/item/ammo_box/magazine/m50,
-/obj/item/ammo_box/magazine/m50,
 /obj/item/ammo_box/magazine/m50,
 /obj/item/ammo_box/magazine/m50,
 /obj/item/ammo_box/magazine/m50,
@@ -3336,13 +3335,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/bluemoon/solfed_ship)
-"sr" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/belt/esabre_belt,
-/obj/item/paper/fluff/ruins/forgottenship/missionobj/sol,
-/obj/item/paper/fluff/ruins/forgottenship/password,
-/turf/open/floor/carpet/royalblue,
 /area/ruin/space/has_grav/bluemoon/solfed_ship)
 "st" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -3815,8 +3807,8 @@
 /obj/machinery/fax{
 	name = "SolarFederation37";
 	radio_channel = "Command";
-	fax_id = "SolarFederation37";
-	fax_name = "SolarFederation37"
+	fax_id = SolarFederation37;
+	fax_name = SolarFederation37
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/bridge)
@@ -4751,11 +4743,11 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/atmos)
 "Bt" = (
-/obj/structure/closet,
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/siding/wood,
-/obj/item/flashlight/seclite,
-/obj/item/storage/box/firingpins,
+/obj/item/paper/fluff/ruins/forgottenship/password,
+/obj/structure/closet/cabinet,
+/obj/item/storage/belt/esabre_belt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bluemoon/solfed_ship)
 "Bz" = (
@@ -4793,6 +4785,7 @@
 /obj/item/ammo_box/shotgun/loaded/buckshot,
 /obj/item/ammo_box/shotgun/loaded/buckshot,
 /obj/item/storage/belt/military,
+/obj/item/inducer/sci/combat,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/outpost)
 "BE" = (
@@ -5612,6 +5605,8 @@
 	dir = 8
 	},
 /obj/item/binoculars/strong,
+/obj/item/folder/syndicate/blue,
+/obj/item/folder/syndicate/blue,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/bridge)
 "GE" = (
@@ -6115,18 +6110,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/solfed_ship)
-"Jx" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Recreation";
-	req_one_access_txt = "152"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/bluemoon/solfed_ship/outpost)
 "Jz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -7704,6 +7687,7 @@
 /obj/machinery/airalarm/inteq{
 	pixel_y = 24
 	},
+/obj/effect/mob_spawn/human/solfed/diplomacy/slut,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/solfed_ship/outpost)
 "SK" = (
@@ -8453,7 +8437,6 @@
 /obj/machinery/plantgenes{
 	pixel_y = 7
 	},
-/obj/machinery/photocopier,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/solfed_ship)
 "WY" = (
@@ -10979,7 +10962,7 @@ VF
 Ly
 IO
 gQ
-sr
+nU
 As
 Nr
 th
@@ -11977,7 +11960,7 @@ SF
 Ze
 IE
 iv
-Jx
+pr
 js
 QN
 sE


### PR DESCRIPTION
# Описание

Убрал пару лишних ящиков, убрал часть магазинов для Дигла адмирала(их было чуть больше чем дохуя), заменил на аванпосте наномед, вернул SolFedSlut, добавил в сейф хранилища собственные секретные документы, положил две папки в конферент зале.

- [✔] Изменения были проверены на локальном сервере
- [✔] Этот пулл-реквест готов к тест-мерджу.
- [❌] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

Доделываем то, что недоделал в прошлый раз.

## Демонстрация изменений

<img width="92" height="82" alt="image" src="https://github.com/user-attachments/assets/c9e28335-5755-48ca-8e4f-f098cfe5622a" />
<img width="723" height="330" alt="image" src="https://github.com/user-attachments/assets/bbb599c9-a4f4-4fc0-8191-6c629b5fcada" />
<img width="145" height="153" alt="image" src="https://github.com/user-attachments/assets/a076861e-c0b7-4bb9-8341-0b8f88c13c18" />
<img width="147" height="117" alt="image" src="https://github.com/user-attachments/assets/1d28afdd-8c3a-4624-a452-eaf228fb4d94" />


## Changelog

:cl:
map: на аванпост солфеда вернулась секретарь(Slut) и пару малых фиксов на самом аванпосте.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Обновлён набор объектов и доступного оборудования на карте космического корабля.
  * Добавлены медицинский автомат, атмосферный смеситель, индуктор, секретные документы, папки и новые точки появления существ.
  * Скорректированы содержимое отдельных помещений, наборы добычи и коммуникационные данные корабля.
  * Удалены устаревшие предметы, шкафчики, боеприпасы, фотокопир и прежние элементы атмосферной инфраструктуры.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->