### PR TITLE
[BLUEMOON] Микроправки

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -249,6 +249,8 @@
 		CL.flags_inv = PCL.flags_inv
 		CL.mutantrace_variation = PCL.mutantrace_variation
 		CL.mob_overlay_icon = PCL.mob_overlay_icon
+		if(istype(CL, /obj/item/clothing/under) && istype(PCL, /obj/item/clothing/under))
+			CL:fitted = PCL:fitted
 		qdel(PCL)
 	chameleon_item.icon = initial(picked_item.icon)
 	chameleon_item.update_icon()

--- a/modular_bluemoon/code/game/objects/items/pet_bowl.dm
+++ b/modular_bluemoon/code/game/objects/items/pet_bowl.dm
@@ -164,7 +164,6 @@
 		empty_bowl()
 	else
 		if(!reagents?.has_reagent(/datum/reagent/consumable/nutriment))
-			cut_overlays()
 			var/datum/reagent/r = reagents.get_master_reagent()
 			name = "[initial(name)] of [replacetext(r.glass_name, "glass of ", "")]"
 	update_icon()

--- a/modular_bluemoon/code/modules/clothing/head/helmet.dm
+++ b/modular_bluemoon/code/modules/clothing/head/helmet.dm
@@ -52,7 +52,7 @@
 /obj/item/clothing/head/helmet/biker
 	name = "biker helmet"
 	desc = "A durable biker helmet. You suddenly get unusual subtle neon retrowave vibes with a smell of blood."
-	armor = list("melee" = 25, "bullet" = 10, "laser" = 30, "energy" = 30, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
 	icon = 'modular_bluemoon/icons/obj/clothing/hats.dmi'
 	mob_overlay_icon = 'modular_bluemoon/icons/mob/clothing/hats.dmi'
 	icon_state = "biker"


### PR DESCRIPTION
Правильное наследование альфа-маски (убирание лишнего пикселя с некоторых обличий хамелеон сьюта), подгон оверлеев миски для питомцев под новые алгротимы, перетасовка статов шлема байкера.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * При изменении внешнего вида хламелеонной одежды теперь корректно учитывается посадка предметов типа нижнего белья.
  * Внешний вид миски для питомца стабильнее обновляется при изменении содержимого.

* **Изменения баланса**
  * Скорректированы характеристики шлема байкера: повышена защита от ближнего боя, пуль и взрывов.
  * Снижена защита от лазеров, энергии и огня; добавлена защита от кислоты.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->