### PR TITLE
Sleeper tooltip & hot pepper & code work

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -99,6 +99,8 @@
 	}\
 }
 
+/* МЫ НЕ ИСПОЛЬЗУЕМ ЭТИ ДЕФАЙНЫ
+При успешной или не успешной инициализации и т.д. вызывайте return ..()
 //! ### SS initialization hints
 /**
  * Negative values incidate a failure or warning of some kind, positive are good.
@@ -116,6 +118,7 @@
 
 /// Successful, but don't print anything. Useful if subsystem was disabled.
 #define SS_INIT_NO_NEED 3
+*/
 
 //! ### SS initialization load orders
 // Subsystem init_order, from highest priority to lowest priority

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -198,7 +198,9 @@
 		var/chem_name = R.name
 		if(istype(R, /datum/reagent/medicine/salglu_solution))
 			chem_name = "Saline-Glucose"
-		data["chems"] += list(list("name" = chem_name, "id" = R.type, "allowed" = chem_allowed(chem)))
+		data["chems"] += list(list("name" = chem_name, "id" = R.type, "allowed" = chem_allowed(chem),
+									"overdose_threshold" = R.overdose_threshold ? R.overdose_threshold : null,
+									"addiction_threshold" = R.addiction_threshold ? R.addiction_threshold : null))
 
 	data["occupant"] = list()
 	var/mob/living/mob_occupant = occupant

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -181,6 +181,15 @@ GLOBAL_LIST_EMPTY(ghost_records)
 	///Weakref to our controller
 	var/datum/weakref/control_computer_weakref
 
+/obj/machinery/cryopod/tele
+	name = "CentCom Teleporter"
+	desc = "Suited for everyone who wishes to leave the station and go back to CentCom.\n<span class='notice'>This is not for actually getting into CentCom, you will leave the round.</span>"
+	icon = 'modular_sand/icons/obj/machines/cent-tele.dmi'
+	tele = TRUE
+
+	on_store_message = "has been teleported to CentCom."
+	on_store_name = "Teleporter Oversight"
+
 /obj/machinery/cryopod/Initialize(mapload)
 	..()
 	set_is_operational(!(machine_stat & (BROKEN|MAINT)))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -168,6 +168,7 @@ GLOBAL_LIST_EMPTY(ghost_records)
 	max_integrity = 500
 	armor = list(MELEE = 10, BULLET = 60, LASER = 60, ENERGY = 60, BOMB = 30, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	flags_1 = NODECONSTRUCT_1
+	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE | INTERACT_MACHINE_OFFLINE
 
 	var/tele = FALSE
 
@@ -182,6 +183,7 @@ GLOBAL_LIST_EMPTY(ghost_records)
 
 /obj/machinery/cryopod/Initialize(mapload)
 	..()
+	set_is_operational(!(machine_stat & (BROKEN|MAINT)))
 	return INITIALIZE_HINT_LATELOAD //Gotta populate the cryopod computer GLOB first
 
 /obj/machinery/cryopod/LateInitialize()
@@ -192,6 +194,14 @@ GLOBAL_LIST_EMPTY(ghost_records)
 /obj/machinery/cryopod/Destroy()
 	control_computer_weakref = null
 	return ..()
+
+/obj/machinery/cryopod/is_operational()
+	return !(machine_stat & (BROKEN|MAINT))
+
+/obj/machinery/cryopod/on_stat_update(old_value)
+	set_is_operational(!(machine_stat & (BROKEN|MAINT)))
+	if(machine_sleeping)
+		update_sleep_static_power()
 
 /obj/machinery/cryopod/close_machine(atom/movable/target)
 	if(!control_computer_weakref)

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -302,7 +302,7 @@
 	desc = "HOT! HOT!"
 	icon_state = "fivealarmburger"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 5)
-	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/capsaicin = 5, /datum/reagent/consumable/condensedcapsaicin = 5, /datum/reagent/consumable/nutriment/vitamin = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/capsaicin = 5, /datum/reagent/consumable/capsaicin/reaper = 5, /datum/reagent/consumable/nutriment/vitamin = 1)
 	foodtype = GRAIN | MEAT
 
 /obj/item/reagent_containers/food/snacks/burger/rat

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -68,7 +68,7 @@
 	yield = 3
 	rarity = 20
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.3, /datum/reagent/consumable/capsaicin = 0.55, /datum/reagent/consumable/nutriment = 0.04)
+	reagents_add = list(/datum/reagent/consumable/capsaicin/reaper = 0.3, /datum/reagent/consumable/capsaicin = 0.55, /datum/reagent/consumable/nutriment = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/ghost_chili
 	seed = /obj/item/seeds/chili/ghost

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -257,8 +257,8 @@
 		if(M.getBruteLoss() && prob(20))
 			M.heal_bodypart_damage(1,0, 0)
 			. = 1
-	if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
-		holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2)
+	holder.remove_reagent(/datum/reagent/consumable/capsaicin, 2)
+	holder.remove_reagent(/datum/reagent/consumable/capsaicin/reaper, 2)
 	if(iscatperson(M)) //cats go purr
 		if(prob(3))
 			to_chat(M, "<span class = 'notice'>[pick("Mmmm~ milk~","Ahh~ fresh milk~","Milk is so tasty!")]</span>")
@@ -783,6 +783,8 @@
 
 /datum/reagent/consumable/ice/on_mob_life(mob/living/carbon/M)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
+	holder.remove_reagent(/datum/reagent/consumable/capsaicin, 1)
+	holder.remove_reagent(/datum/reagent/consumable/capsaicin/reaper, 1)
 	..()
 
 /datum/reagent/consumable/soy_latte

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -252,15 +252,15 @@
 	description = "This is what makes chilis hot."
 	color = "#B31008" // rgb: 179, 16, 8
 	taste_description = "hot peppers"
-	taste_mult = 1.5
+	taste_mult = 4.5
+	var/safe_heating = TRUE
 
 /datum/reagent/consumable/capsaicin/on_mob_life(mob/living/carbon/M)
 	var/heating = 0
 	switch(current_cycle)
 		if(1 to 15)
 			heating = 5 * TEMPERATURE_DAMAGE_COEFFICIENT
-			if(holder.has_reagent(/datum/reagent/cryostylane))
-				holder.remove_reagent(/datum/reagent/cryostylane, 5)
+			holder.remove_reagent(/datum/reagent/cryostylane, 5)
 			if(isslime(M))
 				heating = rand(5,20)
 		if(15 to 25)
@@ -275,8 +275,27 @@
 			heating = 20 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(isslime(M))
 				heating = rand(20,25)
-	M.adjust_bodytemperature(heating)
+	if(safe_heating)
+		M.adjust_bodytemperature(heating, max_temp = BODYTEMP_HEAT_DAMAGE_LIMIT)
+	else
+		M.adjust_bodytemperature(heating)
+		if(prob(8))
+			M.blur_eyes(3)
+			to_chat(M, span_warning(pick("Язык жжет огнем!", "Мой рот в огне!", "ОЧЕНЬ остро!")))
 	..()
+
+/datum/reagent/consumable/capsaicin/reaper
+	name = "Reaper Capsaicin Oil"
+	description = "The spiciest thing you can eat, your tongue will experience hell."
+	color = "#a60800"
+	taste_description = "very, VERY HOT"
+	taste_mult = 10
+	safe_heating = FALSE
+
+/datum/reagent/consumable/capsaicin/reaper/on_mob_metabolize(mob/living/L)
+	. = ..()
+	L.adjust_bodytemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT)
+	to_chat(L, span_warning("Вы чувствуете нестерпимое жжение на языке, ОЧЕНЬ ОСТРО!"))
 
 /datum/reagent/consumable/frostoil
 	name = "Frost Oil"
@@ -291,8 +310,7 @@
 	switch(current_cycle)
 		if(1 to 15)
 			cooling = -10 * TEMPERATURE_DAMAGE_COEFFICIENT
-			if(holder.has_reagent(/datum/reagent/consumable/capsaicin))
-				holder.remove_reagent(/datum/reagent/consumable/capsaicin, 5)
+			holder.remove_reagent(/datum/reagent/consumable/capsaicin, 5)
 			if(isslime(M))
 				cooling = -rand(5,20)
 		if(15 to 25)

--- a/modular_bluemoon/code/controllers/subsystem/hilbertshotel.dm
+++ b/modular_bluemoon/code/controllers/subsystem/hilbertshotel.dm
@@ -26,15 +26,14 @@ SUBSYSTEM_DEF(hilbertshotel)
 	var/hhMysteryroom_number
 
 /datum/controller/subsystem/hilbertshotel/Initialize()
-	. = ..()
 	if(!CONFIG_GET(flag/hilbertshotel_enabled))
-		return SS_INIT_NO_NEED
+		return ..()
 	//RegisterSignal(src, COMSIG_HILBERT_ROOM_UPDATED, PROC_REF(on_room_updated))
 	hhMysteryroom_number = hhMysteryroom_number || rand(1, 999999)
 	prepare_rooms()
 	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(roundtype_check))
 
-	return SS_INIT_SUCCESS
+	return ..()
 
 /// Прок для проверки режима игры и действий со сферой при условии того или иного режима
 /datum/controller/subsystem/hilbertshotel/proc/roundtype_check()

--- a/modular_bluemoon/code/controllers/subsystem/metadollars.dm
+++ b/modular_bluemoon/code/controllers/subsystem/metadollars.dm
@@ -24,13 +24,12 @@ SUBSYSTEM_DEF(metadollars)
 	return parts[parts.len - 1]
 
 /datum/controller/subsystem/metadollars/Initialize()
-	. = ..()
 	prep_metadollar_leaderboard()
 	var/recovered = recover_all_legacy_balances()
 	if(recovered)
 		log_world("Metadollars: restored legacy balances for [recovered] player(s) from preferences.sav backups.")
 	RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(round_begin_reset))
-	return SS_INIT_SUCCESS
+	return ..()
 
 /datum/controller/subsystem/metadollars/proc/round_begin_reset()
 	SIGNAL_HANDLER

--- a/modular_bluemoon/code/modules/decay_subsystem/decaySS.dm
+++ b/modular_bluemoon/code/modules/decay_subsystem/decaySS.dm
@@ -25,16 +25,15 @@ SUBSYSTEM_DEF(decay)
 	var/static/list/activation_chances = list(10, 32, 53, 75, 50)
 
 /datum/controller/subsystem/decay/Initialize()
-	. = ..()
 	if(CONFIG_GET(flag/ssdecay_disabled))
 		message_admins("SSDecay was disabled in config.")
 		log_world("SSDecay was disabled in config.")
-		return SS_INIT_NO_NEED
+		return ..()
 
 	if(SSmapping.config.map_name in station_filter)
 		message_admins("SSDecay was disabled due to map filter.")
 		log_world("SSDecay was disabled due to map filter.")
-		return SS_INIT_NO_NEED
+		return ..()
 
 	var/configured_intensity = CONFIG_GET(number/ssdecay_intensity)
 	configured_intensity = clamp(configured_intensity || 5, 1, 5)
@@ -43,7 +42,7 @@ SUBSYSTEM_DEF(decay)
 	if(!prob(activation_chance))
 		message_admins("SSDecay did not activate this round (rolled against [activation_chance]% chance for intensity [configured_intensity]).")
 		log_world("SSDecay did not activate this round (rolled against [activation_chance]% chance for intensity [configured_intensity]).")
-		return SS_INIT_NO_NEED
+		return ..()
 
 	for(var/area/iterating_area as anything in GLOB.all_areas)
 		if(!is_station_level(iterating_area.z))
@@ -59,7 +58,7 @@ SUBSYSTEM_DEF(decay)
 	if(!length(possible_turfs))
 		message_admins("SSDecay had no possible turfs to use.")
 		log_world("SSDecay had no possible turfs to use.")
-		return SS_INIT_NO_NEED
+		return ..()
 
 	severity_modifier = configured_intensity
 	if(severity_modifier == 5)
@@ -71,7 +70,7 @@ SUBSYSTEM_DEF(decay)
 	do_common()
 	do_maintenance()
 
-	return SS_INIT_SUCCESS
+	return ..()
 
 /// Structural decay across the station — rusted walls and missing floor tiles.
 /datum/controller/subsystem/decay/proc/do_common()

--- a/modular_bluemoon/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/modular_bluemoon/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -19,7 +19,7 @@
 		/datum/reagent/consumable/nutriment = 1,
 		/datum/reagent/consumable/sugar = 3,
 		/datum/reagent/consumable/capsaicin = 2,
-		/datum/reagent/consumable/condensedcapsaicin = 5,
+		/datum/reagent/consumable/capsaicin/reaper = 5,
 		/datum/reagent/consumable/tearjuice = 4,
 	)
 	tastes = list("candy" = 1, "hot" = 2, "bitterness" = 1)

--- a/modular_bluemoon/code/modules/lobby/lobby_subsystem.dm
+++ b/modular_bluemoon/code/modules/lobby/lobby_subsystem.dm
@@ -62,8 +62,7 @@ SUBSYSTEM_DEF(title_bm)
 
 	_build_static_html()
 
-	initialized = TRUE
-	return SS_INIT_SUCCESS
+	return ..()
 
 /datum/controller/subsystem/title_bm/Destroy()
 	UnregisterSignal(SSticker, list(COMSIG_TICKER_ENTER_PREGAME, COMSIG_TICKER_ENTER_SETTING_UP))

--- a/modular_sand/code/game/machinery/cryopod.dm
+++ b/modular_sand/code/game/machinery/cryopod.dm
@@ -1,9 +1,0 @@
-//Teleporters themselves. Also holy crap, what a code crunch i did on this!
-/obj/machinery/cryopod/tele
-	name = "CentCom Teleporter"
-	desc = "Suited for everyone who wishes to leave the station and go back to CentCom.\n<span class='notice'>This is not for actually getting into CentCom, you will leave the round.</span>"
-	icon = 'modular_sand/icons/obj/machines/cent-tele.dmi'
-	tele = TRUE
-
-	on_store_message = "has been teleported to CentCom."
-	on_store_name = "Teleporter Oversight"

--- a/modular_splurt/code/modules/client/genital_fluids.dm
+++ b/modular_splurt/code/modules/client/genital_fluids.dm
@@ -387,6 +387,7 @@
 
 		// Increases temperature
 		/datum/reagent/consumable/capsaicin,
+		/datum/reagent/consumable/capsaicin/reaper,
 
 		// Reduces temperature
 		/datum/reagent/consumable/frostoil,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5435,7 +5435,6 @@
 #include "modular_sand\code\game\area\areas\shuttles.dm"
 #include "modular_sand\code\game\area\areas\ruins\lavaland.dm"
 #include "modular_sand\code\game\machinery\autodoc.dm"
-#include "modular_sand\code\game\machinery\cryopod.dm"
 #include "modular_sand\code\game\machinery\cryptominers.dm"
 #include "modular_sand\code\game\machinery\Sleeper.dm"
 #include "modular_sand\code\game\machinery\computer\arcade\tetris.dm"

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -109,9 +109,9 @@ export const Sleeper = (props) => {
               icon={chem.overdose_threshold || chem.addiction_threshold ? 'triangle-exclamation' : 'flask'}
               iconColor={chem.overdose_threshold ? 'bad' : chem.addiction_threshold ? 'warning' : null}
               tooltip={[
-                chem.overdose_threshold && `Передозировка: ${chem.overdose_threshold} юнитов.`,
-                chem.addiction_threshold && `Зависимость: ${chem.addiction_threshold} юнитов.`,
-              ].filter(Boolean).join('\n')}
+                chem.overdose_threshold && `Передозировка: ${chem.overdose_threshold}u`,
+                chem.addiction_threshold && `Зависимость: ${chem.addiction_threshold}u`,
+              ].filter(Boolean).join(' | ')}
               content={chem.name}
               disabled={!occupied || !chem.allowed}
               width="140px"

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -107,7 +107,6 @@ export const Sleeper = (props) => {
             <Button
               key={chem.name}
               icon={chem.overdose_threshold || chem.addiction_threshold ? 'triangle-exclamation' : 'flask'}
-              iconColor={chem.overdose_threshold || chem.addiction_threshold ? 'warning' : null}
               tooltip={[
                 chem.overdose_threshold && `Передозировка: ${chem.overdose_threshold}u`,
                 chem.addiction_threshold && `Зависимость: ${chem.addiction_threshold}u`,

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -106,7 +106,12 @@ export const Sleeper = (props) => {
           {chems.map(chem => (
             <Button
               key={chem.name}
-              icon="flask"
+              icon={chem.overdose_threshold || chem.addiction_threshold ? 'triangle-exclamation' : 'flask'}
+              iconColor={chem.overdose_threshold ? 'bad' : chem.addiction_threshold ? 'warning' : null}
+              tooltip={[
+                chem.overdose_threshold && `Передозировка: ${chem.overdose_threshold} юнитов.`,
+                chem.addiction_threshold && `Зависимость: ${chem.addiction_threshold} юнитов.`,
+              ].filter(Boolean).join('\n')}
               content={chem.name}
               disabled={!occupied || !chem.allowed}
               width="140px"

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -107,7 +107,7 @@ export const Sleeper = (props) => {
             <Button
               key={chem.name}
               icon={chem.overdose_threshold || chem.addiction_threshold ? 'triangle-exclamation' : 'flask'}
-              iconColor={chem.overdose_threshold ? 'bad' : chem.addiction_threshold ? 'warning' : null}
+              iconColor={chem.overdose_threshold || chem.addiction_threshold ? 'warning' : null}
               tooltip={[
                 chem.overdose_threshold && `Передозировка: ${chem.overdose_threshold}u`,
                 chem.addiction_threshold && `Зависимость: ${chem.addiction_threshold}u`,


### PR DESCRIPTION
# Описание
- Добавил подсказку в слиппер для реагентов, если там есть передозировка или зависимость
- Сделал новый реагент для острой еды, т.к. перцовка улучшилась и теперь не пригодна для этого
- Лед теперь понемногу убирает острое
- Крио теперь работает и без питания (не включая консоль)
- Выпилил лишние дефайны подсистем, что мешали смотреть время их загрузки

## Демонстрация изменений
<img width="301" height="175" alt="image" src="https://github.com/user-attachments/assets/0a69f2c1-f020-404b-b722-cd485c6e6344" />


## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
add: Добавлена подсказка в слиппер для реагентов, если там есть передозировка или зависимость
add: Сделал новый реагент для острой еды, т.к. перцовка улучшилась и теперь не пригодна для этого
add: Лед теперь понемногу убирает острое
add: Крио теперь работает и без питания (не включая консоль)
code: Выпилил лишние дефайны подсистем, что мешали смотреть время их загрузки
/:cl:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * В интерфейсе слиперов отображаются предупреждения о передозировке и зависимостях препаратов.
  * Криоподы получили поддержку проводов, силиконовых пользователей и улучшенное управление рабочим состоянием.
  * Добавлен усиленный реагент «Капсаицин-Reaper» с новыми эффектами нагревания и метаболизма.

* **Изменения**
  * Рецепты острых блюд, семян и сладостей обновлены для использования нового реагента.
  * Молоко и лёд теперь эффективнее нейтрализуют обычный капсаицин и «Капсаицин-Reaper».
  * Удалён телепортирующий вариант криопода из соответствующей конфигурации.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->