### PR TITLE
Задержка на посадку на стул в боевых интентах

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -52,6 +52,12 @@
  */
 /atom/movable/proc/mouse_buckle_handling(mob/living/M, mob/living/user)
 	if(can_buckle && istype(M) && istype(user))
+		// BLUEMOON ADD START - задержка на усаживание другого персонажа в любом интенте,
+		// кроме первого (HELP): в ПВП нельзя мгновенно посадить кого-то на стул/кровать/диван.
+		if(M != user && user.a_intent != INTENT_HELP)
+			if(!do_after(user, 1.5 SECONDS, src))
+				return FALSE
+		// BLUEMOON ADD END
 		return user_buckle_mob(M, user, check_loc = FALSE)
 
 /atom/movable/proc/has_buckled_mobs()

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -33,9 +33,11 @@
 	var/mob/living/carried_mob = riding_item.rider
 	if(carried_mob == user) //Piggyback user.
 		return
+	if(!check_buckle_delay(carried_mob, user))
+		return
 	user.unbuckle_mob(carried_mob)
 	carried_mob.forceMove(get_turf(src))
-	return mouse_buckle_handling(carried_mob, user)
+	return mouse_buckle_handling(carried_mob, user, delay_checked = TRUE)
 
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
@@ -50,15 +52,21 @@
  * M - The mob being buckled to src
  * user - The mob buckling M to src
  */
-/atom/movable/proc/mouse_buckle_handling(mob/living/M, mob/living/user)
+/atom/movable/proc/mouse_buckle_handling(mob/living/M, mob/living/user, delay_checked = FALSE)
 	if(can_buckle && istype(M) && istype(user))
-		// BLUEMOON ADD START - задержка на усаживание другого персонажа в любом интенте,
-		// кроме первого (HELP): в ПВП нельзя мгновенно посадить кого-то на стул/кровать/диван.
-		if(M != user && user.a_intent != INTENT_HELP)
-			if(!do_after(user, 1.5 SECONDS, src))
-				return FALSE
-		// BLUEMOON ADD END
+		if(!delay_checked && !check_buckle_delay(M, user))
+			return FALSE
 		return user_buckle_mob(M, user, check_loc = FALSE)
+
+/atom/movable/proc/check_buckle_delay(mob/living/M, mob/living/user)
+	if(M == user || user.a_intent == INTENT_HELP || M.incapacitated() || M.restrained())
+		return TRUE
+	var/atom/m_loc = M.loc
+	if(!do_after(user, 1.5 SECONDS, src))
+		return FALSE
+	if(QDELETED(M) || M.loc != m_loc)
+		return FALSE
+	return TRUE
 
 /atom/movable/proc/has_buckled_mobs()
 	if(!buckled_mobs)


### PR DESCRIPTION
# Описание

Нельзя садить на стулья в боевых интентах


## Changelog


:cl:
add: Теперь если персонаж находится в любом интенте кроме первого, посадка на стул занимает 1.5 секунды, другим игроком. Убираем СтулоСиюси
/:cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения игрового процесса**
  * Добавлена задержка 1,5 секунды перед усаживанием персонажа при выборе любого интента, кроме «Помощь».
  * Если действие прервано, усаживание не выполняется.
  * Поведение при выборе интента «Помощь» осталось без изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->