### PR TITLE
TGUI: PlayerPanel перевод + Fabricator скролл

### DIFF
--- a/code/modules/jobs/job_types/command/blueshield.dm
+++ b/code/modules/jobs/job_types/command/blueshield.dm
@@ -144,7 +144,7 @@
 //BLUEMOON CHANGE однородность для cqc с ограниченой зоной использования
 ///Subtype of CQC. Only used for the Blueshield.
 /datum/martial_art/cqc/restricted/blueshield
-	name = "Close Quarters Combat, Blueshield Edition"
+	name = "CQC (Blueshield edition)"
 	valid_areas = list(/area/command, /area/command/bridge, /area/command/meeting_room, /area/command/meeting_room/council,
 								/area/command/heads_quarters/captain, /area/command/heads_quarters/ce, /area/command/heads_quarters/ce/private,
 								/area/command/heads_quarters/cmo, /area/command/heads_quarters/cmo/private, /area/command/heads_quarters/hop,

--- a/code/modules/jobs/job_types/service/bouncer.dm
+++ b/code/modules/jobs/job_types/service/bouncer.dm
@@ -83,7 +83,7 @@
 
 //BLUEMOON ADD
 /datum/martial_art/krav_maga/restricted/bouncer
-	name = "Krav Maga (bouncer edition)"
+	name = "Krav Maga (Bouncer edition)"
 	valid_areas = list(/area/service/bar/atrium, /area/service/bar)
 	resist_grab_chance = 40
 

--- a/tgui/packages/tgui/interfaces/Fabricator.js
+++ b/tgui/packages/tgui/interfaces/Fabricator.js
@@ -270,8 +270,8 @@ export const FabricatorContent = (props) => {
   const chemsNameById = chemsArrayToNameById(chems);
 
   return (
-    <Section fill>
-      <Stack fill vertical>
+    <Section fill minHeight={0}>
+      <Stack fill vertical minHeight={0}>
         <Stack.Item>
           <Collapsible
             open
@@ -322,9 +322,10 @@ export const FabricatorContent = (props) => {
           </Collapsible>
         </Stack.Item>
 
-        <Stack.Item grow={1} basis={0}>
+        <Stack.Item grow={1} basis={0} minHeight={0}>
           <Section
             fill
+            minHeight={0}
             title={hacked ? 'Designs (Safety protocols: DISABLED)' : 'Designs'}
             buttons={(
               <>
@@ -349,7 +350,7 @@ export const FabricatorContent = (props) => {
               </>
             )}
           >
-            <Stack fill>
+            <Stack fill minHeight={0}>
               {/* //категории */}
               {!searchIsActive && (
                 <>
@@ -377,7 +378,7 @@ export const FabricatorContent = (props) => {
                 </>
               )}
 
-              <Stack.Item grow={1} basis={0}>
+              <Stack.Item grow={1} basis={0} minHeight={0}>
                 {/* //содержимое-таблицы */}
                 {items.length === 0 && (
                   <NoticeBox>

--- a/tgui/packages/tgui/interfaces/Fabricator.js
+++ b/tgui/packages/tgui/interfaces/Fabricator.js
@@ -12,6 +12,7 @@ import {
   Input,
   NoticeBox,
   Section,
+  Stack,
   Table,
   Tabs,
 } from '../components';
@@ -218,7 +219,7 @@ export const Fabricator = (props) => {
           {' Production...'}
         </Dimmer>
       )}
-      <Window.Content overflow="auto">
+      <Window.Content>
         <FabricatorContent />
       </Window.Content>
     </Window>
@@ -269,9 +270,9 @@ export const FabricatorContent = (props) => {
   const chemsNameById = chemsArrayToNameById(chems);
 
   return (
-    <Section>
-      <Flex direction="column">
-        <Flex.Item>
+    <Section fill>
+      <Stack fill vertical>
+        <Stack.Item>
           <Collapsible
             open
             title={materials_text
@@ -288,9 +289,9 @@ export const FabricatorContent = (props) => {
               }}
             />
           </Collapsible>
-        </Flex.Item>
+        </Stack.Item>
 
-        <Flex.Item mb={2.5}>
+        <Stack.Item mb={2.5}>
           <Collapsible title="Chemicals" color="transparent">
             <Section
               title={`Stored Chemicals: ${chems_total_volume}u / ${chems_maximum}u`}
@@ -319,10 +320,11 @@ export const FabricatorContent = (props) => {
               ))}
             </Section>
           </Collapsible>
-        </Flex.Item>
+        </Stack.Item>
 
-        <Flex.Item>
+        <Stack.Item grow={1} basis={0}>
           <Section
+            fill
             title={hacked ? 'Designs (Safety protocols: DISABLED)' : 'Designs'}
             buttons={(
               <>
@@ -347,31 +349,36 @@ export const FabricatorContent = (props) => {
               </>
             )}
           >
-            <Flex>
+            <Stack fill>
+              {/* //категории */}
               {!searchIsActive && (
-                <Flex.Item>
-                  <Tabs vertical>
-                    {categories
-                      .filter((c) => c.items?.length)
-                      .map((category) => (
-                        <Tabs.Tab
-                          mr={1.5}
-                          key={category.name}
-                          selected={category.name === selectedCategory}
-                          onClick={() => {
-                            setSelectedCategory(category.name);
-                            const ae = document.activeElement;
-                            ae?.blur?.();
-                          }}
-                        >
-                          {category.name} ({category.items.length})
-                        </Tabs.Tab>
-                      ))}
-                  </Tabs>
-                </Flex.Item>
+                <>
+                  <Stack.Item>
+                    <Tabs vertical>
+                      {categories
+                        .filter((c) => c.items?.length)
+                        .map((category) => (
+                          <Tabs.Tab
+                            mr={1.5}
+                            key={category.name}
+                            selected={category.name === selectedCategory}
+                            onClick={() => {
+                              setSelectedCategory(category.name);
+                              const ae = document.activeElement;
+                              ae?.blur?.();
+                            }}
+                          >
+                            {category.name} ({category.items.length})
+                          </Tabs.Tab>
+                        ))}
+                    </Tabs>
+                  </Stack.Item>
+                  <Stack.Divider />
+                </>
               )}
 
-              <Flex.Item grow={1} basis={0}>
+              <Stack.Item grow={1} basis={0}>
+                {/* //содержимое-таблицы */}
                 {items.length === 0 && (
                   <NoticeBox>
                     {!searchIsActive
@@ -380,21 +387,23 @@ export const FabricatorContent = (props) => {
                   </NoticeBox>
                 )}
 
-                <Table>
-                  <ItemList
-                    items={items}
-                    materialsObj={materialsObj}
-                    chemsHaveById={chemsHaveById}
-                    chemsNameById={chemsNameById}
-                    curSecLevel={current_sec_level}
-                    maxBuildButtonAmount={maxBuildButtonAmount}
-                  />
-                </Table>
-              </Flex.Item>
-            </Flex>
+                <Section fill scrollable>
+                  <Table>
+                    <ItemList
+                      items={items}
+                      materialsObj={materialsObj}
+                      chemsHaveById={chemsHaveById}
+                      chemsNameById={chemsNameById}
+                      curSecLevel={current_sec_level}
+                      maxBuildButtonAmount={maxBuildButtonAmount}
+                    />
+                  </Table>
+                </Section>
+              </Stack.Item>
+            </Stack>
           </Section>
-        </Flex.Item>
-      </Flex>
+        </Stack.Item>
+      </Stack>
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/PlayerPanel2.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel2.js
@@ -21,7 +21,7 @@ const PAGES = [
     },
   },
   {
-    title: 'Моб',
+    title: 'Настройки моба',
     component: () => PhysicalActions,
     color: "yellow",
     icon: "bolt",
@@ -30,13 +30,13 @@ const PAGES = [
     },
   },
   {
-    title: 'Превратить',
+    title: 'Трансформация',
     component: () => TransformActions,
     color: "orange",
     icon: "exchange-alt",
   },
   {
-    title: 'Наказать',
+    title: 'Наказания & Логи',
     component: () => PunishmentActions,
     color: "red",
     icon: "gavel",
@@ -239,7 +239,7 @@ const PhysicalActions = (props) => {
 
   return (
     <Section fill>
-      <Section title="Быстрые действия" buttons={
+      <Section title="Настройки цели" buttons={
         <Button
           icon={godmode ? 'check-square-o' : 'square-o'}
           color={godmode ? 'green' : 'transparent'}
@@ -251,7 +251,7 @@ const PhysicalActions = (props) => {
           <Button
             width="100%"
             icon="paw"
-            content="Species"
+            content="Вид"
             tooltip="Изменить биологический вид цели"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
             onClick={() => act("species")}
@@ -259,25 +259,25 @@ const PhysicalActions = (props) => {
           <Button
             width="100%"
             icon="magic"
-            content="Spells"
+            content="Заклинания"
             tooltip="Добавить/убрать заклинания"
             onClick={() => act("spell")}
           />
           <Button.Confirm
             width="100%"
             icon="suitcase"
-            content="Loadout"
+            content="Лодаут"
             color="teal"
             disabled={!mob_type.includes("/mob/living/carbon/human") || !has_loadout}
-            tooltip={!has_loadout ? "Отсутствует loadout data игрока" : "Применить loadout игрока"}
+            tooltip={!has_loadout ? "Отсутствует loadout data игрока" : "Применить loadout настройки игрока"}
             onClick={() => act("apply_loadout")}
           />
           <Button
             width="100%"
             icon="user-cog"
-            content="Appearance"
+            content="Внешность"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
-            tooltip="Применить сохранённые игроком настройки персонажа"
+            tooltip="Обновить name, desc и icon игрока"
             onClick={() => act("update_appearance")}
           />
         </Flex>
@@ -797,7 +797,8 @@ const FeatureBans = (props) => {
                 is_category: true,
               })} />
             <Button
-              content="Добавить все баны"
+              content="Выдать все баны"
+              tooltip="Пробанить позиции в открытой категории"
               color="bad"
               icon="lock"
               minWidth="8rem"
@@ -877,8 +878,8 @@ const GeneralActions = (props) => {
             width="100%"
             icon="heart"
             color="green"
-            content="Rejuvenate"
-            tooltip="Полностью восстановить здоровье и увечья цели"
+            content="Восстановить"
+            tooltip="Полностью восстановить здоровье и увечья цели проком Rejuvenate"
             disabled={!mob_type.includes("/mob/living")}
             onClick={() => act("heal")}
           />
@@ -887,7 +888,7 @@ const GeneralActions = (props) => {
             height="100%"
             icon="band-aid"
             color="teal"
-            content="Light Heal"
+            content="Исцелить"
             tooltip="Вылечить все типы урона цели на 20 единиц"
             disabled={!mob_type.includes("/mob/living")}
             onClick={() => act("light_heal")}
@@ -900,13 +901,13 @@ const GeneralActions = (props) => {
           <Button.Confirm
             width="100%"
             icon="reply"
-            content="Bring"
+            content="На себя"
             tooltip="Переместить цель на себя"
             onClick={() => act("bring")}
           />
           <Button
             width="100%"
-            content="Orbit"
+            content="Кружить над целью"
             tooltip="Телепортироваться к цели как призрак"
             onClick={() => act("orbit")}
           />
@@ -914,7 +915,7 @@ const GeneralActions = (props) => {
             width="100%"
             height="100%"
             icon="share"
-            content="Jump To"
+            content="К цели"
             tooltip="Телепортироваться к цели физически"
             onClick={() => act("jump_to")}
           />
@@ -925,14 +926,14 @@ const GeneralActions = (props) => {
         <Flex>
           <Button
             width="100%"
-            content="Select Equipment"
+            content="Выбрать снаряжение"
             tooltip="Выбрать снаряжение в специальном меню"
             icon="user-tie"
             disabled={!mob_type.includes("/mob/living/carbon/human")}
             onClick={() => act("select_equipment")}
           />
           <Button.Confirm
-            content="Drop All Items"
+            content="Снять все предметы"
             tooltip="Снять с цели все слоты инвентаря"
             icon="trash-alt"
             width="100%"
@@ -960,7 +961,7 @@ const GeneralActions = (props) => {
           <Button.Confirm
             width="100%"
             icon="ghost"
-            content="Eject Ghost"
+            content="Извлечь из тела"
             tooltip="Вытащить игрока из тела цели и сделать призраком"
             confirmColor="bad"
             disabled={!client_ckey || !mob_type.includes("/mob/living")}
@@ -968,7 +969,7 @@ const GeneralActions = (props) => {
           />
           <Button.Confirm
             width="100%"
-            content="Take Control"
+            content="Взять контроль"
             tooltip="Взять контроль над телом цели"
             confirmColor="bad"
             disabled={mob_type.includes("/mob/dead/observer") || !admin_mob_type.includes("/mob/dead/observer")}
@@ -978,7 +979,7 @@ const GeneralActions = (props) => {
             width="100%"
             height="100%" // weird ass bug here, so height set to 100%
             icon="ghost"
-            content="Offer Control"
+            content="Предложить контроль"
             tooltip="Предложить игрокам-призракам контроль над телом цели"
             disabled={!mob_type.includes("/mob/living")}
             onClick={() => act("offer_control")}
@@ -986,7 +987,7 @@ const GeneralActions = (props) => {
         </Flex>
         <Flex>
           <Button.Confirm
-            content="Send To Cryo"
+            content="Отправить в криосон"
             tooltip="Убрать цель из раунда через криосон"
             icon="snowflake"
             width="100%"
@@ -997,7 +998,7 @@ const GeneralActions = (props) => {
           <Button.Confirm
             width="100%"
             height="100%"
-            content="Send To Lobby"
+            content="Отправить в лобби"
             color="orange"
             icon="undo"
             disabled={!mob_type.includes("/mob/dead/observer")}
@@ -1024,7 +1025,7 @@ const PunishmentActions = (props) => {
           py=".5rem"
           icon="clipboard-list"
           color="orange"
-          content="Notes"
+          content="Заметки"
           tooltip="Открыть заметки игрока"
           textAlign="center"
           disabled={!client_ckey}
@@ -1036,7 +1037,7 @@ const PunishmentActions = (props) => {
           py=".5rem"
           icon="clipboard-list"
           color="orange"
-          content="Logs"
+          content="Логи"
           tooltip="Открыть логи раунда игрока"
           textAlign="center"
           onClick={() => act("logs")}
@@ -1046,7 +1047,7 @@ const PunishmentActions = (props) => {
         <Flex>
           <Button
             width="100%"
-            content="Freeze"
+            content="Заморозить"
             tooltip="Заморозить цель в пространстве"
             color={is_frozen ? "orange" : ""}
             icon={is_frozen ? 'check-square-o' : 'square-o'}
@@ -1055,7 +1056,7 @@ const PunishmentActions = (props) => {
           />
           <Button
             width="100%"
-            content="Sleep"
+            content="Усыпить"
             tooltip="Ввести цель в вечный сон"
             color={is_slept ? "orange" : ""}
             icon={is_slept ? 'check-square-o' : 'square-o'}
@@ -1081,7 +1082,7 @@ const PunishmentActions = (props) => {
             width="100%"
             icon="ban"
             color="red"
-            content="Kick"
+            content="Кикнуть"
             tooltip="Кикнуть игрока с сервера"
             disabled={!has_live_client}
             onClick={() => act("kick")}
@@ -1090,7 +1091,7 @@ const PunishmentActions = (props) => {
             width="100%"
             icon="gavel"
             color="red"
-            content="Ban"
+            content="Забанить"
             tooltip="Выдать серверный бан игроку"
             disabled={!client_ckey}
             onClick={() => act("ban")}
@@ -1100,7 +1101,7 @@ const PunishmentActions = (props) => {
             height="100%"
             icon="gavel"
             color="red"
-            content="Sticky Ban"
+            content="Стики-бан"
             tooltip="Выдать бан по CID/железу (HWID)"
             disabled={!client_ckey}
             onClick={() => act("sticky_ban")}
@@ -1335,7 +1336,7 @@ const FunActions = (props) => {
           </Flex.Item>
         </Flex>
       </Section>
-      <Section title="Narrate"
+      <Section title="Создать лог повествования (Narrate)"
         buttons={
           <Button
             content="Global Narrate"
@@ -1492,7 +1493,7 @@ const OtherActions = (props) => {
       <Section title="Антагонизм">
         <Button
           width="100%"
-          content="Traitor Panel"
+          content="Панель антагониста (TP)"
           icon="user-secret"
           color="purple"
           p=".5rem"


### PR DESCRIPTION
# Описание
- Дополировал плеерпанель в вопросе перевода.
- Добавил стаковость и секционность фабрикатора для скроллинга.
- Полировка названий БИ сикуси БЩ и кравмаг баунсера.

## Причина изменений
- Запрос на "нормальный полный перевод".
- Для QoL.
- Для унитарности.

## Демонстрация изменений
https://discord.com/channels/875735187449847830/1053678815714484384/1538954558875766794

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
qol: HUD фабрикаторов, протолатов и принтеров получил скролл-окно содержимого.
admin: Доперевод Player Panel администрации.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения интерфейса**
  * Улучшена компоновка окна фабрикатора: материалы, химикаты и проекты разделены на удобные прокручиваемые области.
  * В панели игрока переведены на русский язык заголовки, кнопки и подсказки.

* **Исправления**
  * Уточнены отображаемые названия боевых искусств для Blueshield и вышибалы.
  * Функциональность доступности и выдачи боевых искусств не изменялась.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->