### PR TITLE
Правим тест

### DIFF
--- a/code/modules/unit_tests/perf_optimizations.dm
+++ b/code/modules/unit_tests/perf_optimizations.dm
@@ -1185,22 +1185,18 @@
 	bot.emagged = 2
 	bot.auto_patrol = FALSE
 	bot.on = TRUE
-	for(var/direction in GLOB.alldirs)
-		allocate(/obj/structure/window/reinforced/fulltile, get_step(bot, direction))
-	var/turf/first_target = locate(bot_turf.x + 2, bot_turf.y, bot_turf.z)
+	var/turf/first_target = locate(1, 1, bot_turf.z)
+	if(get_dist(bot_turf, first_target) <= BOT_TARGET_PATH_LIMIT)
+		first_target = locate(world.maxx, world.maxy, bot_turf.z)
 	var/turf/second_target = locate(bot_turf.x - 2, bot_turf.y, bot_turf.z)
+	TEST_ASSERT(get_dist(bot, first_target) > BOT_TARGET_PATH_LIMIT, "Sanity: the first floorbot target must exceed the JPS distance limit")
 	bot.target = first_target
 
 	var/jps_before = GLOB.ai_metrics.jps_requests
 	bot.handle_automated_action()
 	var/jps_after_failure = GLOB.ai_metrics.jps_requests
-	var/ring_windows = 0
-	for(var/direction in GLOB.alldirs)
-		var/obj/structure/window/ring_window = locate(/obj/structure/window) in get_step(bot, direction)
-		if(ring_window?.density)
-			ring_windows++
-	TEST_ASSERT_EQUAL(jps_after_failure, jps_before + 1, "The sealed floorbot fixture must execute one failed JPS request (mode=[bot.mode], on=[bot.on], target=[bot.target || "null"], path.len=[length(bot.path)], ring=[ring_windows]/8)")
-	TEST_ASSERT(bot.next_path_attempt > world.time, "A failed floorbot path must arm the autonomous retry cooldown (next_path_attempt=[bot.next_path_attempt], world.time=[world.time], mode=[bot.mode], target=[bot.target || "null"], path.len=[length(bot.path)], ring=[ring_windows]/8, jps_delta=[jps_after_failure - jps_before])")
+	TEST_ASSERT_EQUAL(jps_after_failure, jps_before + 1, "The out-of-range floorbot fixture must execute one failed JPS request (mode=[bot.mode], on=[bot.on], target=[bot.target || "null"], path.len=[length(bot.path)])")
+	TEST_ASSERT(bot.next_path_attempt > world.time, "A failed floorbot path must arm the autonomous retry cooldown (next_path_attempt=[bot.next_path_attempt], world.time=[world.time], mode=[bot.mode], target=[bot.target || "null"], path.len=[length(bot.path)], jps_delta=[jps_after_failure - jps_before])")
 
 	bot.handle_automated_action()
 	TEST_ASSERT_EQUAL(GLOB.ai_metrics.jps_requests, jps_after_failure, "The retry cooldown must suppress another JPS request")

--- a/code/modules/unit_tests/perf_optimizations.dm
+++ b/code/modules/unit_tests/perf_optimizations.dm
@@ -1142,42 +1142,37 @@
 
 	TEST_ASSERT_EQUAL(bot.scan_for_target(), mouse, "The indexed LOS branch must keep pest-over-cleanable priority")
 
+/obj/effect/decal/cleanable/ash/unit_test_path_target
+	turf_loc_check = FALSE
+
 /datum/unit_test/cleanbot_failed_path_search_has_cooldown/Run()
 	var/turf/bot_turf = locate(run_loc_floor_bottom_left.x + 2, run_loc_floor_bottom_left.y + 2, run_loc_floor_bottom_left.z)
 	var/mob/living/simple_animal/bot/cleanbot/bot = allocate(/mob/living/simple_animal/bot/cleanbot, bot_turf)
 	bot.toggle_ai(AI_OFF)
 	bot.auto_patrol = FALSE
 	bot.on = TRUE
-	// Transparent dense barriers: targets stay visible, JPS cannot step through.
-	for(var/direction in GLOB.alldirs)
-		allocate(/obj/structure/window/reinforced/fulltile, get_step(bot, direction))
-	var/obj/effect/decal/cleanable/ash/first_target = allocate(/obj/effect/decal/cleanable/ash, locate(bot_turf.x + 2, bot_turf.y, bot_turf.z))
+	var/turf/far_target_turf = locate(1, 1, bot_turf.z)
+	if(get_dist(bot_turf, far_target_turf) <= BOT_TARGET_PATH_LIMIT)
+		far_target_turf = locate(world.maxx, world.maxy, bot_turf.z)
+	var/obj/effect/decal/cleanable/ash/first_target = allocate(/obj/effect/decal/cleanable/ash/unit_test_path_target, far_target_turf)
 	var/obj/effect/decal/cleanable/ash/second_target = allocate(/obj/effect/decal/cleanable/ash, locate(bot_turf.x - 2, bot_turf.y, bot_turf.z))
 	bot.mode = BOT_IDLE
 	bot.path = list()
-	bot.target = first_target
 	TEST_ASSERT(!QDELETED(first_target) && isturf(first_target.loc), "Sanity: the cleanbot target must survive initialization on a turf")
-	TEST_ASSERT_NOTEQUAL(get_turf(bot), get_turf(first_target), "Sanity: the cleanbot target must require movement")
+	TEST_ASSERT(get_dist(bot, first_target) > BOT_TARGET_PATH_LIMIT, "Sanity: the first cleanbot target must exceed the JPS distance limit")
+	TEST_ASSERT_EQUAL(bot.scan_for_target(), second_target, "Sanity: the retry target must remain visible to autonomous scanning")
+	bot.target = first_target
 
 	var/jps_before = GLOB.ai_metrics.jps_requests
 	bot.handle_automated_action()
 	var/jps_after_failure = GLOB.ai_metrics.jps_requests
-	var/ring_windows = 0
-	for(var/direction in GLOB.alldirs)
-		var/obj/structure/window/ring_window = locate(/obj/structure/window) in get_step(bot, direction)
-		if(ring_window?.density)
-			ring_windows++
-	TEST_ASSERT_EQUAL(jps_after_failure, jps_before + 1, "The sealed cleanbot fixture must execute one failed JPS request (mode=[bot.mode], on=[bot.on], target=[bot.target || "null"], path.len=[length(bot.path)], ring=[ring_windows]/8)")
-	TEST_ASSERT(bot.next_path_attempt > world.time, "A failed cleanbot path must arm the autonomous retry cooldown (next_path_attempt=[bot.next_path_attempt], world.time=[world.time], mode=[bot.mode], target=[bot.target || "null"], path.len=[length(bot.path)], ring=[ring_windows]/8, jps_delta=[jps_after_failure - jps_before])")
+	TEST_ASSERT_EQUAL(jps_after_failure, jps_before + 1, "The out-of-range cleanbot fixture must execute one failed JPS request (mode=[bot.mode], on=[bot.on], target=[bot.target || "null"], path.len=[length(bot.path)])")
+	TEST_ASSERT(bot.next_path_attempt > world.time, "A failed cleanbot path must arm the autonomous retry cooldown (next_path_attempt=[bot.next_path_attempt], world.time=[world.time], mode=[bot.mode], target=[bot.target || "null"], path.len=[length(bot.path)], jps_delta=[jps_after_failure - jps_before])")
 
 	bot.handle_automated_action()
 	TEST_ASSERT_EQUAL(GLOB.ai_metrics.jps_requests, jps_after_failure, "The retry cooldown must suppress another cleanbot JPS request")
 
-	// Force another unreachable target after the cooldown: do not depend on scan/ignore_list.
 	bot.next_path_attempt = world.time
-	bot.ignore_list = list()
-	bot.path = list()
-	bot.target = second_target
 	bot.handle_automated_action()
 	TEST_ASSERT_EQUAL(GLOB.ai_metrics.jps_requests, jps_after_failure + 1, "Cleanbot must retry autonomous targets after the cooldown expires")
 


### PR DESCRIPTION
# Описание

Исправляет нестабильность `cleanbot_failed_path_search_has_cooldown`: первый поиск пути теперь гарантированно завершается отказом по лимиту дистанции и ставит cooldown, после чего клинбот самостоятельно находит близкую цель и повторяет JPS.

Изменение ограничено тестовым fixture; игровая логика не менялась.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Причина изменений

В PR #3612 отдельный тест на master падал в map jobs, поскольку его результат зависел от геометрии карты и проходимости окон. Из-за этого исправная логика cooldown проверялась нестабильно.

## Changelog

:cl:
code: Стабилизированы тесты повторного поиска пути клинбота и флорбота
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Тесты**
  * Обновлены проверки отказоустойчивости поиска пути для Cleanbot и Floorbot на удалённых целях, превышающих установленный лимит.
  * Добавлена проверка обработки неудачного запроса: установка задержки и подавление повторных запросов до её завершения.
  * Сохранена проверка успешной повторной попытки после сброса задержки.
  * Добавлена тестовая цель для стабильного воспроизведения сценария с удалённой клеткой.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->