### PR TITLE
Добавил опцию переименовки картонной коробке

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -489,7 +489,7 @@
 	foodtype = FRUIT| BREAKFAST
 
 /obj/item/reagent_containers/food/drinks/bottle/bio_carton
-	name = "Small Carton Box"
+	name = "small carton box"
 	desc = "A small biodegradable carton box made from plant biomatter."
 	icon_state = "eco_box"
 	item_state = "carton"
@@ -497,6 +497,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	volume = 50
 	isGlass = FALSE
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/reagent_containers/food/drinks/bottle/cream
 	name = "Milk Cream"


### PR DESCRIPTION
# Описание
- Добавил опцию переименовки картонной коробке `small carton box`.
- Убрал капитализацию названия `small carton box`

## Причина изменений
- QoL.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: Картонную коробку из биогенератора можно переименовать.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Название небольшой картонной упаковки отображается со строчной буквы.
  * Для упаковки добавлена возможность уникального переименования.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->