### PR TITLE
Фикс фейк проектора 

### DIFF
--- a/modular_bluemoon/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/modular_bluemoon/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -47,6 +47,7 @@
 	. += projection
 
 /obj/effect/projector/skyscraper
+	anchored = TRUE
 	color = null
 	projection_icon = 'modular_bluemoon/icons/projection/skyscraper_width.dmi'
 	projection_icon_state = "window"


### PR DESCRIPTION
# Описание
оказывается всё это время у него не было привязки к полу
но сколько он невидимый его нельзя было взять, а с телекинезом можно

## Причина изменений
тк теперь не может швырять бэкграунд инфинити дорм
## Демонстрация изменений
:cl:
fix: Взаимодействие телекинеза с фейковыми проекторами бэкграунда бесконечного отеля
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Проектор небоскрёба теперь надёжно зафиксирован на месте и не перемещается.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->