### PR TITLE
[HOTFIX] Пацифизм для лазерных глаз

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -93,6 +93,9 @@
 
 /datum/mutation/human/laser_eyes/on_ranged_attack(atom/target, mouseparams)
 	if(owner.a_intent == INTENT_HARM)
+		if(HAS_TRAIT(owner, TRAIT_PACIFISM))
+			to_chat(owner, span_notice("Это может обжечь других! Вы не хотите рисковать навредить кому-либо..."))
+			return
 		owner.LaserEyes(target, mouseparams)
 
 /// Flash Protection — immune to handheld flashes and flashbangs (not welding arcs).


### PR DESCRIPTION
# Описание
Пацифизм никак не влиял на возможность харма мутацией `Laser Eyes`.

## Причина изменений
Пацифизм должен влиять на возможности харма игрока как наказание/ивент.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Мутация Laser Eyes больше не работает при пацифизме у носителя.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Добавлена проверка пацифизма перед атакой лазерными глазами.
  * Персонажи с пацифизмом получают уведомление, а атака отменяется.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->