### PR TITLE
Пытаемся исправить флаки тесты

### DIFF
--- a/code/modules/unit_tests/atmos_speed_lever.dm
+++ b/code/modules/unit_tests/atmos_speed_lever.dm
@@ -8,14 +8,20 @@
 /datum/unit_test/atmos_speed_lever/Run()
 	var/saved_speed = SSair.atmos_speed
 	var/saved_lag_scale = SSair.lag_scale
+	var/saved_saturation_scale = SSair.saturation_scale
 	var/saved_wait = SSair.wait
 	var/base_wait = initial(SSair.wait)
 
-	// Задыхающийся CI-раннер честно взводит лаг-клапан ДО теста (реальная
-	// дилатация SStime_track), и каденция при speed 1 читается уже придушенной -
-	// festive стабильно краснел именно так. Пороги клапана проверяются ниже
-	// через apply_lag_valve, здесь его состояние обязано быть нейтральным.
+	// Задыхающийся CI-раннер честно взводит клапаны ДО теста (реальная дилатация
+	// SStime_track и реально не влезающий в свой слот проход), и каденция при
+	// speed 1 читается уже придушенной - festive стабильно краснел именно так.
+	// Нейтрализовать обязательно ОБА: apply_atmos_cadence() берёт min(lag_scale,
+	// saturation_scale), поэтому одного лаг-клапана мало - в CI ловились ровно
+	// ступени клапана насыщения, 5/0.75 = 6.66667 и 5/0.5 = 10. Пороги клапанов
+	// проверяются ниже через apply_lag_valve, здесь их состояние обязано быть
+	// нейтральным.
 	SSair.lag_scale = 1
+	SSair.saturation_scale = 1
 
 	SSair.set_atmos_speed(1)
 	TEST_ASSERT_EQUAL(SSair.wait, base_wait, "speed 1 must leave the compiled cadence alone")
@@ -61,4 +67,5 @@
 
 	SSair.atmos_speed = saved_speed
 	SSair.lag_scale = saved_lag_scale
+	SSair.saturation_scale = saved_saturation_scale
 	SSair.wait = saved_wait

--- a/code/modules/unit_tests/nightshift.dm
+++ b/code/modules/unit_tests/nightshift.dm
@@ -779,6 +779,12 @@
 	// сама доводила состояние до правильного прямо перед тем, как его напечатать.
 	// Три сессии разбора смотрели на почищенную ею картину и потому не сходились.
 	parts += "light in APC cache: [(test_light in test_apc.cached_area_lights) ? "yes" : "NO"] (cache size [length(test_apc.cached_area_lights)], dirty=[test_apc.light_cache_dirty])"
+	// Питание области и состояние лампы: подпись "цвет застыл + световой датум мёртв"
+	// означает, что лампу погасили мимо ночной смены, и без этих полей неизвестно,
+	// кто именно - канал области, статус плафона или последовательность гашения.
+	parts += "area: requires_power=[test_area.requires_power] lightswitch=[test_area.lightswitch] power_light=[test_area.power_light]"
+	parts += "lamp: on=[test_light.on] status=[test_light.status] loss_stage=[test_light.power_loss_stage] emergency=[test_light.emergency_mode] switchcount=[test_light.switchcount] datum=[test_light.light ? "жив" : "МЁРТВ"]"
+	parts += "APC power: operating=[test_apc.operating] lighting=[test_apc.lighting] shorted=[test_apc.shorted] failure_timer=[test_apc.failure_timer]"
 	parts += "queues: apc=[length(GLOB.nightshift_apc_queue)] light=[length(GLOB.nightshift_light_queue)]"
 	parts += "light queued globally: [(test_light in GLOB.nightshift_light_queue) ? "yes" : "no"]"
 	parts += "SSnightshift: active=[SSnightshift.nightshift_active] can_fire=[SSnightshift.can_fire] refresh_running=[SSnightshift.nightshift_refresh_running]"
@@ -795,11 +801,14 @@
 	var/light_flag_at_check = test_light.nightshift_enabled
 	TEST_ASSERT_EQUAL(light_flag_at_check, expected_enabled, "[message_prefix] fixture nightshift flag should match the expected mode. Захвачено при сравнении: [light_flag_at_check], перечитано при отчёте: [test_light.nightshift_enabled], лампа [REF(test_light)]. [fixture_diagnostics()]")
 	TEST_ASSERT_EQUAL(test_light.nightshift_level, expected_level, "[message_prefix] fixture nightshift level should update immediately. [fixture_diagnostics()]")
-	TEST_ASSERT_EQUAL(lowertext(test_light.light_color), expected_color_value, "[message_prefix] fixture light color should update immediately.")
-	TEST_ASSERT_EQUAL(test_light.light_power, expected_power_value, "[message_prefix] fixture light power should update immediately.")
-	TEST_ASSERT(test_light.light, "[message_prefix] fixture should keep a live light datum.")
-	TEST_ASSERT_EQUAL(lowertext(test_light.light.light_color), expected_color_value, "[message_prefix] live emitted light color should update immediately.")
-	TEST_ASSERT_EQUAL(test_light.light.light_power, expected_power_value, "[message_prefix] live emitted light power should update immediately.")
+	// Диагностика и здесь: в CI (layenia, 2026-08-13) падали именно эти строки -
+	// цвет застыл на прошлом значении, световой датум мёртв, а флаги выше прошли.
+	// Без снимка питания такое падение неотличимо от застрявшей очереди.
+	TEST_ASSERT_EQUAL(lowertext(test_light.light_color), expected_color_value, "[message_prefix] fixture light color should update immediately. [fixture_diagnostics()]")
+	TEST_ASSERT_EQUAL(test_light.light_power, expected_power_value, "[message_prefix] fixture light power should update immediately. [fixture_diagnostics()]")
+	TEST_ASSERT(test_light.light, "[message_prefix] fixture should keep a live light datum. [fixture_diagnostics()]")
+	TEST_ASSERT_EQUAL(lowertext(test_light.light.light_color), expected_color_value, "[message_prefix] live emitted light color should update immediately. [fixture_diagnostics()]")
+	TEST_ASSERT_EQUAL(test_light.light.light_power, expected_power_value, "[message_prefix] live emitted light power should update immediately. [fixture_diagnostics()]")
 	var/list/current_overlays = test_light.update_overlays()
 	TEST_ASSERT(length(current_overlays) >= 2, "[message_prefix] lit fixtures should expose visible and emissive overlays.")
 	for(var/mutable_appearance/O as anything in current_overlays)

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -154,50 +154,76 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 	allocated += instance
 	return instance
 
-/// Сколько проходов SStimer ожидание обязано увидеть после того, как вышло окно по
-/// мировому времени. Мастер считает проход только за фактический незапаузенный
-/// прогон (master.dm, times_fired++ идёт после SS_PAUSED-ветки), поэтому счётчик
-/// стоит ровно тогда, когда подсистема не получает такта - а это и есть случай,
-/// в котором просроченный таймер не виноват.
-#define UNIT_TEST_WAIT_GRACE_FIRES 10
+/// Запас в тиках колеса бакетов сверх срока ожидания. Курсор, доехавший ровно до
+/// срока, гарантирует только то, что бакет вскрыт: колбек выдаётся через
+/// InvokeAsync и свою работу может доделывать уже следующим тиком.
+#define UNIT_TEST_WAIT_GRACE_TICKS 10
 /// Потолок ожидания по РЕАЛЬНОМУ времени, отсчитывается от конца окна: страховка
 /// от вечного цикла, если SStimer встал совсем. От конца, а не от начала, чтобы
 /// потолок никогда не подрезал само окно на медленном мировом времени. Потолок
 /// щедрый сознательно: на перегруженном CI-раннере SStimer может не получать
 /// тактов дольше 10 реальных секунд (наблюдалось на layeniastation), и жадный
-/// потолок валит тест раньше, чем grace-проходы успевают набежать. Платим этим
-/// временем только в двух случаях - мёртвый SStimer или задушенный раннер, и в
-/// обоих спешить некуда.
+/// потолок валит тест раньше, чем колесо доедет до срока. Платим этим временем
+/// только в двух случаях - мёртвый SStimer или задушенный раннер, и в обоих
+/// спешить некуда.
 #define UNIT_TEST_WAIT_HARD_LIMIT (60 SECONDS)
 
 #define WAIT_BUDGET_WORLD_DEADLINE 1
 #define WAIT_BUDGET_REAL_DEADLINE 2
-#define WAIT_BUDGET_TIMER_DEADLINE 3
+#define WAIT_BUDGET_TIMER_FIRES 3
 #define WAIT_BUDGET_DESCRIPTION 4
 
 /// Бюджет одного ожидания отложенной работы, см. wait_budget_tick().
 /datum/unit_test/proc/new_wait_budget(max_wait, description)
 	return list(world.time + max_wait, null, null, description)
 
+/// Мировое время, до которого колесо бакетов SStimer уже разобрано. Таймер,
+/// назначенный на более поздний момент, физически не мог сработать: его бакет ещё
+/// не вскрывали. Курсор считается от head_offset, потому что при отставании колеса
+/// он уходит в прошлое относительно world.time - именно эта разница и есть
+/// опоздание таймеров.
+/datum/unit_test/proc/timer_wheel_time()
+	return SStimer.head_offset + TICKS2DS(SStimer.practical_offset - 1)
+
+/// Снимок состояния колеса для сообщения о таймауте. ТОЛЬКО прямые чтения полей:
+/// спящая диагностика чинит то, что описывает, и уводит разбор в сторону
+/// (история флака nightshift_admin_controls).
+/datum/unit_test/proc/wait_budget_diagnostics(list/budget)
+	var/wheel = timer_wheel_time()
+	return "world.time [world.time], срок [budget[WAIT_BUDGET_WORLD_DEADLINE]], курсор колеса [wheel] \
+		(отставание [max(0, world.time - wheel)] дс), проходов SStimer за ожидание \
+		[SStimer.times_fired - budget[WAIT_BUDGET_TIMER_FIRES]], state [SStimer.state], \
+		бакетов [SStimer.bucket_count], second_queue [length(SStimer.second_queue)]"
+
 /// Спит тик и отвечает, остался ли бюджет ожидания. FALSE = сдаёмся.
 ///
-/// Окно меряется мировым временем, но истёкшее окно само по себе не приговор:
-/// на перегруженном раннере world.time продолжает идти, пока мастер режет очередь
-/// по тик-лимиту, так что назначенный внутри окна таймер может ни разу не получить
-/// шанса исполниться - и тест падает на загрузке машины, а не на баге. Поэтому
-/// после окна ждём ещё UNIT_TEST_WAIT_GRACE_FIRES полных проходов SStimer.
-/// Реальный баг от этого быстрее не чинится: на здоровом сервере эти проходы
-/// набегают за доли секунды.
+/// Окно меряется мировым временем, но истёкшее окно само по себе не приговор: на
+/// перегруженном раннере world.time продолжает идти, пока колесо таймеров ползёт
+/// позади него, так что назначенный внутри окна таймер может ни разу не получить
+/// шанса исполниться - и тест падает на загрузке машины, а не на баге.
+///
+/// Раньше запасом служили десять полных проходов SStimer, и это был неверный
+/// счётчик: МК считает проход только за незапаузенный прогон
+/// (master.dm, times_fired++ стоит после SS_PAUSED-ветки), а задушенный SStimer
+/// паузится каждый фаер - то есть счётчик замирает ровно в том случае, ради
+/// которого запас и вводился. В CI это выглядело как три теста подряд (pet_bonus,
+/// insane_clown, bee_pollination), сжигающих по 60 секунд потолка и падающих с
+/// "SStimer так и не набрал положенных полных проходов".
+///
+/// Честный признак - позиция курсора колеса: пока он не прошёл срок, бакет с нашей
+/// отложкой ещё не вскрывали, и падать не за что. Прошёл - работа была выдана, и
+/// невыполненное условие уже настоящий баг. Потолок по реальному времени остаётся
+/// страховкой на случай совсем вставшего SStimer.
 /datum/unit_test/proc/wait_budget_tick(list/budget)
 	if(world.time >= budget[WAIT_BUDGET_WORLD_DEADLINE])
-		if(isnull(budget[WAIT_BUDGET_TIMER_DEADLINE]))
-			budget[WAIT_BUDGET_TIMER_DEADLINE] = SStimer.times_fired + UNIT_TEST_WAIT_GRACE_FIRES
+		if(isnull(budget[WAIT_BUDGET_REAL_DEADLINE]))
 			budget[WAIT_BUDGET_REAL_DEADLINE] = REALTIMEOFDAY + UNIT_TEST_WAIT_HARD_LIMIT
-		else if(SStimer.times_fired >= budget[WAIT_BUDGET_TIMER_DEADLINE])
-			log_test("\tWAIT TIMEOUT: [budget[WAIT_BUDGET_DESCRIPTION]] - окно вышло, SStimer отработал положенные полные проходы")
+			budget[WAIT_BUDGET_TIMER_FIRES] = SStimer.times_fired
+		else if(timer_wheel_time() > budget[WAIT_BUDGET_WORLD_DEADLINE] + TICKS2DS(UNIT_TEST_WAIT_GRACE_TICKS))
+			log_test("\tWAIT TIMEOUT: [budget[WAIT_BUDGET_DESCRIPTION]] - окно вышло, колесо таймеров его прошло: [wait_budget_diagnostics(budget)]")
 			return FALSE
 		else if(REALTIMEOFDAY >= budget[WAIT_BUDGET_REAL_DEADLINE])
-			log_test("\tWAIT TIMEOUT: [budget[WAIT_BUDGET_DESCRIPTION]] - потолок по реальному времени: SStimer так и не набрал положенных полных проходов")
+			log_test("\tWAIT TIMEOUT: [budget[WAIT_BUDGET_DESCRIPTION]] - потолок по реальному времени, колесо таймеров так и не дошло до срока: [wait_budget_diagnostics(budget)]")
 			return FALSE
 	sleep(world.tick_lag)
 	return TRUE
@@ -224,11 +250,11 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 			break
 	return QDELETED(target)
 
-#undef UNIT_TEST_WAIT_GRACE_FIRES
+#undef UNIT_TEST_WAIT_GRACE_TICKS
 #undef UNIT_TEST_WAIT_HARD_LIMIT
 #undef WAIT_BUDGET_WORLD_DEADLINE
 #undef WAIT_BUDGET_REAL_DEADLINE
-#undef WAIT_BUDGET_TIMER_DEADLINE
+#undef WAIT_BUDGET_TIMER_FIRES
 #undef WAIT_BUDGET_DESCRIPTION
 
 /// Reads repository source files for structural audit tests.


### PR DESCRIPTION
## `atmos_speed_lever` (FestiveStation, 7 прогонов из 12)

`apply_atmos_cadence()` считает каденс по `min(lag_scale, saturation_scale)`, а тест нейтрализовал только лаг-клапан. На задыхающемся раннере взводится второй: проход SSair не влезает в свой слот, `saturation_scale` уходит на ступень 0.75 или 0.5, и `set_atmos_speed(1)` возвращает 5/0.75 = 6.66667 или 5/0.5 = 10 вместо компилированных пяти - оба наблюдавшихся значения ровно ступени лестницы клапана.

Тест сохраняет, обнуляет и возвращает `saturation_scale` наравне с `lag_scale`. Код подсистемы не менялся: клапан отработал штатно, неверна была изоляция теста.

## `element_pet_bonus`, `ai_insane_clown_stalks`, `ai_bee_pollination`

Падают втроём, на одной случайной карте за прогон, каждый сжигает по 60 секунд потолка с `WAIT TIMEOUT ... SStimer так и не набрал положенных полных проходов`.

Запасом после истечения окна служили десять полных проходов SStimer - неверный счётчик: МК увеличивает `times_fired` только за незапаузенный прогон (`master.dm`, инкремент после ветки `SS_PAUSED`), а задушенный SStimer паузится каждый фаер, то есть счётчик замирает ровно в том случае, ради которого запас и вводился. Отложка на один деци при этом не срабатывает и за минуту.

Признак готовности заменён на позицию курсора колеса бакетов: пока `head_offset + practical_offset` не прошёл срок, бакет с отложкой ещё не вскрывали и падать не за что. Потолок по реальному времени остаётся страховкой на вставший SStimer, но теперь печатает отставание колеса, состояние подсистемы и длины очередей.

## `nightshift_admin_controls` (LayeniaStation)

Падают цветовые ассерты и живость светового датума при сошедшихся флагах - лампу гасят мимо ночной смены, а диагностики у этих строк не было вовсе. Добавлен снимок питания области, состояния плафона и каналов АПЦ, только прямые чтения полей (спящая диагностика в этом тесте однажды уже увела разбор на месяцы). Корень не закрыт: правка доводит следующее падение до диагноза.

## Changelog

:cl:
fix: Чиним нестабильные тесты CI: изоляция теста рычага скорости атмоса от клапана насыщения и корректный признак готовности отложенной работы в юнит-тестах
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Повышена стабильность тестов атмосферного рычага скорости при различных ограничениях насыщения.
  * Ожидание отложенных операций в тестах стало точнее и устойчивее к зависанию таймера.
  * При превышении лимита теперь выводится дополнительная диагностика состояния таймера.

* **Диагностика**
  * Расширены сообщения проверки ночной смены: добавлены сведения о питании области, лампе и APC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->