### PR TITLE
absolutemin mode fix

### DIFF
--- a/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
+++ b/code/modules/asset_cache/spritesheet/batched/batched_spritesheet.dm
@@ -198,7 +198,11 @@
 
 /datum/asset/spritesheet_batched/proc/realize_spritesheets_owned(yield)
 	if(!length(entries))
+		#ifdef ABSOLUTE_MINIMUM_MODE
+		return
+		#else
 		CRASH("Спрайтшит [name] ([type]) пустой! Что он тут делает?")
+		#endif
 	if(sprites_per_shard <= 0)
 		CRASH("Спрайтшит [name] ([type]): невалидный sprites_per_shard [sprites_per_shard]")
 


### PR DESCRIPTION
# Описание
Фикс рантайма при минимальном моде, что не грузит спрайтшиты


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Пустые спрайтшиты теперь корректно обрабатываются в режиме минимальной загрузки без возникновения ошибки.
  * В остальных режимах сохранено прежнее поведение с сообщением об ошибке.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->