### PR TITLE
armblade upgrd

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -127,13 +127,16 @@
 	user.do_attack_animation(O)
 	O.attacked_by(src, user)
 	if(force >= 20)
-		shake_camera(user, ((force - 15) * 0.01 + 1), ((force - 15) * 0.01))
+		shake_camera(user, (min(0.75, (force - 15) * 0.01) + 1), (min(0.75, (force - 15) * 0.01)))
+
+/obj/item/proc/get_damage_to_obj(obj/O, mob/living/user)
+	return force
 
 /atom/movable/proc/attacked_by()
 	return
 
 /obj/attacked_by(obj/item/I, mob/living/user, attackchain_flags = NONE, damage_multiplier = 1)
-	var/totitemdamage = I.force * damage_multiplier
+	var/totitemdamage = I.get_damage_to_obj(src, user) * damage_multiplier
 
 	if(I.used_skills && user.mind)
 		if(totitemdamage)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1238,9 +1238,8 @@
 			to_chat(user, "<span class='warning'>It's welded, it won't budge!</span>")
 			return
 
-		var/time_to_open = 5
 		if(hasPower() && !prying_so_hard)
-			time_to_open = 50
+			var/time_to_open = 5 SECONDS
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg',100,1) //is it aliens or just the CE being a dick?
 			prying_so_hard = TRUE
 			if(do_after(user, time_to_open,target = src))

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -737,6 +737,7 @@
 	item_flags = ABSTRACT
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = SHARP_EDGED
+	tool_behaviour = TOOL_CROWBAR
 	wound_bonus = -20
 	bare_wound_bonus = 25
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
@@ -750,6 +751,7 @@
 	name = "unholy blessing"
 	icon_state = "tentacle"
 	item_state = "tentacle"
+	tool_behaviour = NONE
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -98,6 +98,8 @@
 	attack_verb = list("attacked", "impaled", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_EDGED
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
+	tool_behaviour = TOOL_CROWBAR
+	can_force_powered = TRUE
 
 /obj/item/melee/synthetic_arm_blade/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -196,7 +196,7 @@
 	return FALSE
 
 /turf/open/floor/crowbar_act(mob/living/user, obj/item/I)
-	return intact ? FORCE_BOOLEAN(pry_tile(I, user)) : FALSE
+	return (intact && user.a_intent == INTENT_HELP) ? FORCE_BOOLEAN(pry_tile(I, user)) : FALSE
 
 /turf/open/floor/proc/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	if(T.turf_type == type)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -174,6 +174,8 @@
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
+	tool_behaviour = TOOL_CROWBAR
+	can_force_powered = TRUE
 	force = 35
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
@@ -208,26 +210,6 @@
 	else if(istype(target, /obj/machinery/computer))
 		var/obj/machinery/computer/C = target
 		C.attack_alien(user) //muh copypasta
-
-	else if(istype(target, /obj/machinery/door/airlock))
-		var/obj/machinery/door/airlock/A = target
-
-		if(!A.requiresID() || A.allowed(user)) //This is to prevent stupid shit like hitting a door with an arm blade, the door opening because you have acces and still getting a "the airlocks motors resist our efforts to force it" message.
-			return
-		if(A.locked)
-			to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
-			return
-
-		if(A.hasPower())
-			user.visible_message("<span class='warning'>[user] jams [src] into the airlock and starts prying it open!</span>", "<span class='warning'>We start forcing [src] open.</span>", \
-			"<span class='italics'>You hear a metal screeching sound.</span>")
-			playsound(A, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
-			if(!do_after(user, 100, target = A))
-				return
-		//user.say("Heeeeeeeeeerrre's Johnny!")
-		user.visible_message("<span class='warning'>[user] forces the airlock to open with [user.ru_ego()] [src]!</span>", "<span class='warning'>We force [src] to open.</span>", \
-		"<span class='italics'>You hear a metal screeching sound.</span>")
-		A.open(2)
 
 /obj/item/melee/arm_blade/dropped(mob/user)
 	..()

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -131,6 +131,7 @@
 	desc = "A grotesque mass of flesh that used to be your arm. Although it looks dangerous at first, you can tell it's actually quite dull and useless."
 	force = 5 //Basically as strong as a punch
 	fake = TRUE
+	tool_behaviour = NONE
 
 /datum/action/changeling/sting/false_armblade/can_sting(mob/user, mob/target)
 	if(!..())

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -180,12 +180,18 @@
 	item_state = "arm_blade"
 	force = 30
 	armour_penetration = 25
+	stuttering = 5
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL
+	resistance_flags = FIRE_PROOF | ON_FIRE | UNACIDABLE | ACID_PROOF
 	w_class = WEIGHT_CLASS_HUGE
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_EDGED
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
+	tool_behaviour = TOOL_CROWBAR
+	can_force_powered = TRUE
 
 /obj/item/light_eater/Initialize(mapload)
 	. = ..()
@@ -219,20 +225,23 @@
 					disintegrate(O)
 		if(L.pulling && L.pulling.light_range && isitem(L.pulling))
 			disintegrate(L.pulling)
-	else if(isitem(AM))
-		var/obj/item/I = AM
-		if(I.light_range && I.light_power)
-			disintegrate(I)
-	else if (isstructure(AM))
-		var/obj/structure/S = AM
-		if(istype(S, /obj/structure/glowshroom) || istype(S, /obj/structure/marker_beacon))
-			qdel(S)
-			visible_message("<span class='danger'>[S] is disintegrated by [src]!</span>")
-	else if(AM.light_range && AM.light_power  && !(istype(AM, /obj/machinery/power/apc) || istype(AM, /obj/machinery/airalarm)))
-		var/obj/target_object = AM
-		target_object.take_damage(force * 5, BRUTE, MELEE, 0)
+	else if(istype(AM, /obj/structure/glowshroom) || istype(AM, /obj/structure/marker_beacon))
+		qdel(AM)
+		visible_message(span_danger("[AM] is disintegrated by [src]!</span>"))
+	else if(isitem(AM) && AM.light_range && AM.light_power)
+		disintegrate(AM)
+		return
 
-
+/obj/item/light_eater/get_damage_to_obj(obj/O, mob/living/user)
+	. = ..()
+	var/damage_multiplier = 3.5
+	if(istype(O, /obj/machinery/power/apc) || istype(O, /obj/machinery/airalarm))
+		damage_multiplier = 2.5
+	else if(O.light_range && O.light_power)
+		damage_multiplier = 5
+	
+	. *= damage_multiplier
+	
 /obj/item/light_eater/proc/disintegrate(obj/item/O)
 	if(istype(O, /obj/item/modular_computer/pda))
 		var/obj/item/modular_computer/pda/PDA = O

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -770,7 +770,7 @@
 	qdel(src)
 
 /obj/machinery/light/attacked_by(obj/item/I, mob/living/user, attackchain_flags = NONE, damage_multiplier = 1)
-	..()
+	. = ..()
 	if(status == LIGHT_BROKEN || status == LIGHT_EMPTY)
 		if(on && (I.flags_1 & CONDUCT_1))
 			if(prob(12))

--- a/modular_bluemoon/code/modules/clothing/nanosuit/nanosuit.dm
+++ b/modular_bluemoon/code/modules/clothing/nanosuit/nanosuit.dm
@@ -1119,14 +1119,12 @@
 /obj/attack_nanosuit(mob/living/carbon/human/user, does_attack_animation = FALSE)
 	return attack_heavy_melee(user, does_attack_animation)
 
-/obj/attacked_by(obj/item/I, mob/living/user)
-	if(I.force && I.damtype == BRUTE && ishuman(user))
+/obj/item/get_damage_to_obj(obj/O, mob/living/user)
+	. = ..()
+	if(. && damtype == BRUTE && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.mind?.has_martialart(MARTIALART_NANOSUIT) || H.has_heavy_melee())
-			visible_message(span_danger("[H] бьёт [src] с невероятной силой при помощи [I.name]!") , null, null, COMBAT_MESSAGE_RANGE)
-			take_damage(I.force*1.75, I.damtype, "melee", TRUE)//take 75% more damage with strength on
-			return
-	return ..()
+			. *= 1.75
 
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, quickstart = TRUE, params)
 	if(thrower && ishuman(thrower))


### PR DESCRIPTION


# Описание
1. Все армблейды получили статус лома и возможность открывать двери (кроме нулрода и фейкового)
2. Снять пол ломом теперь можно только в хелп интенте (Чтобы во время файта не уничтожать плитку)
3. Поставлен кап тряски камеры при мили атаках
4. Урон по объектам у кошмара увеличен

## Причина изменений
Попросили улучшить найтмара, но нет моральных сил кодить что-то еще

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Все армблейды получили статус лома и возможность открывать двери (кроме нулрода и фейкового)
balence:  Урон по объектам у кошмара увеличен
qol: Снять пол ломом теперь можно только в хелп интенте (Чтобы во время файта не уничтожать плитку)
qol: Поставлен кап тряски камеры при мили атаках
/:cl:
