### PR TITLE
Suppermatter in exta

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -404,6 +404,16 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			SEND_SOUND(M, 'sound/magic/charge.ogg')
 			to_chat(M, "<span class='boldannounce'>Вы чувствуете, как реальность на мгновение искажается...</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
+	if(GLOB.round_type == ROUNDTYPE_DYNAMIC_LIGHT || GLOB.round_type == ROUNDTYPE_EXTENDED)
+		investigate_log("has performed a soft delamination (light round type [GLOB.round_type]).", INVESTIGATE_SUPERMATTER)
+		for(var/obj/machinery/light/light in GLOB.machines)
+			if(light.z == z)
+				light.on = TRUE
+				INVOKE_ASYNC(light, TYPE_PROC_REF(/obj/machinery/light, break_light_tube))
+				light.on = FALSE
+		radiation_pulse(src, 10000, 5, TRUE)
+		qdel(src)
+		return
 	if(combined_gas > MOLE_PENALTY_THRESHOLD)
 		investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
 		if(T) //If something fucks up we blow anyhow. This fix is 4 years old and none ever said why it's here. help.


### PR DESCRIPTION
Админы не должны удалять СМ в эксточку или лайт
## Changelog



:cl:
add: Суперматерия в режиме игры Экстендет и Динамик Лайт, больше не взрывается. Вместо этого, лопаются все лампочки на станции, а также появляется радиация по аналогии с ядерным реактором.
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * В режимах **Dynamic Light** и **Extended** разрушение суперматерии теперь проходит по отдельному сценарию.
  * Вместо обычного взрыва происходит мягкая деламинация с радиационным импульсом и удалением кристалла.
  * Светильники на уровне кристалла постепенно отключаются и разрушаются.
  * Сценарии с сингулярностью и энергетическими шарами в этих режимах больше не запускаются.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->