### PR TITLE
Reagent holder change

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -42,9 +42,9 @@
 #define REAGENT_VALUE_AMAZING		15	//reserved ONLY for non-mass produceable, unsynthetizable reagents.
 #define REAGENT_VALUE_GLORIOUS		150	//reagents that shouldn't be possible to get or farm under normal conditions. e.g. Romerol, fungal TB, adminordrazine...
 
-#define TOUCH			1	// splashing
+#define TOUCH			1	// splashing, foam
 #define INGEST			2	// ingestion
-#define VAPOR			3	// foam, spray, blob attack
+#define VAPOR			3	// cryo, spray, blob attack
 #define PATCH			4	// patches
 #define INJECT			5	// injection
 

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -183,7 +183,7 @@
 				var/turf/T = O.loc
 				if(T.intact && O.level == 1) //hidden under the floor
 					continue
-			reagents.reaction(O, VAPOR, fraction)
+			reagents.reaction(O, TOUCH, fraction)
 	var/hit = 0
 	if(foam_turf)
 		for(var/mob/living/L in foam_turf)
@@ -191,7 +191,7 @@
 	if(hit)
 		lifetime += tick_multiplier //this is so the decrease from mobs hit and the natural decrease don't cumulate.
 	if(lifetime % reagent_divisor)
-		reagents.reaction(foam_turf, VAPOR, fraction)
+		reagents.reaction(foam_turf, TOUCH, fraction)
 
 	if(--amount < 0)
 		// Разлив закончен: пена больше не спредится, дотикивать жизнь и травить
@@ -212,7 +212,7 @@
 		return FALSE
 	var/fraction = tick_multiplier/initial(reagent_divisor)
 	if(lifetime % reagent_divisor)
-		reagents.reaction(L, VAPOR, fraction)
+		reagents.reaction(L, TOUCH, fraction)
 	lifetime -= tick_multiplier
 	return TRUE
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -408,7 +408,7 @@
 			reagent.on_mob_metabolize(owner)
 		if(can_overdose)
 			if(reagent.overdose_threshold)
-				if(reagent.volume >= reagent.overdose_threshold && !reagent.overdosed)
+				if(reagent.volume > reagent.overdose_threshold && !reagent.overdosed)
 					reagent.overdosed = TRUE
 					need_mob_update += reagent.overdose_start(owner)
 					log_game("[key_name(owner)] has started overdosing on [reagent.name] at [reagent.volume] units.")

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -428,7 +428,9 @@
 			if(reagent.overdosed)
 				need_mob_update += reagent.overdose_process(owner, delta_time, times_fired)
 
-		need_mob_update += reagent.on_mob_life(owner, delta_time, times_fired)
+		if(!reagent.overdosed)
+			need_mob_update += reagent.on_mob_life(owner, delta_time, times_fired)
+			
 	return need_mob_update
 
 /// Signals that metabolization has stopped, triggering the end of trait-based effects


### PR DESCRIPTION
# Описание
- Выключает обычный метаболизм у реагентов, при передозировке
- Изменен тип ввода у пены с VAPOR на TOUCH. Решает проблему ввода любых реагентов через прикосновение к пене (Пена она снаружи персонажей, а не внутри емае)

ТЕСТМЕРЖ ДЛЯ ПРОВЕРКИ РАБОТЫ
## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
balance: Выключает обычный метаболизм у реагентов, при передозировке
fix: Изменен тип ввода у пены с VAPOR на TOUCH
/:cl:
