### PR TITLE
MetaStationBugReport

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75866,6 +75866,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/keycard_auth{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
 "qwv" = (
@@ -82117,9 +82120,6 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = 23
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{


### PR DESCRIPTION
# Описание

Переместил кнопку в кабинете КМа.

- [✔] Изменения были проверены на локальном сервере
- [✔] Этот пулл-реквест готов к тест-мерджу.
- [❌] Изменения были портированы с другого сервера <!-- Если да, напиши, с какого. Желательно с ссылкой на их репозиторий-->

## Причина изменений

https://discord.com/channels/875735187449847830/1533270467794698502

## Демонстрация изменений

<img width="416" height="327" alt="image" src="https://github.com/user-attachments/assets/b5b342dc-8907-43ec-876a-99d6d14aa024" />


## Changelog

:cl:
map: кнопка в кабинете КМа на Мете была чуть сдвинута.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Скорректировано расположение терминала авторизации по ключ-картам на карте.
  * Удалён дублирующий экземпляр терминала в другом месте карты.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->