### PR TITLE
dehy_carp убран из списков choice box (plushie)

### DIFF
--- a/modular_sand/code/game/objects/items/plushes.dm
+++ b/modular_sand/code/game/objects/items/plushes.dm
@@ -8,7 +8,7 @@
 		/obj/item/toy/plush/goatplushie/angry/kinggoat/ascendedkinggoat,
 		/obj/item/toy/plush/goatplushie/angry/guardgoat,
 		/obj/item/toy/plush/goatplushie/angry/guardgoat/masterguardgoat,
-		/obj/item/toy/plush/lizardplushie/saliith
+		/obj/item/toy/plush/lizardplushie/saliith,
 		/obj/item/toy/plush/carpplushie/dehy_carp
 		)
 	return returned_plushies

--- a/modular_sand/code/game/objects/items/plushes.dm
+++ b/modular_sand/code/game/objects/items/plushes.dm
@@ -9,6 +9,7 @@
 		/obj/item/toy/plush/goatplushie/angry/guardgoat,
 		/obj/item/toy/plush/goatplushie/angry/guardgoat/masterguardgoat,
 		/obj/item/toy/plush/lizardplushie/saliith
+		/obj/item/toy/plush/carpplushie/dehy_carp
 		)
 	return returned_plushies
 


### PR DESCRIPTION
# Описание
- `dehy_carp` убран из списков `choice box (plushie)`ю

## Причина изменений
- Аплинк-айтем что-то забыл среди бесплатных плюшей.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
del: Дегидрированный карп убран из коробки плюшевых игрушек.
/:cl:
