### PR TITLE
FIX: pixel-шифт будет обнуляться для айтемов радиального меню имплантов-инструментов рук 

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -325,9 +325,12 @@
 		choices["close"] = icon('icons/mob/radial.dmi', "radial_close")
 
 		for (var/item_key in items)
-			var/item = vars[item_key]
+			var/obj/item/item = vars[item_key]
 			if (item)
-				choices[item_key] = item
+				var/image/choice_icon = image(item)
+				choice_icon.pixel_x = item.base_pixel_x
+				choice_icon.pixel_y = item.base_pixel_y
+				choices[item_key] = choice_icon
 			else
 				// If the item doesn't exist, put a silhouette in its place
 				choices[item_key] = items[item_key]

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -159,7 +159,10 @@
 		else
 			var/list/choice_list = list()
 			for(var/obj/item/I in items_list)
-				choice_list[I] = image(I)
+				var/image/choice_icon = image(I)
+				choice_icon.pixel_x = I.base_pixel_x
+				choice_icon.pixel_y = I.base_pixel_y
+				choice_list[I] = choice_icon
 			var/obj/item/choice = show_radial_menu(owner, owner, choice_list)
 			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !holder && (choice in contents))
 				// This monster sanity check is a nice example of how bad input is.


### PR DESCRIPTION
# Описание
- Обновление со попиксельным смещением дропнутых айтемов смещал изображение айтема в радиалке тул имплантов, если "уронить" его. Теперь радиалка создаёт image, которому задаются базовые координаты - оно же используется в колесе.

## Причина изменений
- [Багрепорт](https://discord.com/channels/875735187449847830/1538951527094550568/1538951527094550568)

<!-- Теперь можешь отправлять пулл-реквест на ревью. Не удаляй ветку, пока его полностью не замерджат. -->

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть замечены игроками или администраторами, вам следует добавить список изменений. Если ваши изменения не соответствуют этому описанию, удалите этот раздел. -->

:cl:
fix: Пиксель-шифт обнуляется при "дропе" айтема из радиального меню tool implant и иконка айтема теперь не ездит за пределы своей кнопки.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Исправлено отображение иконок предметов в радиальном меню многопредметного импланта руки: теперь сохраняются их базовые смещения по осям X и Y.
  * Исправлено отображение иконок предметов в радиальном меню установки скафандров: теперь учитываются их базовые смещения по осям X и Y.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->