### PR TITLE
Zombie Changeling: полировка бэкэнда

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -544,10 +544,10 @@
 		all_objectives |= A.objectives
 
 	if(all_objectives.len)
-		output += "<B>Objectives:</B>"
+		output += "<B>Текущие цели:</B>"
 		var/obj_count = 1
 		for(var/datum/objective/objective in all_objectives)
-			output += "<br><B>Objective #[obj_count++]</B>: [objective.explanation_text]"
+			output += "<br><B>Цель #[obj_count++]</B>: [objective.explanation_text]"
 			var/list/datum/mind/other_owners = objective.get_owners() - src
 			if(other_owners.len)
 				output += "<ul>"
@@ -1748,10 +1748,10 @@ GLOBAL_LIST(objective_choices)
 
 /datum/mind/proc/announce_objectives()
 	var/obj_count = 1
-	to_chat(current, "<span class='notice'>Your current objectives:</span>")
+	to_chat(current, span_notice("Ваши текущие цели:"))
 	for(var/objective in get_all_objectives())
 		var/datum/objective/O = objective
-		to_chat(current, "<B>Objective #[obj_count]</B>: [O.explanation_text]")
+		to_chat(current, "<B>Цель #[obj_count]</B>: [O.explanation_text]")
 		obj_count++
 
 /datum/mind/proc/find_syndicate_uplink()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -552,7 +552,7 @@
 			if(other_owners.len)
 				output += "<ul>"
 				for(var/datum/mind/M in other_owners)
-					output += "<li>Conspirator: [M.name]</li>"
+					output += "<li>Сообщники: [M.name]</li>"
 				output += "</ul>"
 
 // Кнопки для амбиций и их отображение

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -556,6 +556,7 @@
 /obj/item/clothing/suit/armor/changeling
 	name = "chitinous mass"
 	desc = "A tough, hard covering of black chitin."
+	icon = 'icons/mob/clothing/suit.dmi' // Плейсхолдер: спрайта нет
 	icon_state = "lingarmor"
 	tail_state = "lingarmor"
 	item_flags = DROPDEL

--- a/modular_bluemoon/code/modules/antagonists/changeling/changeling_zombie.dm
+++ b/modular_bluemoon/code/modules/antagonists/changeling/changeling_zombie.dm
@@ -18,18 +18,42 @@
 	host.AddComponent(/datum/component/changeling_zombie_infection)
 
 /datum/antagonist/changeling_zombie
-	name = "Changeling Mutant"
+	name = "Changeling Zombie"
 	show_in_antagpanel = TRUE
 	antagpanel_category = "Changeling"
 	roundend_category = "changelings"
+	var/datum/objective/changeling_zombie_infect/infect_objective
+
+/datum/antagonist/changeling_zombie/on_gain()
+	var/datum/objective/changeling_zombie_infect/objec = new
+	objec.owner = owner
+	objectives += objec
+	infect_objective = objec
+	. = ..()
+
+/datum/antagonist/changeling_zombie/greet()
+	var/zombified_text = ""
+	zombified_text += "[span_userdanger("Вы – [name] <br>")]"
+	zombified_text += "<hr>"
+	zombified_text += "<div style='margin-bottom:6px'>Вы преобразились ужасным образом и вами движет [span_danger("жажда плоти")]... Вы мутант, порождённый генокрадом!</div>"
+	zombified_text += "<div style='margin-bottom:6px'>Рассудок помутняется и кипящее ощущение адреналина под мутировавшей кожей злит вас.</div>"
+	zombified_text += "<div style='margin-bottom:6px'>Вид окружающих живых существ вызывает у вас агрессию. Внутри начинают бороться два единственных позыва: \
+	[span_purple("заразить")] или [span_danger("разорвать на куски")].</div>"
+	zombified_text += "Заразу можно распространять через ваши мутировавшие руки. Мёртвые встанут вновь."
+	to_chat(owner.current, examine_block(zombified_text))
+	owner.announce_objectives()
+	owner.current.playsound_local(get_turf(owner.current), 'sound/effects/lingreadapt.ogg', 75)
+
+/datum/antagonist/changeling_zombie/farewell()
+	to_chat(owner.current, span_userdanger("Безумие внутри вашего умирающего мозга утихает. Что происх-..."))
 
 /datum/objective/changeling_zombie_infect
-	explanation_text = "Infect at least 5 humanoids with your blades."
 	var/required_infections = 5
 	var/total_infections = 0
+	explanation_text = "Заразите хотя бы 5 гуманоидов своими клинками."
 
 /datum/objective/changeling_zombie_infect/update_explanation_text()
-	explanation_text = "Infect at least [required_infections] humanoids with your blades."
+	explanation_text = "Заразите хотя бы [required_infections] гуманоидов своими клинками."
 
 /datum/objective/changeling_zombie_infect/check_completion()
 	return total_infections >= required_infections
@@ -44,7 +68,6 @@
 	var/list/bodypart_zones_to_regenerate = list()
 	COOLDOWN_DECLARE(limb_regen_cooldown)
 	COOLDOWN_DECLARE(transformation_grace_period)
-	var/datum/objective/changeling_zombie_infect/infect_objective
 	var/infection_timestamp = 0
 	var/spaceacillin_resistance = 0
 
@@ -98,7 +121,7 @@
 		if(length(bodypart_zones_to_regenerate) && COOLDOWN_FINISHED(src, limb_regen_cooldown))
 			var/selected_zone = pick_n_take(bodypart_zones_to_regenerate)
 			if(host.regenerate_limb(selected_zone))
-				host.visible_message("<span class='danger'>[host]'s flesh writhes as a limb reforms!</span>", "<span class='userdanger'>You regenerate a limb!</span>")
+				host.visible_message(span_danger("Плоть [host] извивается с преображением конечности!"), span_userdanger("Вы отрастили конечность!"))
 				playsound(host, 'sound/effects/splat.ogg', 40, TRUE)
 	else if(spaceacillin_resistance < 100 && host.reagents?.has_reagent(/datum/reagent/medicine/spaceacillin))
 		var/current_toxin_damage = host.getToxLoss()
@@ -124,7 +147,7 @@
 				else
 					if(!can_cure && current_toxin_damage >= CHANGELING_ZOMBIE_TOXINS_THRESHOLD_TO_CURE)
 						can_cure = TRUE
-						host.visible_message("<span class='danger'>[host]'s flesh hardens — purge toxins now or lose them forever!</span>", "<span class='userdanger'>Your body convulses violently...</span>")
+						host.visible_message(span_danger("Плоть [host] отвердевает — немедленно очистите токсины или с [host.ru_nim()] будет покончено!"), span_userdanger("Ваше тело болезненно дёргается..."))
 					host.adjustToxLoss(round(CHANGELING_ZOMBIE_TOXINS_PER_SECOND_LIVING * seconds_per_tick * damage_multiplier, 0.1))
 				if(SPT_PROB(4, seconds_per_tick) && current_toxin_damage > CHANGELING_ZOMBIE_TOXINS_THRESHOLD_TO_CURE)
 					host.adjustBruteLoss(3)
@@ -137,7 +160,7 @@
 	host.grab_ghost()
 	zombified = TRUE
 	host.cure_husk(CHANGELING_DRAIN)
-	to_chat(host, "<span class='notice'>Something awful stitches your corpse back together.</span>")
+	to_chat(host, span_danger("Нечто ужасающее собирает ваш труп по частям."))
 	ADD_TRAIT(host, TRAIT_CHUNKYFINGERS, TRAIT_CHANGELING_ZOMBIE)
 	ADD_TRAIT(host, TRAIT_RESISTCOLD, TRAIT_CHANGELING_ZOMBIE)
 	ADD_TRAIT(host, TRAIT_RESISTLOWPRESSURE, TRAIT_CHANGELING_ZOMBIE)
@@ -172,11 +195,7 @@
 	RegisterSignal(host, COMSIG_CARBON_ATTACH_LIMB, PROC_REF(on_gain_limb))
 	RegisterSignal(host, COMSIG_MOB_SAY, PROC_REF(handle_speech))
 	if(host.mind)
-		var/datum/antagonist/changeling_zombie/antag = host.mind.add_antag_datum(/datum/antagonist/changeling_zombie)
-		var/datum/objective/changeling_zombie_infect/objec = new
-		objec.owner = host.mind
-		antag.objectives += objec
-		infect_objective = objec
+		host.mind.add_antag_datum(/datum/antagonist/changeling_zombie)
 	return TRUE
 
 /datum/component/changeling_zombie_infection/proc/generate_armblade(mob/living/carbon/human/host, hand_index)
@@ -224,7 +243,7 @@
 
 /obj/item/melee/arm_blade/changeling_zombie
 	name = "warped arm blade"
-	desc = "Misgrown bone and tendon — still hungry."
+	desc = "Неправильно срощенные кости и сухожилия — все ещё голодные."
 	force = 21
 	var/infect_chance = 100
 	COOLDOWN_DECLARE(sound_cooldown)
@@ -246,8 +265,8 @@
 	if(V.GetComponent(/datum/component/changeling_zombie_infection))
 		return
 	V.AddComponent(/datum/component/changeling_zombie_infection)
-	user.visible_message("<span class='danger'>[V]'s wounds froth — infection takes hold!</span>")
-	var/datum/component/changeling_zombie_infection/us = user.GetComponent(/datum/component/changeling_zombie_infection)
+	user.visible_message(span_danger("Рана на теле [V] вспенивается – инфекция развивается внутри неё!"))
+		var/datum/antagonist/changeling_zombie/us = user.mind.has_antag_datum(/datum/antagonist/changeling_zombie)
 	if(us?.infect_objective)
 		us.infect_objective.total_infections += 1
 

--- a/modular_bluemoon/code/modules/antagonists/changeling/changeling_zombie.dm
+++ b/modular_bluemoon/code/modules/antagonists/changeling/changeling_zombie.dm
@@ -266,7 +266,7 @@
 		return
 	V.AddComponent(/datum/component/changeling_zombie_infection)
 	user.visible_message(span_danger("Рана на теле [V] вспенивается – инфекция развивается внутри неё!"))
-		var/datum/antagonist/changeling_zombie/us = user.mind.has_antag_datum(/datum/antagonist/changeling_zombie)
+	var/datum/antagonist/changeling_zombie/us = user.mind.has_antag_datum(/datum/antagonist/changeling_zombie)
 	if(us?.infect_objective)
 		us.infect_objective.total_infections += 1
 

--- a/modular_bluemoon/code/modules/antagonists/changeling/changeling_zombie.dm
+++ b/modular_bluemoon/code/modules/antagonists/changeling/changeling_zombie.dm
@@ -27,6 +27,7 @@
 /datum/antagonist/changeling_zombie/on_gain()
 	var/datum/objective/changeling_zombie_infect/objec = new
 	objec.owner = owner
+	objec.update_explanation_text()
 	objectives += objec
 	infect_objective = objec
 	. = ..()
@@ -266,7 +267,7 @@
 		return
 	V.AddComponent(/datum/component/changeling_zombie_infection)
 	user.visible_message(span_danger("Рана на теле [V] вспенивается – инфекция развивается внутри неё!"))
-	var/datum/antagonist/changeling_zombie/us = user.mind.has_antag_datum(/datum/antagonist/changeling_zombie)
+	var/datum/antagonist/changeling_zombie/us = user.mind?.has_antag_datum(/datum/antagonist/changeling_zombie)
 	if(us?.infect_objective)
 		us.infect_objective.total_infections += 1
 

--- a/modular_bluemoon/code/modules/client/pronouns_ru.dm
+++ b/modular_bluemoon/code/modules/client/pronouns_ru.dm
@@ -22,6 +22,9 @@
 /datum/proc/ru_na(temp_gender)
 	. = "нём"
 
+/datum/proc/ru_nim(temp_gender)
+	. = "ним"
+
 /datum/proc/ru_emu(temp_gender)
 	. = "ему"
 
@@ -80,6 +83,18 @@
 			. = "ней"
 		if(MALE)
 			. = "нём"
+	if(capitalized)
+		. = capitalize(.)
+
+/client/ru_nim(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "ним"
+	switch(temp_gender)
+		if(FEMALE)
+			. = "ней"
+		if(MALE)
+			. = "ним"
 	if(capitalized)
 		. = capitalize(.)
 
@@ -189,6 +204,18 @@
 			. = "ней"
 		if(MALE)
 			. = "нём"
+	if(capitalized)
+		. = capitalize(.)
+
+/atom/ru_nim(capitalized, temp_gender)
+	if(!temp_gender)
+		temp_gender = gender
+	. = "ним"
+	switch(temp_gender)
+		if(FEMALE)
+			. = "ней"
+		if(MALE)
+			. = "ним"
 	if(capitalized)
 		. = capitalize(.)
 


### PR DESCRIPTION
# Описание
- Перенесена логика целей в датум/антаг чейнджлинг зомби.
- Добавлены `greet()` + `farewell()` текста антагроли зомби, поясняющие игроки что они такое.
- Проведён перевод генкозомби и перевод "Текущих целей" в двух проках mind.
- Добавлен плейсхолдер icon файла для `Chitinous Mass` генокрада.
- Добавлены "ним/ей" пронауны на ру.

## Причина изменений
- Игроки не понимали что они такое, если играли за роль впервые.
- Исполнение всей роли через датум/компонент это ебаный позор. Исправим это хотя бы немного.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Добавлен greet и farewell текста для роли Changeling Zombie, для информации игрокам.
image: Добавлен плейсхолдер спрайт для Chitinous Mass suit у генокрада.
spellcheck: Переведены строки информации, связанные с Changeling Zombie.
code: Добавлены ру-пронауны "Ним/ней" для локализаторов.
refactor: Код целей Changeling Zombie перенесен с datum/component его вируса в datum/antagonist его роли.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена локализация целей, приветствий, предупреждений и игровых сообщений для антагониста «Чейнджлинг-зомби».
  * Для заражённых корректно назначается цель заражения и антагонист после превращения.
  * Добавлена поддержка русских местоимений с учётом рода и капитализации.

* **Исправления**
  * Исправено отображение иконки костюма химерной брони.
  * Уточнено название антагониста и описание его оружия.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->