### PR TITLE
Как всегда, чиним красный CI

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -20529,7 +20529,7 @@
 /turf/open/floor/mineral/abductor,
 /area/centcom/holding)
 "lnl" = (
-/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/centcom/holding/shootingrange)
 "lnq" = (
@@ -31407,14 +31407,6 @@
 /obj/structure/sign/flag/nri,
 /turf/closed/indestructible/fakeglass,
 /area/tdome/arena_source)
-"vHR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic,
-/turf/open/floor/plating,
-/area/centcom/holding)
 "vIM" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/effect/turf_decal/stripes/yellow/line,
@@ -58720,7 +58712,7 @@ pKy
 tbC
 fON
 fON
-vHR
+tYG
 iOM
 oom
 oom

--- a/modular_sand/code/datums/components/interaction_menu_granter.dm
+++ b/modular_sand/code/datums/components/interaction_menu_granter.dm
@@ -684,7 +684,10 @@
 		else
 			return "No"
 
-/datum/component/interaction_menu_granter/ui_act(action, params)
+/datum/component/interaction_menu_granter/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
 	return panel_ui_act(null, action, params)
 
 /datum/component/interaction_menu_granter/proc/panel_ui_act(datum/interaction_menu_panel/panel, action, params)
@@ -1150,7 +1153,10 @@
 		return list()
 	return granter.ui_static_data(user)
 
-/datum/interaction_menu_panel/ui_act(action, params)
+/datum/interaction_menu_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
 	if(QDELETED(granter))
 		return FALSE
 	return granter.panel_ui_act(src, action, params)

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -54,6 +54,10 @@ if grep -P '\W\/turf\s*[,\){]' _maps/**/*.dmm; then
     echo "ERROR: base /turf path use detected in maps, please replace with proper paths."
     st=1
 fi;
+if grep -P '^/obj/effect/spawner/structure/window/\S*electrochromatic,$' _maps/**/*.dmm; then
+    echo "ERROR: electrochromatic window spawner without electrochromatic_id detected in maps, it runtimes on every round start. Set the id or use the plain tinted spawner."
+    st=1
+fi;
 if grep -P '^/*var/' code/**/*.dm; then
     echo "ERROR: Unmanaged global var use detected in code, please use the helpers."
     st=1


### PR DESCRIPTION
# Описание

Чиню красный CI на мастере: 11 тайлов электрохромных окон в ЦК стояли без `electrochromatic_id` и сыпали рантаймами на старте любой карты, а два оверрайда `ui_act()` в панели интеракций не звали родителя и валили dreamchecker. Заодно `check_grep` научился ловить такой спавнер без id в линтерах.

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: Окна тира и кофейни на ЦК больше не сыпят ошибками при старте раунда, а средняя секция окна в кофейне тонируется кнопкой вместе с соседними.
code: Панель интеракций зовёт родителя в ui_act, dreamchecker снова чистый.
/:cl:
