### PR TITLE
Фикс красного CI

### DIFF
--- a/modular_splurt/code/datums/components/pregnancy.dm
+++ b/modular_splurt/code/datums/components/pregnancy.dm
@@ -235,7 +235,8 @@
 	if(stage < max_stage)
 		return
 
-	balloon_alert(src.loc, "Вы пытаетесь вылупить яйцо!")
+	var/obj/item/egg = parent
+	egg.balloon_alert(user, "Вы пытаетесь вылупить яйцо!")
 	INVOKE_ASYNC(src, PROC_REF(hatch), source, I, user, params)
 
 /datum/component/pregnancy/proc/hatch(datum/source, obj/item/I, mob/user, params)


### PR DESCRIPTION
# Описание

Коммит 975ddb2055a вызвал `balloon_alert(src.loc, ...)` из `/datum/component/pregnancy` - прок есть только на `/atom`, вара `loc` у датума нет. Мастер не компилируется, весь CI Suite красный на любой ветке. Алерт перевешен на яйцо и адресован тому, кто по нему бьёт

- [x] Изменения были проверены на локальном сервере
- [x] Этот пулл-реквест готов к тест-мерджу.
- [ ] Изменения были портированы с другого сервера

## Changelog

:cl:
fix: Починена компиляция - попытка вылупить яйцо больше не ломает сборку
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшено отображение предупреждения при вылуплении: сообщение теперь появляется у объекта яйца и корректно отображается пользователю.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->