### PR TITLE
TGUI Player Panel: улучшение вёрстки, перевод

### DIFF
--- a/tgui/packages/tgui/interfaces/PlayerPanel2.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel2.js
@@ -1,18 +1,18 @@
 import { Fragment, useState } from 'react';
 
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Collapsible, Dropdown, Flex, Input, LabeledList, NoticeBox, NumberInput, Section, Slider, Tabs } from '../components';
+import { Box, Button, Collapsible, Dropdown, Flex, Input, LabeledList, NoticeBox, NumberInput, Section, Slider, Stack, Tabs } from '../components';
 import { Window } from '../layouts';
 
 const PAGES = [
   {
-    title: 'General',
+    title: 'Основное',
     component: () => GeneralActions,
     color: "green",
     icon: "tools",
   },
   {
-    title: 'Smites',
+    title: 'Смайты',
     component: () => SmiteActions,
     color: "orange",
     icon: "hammer",
@@ -21,7 +21,7 @@ const PAGES = [
     },
   },
   {
-    title: 'Mob',
+    title: 'Моб',
     component: () => PhysicalActions,
     color: "yellow",
     icon: "bolt",
@@ -30,19 +30,19 @@ const PAGES = [
     },
   },
   {
-    title: 'Transform',
+    title: 'Превратить',
     component: () => TransformActions,
     color: "orange",
     icon: "exchange-alt",
   },
   {
-    title: 'Punish',
+    title: 'Наказать',
     component: () => PunishmentActions,
     color: "red",
     icon: "gavel",
   },
   {
-    title: 'Feature Bans',
+    title: 'Банлисты',
     component: () => FeatureBanTabs,
     color: "red",
     icon: "gavel",
@@ -51,13 +51,13 @@ const PAGES = [
     },
   },
   {
-    title: 'Fun',
+    title: 'Веселье',
     component: () => FunActions,
     color: "blue",
     icon: "laugh",
   },
   {
-    title: 'Antag & Other',
+    title: 'Антаг & Прочее',
     component: () => OtherActions,
     color: "purple",
     icon: "user-secret",
@@ -74,108 +74,116 @@ export const PlayerPanel2 = (props) => {
 
   return (
     <Window
-      title={`${mob_name} Player Panel`}
+      title={`Панель игрока: ${mob_name}`}
       width={700}
       height={600}
     >
-      <Window.Content scrollable>
-        <Section md={1}>
-          <Flex>
-            <Flex.Item width="80px" color="label" align="center">Name:</Flex.Item>
-            <Flex.Item grow={1}>
-              <Input width="100%" value={mob_name} onChange={(e, value) => act("set_name", { name: value })} />
-            </Flex.Item>
-            {!!client_ckey && !!client_rank && (
-              <Flex.Item>
-                <Box inline ml=".75rem" mr=".5rem" color="label">Rank:</Box>
-                <Flex.Item inline>
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <Section md={1}>
+              <Flex>
+                <Flex.Item width="80px" color="label" align="center">Имя:</Flex.Item>
+                <Flex.Item grow={1}>
+                  <Input width="100%" value={mob_name} onChange={(e, value) => act("set_name", { name: value })} />
+                </Flex.Item>
+                {!!client_ckey && !!client_rank && (
+                  <Flex.Item>
+                    <Box inline ml=".75rem" mr=".5rem" color="label">Роль:</Box>
+                    <Flex.Item inline>
+                      <Button
+                        minWidth="11rem" textAlign="center"
+                        content={client_rank}
+                        onClick={() => act("edit_rank")}
+                      />
+                    </Flex.Item>
+                  </Flex.Item>
+                )}
+              </Flex>
+              <Flex mt={1} align="center" wrap="wrap" justify="flex-end">
+                <Flex.Item width="80px" color="label">Тип моба:</Flex.Item>
+                <Flex.Item grow={1} align="right">{mob_type}</Flex.Item>
+                <Flex.Item align="right">
                   <Button
                     minWidth="11rem" textAlign="center"
-                    content={client_rank}
-                    onClick={() => act("edit_rank")}
+                    ml=".5rem"
+                    icon="window-restore"
+                    content="Окно VV"
+                    onClick={() => act("access_variables")}
                   />
                 </Flex.Item>
-              </Flex.Item>
-            )}
-          </Flex>
-          <Flex mt={1} align="center" wrap="wrap" justify="flex-end">
-            <Flex.Item width="80px" color="label">Mob Type:</Flex.Item>
-            <Flex.Item grow={1} align="right">{mob_type}</Flex.Item>
-            <Flex.Item align="right">
-              <Button
-                minWidth="11rem" textAlign="center"
-                ml=".5rem"
-                icon="window-restore"
-                content="Access Variables"
-                onClick={() => act("access_variables")}
-              />
-            </Flex.Item>
-            {!!client_ckey && (
-              <Flex.Item>
-                <Button
-                  minWidth="11rem" textAlign="center"
-                  ml=".5rem"
-                  icon="window-restore"
-                  content={playtimes_enabled ? playtime : "Playtimes"}
-                  disabled={!playtimes_enabled}
-                  onClick={() => act("access_playtimes")}
-                />
-              </Flex.Item>
-            )}
-          </Flex>
-          {!!client_ckey && (
-            <Flex mt={1} align="center">
-              <Flex.Item width="80px" color="label">Client:</Flex.Item>
-              <Flex.Item grow={1}>{client_ckey}</Flex.Item>
+                {!!client_ckey && (
+                  <Flex.Item>
+                    <Button
+                      minWidth="11rem" textAlign="center"
+                      ml=".5rem"
+                      icon="window-restore"
+                      content={playtimes_enabled ? playtime : "Время игры"}
+                      disabled={!playtimes_enabled}
+                      onClick={() => act("access_playtimes")}
+                    />
+                  </Flex.Item>
+                )}
+              </Flex>
+              {!!client_ckey && (
+                <Flex mt={1} align="center">
+                  <Flex.Item width="80px" color="label">Клиент:</Flex.Item>
+                  <Flex.Item grow={1}>{client_ckey}</Flex.Item>
 
-              <Flex.Item align="right">
-                <Button
-                  minWidth="11rem" textAlign="center"
-                  mx=".5rem"
-                  icon="comment-dots"
-                  disabled={!has_live_client}
-                  onClick={() => act("private_message")}
-                  content="Private Message"
-                />
-                <Button
-                  minWidth="11rem" textAlign="center"
-                  icon="phone-alt"
-                  disabled={!has_live_client}
-                  onClick={() => act("subtle_message")}
-                  content="Subtle Message"
-                />
-              </Flex.Item>
-            </Flex>
-          )}
-        </Section>
-        <Flex grow>
-          <Flex.Item>
-            <Section fitted>
-              <Tabs vertical>
-                {PAGES.map((page, i) => {
-                  if (page.canAccess && !page.canAccess(data)) {
-                    return;
-                  }
-
-                  return (
-                    <Tabs.Tab
-                      key={i}
-                      color={page.color}
-                      selected={i === pageIndex}
-                      icon={page.icon}
-                      onClick={() => setPageIndex(i)}>
-                      {page.title}
-                    </Tabs.Tab>
-                  );
-                })}
-              </Tabs>
-
+                  <Flex.Item align="right">
+                    <Button
+                      minWidth="11rem" textAlign="center"
+                      mx=".5rem"
+                      icon="comment-dots"
+                      disabled={!has_live_client}
+                      onClick={() => act("private_message")}
+                      content="Админ-PM"
+                    />
+                    <Button
+                      minWidth="11rem" textAlign="center"
+                      icon="phone-alt"
+                      disabled={!has_live_client}
+                      onClick={() => act("subtle_message")}
+                      content="IC-сообщение"
+                    />
+                  </Flex.Item>
+                </Flex>
+              )}
             </Section>
-          </Flex.Item>
-          <Flex.Item grow>
-            <PageComponent />
-          </Flex.Item>
-        </Flex>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Stack fill>
+              <Stack.Item>
+                <Section fitted fill>
+                  <Tabs vertical>
+                    {PAGES.map((page, i) => {
+                      if (page.canAccess && !page.canAccess(data)) {
+                        return;
+                      }
+
+                      return (
+                        <Tabs.Tab
+                          key={i}
+                          color={page.color}
+                          selected={i === pageIndex}
+                          icon={page.icon}
+                          onClick={() => setPageIndex(i)}>
+                          {page.title}
+                        </Tabs.Tab>
+                      );
+                    })}
+                  </Tabs>
+
+                </Section>
+              </Stack.Item>
+              <Stack.Item grow>
+                <Section fill scrollable>
+                  <PageComponent />
+                </Section>
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -231,7 +239,7 @@ const PhysicalActions = (props) => {
 
   return (
     <Section fill>
-      <Section title="Quick Actions" buttons={
+      <Section title="Быстрые действия" buttons={
         <Button
           icon={godmode ? 'check-square-o' : 'square-o'}
           color={godmode ? 'green' : 'transparent'}
@@ -244,6 +252,7 @@ const PhysicalActions = (props) => {
             width="100%"
             icon="paw"
             content="Species"
+            tooltip="Изменить биологический вид цели"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
             onClick={() => act("species")}
           />
@@ -251,6 +260,7 @@ const PhysicalActions = (props) => {
             width="100%"
             icon="magic"
             content="Spells"
+            tooltip="Добавить/убрать заклинания"
             onClick={() => act("spell")}
           />
           <Button.Confirm
@@ -259,7 +269,7 @@ const PhysicalActions = (props) => {
             content="Loadout"
             color="teal"
             disabled={!mob_type.includes("/mob/living/carbon/human") || !has_loadout}
-            tooltip={!has_loadout ? "Player has no loadout data" : "Apply player's loadout"}
+            tooltip={!has_loadout ? "Отсутствует loadout data игрока" : "Применить loadout игрока"}
             onClick={() => act("apply_loadout")}
           />
           <Button
@@ -267,23 +277,23 @@ const PhysicalActions = (props) => {
             icon="user-cog"
             content="Appearance"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
-            tooltip="Apply saved character appearance"
+            tooltip="Применить сохранённые игроком настройки персонажа"
             onClick={() => act("update_appearance")}
           />
         </Flex>
       </Section>
 
       {!!can_toggle_dextrous && (
-        <Section title="Simple Mob">
+        <Section title="Настройки Simple Mob">
           <Flex>
             <Button.Confirm
               width="100%"
               icon="hand-paper"
-              content={is_dextrous ? "Remove Hands" : "Give Hands"}
+              content={is_dextrous ? "Забрать слоты рук" : "Дать слоты рук"}
               color={is_dextrous ? 'red' : 'green'}
               tooltip={is_dextrous
-                ? "Remove dexterity (drops held items)"
-                : "Give dexterity so the simple mob can hold items"}
+                ? "Забирает \"ловкость\" (Уронит взятые предметы)"
+                : "Дать \"ловкость\" цели для возможности держать предметы"}
               onClick={() => act("toggle_dextrous")}
             />
           </Flex>
@@ -291,18 +301,18 @@ const PhysicalActions = (props) => {
       )}
 
       <Section
-        title={"Martial Art (" + (active_martial_art || "None") + ")"}
+        title={"Боевые искусства (" + (active_martial_art || "Отсутствуют") + ")"}
         buttons={active_martial_art ? (
           <Button
             icon="times"
             color="red"
-            content="Remove"
+            content="Убрать"
             onClick={() => act("remove_martial_art")}
           />
         ) : null}
       >
         <Input
-          placeholder="Search martial arts..."
+          placeholder="Поиск боевых искусств..."
           width="100%"
           mb={1}
           onInput={(e, value) => setMaSearch(value)}
@@ -331,25 +341,25 @@ const PhysicalActions = (props) => {
       </Section>
 
       <Section
-        title={"Quirks (" + (active_quirks ? active_quirks.length : 0) + " active)"}
+        title={"Квирки (Активных: " + (active_quirks ? active_quirks.length : 0) + ")"}
         buttons={(
           <Button.Confirm
             icon="trash"
             color="red"
-            content="Clear All"
+            content="Убрать все"
             disabled={!active_quirks || !active_quirks.length}
             onClick={() => act("clear_quirks")}
           />
         )}
       >
         <Input
-          placeholder="Search quirks..."
+          placeholder="Поиск квирков..."
           width="100%"
           mb={1}
           onInput={(e, value) => setQuirkSearch(value)}
         />
         <QuirkCategory
-          title="Positive"
+          title="Положительные"
           color="green"
           icon="plus-circle"
           quirks={positiveQuirks}
@@ -358,7 +368,7 @@ const PhysicalActions = (props) => {
           act={act}
         />
         <QuirkCategory
-          title="Negative"
+          title="Негативные"
           color="red"
           icon="minus-circle"
           quirks={negativeQuirks}
@@ -367,7 +377,7 @@ const PhysicalActions = (props) => {
           act={act}
         />
         <QuirkCategory
-          title="Neutral"
+          title="Нейтральные"
           color="grey"
           icon="circle"
           quirks={neutralQuirks}
@@ -377,7 +387,7 @@ const PhysicalActions = (props) => {
         />
       </Section>
 
-      <Section title="Limbs" buttons={(
+      <Section title="Конечности" buttons={(
         <Flex>
           {limbs.map((val, index) => (
             <Button.Checkbox
@@ -400,6 +410,7 @@ const PhysicalActions = (props) => {
             width="100%"
             icon="unlink"
             content="Delimb"
+            tooltip="Оторвать ВЫБРАННЫЕ конечности цели"
             color="red"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
             onClick={() => act("limb", {
@@ -414,6 +425,7 @@ const PhysicalActions = (props) => {
             height="100%"
             icon="link"
             content="Relimb"
+            tooltip="Восстановить ВЫБРАННЫЕ конечности цели"
             color="green"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
             onClick={() => act("limb", {
@@ -425,10 +437,10 @@ const PhysicalActions = (props) => {
         </Flex>
       </Section>
 
-      <Section title={"Organs (" + (current_organs ? current_organs.length : 0) + " installed)"}>
-        <Collapsible title="Organ Slots" color="green">
+      <Section title={"Органы (Установлено: " + (current_organs ? current_organs.length : 0) + ")"}>
+        <Collapsible title="Слоты органов" color="green">
           <Input
-            placeholder="Search organ slots..."
+            placeholder="Поиск слотов органов..."
             width="100%"
             mb={1}
             onInput={(e, value) => setOrganSearch(value)}
@@ -461,10 +473,11 @@ const PhysicalActions = (props) => {
         act={act}
       />
 
-      <Section title="Scale" buttons={
+      <Section title="Размеры (Scale)" buttons={
         <Button
           icon="sync"
-          content="Reset"
+          content="Сбросить"
+          tooltip="Задать размеры цели по сохранённому игроком body size"
           onClick={() => {
             setMobScale(initial_scale);
             act("scale", { new_scale: initial_scale });
@@ -488,7 +501,7 @@ const PhysicalActions = (props) => {
           />
         </Flex>
       </Section>
-      <Section title="Weight">
+      <Section title="Вес">
         <Flex wrap="wrap" justify="space-between">
           {(weight_options || []).map((opt) => (
             <Flex.Item key={opt.value} width="49%" mb=".25rem">
@@ -502,7 +515,7 @@ const PhysicalActions = (props) => {
           ))}
         </Flex>
       </Section>
-      <Section title="Speak">
+      <Section title="Коммуникация">
         <Flex mt={1}>
           <Flex.Item width="100px" color="label">Force Say:</Flex.Item>
           <Flex.Item grow={1}>
@@ -607,7 +620,7 @@ const OrganSlotRow = (props) => {
             <Button
               icon="trash"
               color="red"
-              tooltip={"Remove " + current.name}
+              tooltip={"Убрать " + current.name}
               disabled={!mob_type.includes("/mob/living/carbon")}
               onClick={() => act("remove_organ", { organ_slot: slot })}
             />
@@ -655,12 +668,12 @@ const ImplantSection = (props) => {
 
   return (
     <Section
-      title={"Implants (" + (current_implants ? current_implants.length : 0) + " installed)"}
+      title={"Импланты (Установлено: " + (current_implants ? current_implants.length : 0) + ")"}
       buttons={
         <Button
           icon={showAdd ? "minus" : "plus"}
           color={showAdd ? "red" : "green"}
-          content={showAdd ? "Hide List" : "Add Implant"}
+          content={showAdd ? "Спрятать список" : "Добавить имплант"}
           onClick={() => setShowAdd(!showAdd)}
         />
       }
@@ -688,7 +701,7 @@ const ImplantSection = (props) => {
                   <Button
                     icon="trash"
                     color="red"
-                    tooltip={"Remove " + imp.name}
+                    tooltip={"Убрать " + imp.name}
                     onClick={() => act("remove_implant", { implant_ref: imp.ref })}
                   />
                 </Flex.Item>
@@ -698,13 +711,13 @@ const ImplantSection = (props) => {
         </Box>
       ) : (
         <Box color="grey" italic mb={showAdd ? 1 : 0}>
-          No implants installed.
+          Нет установленных имплантов.
         </Box>
       )}
       {showAdd && (
         <Box>
           <Input
-            placeholder="Search implants..."
+            placeholder="Поиск имплантов..."
             width="100%"
             mb={1}
             onInput={(e, value) => setImplantSearch(value)}
@@ -736,9 +749,9 @@ const FeatureBanTabs = (props) => {
   const [jobbanTab, setJobbanTab] = useLocalState('jobbanTab', 0);
   const { roles } = data;
   return (
-    <Flex>
-      <Flex.Item>
-        <Section fitted>
+    <Stack fill>
+      <Stack.Item>
+        <Section fill minWidth="8rem">
           <Tabs vertical>
             {roles.map((role_category, i) => { return (
               <Tabs.Tab
@@ -752,12 +765,14 @@ const FeatureBanTabs = (props) => {
             ); })}
           </Tabs>
         </Section>
-      </Flex.Item>
-
-      <Flex.Item grow>
-        <FeatureBans />
-      </Flex.Item>
-    </Flex>
+      </Stack.Item>
+      <Stack.Divider />
+      <Stack.Item grow>
+          <Section fill>
+            <FeatureBans />
+          </Section>
+      </Stack.Item>
+    </Stack>
   );
 };
 
@@ -772,7 +787,7 @@ const FeatureBans = (props) => {
         buttons={(
           <>
             <Button
-              content="Unban All"
+              content="Снять все баны"
               color="good"
               icon="lock-open"
               minWidth="8rem"
@@ -782,7 +797,7 @@ const FeatureBans = (props) => {
                 is_category: true,
               })} />
             <Button
-              content="Ban All"
+              content="Добавить все баны"
               color="bad"
               icon="lock"
               minWidth="8rem"
@@ -856,13 +871,14 @@ const GeneralActions = (props) => {
   const { client_ckey, client_hearted, mob_type, admin_mob_type } = data;
   return (
     <Section>
-      <Section title="Damage">
+      <Section title="Повреждения">
         <Flex>
           <Button
             width="100%"
             icon="heart"
             color="green"
             content="Rejuvenate"
+            tooltip="Полностью восстановить здоровье и увечья цели"
             disabled={!mob_type.includes("/mob/living")}
             onClick={() => act("heal")}
           />
@@ -872,23 +888,26 @@ const GeneralActions = (props) => {
             icon="band-aid"
             color="teal"
             content="Light Heal"
+            tooltip="Вылечить все типы урона цели на 20 единиц"
             disabled={!mob_type.includes("/mob/living")}
             onClick={() => act("light_heal")}
           />
         </Flex>
       </Section>
 
-      <Section title="Teleportation">
+      <Section title="Перемещение">
         <Flex>
           <Button.Confirm
             width="100%"
             icon="reply"
             content="Bring"
+            tooltip="Переместить цель на себя"
             onClick={() => act("bring")}
           />
           <Button
             width="100%"
             content="Orbit"
+            tooltip="Телепортироваться к цели как призрак"
             onClick={() => act("orbit")}
           />
           <Button.Confirm
@@ -896,22 +915,25 @@ const GeneralActions = (props) => {
             height="100%"
             icon="share"
             content="Jump To"
+            tooltip="Телепортироваться к цели физически"
             onClick={() => act("jump_to")}
           />
         </Flex>
       </Section>
 
-      <Section title="Miscellaneous">
+      <Section title="Прочее">
         <Flex>
           <Button
             width="100%"
             content="Select Equipment"
+            tooltip="Выбрать снаряжение в специальном меню"
             icon="user-tie"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
             onClick={() => act("select_equipment")}
           />
           <Button.Confirm
             content="Drop All Items"
+            tooltip="Снять с цели все слоты инвентаря"
             icon="trash-alt"
             width="100%"
             height="100%"
@@ -927,14 +949,45 @@ const GeneralActions = (props) => {
             content={client_hearted ? 'Сердечко активно' : 'Выдать сердечко'}
             disabled={!client_ckey}
             tooltip={client_hearted
-              ? 'У игрока уже есть активное OOC-сердечко'
+              ? 'У цели уже есть активное OOC-сердечко'
               : 'Выдать OOC-сердечко на 24 часа'}
             onClick={() => act('commend')}
+          />
+        </Flex>
+      </Section>
+      <Section title="Контроль над целью">
+        <Flex>
+          <Button.Confirm
+            width="100%"
+            icon="ghost"
+            content="Eject Ghost"
+            tooltip="Вытащить игрока из тела цели и сделать призраком"
+            confirmColor="bad"
+            disabled={!client_ckey || !mob_type.includes("/mob/living")}
+            onClick={() => act("ghost")}
+          />
+          <Button.Confirm
+            width="100%"
+            content="Take Control"
+            tooltip="Взять контроль над телом цели"
+            confirmColor="bad"
+            disabled={mob_type.includes("/mob/dead/observer") || !admin_mob_type.includes("/mob/dead/observer")}
+            onClick={() => act("take_control")}
+          />
+          <Button.Confirm
+            width="100%"
+            height="100%" // weird ass bug here, so height set to 100%
+            icon="ghost"
+            content="Offer Control"
+            tooltip="Предложить игрокам-призракам контроль над телом цели"
+            disabled={!mob_type.includes("/mob/living")}
+            onClick={() => act("offer_control")}
           />
         </Flex>
         <Flex>
           <Button.Confirm
             content="Send To Cryo"
+            tooltip="Убрать цель из раунда через криосон"
             icon="snowflake"
             width="100%"
             color="orange"
@@ -948,36 +1001,8 @@ const GeneralActions = (props) => {
             color="orange"
             icon="undo"
             disabled={!mob_type.includes("/mob/dead/observer")}
-            tooltip={mob_type !== "/mob/dead/observer" ? "Can only be used on ghosts" : ""}
+            tooltip={mob_type !== "/mob/dead/observer" ? "Можно использовать только на призраках" : ""}
             onClick={() => act("lobby")}
-          />
-        </Flex>
-      </Section>
-      <Section title="Control">
-        <Flex>
-          <Button.Confirm
-            width="100%"
-            icon="ghost"
-            content="Eject Ghost"
-            confirmColor="bad"
-            disabled={!client_ckey || !mob_type.includes("/mob/living")}
-            onClick={() => act("ghost")}
-          />
-          <Button.Confirm
-            width="100%"
-            content="Take Control"
-            confirmColor="bad"
-            disabled={mob_type.includes("/mob/dead/observer") || !admin_mob_type.includes("/mob/dead/observer")}
-            onClick={() => act("take_control")}
-          />
-          <Button.Confirm
-            width="100%"
-            height="100%" // weird ass bug here, so height set to 100%
-            icon="ghost"
-            content="Offer Control"
-            tooltip="Offers control to ghosts"
-            disabled={!mob_type.includes("/mob/living")}
-            onClick={() => act("offer_control")}
           />
         </Flex>
       </Section>
@@ -1000,6 +1025,7 @@ const PunishmentActions = (props) => {
           icon="clipboard-list"
           color="orange"
           content="Notes"
+          tooltip="Открыть заметки игрока"
           textAlign="center"
           disabled={!client_ckey}
           onClick={() => act("notes")}
@@ -1011,15 +1037,17 @@ const PunishmentActions = (props) => {
           icon="clipboard-list"
           color="orange"
           content="Logs"
+          tooltip="Открыть логи раунда игрока"
           textAlign="center"
           onClick={() => act("logs")}
         />
       </Flex>
-      <Section title="Contain">
+      <Section title="Сдерживание">
         <Flex>
           <Button
             width="100%"
             content="Freeze"
+            tooltip="Заморозить цель в пространстве"
             color={is_frozen ? "orange" : ""}
             icon={is_frozen ? 'check-square-o' : 'square-o'}
             disabled={!mob_type.includes("/mob/living")}
@@ -1028,6 +1056,7 @@ const PunishmentActions = (props) => {
           <Button
             width="100%"
             content="Sleep"
+            tooltip="Ввести цель в вечный сон"
             color={is_slept ? "orange" : ""}
             icon={is_slept ? 'check-square-o' : 'square-o'}
             disabled={!mob_type.includes("/mob/living")}
@@ -1037,6 +1066,7 @@ const PunishmentActions = (props) => {
             width="100%"
             height="100%"
             content="Admin Prison"
+            tooltip="Отправить цель в камеру под Thunderdome"
             icon="share"
             color="bad"
             disabled={!mob_type.includes("/mob/living")}
@@ -1045,13 +1075,14 @@ const PunishmentActions = (props) => {
         </Flex>
       </Section>
 
-      <Section title="Banishment">
+      <Section title="Блокировки">
         <Flex>
           <Button.Confirm
             width="100%"
             icon="ban"
             color="red"
             content="Kick"
+            tooltip="Кикнуть игрока с сервера"
             disabled={!has_live_client}
             onClick={() => act("kick")}
           />
@@ -1060,6 +1091,7 @@ const PunishmentActions = (props) => {
             icon="gavel"
             color="red"
             content="Ban"
+            tooltip="Выдать серверный бан игроку"
             disabled={!client_ckey}
             onClick={() => act("ban")}
           />
@@ -1069,25 +1101,27 @@ const PunishmentActions = (props) => {
             icon="gavel"
             color="red"
             content="Sticky Ban"
+            tooltip="Выдать бан по CID/железу (HWID)"
             disabled={!client_ckey}
             onClick={() => act("sticky_ban")}
           />
         </Flex>
       </Section>
 
-      <Section title="Mute" buttons={
+      <Section title="Мут-панель" buttons={
         <>
           <Button
             icon="lock-open"
             color="green"
-            content="Unmute All"
+            content="Снять все муты"
+            tooltip=""
             disabled={!has_live_client || !client_ckey}
             onClick={() => act("unmute_all")}
           />
           <Button
             icon="lock"
             color="red"
-            content="Mute All"
+            content="Выдать все муты"
             disabled={!has_live_client || !client_ckey}
             onClick={() => act("mute_all")}
           />
@@ -1111,11 +1145,11 @@ const PunishmentActions = (props) => {
           }) }
         </Flex>
       </Section>
-      <Section title="Investigate"
+      <Section title="Подробности"
         buttons={(
           <Flex>
             <Flex.Item align="center" mr=".5rem" color="label">
-              Related accounts by:
+              Причастные аккаунты, по:
             </Flex.Item>
             <Button
               minWidth="5rem"
@@ -1140,16 +1174,16 @@ const PunishmentActions = (props) => {
         <Collapsible
           width="100%"
           color="orange"
-          content="Details"
+          content="Детали"
           disabled={!client_ckey}
         >
           <LabeledList >
-            <LabeledList.Item label="NOW" color="label">{current_time}</LabeledList.Item>
-            <LabeledList.Item label="Account made">{data_account_join_date}</LabeledList.Item>
-            <LabeledList.Item label="First joined server">{data_player_join_date}</LabeledList.Item>
-            <LabeledList.Item label="Byond version">{data_byond_version}</LabeledList.Item>
+            <LabeledList.Item label="Текущее время" color="label">{current_time}</LabeledList.Item>
+            <LabeledList.Item label="Аккаунт создан">{data_account_join_date}</LabeledList.Item>
+            <LabeledList.Item label="Впервые зашёл">{data_player_join_date}</LabeledList.Item>
+            <LabeledList.Item label="Версия Byond">{data_byond_version}</LabeledList.Item>
             <LabeledList.Item label="CID">{data_cid || "N/A"}</LabeledList.Item>
-            <LabeledList.Item label="Active bans">{active_role_ban_count}</LabeledList.Item>
+            <LabeledList.Item label="Активных банов">{active_role_ban_count}</LabeledList.Item>
           </LabeledList>
         </Collapsible>
       </Section>
@@ -1165,7 +1199,7 @@ const TransformActions = (props) => {
 
       <Button
         width="100%"
-        content="Custom"
+        content="Найти и превратить по mob type"
         py=".5rem"
         textAlign="center"
         onClick={() => act("transform", { newType: "/mob/living" })}
@@ -1239,21 +1273,21 @@ const FunActions = (props) => {
   return (
     <Section fill>
       <NoticeBox info textAlign="center">
-        These features are centred on YOUR viewport
+        Действие этих эффектов центрировано от ВАШЕЙ локации
       </NoticeBox>
 
-      <Section title="Explosion" buttons={(
+      <Section title="Сгенерировать взрыв" buttons={(
         <>
           <Button.Checkbox
             checked={extinguishMode}
             color="transparent"
-            content="Extinguish Mode"
+            content="Огнетушение"
             onClick={() => setExtinguishMode(!extinguishMode)}
           />
           <Button.Checkbox
             checked={empMode}
             color="transparent"
-            content="EMP Mode"
+            content="EMP-режим"
             onClick={() => setEmpMode(!empMode)}
           />
           <Button
@@ -1277,7 +1311,7 @@ const FunActions = (props) => {
               disabled={lockExplode}
               onClick={() => act("explode", { power: expPower, emp_mode: empMode, extinguish_mode: extinguishMode })}
             >
-              <Box height="100%" pt={2} pb={2} textAlign="center">Detonate</Box>
+              <Box height="100%" pt={2} pb={2} textAlign="center">Взорвать</Box>
             </Button>
           </Flex.Item>
           <Flex.Item
@@ -1285,7 +1319,7 @@ const FunActions = (props) => {
             grow={1}
           >
             <Slider
-              unit="Range"
+              unit="м. радиуса"
               value={expPower}
               stepPixelSize={15}
               onDrag={(e, value) => setExpPower(value)}
@@ -1315,7 +1349,7 @@ const FunActions = (props) => {
           <Flex width="100%" wrap>
             <Flex.Item width="52%">
               <LabeledList>
-                <LabeledList.Item label="Colour">
+                <LabeledList.Item label="Цвет">
                   <Dropdown
                     width="calc(100% - 1rem)"
                     displayText={narrateColour}
@@ -1323,7 +1357,7 @@ const FunActions = (props) => {
                     onSelected={(value) => setNarrateColour(value)}
                   />
                 </LabeledList.Item>
-                <LabeledList.Item label="Font">
+                <LabeledList.Item label="Шрифт">
                   <Dropdown
                     width="calc(100% - 1rem)"
                     displayText={narrateFont}
@@ -1334,7 +1368,7 @@ const FunActions = (props) => {
             </Flex.Item>
             <Flex.Item width="20%">
               <LabeledList>
-                <LabeledList.Item label="Bold">
+                <LabeledList.Item label="Жирность">
                   <Button.Checkbox
                     checked={narrateBold}
                     height="100%"
@@ -1342,7 +1376,7 @@ const FunActions = (props) => {
                     onClick={() => setNarrateBold(!narrateBold)}
                   />
                 </LabeledList.Item>
-                <LabeledList.Item label="Italic">
+                <LabeledList.Item label="Курсив">
                   <Button.Checkbox
                     checked={narrateItalic}
                     height="100%"
@@ -1354,7 +1388,7 @@ const FunActions = (props) => {
             </Flex.Item>
             <Flex.Item width="28%">
               <LabeledList>
-                <LabeledList.Item label="Size">
+                <LabeledList.Item label="Размер">
                   <NumberInput
                     width="100%"
                     value={narrateSize}
@@ -1366,13 +1400,13 @@ const FunActions = (props) => {
                     onDrag={(e, value) => setNarrateSize(value)} />
                 </LabeledList.Item>
                 {!narrateGlobal && (
-                  <LabeledList.Item label="Range">
+                  <LabeledList.Item label="Дальность">
                     <NumberInput
                       width="100%"
                       value={narrateRange}
                       minValue={1}
                       maxValue={14}
-                      unit="Tiles"
+                      unit="м."
                       align="center"
                       stepPixelSize="25"
                       onDrag={(e, value) => setNarrateRange(value)} />
@@ -1393,7 +1427,7 @@ const FunActions = (props) => {
           </Flex.Item>
 
           <Button
-            content="Broadcast"
+            content="Вещать"
             color="green"
             p=".5rem"
             textAlign="center"
@@ -1425,9 +1459,9 @@ const SmiteActions = (props) => {
   );
 
   return (
-    <Section title="Smites" fill>
+    <Section title="Смайты (Наказания)" fill>
       <Input
-        placeholder="Search smites..."
+        placeholder="Сломать колени..."
         width="100%"
         mb={1}
         onInput={(e, value) => setSmiteSearch(value)}
@@ -1455,7 +1489,7 @@ const OtherActions = (props) => {
 
   return (
     <Section fill>
-      <Section title="Antagonist">
+      <Section title="Антагонизм">
         <Button
           width="100%"
           content="Traitor Panel"
@@ -1469,7 +1503,7 @@ const OtherActions = (props) => {
         />
         <Button
           width="100%"
-          content="Objectives / Ambitions"
+          content="Цели / Амбиции"
           icon="bullseye"
           p=".5rem"
           textAlign="center"
@@ -1477,10 +1511,10 @@ const OtherActions = (props) => {
           onClick={(e) => act("ambitions")}
         />
       </Section>
-      <Section title="Miscellaneous">
+      <Section title="Прочее">
         <Button
           width="100%"
-          content="Languages"
+          content="Языки"
           icon="language"
           p=".5rem"
           mb=".5rem"
@@ -1491,7 +1525,8 @@ const OtherActions = (props) => {
         <Flex>
           <Button
             width="100%"
-            content="Make Mentor"
+            minHeight="2.5rem"
+            content="Дать права ментора"
             icon="graduation-cap"
             color="green"
             p=".5rem"
@@ -1501,7 +1536,8 @@ const OtherActions = (props) => {
           />
           <Button
             width="100%"
-            content="Remove Mentor"
+            minHeight="2.5rem"
+            content="Убрать права ментора"
             icon="user-minus"
             color="red"
             p=".5rem"


### PR DESCRIPTION
# Описание
- Проведена частичная локализация.
   - Важные verb'ы, типа реджува, бана и `bring`/`jump to`, не переведены. Аналогично названиям мобов в бывшем `mob`.
   - Переведены все названия вкладок, разделов внутри вкладок и содержание малоиспользуемых вкладок целиком, таких как `fun`. Часть названий переписаны с нуля для лучшего отображения функции кнопки.
   - Почти всем кнопкам выдано описание-подсказка при наведении мышкой. 
- Вёрстка была улучшена. 
   - Вынесение вкладок отдельно теперь фиксирует их, если листать длинное содержимое, как у вкладки `mob`.
   - `Send to cryo` & `Send to lobby` переместились в категорию "Контроль над целью" вместо "Прочее".

## Причина изменений
- Теперь содержимое не ездит благодаря `stack`, если выбрать разные вкладки разной длины строки, т.к. вкладки вынесены отдельно. Не ездит содержимое и бывшего feature bans, оставаясь стабильно на месте.
- Уточнения через `tooltip` будут помогать новичкам-триалам разобраться с функционалом кнопок внутри панели, особенно малоиспользуемыми.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
spellcheck: Добавлен перевод player panel.
admin: Player panel: перемещение отправки в крио и лобби; добавление подсказок при наведении мышью; улучшение вёрстки ради устранения съезжающего интерфейса.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения интерфейса**
  * Панель управления игроком переведена на русский язык.
  * Обновлена структура панели и добавлена независимая прокрутка вкладок и содержимого.
  * Добавлены подсказки для административных действий.
  * Выделены отдельные разделы для простых мобов и управления целью.
  * Улучшено оформление вкладок банов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->